### PR TITLE
Fix(application): nil pointer for component properties

### DIFF
--- a/apis/core.oam.dev/v1alpha2/conversion.go
+++ b/apis/core.oam.dev/v1alpha2/conversion.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -115,10 +116,17 @@ func (app *Application) ConvertFrom(src conversion.Hub) error {
 			}
 			// convert component
 			//  `.properties` -> `.settings`
+
+			var compProperties runtime.RawExtension
+
+			if comp.Properties != nil {
+				compProperties = *comp.Properties.DeepCopy()
+			}
+
 			app.Spec.Components = append(app.Spec.Components, ApplicationComponent{
 				Name:         comp.Name,
 				WorkloadType: comp.Type,
-				Settings:     *comp.Properties.DeepCopy(),
+				Settings:     compProperties,
 				Traits:       traits,
 				Scopes:       scopes,
 			})


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
https://github.com/oam-dev/kubevela/pull/2451 makes `properties` optional. But it causes a runtime error when we apply an application without properties:

```
2021/10/14 08:33:28 http: panic serving 10.64.1.1:37292: runtime error: invalid memory address or nil pointer dereference
goroutine 1202209 [running]:
net/http.(*conn).serve.func1(0xc009d95360)
	/usr/local/go/src/net/http/server.go:1804 +0x153
panic(0x1fe0880, 0x34bdb10)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2.(*Application).ConvertFrom(0xc0152843c0, 0x25a9ad0, 0xc01069b600, 0x25a9ad0, 0xc01069b600)
	/workspace/apis/core.oam.dev/v1alpha2/conversion.go:121 +0x413
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).convertObject(0xc001bf9ae0, 0x2585120, 0xc01069b600, 0x2584cc0, 0xc0152843c0, 0x2584cc0, 0xc0152843c0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/webhook/conversion/conversion.go:142 +0x7db
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).handleConvertRequest(0xc001bf9ae0, 0xc00f55d640, 0xc00b8adbf0, 0x0, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/webhook/conversion/conversion.go:107 +0x1d6
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).ServeHTTP(0xc001bf9ae0, 0x7f9e155cdce0, 0xc001ead220, 0xc016c4d500)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/webhook/conversion/conversion.go:74 +0x10e
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1(0x7f9e155cdce0, 0xc001ead220, 0xc016c4d500)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:40 +0xab
net/http.HandlerFunc.ServeHTTP(0xc013ffb7d0, 0x7f9e155cdce0, 0xc001ead220, 0xc016c4d500)
	/usr/local/go/src/net/http/server.go:2049 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1(0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:101 +0xdf
net/http.HandlerFunc.ServeHTTP(0xc013ffb9b0, 0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/usr/local/go/src/net/http/server.go:2049 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2(0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:76 +0xb2
net/http.HandlerFunc.ServeHTTP(0xc013ffbb30, 0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/usr/local/go/src/net/http/server.go:2049 +0x44
net/http.(*ServeMux).ServeHTTP(0xc00c9ccd80, 0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/usr/local/go/src/net/http/server.go:2428 +0x1ad
net/http.serverHandler.ServeHTTP(0xc00b6262a0, 0x25b5f20, 0xc00f573260, 0xc016c4d500)
	/usr/local/go/src/net/http/server.go:2867 +0xa3
net/http.(*conn).serve(0xc009d95360, 0x25bbe00, 0xc00bb93b80)
	/usr/local/go/src/net/http/server.go:1932 +0x8cd
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2993 +0x39b
```

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->