### PR TITLE
Fix: incorrect addon status

### DIFF
--- a/charts/vela-core/templates/addons/terraform-provider-alibaba.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-alibaba.yaml
@@ -8,7 +8,7 @@ data:
         addons.oam.dev/description: Kubernetes Terraform Controller for Alibaba Cloud
         addons.oam.dev/name: terraform/provider-alibaba
       name: terraform-provider-alibaba
-      namespace: default
+      namespace: vela-system
     spec:
       components:
       - name: alibaba-account-creds

--- a/charts/vela-core/templates/addons/terraform-provider-aws.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-aws.yaml
@@ -8,7 +8,7 @@ data:
         addons.oam.dev/description: Kubernetes Terraform Controller for AWS
         addons.oam.dev/name: terraform/provider-aws
       name: terraform-provider-aws
-      namespace: default
+      namespace: vela-system
     spec:
       components:
       - name: aws-account-creds

--- a/charts/vela-core/templates/addons/terraform-provider-azure.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-azure.yaml
@@ -8,7 +8,7 @@ data:
         addons.oam.dev/description: Kubernetes Terraform Controller for Azure
         addons.oam.dev/name: terraform/provider-azure
       name: terraform-provider-azure
-      namespace: default
+      namespace: vela-system
     spec:
       components:
       - name: azure-account-creds

--- a/vela-templates/addons/auto-gen/terraform-provider-alibaba.yaml
+++ b/vela-templates/addons/auto-gen/terraform-provider-alibaba.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for Alibaba Cloud
     addons.oam.dev/name: terraform/provider-alibaba
   name: terraform-provider-alibaba
-  namespace: default
+  namespace: vela-system
 spec:
   components:
   - name: alibaba-account-creds

--- a/vela-templates/addons/auto-gen/terraform-provider-aws.yaml
+++ b/vela-templates/addons/auto-gen/terraform-provider-aws.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for AWS
     addons.oam.dev/name: terraform/provider-aws
   name: terraform-provider-aws
-  namespace: default
+  namespace: vela-system
 spec:
   components:
   - name: aws-account-creds

--- a/vela-templates/addons/auto-gen/terraform-provider-azure.yaml
+++ b/vela-templates/addons/auto-gen/terraform-provider-azure.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for Azure
     addons.oam.dev/name: terraform/provider-azure
   name: terraform-provider-azure
-  namespace: default
+  namespace: vela-system
 spec:
   components:
   - name: azure-account-creds

--- a/vela-templates/addons/terraform-provider-alibaba/template.yaml
+++ b/vela-templates/addons/terraform-provider-alibaba/template.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for Alibaba Cloud
     addons.oam.dev/name: terraform/provider-alibaba
   name: terraform-provider-alibaba
-  namespace: default
+  namespace: vela-system
 spec:
   components:
     - name: alibaba-account-creds

--- a/vela-templates/addons/terraform-provider-aws/template.yaml
+++ b/vela-templates/addons/terraform-provider-aws/template.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for AWS
     addons.oam.dev/name: terraform/provider-aws
   name: terraform-provider-aws
-  namespace: default
+  namespace: vela-system
 spec:
   components:
     - name: aws-account-creds

--- a/vela-templates/addons/terraform-provider-azure/template.yaml
+++ b/vela-templates/addons/terraform-provider-azure/template.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: Kubernetes Terraform Controller for Azure
     addons.oam.dev/name: terraform/provider-azure
   name: terraform-provider-azure
-  namespace: default
+  namespace: vela-system
 spec:
   components:
     - name: azure-account-creds


### PR DESCRIPTION
### Description of your changes

Now if one enable terraform/provider-xxx, the status won't change. Fix this.
![image](https://user-images.githubusercontent.com/47812250/139225018-e91b9dc3-50a5-40e1-a365-6e0ec6acbb6b.png)

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

cc @BinaryHB0916 
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->