### PR TITLE
Fix: aws/azure Terraform provider are broken

### DIFF
--- a/charts/vela-core/templates/addons/terraform.yaml
+++ b/charts/vela-core/templates/addons/terraform.yaml
@@ -23,7 +23,7 @@ data:
           chart: terraform-controller
           repoType: helm
           url: https://charts.kubevela.net/addons
-          version: 0.1.19
+          version: 0.2.4
         type: helm
       - name: alibaba-ack
         properties:
@@ -455,7 +455,7 @@ data:
                     value = var.password
                   }
                   output "DB_PORT" {
-                    value = 3306
+                    value = "3306"
                   }
                   output "DB_HOST" {
                     value = azurerm_mariadb_server.example.fqdn

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/oam-dev/cluster-gateway v1.1.2
 	github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28
-	github.com/oam-dev/terraform-controller v0.2.1
+	github.com/oam-dev/terraform-controller v0.2.4
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1207,8 +1207,8 @@ github.com/oam-dev/stern v1.13.0-alpha h1:EVjM8Qvh6LssB6t4RZrjf9DtCq1cz+/cy6OF7f
 github.com/oam-dev/stern v1.13.0-alpha/go.mod h1:AOkvfFUv0Arz7GBi0jz7S0Jsu4K/kdvSjNsnRt1+BIg=
 github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28 h1:tD8HiFKnt0jnwdTWjeqUnfnUYLD/+Nsmj8ZGIxqDWiU=
 github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28/go.mod h1:Mu8i0/DdplvnjwRbAYPsc8+LRR27n/mp8VWdkN10GzE=
-github.com/oam-dev/terraform-controller v0.2.1 h1:gGXcUDBMWKfWet84STm99RX6gXo89pyTRsgQSLq2mog=
-github.com/oam-dev/terraform-controller v0.2.1/go.mod h1:5Vy6jLx9fjotEd6E005Ve1f0x3fEpVlG/DVjmqLjAq0=
+github.com/oam-dev/terraform-controller v0.2.4 h1:yGgIzm2EWNghuRutnChrRfhMjdlU/jE/cLfBizCgE24=
+github.com/oam-dev/terraform-controller v0.2.4/go.mod h1:wd4rnqnJzz274Sg1/qoeIhBx1rvTZ/ECzXoMff0ucR0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=

--- a/vela-templates/addons/auto-gen/terraform.yaml
+++ b/vela-templates/addons/auto-gen/terraform.yaml
@@ -20,7 +20,7 @@ spec:
       chart: terraform-controller
       repoType: helm
       url: https://charts.kubevela.net/addons
-      version: 0.1.19
+      version: 0.2.4
     type: helm
   - name: alibaba-ack
     properties:
@@ -452,7 +452,7 @@ spec:
                 value = var.password
               }
               output "DB_PORT" {
-                value = 3306
+                value = "3306"
               }
               output "DB_HOST" {
                 value = azurerm_mariadb_server.example.fqdn

--- a/vela-templates/addons/terraform/definitions/terraform-azure-database-mariadb.yaml
+++ b/vela-templates/addons/terraform/definitions/terraform-azure-database-mariadb.yaml
@@ -102,7 +102,7 @@ spec:
           value = var.password
         }
         output "DB_PORT" {
-          value = 3306
+          value = "3306"
         }
         output "DB_HOST" {
           value = azurerm_mariadb_server.example.fqdn

--- a/vela-templates/addons/terraform/template.yaml
+++ b/vela-templates/addons/terraform/template.yaml
@@ -33,7 +33,7 @@ spec:
         repoType: helm
         url: https://charts.kubevela.net/addons
         chart: terraform-controller
-        version: 0.1.19
+        version: 0.2.4
 {{ range .ResourceFiles }}
     - name: {{ .Name }}
       type: raw


### PR DESCRIPTION
Removed built-in aws/azure Terraform providers, and fix azure
mariadb definition issue.

Fix #2475


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->