### PR TITLE
Fix: backport 2569 to release to 1.1

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -24,8 +24,10 @@ spec:
         		componentName:      context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
-        			rolloutBatches:  parameter.rolloutBatches
-        			targetSize:      parameter.targetSize
+        			if parameter.rolloutBatches != _|_ {
+        				rolloutBatches: parameter.rolloutBatches
+        			}
+        			targetSize: parameter.targetSize
         			if parameter["batchPartition"] != _|_ {
         				batchPartition: parameter.batchPartition
         			}
@@ -35,7 +37,7 @@ spec:
         parameter: {
         	targetRevision: *context.revision | string
         	targetSize:     int
-        	rolloutBatches: [...rolloutBatch]
+        	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int
         }
         rolloutBatch: replicas: int

--- a/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
@@ -24,8 +24,10 @@ spec:
         		componentName:      context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
-        			rolloutBatches:  parameter.rolloutBatches
-        			targetSize:      parameter.targetSize
+        			if parameter.rolloutBatches != _|_ {
+        				rolloutBatches: parameter.rolloutBatches
+        			}
+        			targetSize: parameter.targetSize
         			if parameter["batchPartition"] != _|_ {
         				batchPartition: parameter.batchPartition
         			}
@@ -35,7 +37,7 @@ spec:
         parameter: {
         	targetRevision: *context.revision | string
         	targetSize:     int
-        	rolloutBatches: [...rolloutBatch]
+        	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int
         }
         rolloutBatch: replicas: int

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	oamstandard "github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
 
 	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -190,5 +191,39 @@ func TestHandleTerminated(t *testing.T) {
 		if got != c.want {
 			t.Errorf("%s result missmatch want:%v got: %v", casename, c.want, got)
 		}
+	}
+}
+
+func TestGetWorkloadReplicasPath(t *testing.T) {
+	deploy := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appsv1",
+			Kind:       "Deployment",
+		},
+	}
+	u, err := util.Object2Unstructured(deploy)
+	if err != nil {
+		t.Errorf("deployment shounld't meet an error %w", err)
+	}
+	pathStr, err := GetWorkloadReplicasPath(*u)
+	if err != nil {
+		t.Errorf("deployment should handle deployment")
+	}
+	if pathStr != "spec.replicas" {
+		t.Errorf("deployPath error got %s", pathStr)
+	}
+	ds := appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appsv1",
+			Kind:       "DaemonSet",
+		},
+	}
+	u, err = util.Object2Unstructured(ds)
+	if err != nil {
+		t.Errorf("ds shounld't meet an error %w", err)
+	}
+	_, err = GetWorkloadReplicasPath(*u)
+	if err == nil {
+		t.Errorf("daemonset shouldn't support")
 	}
 }

--- a/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
+++ b/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
@@ -238,6 +239,19 @@ func (h *handler) checkWorkloadNotExist(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return false, nil
+}
+
+func getWorkloadReplicasNum(u unstructured.Unstructured) (int32, error) {
+	replicaPath, err := applicationrollout.GetWorkloadReplicasPath(u)
+	if err != nil {
+		return 0, fmt.Errorf("get workload replicas path err %w", err)
+	}
+	wlpv := fieldpath.Pave(u.UnstructuredContent())
+	replicas, err := wlpv.GetInteger(replicaPath)
+	if err != nil {
+		return 0, fmt.Errorf("get workload replicas err %w", err)
+	}
+	return int32(replicas), nil
 }
 
 // checkRollingTerminated check the rollout if have finished

--- a/test/e2e-test/testdata/rollout/deployment/application.yaml
+++ b/test/e2e-test/testdata/rollout/deployment/application.yaml
@@ -12,3 +12,5 @@ spec:
         - type: rollout
           properties:
             targetSize: 2
+            firstBatchReplicas: 1
+            secondBatchReplicas: 1

--- a/vela-templates/definitions/internal/rollout.cue
+++ b/vela-templates/definitions/internal/rollout.cue
@@ -20,8 +20,10 @@ template: {
 			componentName:      context.name
 			rolloutPlan: {
 				rolloutStrategy: "IncreaseFirst"
-				rolloutBatches:  parameter.rolloutBatches
-				targetSize:      parameter.targetSize
+				if parameter.rolloutBatches != _|_ {
+					rolloutBatches: parameter.rolloutBatches
+				}
+				targetSize: parameter.targetSize
 				if parameter["batchPartition"] != _|_ {
 					batchPartition: parameter.batchPartition
 				}
@@ -32,7 +34,7 @@ template: {
 	parameter: {
 		targetRevision: *context.revision | string
 		targetSize:     int
-		rolloutBatches: [...rolloutBatch]
+		rolloutBatches?: [...rolloutBatch]
 		batchPartition?: int
 	}
 


### PR DESCRIPTION
backport 2569 to release to 1.1


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->