### PR TITLE
Fix: #2534 can't exit make when error occurs in curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,9 +332,9 @@ KUSTOMIZE_VERSION ?= 3.8.2
 kustomize:
 ifeq (, $(shell kustomize version | grep $(KUSTOMIZE_VERSION)))
 	@{ \
-	set -e ;\
+	set -eo pipefail ;\
 	echo 'installing kustomize-v$(KUSTOMIZE_VERSION) into $(GOBIN)' ;\
-	curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s $(KUSTOMIZE_VERSION) $(GOBIN);\
+	curl -sS https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s $(KUSTOMIZE_VERSION) $(GOBIN);\
 	echo 'Install succeed' ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #2534
- use `curl -sS` to show error
- use `set -eo pipefail` to exit `make` when error occurs in `curl`
*More information about pipefail: https://www.gnu.org/software/bash/manual/bash.html#Pipelines*

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
make kustomize
```
### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->