### PR TITLE
fix rudr traits

### DIFF
--- a/pkg/test/cli.go
+++ b/pkg/test/cli.go
@@ -115,7 +115,7 @@ func (c *clitestImpl) Run() {
 
 			// check output messages
 			if tc.ExpectedOutput != "" {
-				assert.Equal(t, tc.ExpectedOutput, outPut.String())
+				assert.Equal(t, tc.ExpectedOutput, outPut.String(), name)
 				return
 			}
 


### PR DESCRIPTION
```
$ go run ./cmd/rudrx/main.go traits                
NAME                            SHORT   DEFINITION                      APPLIES TO      STATUS
manualscalertraits.core.oam.dev         manualscalertraits.core.oam.dev                 -     %   
$ go run ./cmd/rudrx/main.go traits --apply-to xsxs
NAME    SHORT   DEFINITION      APPLIES TO      STATUS%
```