### PR TITLE
Feat: add secure tls for cluster-gateway

### DIFF
--- a/charts/vela-core/templates/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway.yaml
@@ -32,12 +32,28 @@ spec:
             - "--secure-port={{ .Values.multicluster.clusterGateway.port }}"
             - "--secret-namespace={{ .Release.Namespace }}"
             - "--feature-gates=APIPriorityAndFairness=false"
+            {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+            - "--cert-dir={{ .Values.multicluster.clusterGateway.secureTLS.certPath }}"
+            {{ end }}
           image: {{ .Values.multicluster.clusterGateway.image.repository }}:{{ .Values.multicluster.clusterGateway.image.tag }}
           imagePullPolicy: {{ .Values.multicluster.clusterGateway.image.pullPolicy }}
           resources:
           {{- toYaml .Values.multicluster.clusterGateway.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.multicluster.clusterGateway.port }}
+          {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.multicluster.clusterGateway.secureTLS.certPath }}
+              name: tls-cert-vol
+              readOnly: true
+          {{- end }}
+      {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+      volumes:
+        - name: tls-cert-vol
+          secret:
+            defaultMode: 420
+            secretName: {{ template "kubevela.fullname" . }}-cluster-gateway-tls
+      {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -84,5 +100,92 @@ spec:
     namespace: {{ .Release.Namespace }}
     port: {{ .Values.multicluster.clusterGateway.port }}
   versionPriority: 10
-  insecureSkipTLSVerify: true
+  insecureSkipTLSVerify: {{ not .Values.multicluster.clusterGateway.secureTLS.enabled }}
+  {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+  caBundle: Cg==
+  {{ end }}
+{{ end }}
+---
+{{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+    {{- include "kubevela.labels" . | nindent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+      labels:
+        app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+        {{- include "kubevela.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: create
+        image: {{ .Values.admissionWebhooks.patch.image.repository }}:{{ .Values.admissionWebhooks.patch.image.tag }}
+        imagePullPolicy: {{ .Values.admissionWebhooks.patch.image.pullPolicy }}
+        args:
+          - create
+          - --host={{ .Release.Name }}-cluster-gateway-service,{{ .Release.Name }}-cluster-gateway-service.{{ .Release.Namespace }}.svc
+          - --namespace={{ .Release.Namespace }}
+          - --secret-name={{ template "kubevela.fullname" . }}-cluster-gateway-tls
+          - --key-name=apiserver.key
+          - --cert-name=apiserver.crt
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "kubevela.fullname" . }}-admission
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+{{ end }}
+---
+{{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+    {{- include "kubevela.labels" . | nindent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+      labels:
+        app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+        {{- include "kubevela.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: patch
+        image: {{ .Values.multicluster.clusterGateway.image.repository }}:{{ .Values.multicluster.clusterGateway.image.tag }}
+        imagePullPolicy: {{ .Values.multicluster.clusterGateway.image.pullPolicy }}
+        command:
+          - /patch
+        args:
+          - --secret-namespace={{ .Release.Namespace }}
+          - --secret-name={{ template "kubevela.fullname" . }}-cluster-gateway-tls
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "kubevela.serviceAccountName" . }}
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
 {{ end }}

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -118,9 +118,12 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: v1.1.2
+      tag: v1.1.3
       pullPolicy: Always
     resources:
       limits:
         cpu: 100m
         memory: 200Mi
+    secureTLS:
+      enabled: true
+      certPath: /etc/k8s-cluster-gateway-certs

--- a/charts/vela-minimal/templates/cluster-gateway.yaml
+++ b/charts/vela-minimal/templates/cluster-gateway.yaml
@@ -32,12 +32,28 @@ spec:
             - "--secure-port={{ .Values.multicluster.clusterGateway.port }}"
             - "--secret-namespace={{ .Release.Namespace }}"
             - "--feature-gates=APIPriorityAndFairness=false"
+            {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+            - "--cert-dir={{ .Values.multicluster.clusterGateway.secureTLS.certPath }}"
+            {{ end }}
           image: {{ .Values.multicluster.clusterGateway.image.repository }}:{{ .Values.multicluster.clusterGateway.image.tag }}
           imagePullPolicy: {{ .Values.multicluster.clusterGateway.image.pullPolicy }}
           resources:
           {{- toYaml .Values.multicluster.clusterGateway.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.multicluster.clusterGateway.port }}
+          {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.multicluster.clusterGateway.secureTLS.certPath }}
+              name: tls-cert-vol
+              readOnly: true
+          {{- end }}
+      {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+      volumes:
+        - name: tls-cert-vol
+          secret:
+            defaultMode: 420
+            secretName: {{ template "kubevela.fullname" . }}-cluster-gateway-tls
+      {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -50,9 +66,9 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-{{ end }}
+  {{ end }}
 ---
-{{ if .Values.multicluster.enabled }}
+  {{ if .Values.multicluster.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -65,9 +81,9 @@ spec:
     - protocol: TCP
       port: {{ .Values.multicluster.clusterGateway.port }}
       targetPort: {{ .Values.multicluster.clusterGateway.port }}
-{{ end }}
+  {{ end }}
 ---
-{{ if .Values.multicluster.enabled }}
+  {{ if .Values.multicluster.enabled }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -84,5 +100,92 @@ spec:
     namespace: {{ .Release.Namespace }}
     port: {{ .Values.multicluster.clusterGateway.port }}
   versionPriority: 10
-  insecureSkipTLSVerify: true
-{{ end }}
+  insecureSkipTLSVerify: {{ not .Values.multicluster.clusterGateway.secureTLS.enabled }}
+  {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+  caBundle: Cg==
+  {{ end }}
+  {{ end }}
+---
+  {{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+    {{- include "kubevela.labels" . | nindent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+      labels:
+        app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-create
+        {{- include "kubevela.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: create
+          image: {{ .Values.admissionWebhooks.patch.image.repository }}:{{ .Values.admissionWebhooks.patch.image.tag }}
+          imagePullPolicy: {{ .Values.admissionWebhooks.patch.image.pullPolicy }}
+          args:
+            - create
+            - --host={{ .Release.Name }}-cluster-gateway-service,{{ .Release.Name }}-cluster-gateway-service.{{ .Release.Namespace }}.svc
+            - --namespace={{ .Release.Namespace }}
+            - --secret-name={{ template "kubevela.fullname" . }}-cluster-gateway-tls
+            - --key-name=apiserver.key
+            - --cert-name=apiserver.crt
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "kubevela.fullname" . }}-admission
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+  {{ end }}
+---
+  {{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+    {{- include "kubevela.labels" . | nindent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+      labels:
+        app: {{ template "kubevela.fullname" . }}-cluster-gateway-tls-secret-patch
+        {{- include "kubevela.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: patch
+          image: {{ .Values.multicluster.clusterGateway.image.repository }}:{{ .Values.multicluster.clusterGateway.image.tag }}
+          imagePullPolicy: {{ .Values.multicluster.clusterGateway.image.pullPolicy }}
+          command:
+            - /patch
+          args:
+            - --secret-namespace={{ .Release.Namespace }}
+            - --secret-name={{ template "kubevela.fullname" . }}-cluster-gateway-tls
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "kubevela.serviceAccountName" . }}
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+  {{ end }}

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -117,9 +117,12 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: v1.1.2
+      tag: v1.1.3
       pullPolicy: Always
     resources:
       limits:
         cpu: 100m
         memory: 200Mi
+    secureTLS:
+      enabled: true
+      certPath: /etc/k8s-cluster-gateway-certs


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Previous cluster-gateway do not use TLS verification for communicating with APIService(kube-apiserver). This PR is developed for enabling TLS option in cluster-gateway. Specifically, there are several things done in this PR:
1. Upgrade cluster-gateway to v1.1.3 where additional patch is embedded in the image.
2. Setup secure TLS option in chart values.
3. If TLS option is enabled for cluster-gateway, a certgen job will be launched before deploying cluster-gateway, which is responsible for creating CA Certificate, cluster-gateway Certificate and cluster-gateway Private Key. Then cluster-gateway then will be deployed with using Certificate and Private Key instead of previous Self-Signed cert. Finally, a patch job is launched to update APIService object with the CA Certificate. 
4. The TLS secure option is enabled by default.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->