### PR TITLE
Fix: backport 2394 to release 1.1

### DIFF
--- a/pkg/controller/common/rollout/workloads/cloneset_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/cloneset_rollout_integration_test.go
@@ -137,14 +137,14 @@ var _ = Describe("cloneset controller", func() {
 			Expect(consistent).Should(BeFalse())
 		})
 
-		It("there is no difference between the source and target", func() {
+		It("verify rollout spec hash", func() {
 			By("Create a CloneSet")
+			cloneSet.Spec.UpdateStrategy.Paused = true
 			Expect(k8sClient.Create(ctx, &cloneSet)).Should(Succeed())
 
-			By("Verify should fail because the cloneset hash is not computed without kruise controller")
 			consistent, err := c.VerifySpec(ctx)
-			Expect(err).Should(Equal(fmt.Errorf("there is no difference between the source and target, hash = ")))
-			Expect(consistent).Should(BeFalse())
+			Expect(err).Should(BeNil())
+			Expect(consistent).Should(BeTrue())
 		})
 
 		It("the cloneset is in the middle of updating", func() {

--- a/pkg/controller/common/rollout/workloads/statefulset_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/statefulset_rollout_integration_test.go
@@ -145,7 +145,7 @@ var _ = Describe("StatefulSet controller", func() {
 			targetHash := statefulSet.Status.UpdateRevision
 			c.rolloutStatus.LastAppliedPodTemplateIdentifier = targetHash
 			consistent, err := c.VerifySpec(ctx)
-			Expect(err).Should(Equal(fmt.Errorf("there is no difference between the source and target, hash = ")))
+			Expect(err).ShouldNot(Equal(fmt.Errorf("there is no difference between the source and target, hash = ")))
 			Expect(consistent).Should(BeFalse())
 		})
 
@@ -203,7 +203,8 @@ var _ = Describe("StatefulSet controller", func() {
 			Expect(err).Should(BeNil())
 			Expect(consistent).Should(BeTrue())
 			Expect(c.rolloutStatus.RolloutTargetSize).Should(BeEquivalentTo(*statefulSet.Spec.Replicas))
-			Expect(c.rolloutStatus.NewPodTemplateIdentifier).Should(BeEmpty())
+			// NewPodTemplateIdenifier should be fill with computed hash
+			Expect(c.rolloutStatus.NewPodTemplateIdentifier).ShouldNot(BeEmpty())
 		})
 	})
 

--- a/test/e2e-test/app_embed_rollout_test.go
+++ b/test/e2e-test/app_embed_rollout_test.go
@@ -158,6 +158,9 @@ var _ = Describe("rollout related e2e-test,Cloneset based app embed rollout test
 				if app.Status.Rollout.RollingState != v1alpha1.RolloutSucceedState {
 					return fmt.Errorf("app status rollingStatus not succeed acctually %s", app.Status.Rollout.RollingState)
 				}
+				if app.Status.Rollout.LastUpgradedTargetAppRevision != app.Status.LatestRevision.Name {
+					return fmt.Errorf("rollout controller haven't handle this change, targetRevision isn't right")
+				}
 				if app.Status.Phase != apicommon.ApplicationRunning {
 					return fmt.Errorf("app status not running acctually %s", app.Status.Phase)
 				}
@@ -252,8 +255,7 @@ var _ = Describe("rollout related e2e-test,Cloneset based app embed rollout test
 		verifyRolloutSucceeded(utils.ConstructRevisionName(appName, 3), "3")
 	})
 
-	// TODO(@wangyikewxgm): pending this test as it's flaky, will fix it soon
-	PIt("Test application only upgrade batchPartition", func() {
+	It("Test application only upgrade batchPartition", func() {
 		plan := &v1alpha1.RolloutPlan{
 			RolloutStrategy: v1alpha1.IncreaseFirstRolloutStrategyType,
 			RolloutBatches: []v1alpha1.RolloutBatch{
@@ -510,8 +512,7 @@ var _ = Describe("rollout related e2e-test,Cloneset based app embed rollout test
 		Expect(checkApp.Status.LatestRevision.Name).Should(BeEquivalentTo(utils.ConstructRevisionName(appName, 3)))
 	})
 
-	// TODO(@wangyikewxgm): pending this test as it's flaky, will fix it soon
-	PIt("Test rollout with another component only rollout first component", func() {
+	It("Test rollout with another component only rollout first component", func() {
 		plan := &v1alpha1.RolloutPlan{
 			RolloutStrategy: v1alpha1.IncreaseFirstRolloutStrategyType,
 			RolloutBatches: []v1alpha1.RolloutBatch{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Cherry pick #2394 to branch release 1.1

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->