### PR TITLE
Fix: format canary rollout manifests

### DIFF
--- a/docs/examples/canary-rollout-use-case/first-deploy.yaml
+++ b/docs/examples/canary-rollout-use-case/first-deploy.yaml
@@ -11,19 +11,18 @@ spec:
         image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
         port: 9080
         volumes:
-            - name: wlp-output
-              type: emptyDir
-              mountPath: /opt/ibm/wlp/output
-            - name: tmp
-              type: emptyDir
-              mountPath: /tmp
-
+          - name: wlp-output
+            type: emptyDir
+            mountPath: /opt/ibm/wlp/output
+          - name: tmp
+            type: emptyDir
+            mountPath: /tmp
 
       traits:
         - type: canary-traffic
           properties:
             port:
-            - 9080
+              - 9080
 
         - type: rollout
           properties:
@@ -42,18 +41,18 @@ spec:
         - type: expose
           properties:
             port:
-            - 9080
+              - 9080
 
         - type: istio-gateway
           properties:
             hosts:
-            - "*"
+              - "*"
             gateway: ingressgateway
             match:
-               - exact: /productpage
-               - prefix: /static
-               - exact: /login
-               - prefix: /api/v1/products
+              - exact: /productpage
+              - prefix: /static
+              - exact: /login
+              - prefix: /api/v1/products
             port: 9080
 
     - name: ratings
@@ -66,7 +65,7 @@ spec:
         - type: expose
           properties:
             port:
-            - 9080
+              - 9080
 
     - name: details
       type: webservice
@@ -78,6 +77,6 @@ spec:
         - type: expose
           properties:
             port:
-            - 9080
+              - 9080
 
 

--- a/docs/examples/canary-rollout-use-case/rollback.yaml
+++ b/docs/examples/canary-rollout-use-case/rollback.yaml
@@ -18,62 +18,61 @@ spec:
             type: emptyDir
             mountPath: /tmp
 
-
       traits:
-        - type: rollout
-          properties:
-            targetSize: 2
-            # This means to rollout two more replicas in two batches.
-            rolloutBatches:
-              - replicas: 1
-              - replicas: 1
-
         - type: canary-traffic
           properties:
             port:
               - 9080
 
+            - type: rollout
+              properties:
+                targetSize: 2
+                # This means to rollout two more replicas in two batches.
+                rolloutBatches:
+                  - replicas: 1
+                  - replicas: 1
+
     - name: productpage
       type: webservice
       properties:
-          image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
-          port: 9080
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
+        port: 9080
 
       traits:
-          - type: expose
-            properties:
-              port:
-                - 9080
+        - type: expose
+          properties:
+            port:
+              - 9080
 
-          - type: istio-gateway
-            properties:
-              hosts:
-                - "*"
-              gateway: ingressgateway
-              match:
-                - exact: /productpage
-                - prefix: /static
-                - exact: /login
-                - prefix: /api/v1/products
-              port: 9080
+        - type: istio-gateway
+          properties:
+            hosts:
+              - "*"
+            gateway: ingressgateway
+            match:
+              - exact: /productpage
+              - prefix: /static
+              - exact: /login
+              - prefix: /api/v1/products
+            port: 9080
 
     - name: ratings
       type: webservice
       properties:
-          image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
-          port: 9080
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
+        port: 9080
 
       traits:
-          - type: expose
-            properties:
-              port:
-                - 9080
+        - type: expose
+          properties:
+            port:
+              - 9080
 
     - name: details
       type: webservice
       properties:
-          image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
-          port: 9080
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
+        port: 9080
 
       traits:
         - type: expose

--- a/docs/examples/canary-rollout-use-case/rollout-v2.yaml
+++ b/docs/examples/canary-rollout-use-case/rollout-v2.yaml
@@ -18,8 +18,12 @@ spec:
             type: emptyDir
             mountPath: /tmp
 
-
       traits:
+        - type: canary-traffic
+          properties:
+            port:
+              - 9080
+
         - type: rollout
           properties:
             targetSize: 2
@@ -28,52 +32,11 @@ spec:
               - replicas: 1
               - replicas: 1
 
-        - type: canary-traffic
-          properties:
-            port:
-              - 9080
-
     - name: productpage
       type: webservice
       properties:
-          image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
-          port: 9080
-
-      traits:
-          - type: expose
-            properties:
-              port:
-                - 9080
-
-          - type: istio-gateway
-            properties:
-              hosts:
-                - "*"
-              gateway: ingressgateway
-              match:
-                - exact: /productpage
-                - prefix: /static
-                - exact: /login
-                - prefix: /api/v1/products
-              port: 9080
-
-    - name: ratings
-      type: webservice
-      properties:
-          image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
-          port: 9080
-
-      traits:
-          - type: expose
-            properties:
-              port:
-                - 9080
-
-    - name: details
-      type: webservice
-      properties:
-          image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
-          port: 9080
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
+        port: 9080
 
       traits:
         - type: expose
@@ -81,7 +44,41 @@ spec:
             port:
               - 9080
 
+        - type: istio-gateway
+          properties:
+            hosts:
+              - "*"
+            gateway: ingressgateway
+            match:
+              - exact: /productpage
+              - prefix: /static
+              - exact: /login
+              - prefix: /api/v1/products
+            port: 9080
 
+    - name: ratings
+      type: webservice
+      properties:
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
+        port: 9080
+
+      traits:
+        - type: expose
+          properties:
+            port:
+              - 9080
+
+    - name: details
+      type: webservice
+      properties:
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
+        port: 9080
+
+      traits:
+        - type: expose
+          properties:
+            port:
+              - 9080
 
   workflow:
     steps:


### PR DESCRIPTION
Formated canaray rollout manifests and changed orders for some traits
of a component to make it clear to see the difference between first-deploy.yaml
and rollout-v2.yaml, between rollout-v2.yaml and rollback.yaml


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->