### PR TITLE
Fix(cli): use flag instead of env in workflow cli

### DIFF
--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -51,7 +51,7 @@ func NewWorkflowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 
 // NewWorkflowSuspendCommand create workflow suspend command
 func NewWorkflowSuspendCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "suspend",
 		Short:   "Suspend an application workflow",
 		Long:    "Suspend an application workflow in cluster",
@@ -60,11 +60,18 @@ func NewWorkflowSuspendCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			if len(args) < 1 {
 				return fmt.Errorf("must specify application name")
 			}
-			env, err := GetFlagEnvOrCurrent(cmd, c)
+			namespace, err := cmd.Flags().GetString(FlagNamespace)
 			if err != nil {
 				return err
 			}
-			app, err := appfile.LoadApplication(env.Namespace, args[0], c)
+			if namespace == "" {
+				env, err := GetFlagEnvOrCurrent(cmd, c)
+				if err != nil {
+					return err
+				}
+				namespace = env.Namespace
+			}
+			app, err := appfile.LoadApplication(namespace, args[0], c)
 			if err != nil {
 				return err
 			}
@@ -86,11 +93,13 @@ func NewWorkflowSuspendCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			return nil
 		},
 	}
+	cmd.Flags().StringP(FlagNamespace, "n", "", "Specify which namespace to get. If empty, uses namespace in env.")
+	return cmd
 }
 
 // NewWorkflowResumeCommand create workflow resume command
 func NewWorkflowResumeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "resume",
 		Short:   "Resume a suspend application workflow",
 		Long:    "Resume a suspend application workflow in cluster",
@@ -99,11 +108,18 @@ func NewWorkflowResumeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.
 			if len(args) < 1 {
 				return fmt.Errorf("must specify application name")
 			}
-			env, err := GetFlagEnvOrCurrent(cmd, c)
+			namespace, err := cmd.Flags().GetString(FlagNamespace)
 			if err != nil {
 				return err
 			}
-			app, err := appfile.LoadApplication(env.Namespace, args[0], c)
+			if namespace == "" {
+				env, err := GetFlagEnvOrCurrent(cmd, c)
+				if err != nil {
+					return err
+				}
+				namespace = env.Namespace
+			}
+			app, err := appfile.LoadApplication(namespace, args[0], c)
 			if err != nil {
 				return err
 			}
@@ -135,11 +151,13 @@ func NewWorkflowResumeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.
 			return nil
 		},
 	}
+	cmd.Flags().StringP(FlagNamespace, "n", "", "Specify which namespace to get. If empty, uses namespace in env.")
+	return cmd
 }
 
 // NewWorkflowTerminateCommand create workflow terminate command
 func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "terminate",
 		Short:   "Terminate an application workflow",
 		Long:    "Terminate an application workflow in cluster",
@@ -148,11 +166,18 @@ func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cob
 			if len(args) < 1 {
 				return fmt.Errorf("must specify application name")
 			}
-			env, err := GetFlagEnvOrCurrent(cmd, c)
+			namespace, err := cmd.Flags().GetString(FlagNamespace)
 			if err != nil {
 				return err
 			}
-			app, err := appfile.LoadApplication(env.Namespace, args[0], c)
+			if namespace == "" {
+				env, err := GetFlagEnvOrCurrent(cmd, c)
+				if err != nil {
+					return err
+				}
+				namespace = env.Namespace
+			}
+			app, err := appfile.LoadApplication(namespace, args[0], c)
 			if err != nil {
 				return err
 			}
@@ -174,11 +199,13 @@ func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cob
 			return nil
 		},
 	}
+	cmd.Flags().StringP(FlagNamespace, "n", "", "Specify which namespace to get. If empty, uses namespace in env.")
+	return cmd
 }
 
 // NewWorkflowRestartCommand create workflow restart command
 func NewWorkflowRestartCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "restart",
 		Short:   "Restart an application workflow",
 		Long:    "Restart an application workflow in cluster",
@@ -187,11 +214,18 @@ func NewWorkflowRestartCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			if len(args) < 1 {
 				return fmt.Errorf("must specify application name")
 			}
-			env, err := GetFlagEnvOrCurrent(cmd, c)
+			namespace, err := cmd.Flags().GetString(FlagNamespace)
 			if err != nil {
 				return err
 			}
-			app, err := appfile.LoadApplication(env.Namespace, args[0], c)
+			if namespace == "" {
+				env, err := GetFlagEnvOrCurrent(cmd, c)
+				if err != nil {
+					return err
+				}
+				namespace = env.Namespace
+			}
+			app, err := appfile.LoadApplication(namespace, args[0], c)
 			if err != nil {
 				return err
 			}
@@ -213,6 +247,8 @@ func NewWorkflowRestartCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			return nil
 		},
 	}
+	cmd.Flags().StringP(FlagNamespace, "n", "", "Specify which namespace to get. If empty, uses namespace in env.")
+	return cmd
 }
 
 func suspendWorkflow(kubecli client.Client, app *v1beta1.Application) error {

--- a/references/cli/workflow_test.go
+++ b/references/cli/workflow_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -83,7 +84,7 @@ func TestWorkflowSuspend(t *testing.T) {
 			app: &v1beta1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workflow",
-					Namespace: "default",
+					Namespace: "test",
 				},
 				Spec: workflowSpec,
 				Status: common.AppStatus{
@@ -105,7 +106,17 @@ func TestWorkflowSuspend(t *testing.T) {
 				err := c.Client.Create(ctx, tc.app)
 				r.NoError(err)
 
-				cmd.SetArgs([]string{tc.app.Name})
+				if tc.app.Namespace != corev1.NamespaceDefault {
+					err := c.Client.Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tc.app.Namespace,
+						},
+					})
+					r.NoError(err)
+					cmd.SetArgs([]string{tc.app.Name, "-n", tc.app.Namespace})
+				} else {
+					cmd.SetArgs([]string{tc.app.Name})
+				}
 			}
 			err := cmd.Execute()
 			if tc.expectedErr != nil {
@@ -190,7 +201,7 @@ func TestWorkflowResume(t *testing.T) {
 			app: &v1beta1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workflow",
-					Namespace: "default",
+					Namespace: "test",
 				},
 				Spec: workflowSpec,
 				Status: common.AppStatus{
@@ -212,7 +223,17 @@ func TestWorkflowResume(t *testing.T) {
 				err := c.Client.Create(ctx, tc.app)
 				r.NoError(err)
 
-				cmd.SetArgs([]string{tc.app.Name})
+				if tc.app.Namespace != corev1.NamespaceDefault {
+					err := c.Client.Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tc.app.Namespace,
+						},
+					})
+					r.NoError(err)
+					cmd.SetArgs([]string{tc.app.Name, "-n", tc.app.Namespace})
+				} else {
+					cmd.SetArgs([]string{tc.app.Name})
+				}
 			}
 			err := cmd.Execute()
 			if tc.expectedErr != nil {
@@ -268,7 +289,7 @@ func TestWorkflowTerminate(t *testing.T) {
 			app: &v1beta1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workflow",
-					Namespace: "default",
+					Namespace: "test",
 				},
 				Spec: workflowSpec,
 				Status: common.AppStatus{
@@ -290,7 +311,17 @@ func TestWorkflowTerminate(t *testing.T) {
 				err := c.Client.Create(ctx, tc.app)
 				r.NoError(err)
 
-				cmd.SetArgs([]string{tc.app.Name})
+				if tc.app.Namespace != corev1.NamespaceDefault {
+					err := c.Client.Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tc.app.Namespace,
+						},
+					})
+					r.NoError(err)
+					cmd.SetArgs([]string{tc.app.Name, "-n", tc.app.Namespace})
+				} else {
+					cmd.SetArgs([]string{tc.app.Name})
+				}
 			}
 			err := cmd.Execute()
 			if tc.expectedErr != nil {
@@ -346,7 +377,7 @@ func TestWorkflowRestart(t *testing.T) {
 			app: &v1beta1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workflow",
-					Namespace: "default",
+					Namespace: "test",
 				},
 				Spec: workflowSpec,
 				Status: common.AppStatus{
@@ -368,7 +399,17 @@ func TestWorkflowRestart(t *testing.T) {
 				err := c.Client.Create(ctx, tc.app)
 				r.NoError(err)
 
-				cmd.SetArgs([]string{tc.app.Name})
+				if tc.app.Namespace != corev1.NamespaceDefault {
+					err := c.Client.Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tc.app.Namespace,
+						},
+					})
+					r.NoError(err)
+					cmd.SetArgs([]string{tc.app.Name, "-n", tc.app.Namespace})
+				} else {
+					cmd.SetArgs([]string{tc.app.Name})
+				}
 			}
 			err := cmd.Execute()
 			if tc.expectedErr != nil {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

/cc @Somefive 