### PR TITLE
Feat: multicluster api in apiserver

### DIFF
--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -60,6 +60,15 @@ jobs:
           version: ${{ env.KIND_VERSION }}
           skipClusterCreation: true
 
+      - name: Setup Kind Cluster (Worker)
+        run: |
+          kind delete cluster --name worker
+          kind create cluster --image kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4 --name worker
+          kubectl version
+          kubectl cluster-info
+          kind get kubeconfig --name worker --internal > /tmp/worker.kubeconfig
+          kind get kubeconfig --name worker > /tmp/worker.client.kubeconfig
+
       - name: Setup Kind Cluster (Hub)
         run: |
           kind delete cluster
@@ -67,7 +76,7 @@ jobs:
           kubectl version
           kubectl cluster-info
 
-      - name: Load Image to kind cluster (Hub)
+      - name: Load Image to kind cluster
         run: make kind-load
 
       - name: Cleanup for e2e tests

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -187,7 +187,7 @@ func main() {
 
 	// wrapper the round tripper by multi cluster rewriter
 	if enableClusterGateway {
-		if err := multicluster.Initialize(restConfig); err != nil {
+		if _, err := multicluster.Initialize(restConfig, true); err != nil {
 			klog.ErrorS(err, "failed to enable multicluster")
 			os.Exit(1)
 		}

--- a/pkg/apiserver/model/cluster.go
+++ b/pkg/apiserver/model/cluster.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import v1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+
+// Cluster describes the model of cluster in apiserver
+type Cluster struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Icon        string            `json:"icon"`
+	Labels      map[string]string `json:"labels"`
+	Status      string            `json:"status"`
+	Reason      string            `json:"reason"`
+
+	KubeConfig       string `json:"kubeConfig"`
+	KubeConfigSecret string `json:"kubeConfigSecret"`
+
+	ResourceInfo v1.ClusterResourceInfo `json:"resourceInfo"`
+}
+
+// TableName table name for datastore
+func (c *Cluster) TableName() string {
+	return tableNamePrefix + "cluster"
+}
+
+// PrimaryKey primary key for datastore
+func (c *Cluster) PrimaryKey() string {
+	return c.Name
+}
+
+// Index set to nil for list
+func (c *Cluster) Index() map[string]string {
+	return nil
+}
+
+// ToClusterBase converts to ClusterBase
+func (c *Cluster) ToClusterBase() *v1.ClusterBase {
+	return &v1.ClusterBase{
+		Name:        c.Name,
+		Description: c.Description,
+		Icon:        c.Icon,
+		Labels:      c.Labels,
+		Status:      c.Status,
+		Reason:      c.Reason,
+	}
+}
+
+// DeepCopy create a copy of cluster
+func (c *Cluster) DeepCopy() *Cluster {
+	return deepCopy(c).(*Cluster)
+}

--- a/pkg/apiserver/model/model.go
+++ b/pkg/apiserver/model/model.go
@@ -19,6 +19,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -36,4 +37,17 @@ func NewJSONStruct(raw runtime.RawExtension) (*JSONStruct, error) {
 		return nil, fmt.Errorf("parse raw data failure %w", err)
 	}
 	return &data, nil
+}
+
+func deepCopy(src interface{}) interface{} {
+	dst := reflect.New(reflect.TypeOf(src).Elem())
+
+	val := reflect.ValueOf(src).Elem()
+	nVal := dst.Elem()
+	for i := 0; i < val.NumField(); i++ {
+		nvField := nVal.Field(i)
+		nvField.Set(val.Field(i))
+	}
+
+	return dst.Interface()
 }

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -100,11 +100,11 @@ type AddonStatusResponse struct {
 
 // CreateClusterRequest request parameters to create a cluster
 type CreateClusterRequest struct {
-	Name             string            `json:"name" validate:"name"`
+	Name             string            `json:"name"`
 	Description      string            `json:"description,omitempty"`
 	Icon             string            `json:"icon"`
-	KubeConfig       string            `json:"kubeConfig" validate:"required_without=kubeConfigSecret"`
-	KubeConfigSecret string            `json:"kubeConfigSecret,omitempty" validate:"required_without=kubeConfig"`
+	KubeConfig       string            `json:"kubeConfig"`
+	KubeConfigSecret string            `json:"kubeConfigSecret,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty"`
 }
 

--- a/pkg/apiserver/rest/usecase/cluster.go
+++ b/pkg/apiserver/rest/usecase/cluster.go
@@ -18,25 +18,200 @@ package usecase
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/pkg/apiserver/datastore"
+	"github.com/oam-dev/kubevela/pkg/apiserver/model"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
 // ClusterUsecase cluster manage
 type ClusterUsecase interface {
+	ListKubeClusters(context.Context, string, int, int) (*apis.ListClusterResponse, error)
 	CreateKubeCluster(context.Context, apis.CreateClusterRequest) (*apis.ClusterBase, error)
+	GetKubeCluster(context.Context, string) (*apis.DetailClusterResponse, error)
+	ModifyKubeCluster(context.Context, apis.CreateClusterRequest, string) (*apis.ClusterBase, error)
+	DeleteKubeCluster(context.Context, string) (*apis.ClusterBase, error)
 }
 
 type clusterUsecaseImpl struct {
-	ds datastore.DataStore
+	ds        datastore.DataStore
+	k8sClient client.Client
 }
 
 // NewClusterUsecase new cluster usecase
-func NewClusterUsecase(ds datastore.DataStore) ClusterUsecase {
-	return &clusterUsecaseImpl{ds: ds}
+func NewClusterUsecase(ds datastore.DataStore, k8sClient client.Client) ClusterUsecase {
+	return &clusterUsecaseImpl{ds: ds, k8sClient: k8sClient}
+}
+
+func (c *clusterUsecaseImpl) getClusterFromDataStore(ctx context.Context, clusterName string) (*model.Cluster, error) {
+	cluster := &model.Cluster{
+		Name: clusterName,
+	}
+	if err := c.ds.Get(ctx, cluster); err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+func (c *clusterUsecaseImpl) ListKubeClusters(ctx context.Context, query string, page int, pageSize int) (*apis.ListClusterResponse, error) {
+	// TODO: Fuzzy query
+	clusters, err := c.ds.List(ctx, &model.Cluster{}, &datastore.ListOptions{Page: page, PageSize: pageSize})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list cluster with query %s in data store", query)
+	}
+	resp := &apis.ListClusterResponse{
+		Clusters: []apis.ClusterBase{},
+	}
+	for _, raw := range clusters {
+		cluster, ok := raw.(*model.Cluster)
+		if ok {
+			resp.Clusters = append(resp.Clusters, *cluster.ToClusterBase())
+		}
+	}
+	return resp, nil
+}
+
+func joinClusterByKubeConfigString(ctx context.Context, k8sClient client.Client, clusterName string, kubeConfig string) error {
+	tmpFileName := fmt.Sprintf("/tmp/cluster-secret-%s-%s-%d.kubeconfig", clusterName, utils.RandomString(8), time.Now().UnixNano())
+	if err := ioutil.WriteFile(tmpFileName, []byte(kubeConfig), 0600); err != nil {
+		return errors.Wrapf(err, "failed to write kubeconfig to temp file %s", tmpFileName)
+	}
+	_, err := multicluster.JoinClusterByKubeConfig(ctx, k8sClient, tmpFileName, clusterName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to join cluster")
+	}
+	return nil
+}
+
+func createClusterModelFromRequest(req apis.CreateClusterRequest) *model.Cluster {
+	return &model.Cluster{
+		Name:             req.Name,
+		Description:      req.Description,
+		Icon:             req.Icon,
+		Labels:           req.Labels,
+		KubeConfig:       req.KubeConfig,
+		KubeConfigSecret: req.KubeConfigSecret,
+	}
 }
 
 func (c *clusterUsecaseImpl) CreateKubeCluster(ctx context.Context, req apis.CreateClusterRequest) (*apis.ClusterBase, error) {
-	return nil, nil
+	cluster := createClusterModelFromRequest(req)
+	if req.KubeConfig != "" {
+		if err := joinClusterByKubeConfigString(ctx, c.k8sClient, req.Name, req.KubeConfig); err != nil {
+			return nil, err
+		}
+		c.setClusterStatusAndResourceInfo(ctx, cluster)
+		return cluster.ToClusterBase(), c.ds.Add(ctx, cluster)
+	}
+	if req.KubeConfigSecret != "" {
+		return nil, errors.Errorf("kubeconfig secret is not supported now")
+	}
+	return nil, errors.Errorf("kubeconfig or kubeconfig secret must be set")
+}
+
+func (c *clusterUsecaseImpl) GetKubeCluster(ctx context.Context, clusterName string) (*apis.DetailClusterResponse, error) {
+	cluster, err := c.getClusterFromDataStore(ctx, clusterName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to found cluster %s in data store", clusterName)
+	}
+	c.setClusterStatusAndResourceInfo(ctx, cluster)
+	if err = c.ds.Put(ctx, cluster); err != nil {
+		return nil, errors.Wrapf(err, "failed to update cluster %s status info", clusterName)
+	}
+	return &apis.DetailClusterResponse{
+		ClusterBase:     *cluster.ToClusterBase(),
+		ResourceInfo:    cluster.ResourceInfo,
+		RemoteManageURL: "NA",
+		DashboardURL:    "NA",
+	}, nil
+}
+
+func (c *clusterUsecaseImpl) ModifyKubeCluster(ctx context.Context, req apis.CreateClusterRequest, clusterName string) (*apis.ClusterBase, error) {
+	oldCluster, err := c.getClusterFromDataStore(ctx, clusterName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to found cluster %s in data store", clusterName)
+	}
+
+	newCluster := createClusterModelFromRequest(req)
+	if oldCluster.Name != newCluster.Name || oldCluster.KubeConfig != newCluster.KubeConfig || oldCluster.KubeConfigSecret != newCluster.KubeConfigSecret {
+		if newCluster.KubeConfig == "" && newCluster.KubeConfigSecret != "" {
+			return nil, errors.Errorf("kubeconfig secret is not supported now")
+		}
+		if err = multicluster.DetachCluster(ctx, c.k8sClient, oldCluster.Name); err != nil {
+			return nil, errors.Wrapf(err, "failed to detach old cluster %s", oldCluster.Name)
+		}
+		if err = c.ds.Delete(ctx, oldCluster); err != nil {
+			return nil, errors.Wrapf(err, "failed to delete old cluster %s from datastore", oldCluster.Name)
+		}
+		if err = joinClusterByKubeConfigString(ctx, c.k8sClient, newCluster.Name, newCluster.KubeConfig); err != nil {
+			return nil, errors.Wrapf(err, "failed to join new cluster %s", newCluster.Name)
+		}
+		c.setClusterStatusAndResourceInfo(ctx, newCluster)
+		if err = c.ds.Add(ctx, newCluster); err != nil {
+			return nil, errors.Wrapf(err, "failed to add new cluster %s to datastore", newCluster.Name)
+		}
+	} else {
+		newCluster.ResourceInfo = oldCluster.ResourceInfo
+		newCluster.Status = oldCluster.Status
+		newCluster.Reason = oldCluster.Reason
+		if err = c.ds.Put(ctx, newCluster); err != nil {
+			return nil, errors.Wrapf(err, "failed to update cluster %s", newCluster.Name)
+		}
+	}
+	return newCluster.ToClusterBase(), nil
+}
+
+func (c *clusterUsecaseImpl) DeleteKubeCluster(ctx context.Context, clusterName string) (*apis.ClusterBase, error) {
+	cluster, err := c.getClusterFromDataStore(ctx, clusterName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to found cluster %s in data store", clusterName)
+	}
+	if err = c.ds.Delete(ctx, cluster); err != nil {
+		return nil, errors.Wrapf(err, "failed to delete cluster %s in data store", clusterName)
+	}
+	if err = multicluster.DetachCluster(ctx, c.k8sClient, clusterName); err != nil {
+		return nil, errors.Wrapf(err, "failed to delete cluster %s in kubernetes", clusterName)
+	}
+	return cluster.ToClusterBase(), nil
+}
+
+func (c *clusterUsecaseImpl) setClusterStatusAndResourceInfo(ctx context.Context, cluster *model.Cluster) {
+	// TODO add cache
+	resourceInfo, err := c.getClusterResourceInfoFromK8s(ctx, cluster.Name)
+	if err != nil {
+		cluster.Status = "Unhealthy"
+		cluster.Reason = fmt.Sprintf("Failed to get cluster resource info: %v", err)
+	} else {
+		cluster.Status = "Healthy"
+		cluster.Reason = ""
+		cluster.ResourceInfo = resourceInfo
+	}
+}
+
+func (c *clusterUsecaseImpl) getClusterResourceInfoFromK8s(ctx context.Context, clusterName string) (apis.ClusterResourceInfo, error) {
+	clusterInfo, err := multicluster.GetClusterInfo(ctx, c.k8sClient, clusterName)
+	if err != nil {
+		return apis.ClusterResourceInfo{}, err
+	}
+	var storageClassList []string
+	for _, cls := range clusterInfo.StorageClasses.Items {
+		storageClassList = append(storageClassList, cls.Name)
+	}
+	// TODO add support for gpu capacity
+	return apis.ClusterResourceInfo{
+		WorkerNumber:     clusterInfo.WorkerNumber,
+		MasterNumber:     clusterInfo.MasterNumber,
+		MemoryCapacity:   clusterInfo.MemoryCapacity.Value(),
+		CPUCapacity:      clusterInfo.CPUCapacity.Value(),
+		GPUCapacity:      0,
+		StorageClassList: storageClassList,
+	}, nil
 }

--- a/pkg/apiserver/rest/utils/params.go
+++ b/pkg/apiserver/rest/utils/params.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strconv"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/pkg/errors"
+)
+
+// ExtractPagingParams extract `page` and `pageSize` params from request
+func ExtractPagingParams(req *restful.Request, minPageSize int, maxPageSize int) (int, int, error) {
+	pageStr := req.QueryParameter("page")
+	pageSizeStr := req.QueryParameter("pageSize")
+	page64, err := strconv.ParseInt(pageStr, 10, 32)
+	if err != nil {
+		return 0, 0, errors.Errorf("invalid page %s: %v", pageStr, err)
+	}
+	pageSize64, err := strconv.ParseInt(pageSizeStr, 10, 32)
+	if err != nil {
+		return 0, 0, errors.Errorf("invalid pageSize %s: %v", pageSizeStr, err)
+	}
+	page := int(page64)
+	pageSize := int(pageSize64)
+	if page < 0 {
+		page = 0
+	}
+	if pageSize < minPageSize {
+		pageSize = minPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	return page, pageSize, nil
+}

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/pkg/apiserver/datastore"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
@@ -58,8 +59,8 @@ func returns500(b *restful.RouteBuilder) {
 
 // Init init all webservice, pass in the required parameter object.
 // It can be implemented using the idea of dependency injection.
-func Init(ctx context.Context, ds datastore.DataStore) {
-	clusterUsecase := usecase.NewClusterUsecase(ds)
+func Init(ctx context.Context, ds datastore.DataStore, k8sClient client.Client) {
+	clusterUsecase := usecase.NewClusterUsecase(ds, k8sClient)
 	applicationUsecase := usecase.NewApplicationUsecase(ds)
 	RegistWebService(NewClusterWebService(clusterUsecase))
 	RegistWebService(NewApplicationWebService(applicationUsecase))

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"context"
+	"fmt"
+
+	v1alpha12 "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	v14 "k8s.io/api/storage/v1"
+	v13 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types2 "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	errors3 "github.com/oam-dev/kubevela/pkg/utils/errors"
+)
+
+// ensureResourceTrackerCRDInstalled ensures resourcetracker to be installed in child cluster
+func ensureResourceTrackerCRDInstalled(ctx context.Context, c client.Client, clusterName string) error {
+	remoteCtx := ContextWithClusterName(ctx, clusterName)
+	crdName := types2.NamespacedName{Name: "resourcetrackers." + v1beta1.Group}
+	if err := c.Get(remoteCtx, crdName, &v13.CustomResourceDefinition{}); err != nil {
+		if !errors2.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to check resourcetracker crd in cluster %s", clusterName)
+		}
+		crd := &v13.CustomResourceDefinition{}
+		if err = c.Get(ctx, crdName, crd); err != nil {
+			return errors.Wrapf(err, "failed to get resourcetracker crd in hub cluster")
+		}
+		crd.ObjectMeta = v12.ObjectMeta{
+			Name:        crdName.Name,
+			Annotations: crd.Annotations,
+			Labels:      crd.Labels,
+		}
+		if err = c.Create(remoteCtx, crd); err != nil {
+			return errors.Wrapf(err, "failed to create resourcetracker crd in cluster %s", clusterName)
+		}
+	}
+	return nil
+}
+
+// ensureClusterNotExists checks if child cluster has already been joined, if joined, error is returned
+func ensureClusterNotExists(ctx context.Context, c client.Client, clusterName string) error {
+	secret := &v1.Secret{}
+	err := c.Get(ctx, types2.NamespacedName{Name: clusterName, Namespace: ClusterGatewaySecretNamespace}, secret)
+	if err == nil {
+		return fmt.Errorf("cluster %s already exists", clusterName)
+	}
+	if !errors2.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to check duplicate cluster secret")
+	}
+	return nil
+}
+
+// getMutableClusterSecret retrieves the cluster secret and check if any application is using the cluster
+func getMutableClusterSecret(ctx context.Context, c client.Client, clusterName string) (*v1.Secret, error) {
+	clusterSecret := &v1.Secret{}
+	if err := c.Get(ctx, types2.NamespacedName{Namespace: ClusterGatewaySecretNamespace, Name: clusterName}, clusterSecret); err != nil {
+		return nil, errors.Wrapf(err, "failed to find target cluster secret %s", clusterName)
+	}
+	labels := clusterSecret.GetLabels()
+	if labels == nil || labels[v1alpha12.LabelKeyClusterCredentialType] == "" {
+		return nil, fmt.Errorf("invalid cluster secret %s: cluster credential type label %s is not set", clusterName, v1alpha12.LabelKeyClusterCredentialType)
+	}
+	ebs := &v1alpha1.EnvBindingList{}
+	if err := c.List(ctx, ebs); err != nil {
+		return nil, errors.Wrap(err, "failed to find EnvBindings to check clusters")
+	}
+	errs := errors3.ErrorList{}
+	for _, eb := range ebs.Items {
+		for _, decision := range eb.Status.ClusterDecisions {
+			if decision.Cluster == clusterName {
+				errs.Append(fmt.Errorf("application %s/%s (env: %s, envBinding: %s) is currently using cluster %s", eb.Namespace, eb.Labels[oam.LabelAppName], decision.Env, eb.Name, clusterName))
+			}
+		}
+	}
+	if errs.HasError() {
+		return nil, errors.Wrapf(errs, "cluster %s is in use now", clusterName)
+	}
+	return clusterSecret, nil
+}
+
+// JoinClusterByKubeConfig add child cluster by kubeconfig path, return cluster info and error
+func JoinClusterByKubeConfig(_ctx context.Context, k8sClient client.Client, kubeconfigPath string, clusterName string) (*api.Cluster, error) {
+	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get kubeconfig")
+	}
+	if len(config.CurrentContext) == 0 {
+		return nil, fmt.Errorf("current-context is not set")
+	}
+	ctx, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return nil, fmt.Errorf("current-context %s not found", config.CurrentContext)
+	}
+	cluster, ok := config.Clusters[ctx.Cluster]
+	if !ok {
+		return nil, fmt.Errorf("cluster %s not found", ctx.Cluster)
+	}
+	authInfo, ok := config.AuthInfos[ctx.AuthInfo]
+	if !ok {
+		return nil, fmt.Errorf("authInfo %s not found", ctx.AuthInfo)
+	}
+
+	if clusterName == "" {
+		clusterName = ctx.Cluster
+	}
+	if clusterName == ClusterLocalName {
+		return cluster, fmt.Errorf("cannot use `%s` as cluster name, it is reserved as the local cluster", ClusterLocalName)
+	}
+
+	if err := ensureClusterNotExists(_ctx, k8sClient, clusterName); err != nil {
+		return cluster, errors.Wrapf(err, "cannot use cluster name %s", clusterName)
+	}
+
+	var credentialType v1alpha12.CredentialType
+	data := map[string][]byte{
+		"endpoint": []byte(cluster.Server),
+		"ca.crt":   cluster.CertificateAuthorityData,
+	}
+	if len(authInfo.Token) > 0 {
+		credentialType = v1alpha12.CredentialTypeServiceAccountToken
+		data["token"] = []byte(authInfo.Token)
+	} else {
+		credentialType = v1alpha12.CredentialTypeX509Certificate
+		data["tls.crt"] = authInfo.ClientCertificateData
+		data["tls.key"] = authInfo.ClientKeyData
+	}
+	secret := &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ClusterGatewaySecretNamespace,
+			Labels: map[string]string{
+				v1alpha12.LabelKeyClusterCredentialType: string(credentialType),
+			},
+		},
+		Type: v1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	if err := k8sClient.Create(_ctx, secret); err != nil {
+		return cluster, errors.Wrapf(err, "failed to add cluster to kubernetes")
+	}
+	if err := ensureResourceTrackerCRDInstalled(_ctx, k8sClient, clusterName); err != nil {
+		_ = k8sClient.Delete(_ctx, secret)
+		return cluster, errors.Wrapf(err, "failed to ensure resourcetracker crd installed in cluster %s", clusterName)
+	}
+	return cluster, nil
+}
+
+// DetachCluster detach cluster by name, if cluster is using by application, it will return error
+func DetachCluster(ctx context.Context, k8sClient client.Client, clusterName string) error {
+	if clusterName == ClusterLocalName {
+		return fmt.Errorf("cannot delete `%s` cluster, it is reserved as the local cluster", ClusterLocalName)
+	}
+	clusterSecret, err := getMutableClusterSecret(ctx, k8sClient, clusterName)
+	if err != nil {
+		return errors.Wrapf(err, "cluster %s is not mutable now", clusterName)
+	}
+	return k8sClient.Delete(ctx, clusterSecret)
+}
+
+// RenameCluster rename cluster
+func RenameCluster(ctx context.Context, k8sClient client.Client, oldClusterName string, newClusterName string) error {
+	if newClusterName == ClusterLocalName {
+		return fmt.Errorf("cannot use `%s` as cluster name, it is reserved as the local cluster", ClusterLocalName)
+	}
+	clusterSecret, err := getMutableClusterSecret(ctx, k8sClient, oldClusterName)
+	if err != nil {
+		return errors.Wrapf(err, "cluster %s is not mutable now", oldClusterName)
+	}
+	if err := ensureClusterNotExists(ctx, k8sClient, newClusterName); err != nil {
+		return errors.Wrapf(err, "cannot set cluster name to %s", newClusterName)
+	}
+	if err := k8sClient.Delete(ctx, clusterSecret); err != nil {
+		return errors.Wrapf(err, "failed to rename cluster from %s to %s", oldClusterName, newClusterName)
+	}
+	clusterSecret.ObjectMeta = v12.ObjectMeta{
+		Name:        newClusterName,
+		Namespace:   ClusterGatewaySecretNamespace,
+		Labels:      clusterSecret.Labels,
+		Annotations: clusterSecret.Annotations,
+	}
+	if err := k8sClient.Create(ctx, clusterSecret); err != nil {
+		return errors.Wrapf(err, "failed to rename cluster from %s to %s", oldClusterName, newClusterName)
+	}
+	return nil
+}
+
+// ClusterInfo describes the basic information of a cluster
+type ClusterInfo struct {
+	Nodes          *v1.NodeList
+	WorkerNumber   int
+	MasterNumber   int
+	MemoryCapacity resource.Quantity
+	CPUCapacity    resource.Quantity
+	StorageClasses *v14.StorageClassList
+}
+
+// GetClusterInfo retrieves current cluster info from cluster
+func GetClusterInfo(_ctx context.Context, k8sClient client.Client, clusterName string) (*ClusterInfo, error) {
+	ctx := ContextWithClusterName(_ctx, clusterName)
+	nodes := &v1.NodeList{}
+	if err := k8sClient.List(ctx, nodes); err != nil {
+		return nil, errors.Wrapf(err, "failed to list cluster nodes")
+	}
+	var workerNumber, masterNumber int
+	var memoryCapacity, cpuCapacity resource.Quantity
+	for _, node := range nodes.Items {
+		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+			masterNumber++
+		} else {
+			workerNumber++
+		}
+		capacity := node.Status.Capacity
+		memoryCapacity.Add(*capacity.Memory())
+		cpuCapacity.Add(*capacity.Cpu())
+	}
+	storageClasses := &v14.StorageClassList{}
+	if err := k8sClient.List(ctx, storageClasses); err != nil {
+		return nil, errors.Wrapf(err, "failed to list storage classes")
+	}
+	return &ClusterInfo{
+		Nodes:          nodes,
+		WorkerNumber:   workerNumber,
+		MasterNumber:   masterNumber,
+		MemoryCapacity: memoryCapacity,
+		CPUCapacity:    cpuCapacity,
+		StorageClasses: storageClasses,
+	}, nil
+}

--- a/pkg/multicluster/utils.go
+++ b/pkg/multicluster/utils.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	errors3 "github.com/oam-dev/kubevela/pkg/utils/errors"
@@ -114,23 +115,25 @@ func WaitUntilClusterGatewayReady(ctx context.Context, c client.Client, maxRetry
 
 // Initialize prepare multicluster environment by checking cluster gateway service in clusters and hack rest config to use cluster gateway
 // if cluster gateway service is not ready, it will wait up to 5 minutes
-func Initialize(restConfig *rest.Config) error {
+func Initialize(restConfig *rest.Config, autoUpgrade bool) (client.Client, error) {
 	c, err := client.New(restConfig, client.Options{Scheme: common.Scheme})
 	if err != nil {
-		return errors2.Wrapf(err, "unable to get client to find cluster gateway service")
+		return nil, errors2.Wrapf(err, "unable to get client to find cluster gateway service")
 	}
 	svc, err := WaitUntilClusterGatewayReady(context.Background(), c, 60, 5*time.Second)
 	if err != nil {
-		return errors2.Wrapf(err, "failed to wait for cluster gateway, unable to use multi-cluster")
+		return nil, errors2.Wrapf(err, "failed to wait for cluster gateway, unable to use multi-cluster")
 	}
 	ClusterGatewaySecretNamespace = svc.Namespace
 	klog.Infof("find cluster gateway service %s/%s:%d", svc.Namespace, svc.Name, *svc.Port)
 	restConfig.Wrap(NewSecretModeMultiClusterRoundTripper)
-	if err = UpgradeExistingClusterSecret(context.Background(), c); err != nil {
-		// this error do not affect the running of current version
-		klog.ErrorS(err, "error encountered while grading existing cluster secret to the latest version")
+	if autoUpgrade {
+		if err = UpgradeExistingClusterSecret(context.Background(), c); err != nil {
+			// this error do not affect the running of current version
+			klog.ErrorS(err, "error encountered while grading existing cluster secret to the latest version")
+		}
 	}
-	return nil
+	return c, nil
 }
 
 // UpgradeExistingClusterSecret upgrade outdated cluster secrets in v1.1.1 to latest
@@ -156,4 +159,13 @@ func UpgradeExistingClusterSecret(ctx context.Context, c client.Client) error {
 		return errs
 	}
 	return nil
+}
+
+// GetMulticlusterKubernetesClient get client with multicluster function enabled
+func GetMulticlusterKubernetesClient() (client.Client, error) {
+	k8sConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	return Initialize(k8sConfig, false)
 }

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -18,26 +18,16 @@ package cli
 
 import (
 	"context"
-	"fmt"
 
 	v1alpha12 "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
-	v13 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	errors2 "k8s.io/apimachinery/pkg/api/errors"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types2 "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
-	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
-	errors3 "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"github.com/oam-dev/kubevela/references/a/preimport"
 )
 
@@ -115,42 +105,6 @@ func NewClusterListCommand(c *common.Args) *cobra.Command {
 	return cmd
 }
 
-func ensureClusterNotExists(c client.Client, clusterName string) error {
-	secret := &v1.Secret{}
-	err := c.Get(context.Background(), types2.NamespacedName{Name: clusterName, Namespace: multicluster.ClusterGatewaySecretNamespace}, secret)
-	if err == nil {
-		return fmt.Errorf("cluster %s already exists", clusterName)
-	}
-	if !errors2.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to check duplicate cluster secret")
-	}
-	return nil
-}
-
-func ensureResourceTrackerCRDInstalled(c client.Client, clusterName string) error {
-	ctx := context.Background()
-	remoteCtx := multicluster.ContextWithClusterName(ctx, clusterName)
-	crdName := types2.NamespacedName{Name: "resourcetrackers." + v1beta1.Group}
-	if err := c.Get(remoteCtx, crdName, &v13.CustomResourceDefinition{}); err != nil {
-		if !errors2.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to check resourcetracker crd in cluster %s", clusterName)
-		}
-		crd := &v13.CustomResourceDefinition{}
-		if err = c.Get(ctx, crdName, crd); err != nil {
-			return errors.Wrapf(err, "failed to get resourcetracker crd in hub cluster")
-		}
-		crd.ObjectMeta = v12.ObjectMeta{
-			Name:        crdName.Name,
-			Annotations: crd.Annotations,
-			Labels:      crd.Labels,
-		}
-		if err = c.Create(remoteCtx, crd); err != nil {
-			return errors.Wrapf(err, "failed to create resourcetracker crd in cluster %s", clusterName)
-		}
-	}
-	return nil
-}
-
 // NewClusterJoinCommand create command to help user join cluster to multicluster management
 func NewClusterJoinCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
@@ -161,71 +115,14 @@ func NewClusterJoinCommand(c *common.Args) *cobra.Command {
 			"> vela cluster join my-child-cluster.kubeconfig --name example-cluster",
 		Args: cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := clientcmd.LoadFromFile(args[0])
-			if err != nil {
-				return errors.Wrapf(err, "failed to get kubeconfig")
-			}
-			if len(config.CurrentContext) == 0 {
-				return fmt.Errorf("current-context is not set")
-			}
-			ctx, ok := config.Contexts[config.CurrentContext]
-			if !ok {
-				return fmt.Errorf("current-context %s not found", config.CurrentContext)
-			}
-			cluster, ok := config.Clusters[ctx.Cluster]
-			if !ok {
-				return fmt.Errorf("cluster %s not found", ctx.Cluster)
-			}
-			authInfo, ok := config.AuthInfos[ctx.AuthInfo]
-			if !ok {
-				return fmt.Errorf("authInfo %s not found", ctx.AuthInfo)
-			}
-
 			// get ClusterName from flag or config
 			clusterName, err := cmd.Flags().GetString(FlagClusterName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get cluster name flag")
 			}
-			if clusterName == "" {
-				clusterName = ctx.Cluster
-			}
-			if clusterName == multicluster.ClusterLocalName {
-				return fmt.Errorf("cannot use `%s` as cluster name, it is reserved as the local cluster", multicluster.ClusterLocalName)
-			}
-
-			if err := ensureClusterNotExists(c.Client, clusterName); err != nil {
-				return errors.Wrapf(err, "cannot use cluster name %s", clusterName)
-			}
-			var credentialType v1alpha12.CredentialType
-			data := map[string][]byte{
-				"endpoint": []byte(cluster.Server),
-				"ca.crt":   cluster.CertificateAuthorityData,
-			}
-			if len(authInfo.Token) > 0 {
-				credentialType = v1alpha12.CredentialTypeServiceAccountToken
-				data["token"] = []byte(authInfo.Token)
-			} else {
-				credentialType = v1alpha12.CredentialTypeX509Certificate
-				data["tls.crt"] = authInfo.ClientCertificateData
-				data["tls.key"] = authInfo.ClientKeyData
-			}
-			secret := &v1.Secret{
-				ObjectMeta: v12.ObjectMeta{
-					Name:      clusterName,
-					Namespace: multicluster.ClusterGatewaySecretNamespace,
-					Labels: map[string]string{
-						v1alpha12.LabelKeyClusterCredentialType: string(credentialType),
-					},
-				},
-				Type: v1.SecretTypeOpaque,
-				Data: data,
-			}
-			if err := c.Client.Create(context.Background(), secret); err != nil {
-				return errors.Wrapf(err, "failed to add cluster to kubernetes")
-			}
-			if err := ensureResourceTrackerCRDInstalled(c.Client, clusterName); err != nil {
-				_ = c.Client.Delete(context.Background(), secret)
-				return errors.Wrapf(err, "failed to ensure resourcetracker crd installed in cluster %s", clusterName)
+			cluster, err := multicluster.JoinClusterByKubeConfig(context.Background(), c.Client, args[0], clusterName)
+			if err != nil {
+				return err
 			}
 			cmd.Printf("Successfully add cluster %s, endpoint: %s.\n", clusterName, cluster.Server)
 			return nil
@@ -233,33 +130,6 @@ func NewClusterJoinCommand(c *common.Args) *cobra.Command {
 	}
 	cmd.Flags().StringP(FlagClusterName, "n", "", "Specify the cluster name. If empty, it will use the cluster name in config file. Default to be empty.")
 	return cmd
-}
-
-func getMutableClusterSecret(c client.Client, clusterName string) (*v1.Secret, error) {
-	clusterSecret := &v1.Secret{}
-	if err := c.Get(context.Background(), types2.NamespacedName{Namespace: multicluster.ClusterGatewaySecretNamespace, Name: clusterName}, clusterSecret); err != nil {
-		return nil, errors.Wrapf(err, "failed to find target cluster secret %s", clusterName)
-	}
-	labels := clusterSecret.GetLabels()
-	if labels == nil || labels[v1alpha12.LabelKeyClusterCredentialType] == "" {
-		return nil, fmt.Errorf("invalid cluster secret %s: cluster credential type label %s is not set", clusterName, v1alpha12.LabelKeyClusterCredentialType)
-	}
-	ebs := &v1alpha1.EnvBindingList{}
-	if err := c.List(context.Background(), ebs); err != nil {
-		return nil, errors.Wrap(err, "failed to find EnvBindings to check clusters")
-	}
-	errs := errors3.ErrorList{}
-	for _, eb := range ebs.Items {
-		for _, decision := range eb.Status.ClusterDecisions {
-			if decision.Cluster == clusterName {
-				errs.Append(fmt.Errorf("application %s/%s (env: %s, envBinding: %s) is currently using cluster %s", eb.Namespace, eb.Labels[oam.LabelAppName], decision.Env, eb.Name, clusterName))
-			}
-		}
-	}
-	if errs.HasError() {
-		return nil, errors.Wrapf(errs, "cluster %s is in use now", clusterName)
-	}
-	return clusterSecret, nil
 }
 
 // NewClusterRenameCommand create command to help user rename cluster
@@ -271,27 +141,8 @@ func NewClusterRenameCommand(c *common.Args) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oldClusterName := args[0]
 			newClusterName := args[1]
-			if newClusterName == multicluster.ClusterLocalName {
-				return fmt.Errorf("cannot use `%s` as cluster name, it is reserved as the local cluster", multicluster.ClusterLocalName)
-			}
-			clusterSecret, err := getMutableClusterSecret(c.Client, oldClusterName)
-			if err != nil {
-				return errors.Wrapf(err, "cluster %s is not mutable now", oldClusterName)
-			}
-			if err := ensureClusterNotExists(c.Client, newClusterName); err != nil {
-				return errors.Wrapf(err, "cannot set cluster name to %s", newClusterName)
-			}
-			if err := c.Client.Delete(context.Background(), clusterSecret); err != nil {
-				return errors.Wrapf(err, "failed to rename cluster from %s to %s", oldClusterName, newClusterName)
-			}
-			clusterSecret.ObjectMeta = v12.ObjectMeta{
-				Name:        newClusterName,
-				Namespace:   multicluster.ClusterGatewaySecretNamespace,
-				Labels:      clusterSecret.Labels,
-				Annotations: clusterSecret.Annotations,
-			}
-			if err := c.Client.Create(context.Background(), clusterSecret); err != nil {
-				return errors.Wrapf(err, "failed to rename cluster from %s to %s", oldClusterName, newClusterName)
+			if err := multicluster.RenameCluster(context.Background(), c.Client, oldClusterName, newClusterName); err != nil {
+				return err
 			}
 			cmd.Printf("Rename cluster %s to %s successfully.\n", oldClusterName, newClusterName)
 			return nil
@@ -308,15 +159,8 @@ func NewClusterDetachCommand(c *common.Args) *cobra.Command {
 		Args:  cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
-			if clusterName == multicluster.ClusterLocalName {
-				return fmt.Errorf("cannot delete `%s` cluster, it is reserved as the local cluster", multicluster.ClusterLocalName)
-			}
-			clusterSecret, err := getMutableClusterSecret(c.Client, clusterName)
-			if err != nil {
-				return errors.Wrapf(err, "cluster %s is not mutable now", clusterName)
-			}
-			if err := c.Client.Delete(context.Background(), clusterSecret); err != nil {
-				return errors.Wrapf(err, "failed to detach cluster %s", clusterName)
+			if err := multicluster.DetachCluster(context.Background(), c.Client, clusterName); err != nil {
+				return err
 			}
 			cmd.Printf("Detach cluster %s successfully.\n", clusterName)
 			return nil

--- a/test/e2e-apiserver-test/cluster_test.go
+++ b/test/e2e-apiserver-test/cluster_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_apiserver
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	util "github.com/oam-dev/kubevela/pkg/utils"
+)
+
+const (
+	WorkerClusterName           = "cluster-worker"
+	WorkerClusterKubeConfigPath = "/tmp/worker.kubeconfig"
+)
+
+var _ = Describe("Test cluster rest api", func() {
+
+	var clusterName string
+
+	BeforeEach(func() {
+		clusterName = WorkerClusterName + "-" + util.RandomString(8)
+		kubeconfigBytes, err := ioutil.ReadFile(WorkerClusterKubeConfigPath)
+		Expect(err).Should(Succeed())
+		resp, err := CreateRequest(http.MethodPost, "/clusters", v1.CreateClusterRequest{
+			Name:       clusterName,
+			KubeConfig: string(kubeconfigBytes),
+		})
+		Expect(err).Should(Succeed())
+		Expect(resp.StatusCode).Should(Equal(200))
+		Expect(resp.Body).ShouldNot(BeNil())
+		Expect(resp.Body.Close()).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		resp, err := CreateRequest(http.MethodDelete, "/clusters/"+clusterName, nil)
+		Expect(err).Should(Succeed())
+		Expect(resp.StatusCode).Should(Equal(200))
+		Expect(resp.Body).ShouldNot(BeNil())
+		Expect(resp.Body.Close()).Should(Succeed())
+	})
+
+	It("Test get cluster", func() {
+		resp, err := CreateRequest(http.MethodGet, "/clusters/"+clusterName, nil)
+		clusterResp := &v1.DetailClusterResponse{}
+		Expect(DecodeResponseBody(resp, err, clusterResp)).Should(Succeed())
+		Expect(clusterResp.Status).Should(Equal("Healthy"))
+	})
+
+	It("Test get clusters", func() {
+		resp, err := CreateRequest(http.MethodGet, "/clusters/?page=1&pageSize=5", nil)
+		clusterResp := &v1.ListClusterResponse{}
+		Expect(DecodeResponseBody(resp, err, clusterResp)).Should(Succeed())
+		Expect(len(clusterResp.Clusters)).ShouldNot(Equal(0))
+	})
+
+	It("Test modify cluster", func() {
+		kubeconfigBytes, err := ioutil.ReadFile(WorkerClusterKubeConfigPath)
+		Expect(err).Should(Succeed())
+		resp, err := CreateRequest(http.MethodPost, "/clusters/"+clusterName, v1.CreateClusterRequest{
+			Name:        clusterName,
+			KubeConfig:  string(kubeconfigBytes),
+			Description: "Example description",
+		})
+		clusterResp := &v1.ClusterBase{}
+		Expect(DecodeResponseBody(resp, err, clusterResp)).Should(Succeed())
+		Expect(clusterResp.Description).ShouldNot(Equal(""))
+	})
+})

--- a/test/e2e-apiserver-test/utils.go
+++ b/test/e2e-apiserver-test/utils.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CreateRequest wraps request
+func CreateRequest(method string, path string, body interface{}) (*http.Response, error) {
+	if body == nil {
+		body = map[string]string{}
+	}
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, "http://127.0.0.1:8000/api/v1"+path, bytes.NewBuffer(bs))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+// DecodeResponseBody decode response and close response
+func DecodeResponseBody(resp *http.Response, err error, dst interface{}) error {
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("response code is not 200: %d", resp.StatusCode)
+	}
+	if resp.Body == nil {
+		return fmt.Errorf("response body is nil")
+	}
+	err = json.NewDecoder(resp.Body).Decode(dst)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Init cluster api in apiserver, including:
- Add cluster
- Update cluster
- Delete cluster
- List cluster
- Get cluster

e2e-test is also set-up.

Several problems left:
- [ ] GPU resource is not fetched now.
- [ ] Cluster get api always check remote Kubernetes to update status. Could be improved by adding cache timeout.
- [ ] List API has not supported fuzzy query due to the lack of function in datastore engine.
- [ ] This PR is mixed with refactor of apiserver-e2e-test, should be splitted.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->