### PR TITLE
Feat: add mode in workflow, default to step by step

### DIFF
--- a/apis/core.oam.dev/v1beta1/application_types.go
+++ b/apis/core.oam.dev/v1beta1/application_types.go
@@ -68,8 +68,9 @@ type WorkflowStep struct {
 
 // Workflow defines workflow steps and other attributes
 type Workflow struct {
-	Ref   string         `json:"ref,omitempty"`
-	Steps []WorkflowStep `json:"steps,omitempty"`
+	Ref   string              `json:"ref,omitempty"`
+	Mode  common.WorkflowMode `json:"mode,omitempty"`
+	Steps []WorkflowStep      `json:"steps,omitempty"`
 }
 
 // ApplicationSpec is the spec of Application

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -2225,6 +2225,9 @@ spec:
                           a context in annotation. - should mark "finish" phase in
                           status.conditions.'
                         properties:
+                          mode:
+                            description: WorkflowMode describes the mode of workflow
+                            type: string
                           ref:
                             type: string
                           steps:

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -803,6 +803,9 @@ spec:
               workflow:
                 description: 'Workflow defines how to customize the control logic. If workflow is specified, Vela won''t apply any resource, but provide rendered output in AppRevision. Workflow steps are executed in array order, and each step: - will have a context in annotation. - should mark "finish" phase in status.conditions.'
                 properties:
+                  mode:
+                    description: WorkflowMode describes the mode of workflow
+                    type: string
                   ref:
                     type: string
                   steps:

--- a/charts/vela-core/crds/core.oam.dev_workflows.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workflows.yaml
@@ -89,6 +89,9 @@ spec:
       openAPIV3Schema:
         description: Workflow defines workflow steps and other attributes
         properties:
+          mode:
+            description: WorkflowMode describes the mode of workflow
+            type: string
           ref:
             type: string
           steps:

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -2225,6 +2225,9 @@ spec:
                           a context in annotation. - should mark "finish" phase in
                           status.conditions.'
                         properties:
+                          mode:
+                            description: WorkflowMode describes the mode of workflow
+                            type: string
                           ref:
                             type: string
                           steps:

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -803,6 +803,9 @@ spec:
               workflow:
                 description: 'Workflow defines how to customize the control logic. If workflow is specified, Vela won''t apply any resource, but provide rendered output in AppRevision. Workflow steps are executed in array order, and each step: - will have a context in annotation. - should mark "finish" phase in status.conditions.'
                 properties:
+                  mode:
+                    description: WorkflowMode describes the mode of workflow
+                    type: string
                   ref:
                     type: string
                   steps:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -2225,6 +2225,9 @@ spec:
                           a context in annotation. - should mark "finish" phase in
                           status.conditions.'
                         properties:
+                          mode:
+                            description: WorkflowMode describes the mode of workflow
+                            type: string
                           ref:
                             type: string
                           steps:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -1041,6 +1041,9 @@ spec:
                   order, and each step: - will have a context in annotation. - should
                   mark "finish" phase in status.conditions.'
                 properties:
+                  mode:
+                    description: WorkflowMode describes the mode of workflow
+                    type: string
                   ref:
                     type: string
                   steps:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
@@ -89,6 +89,9 @@ spec:
       openAPIV3Schema:
         description: Workflow defines workflow steps and other attributes
         properties:
+          mode:
+            description: WorkflowMode describes the mode of workflow
+            type: string
           ref:
             type: string
           steps:

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -109,7 +109,11 @@ func (p *Parser) GenerateAppFile(ctx context.Context, app *v1beta1.Application) 
 	// parse workflow steps
 	appfile.WorkflowMode = common.WorkflowModeDAG
 	if wfSpec := app.Spec.Workflow; wfSpec != nil && len(wfSpec.Steps) > 0 {
-		appfile.WorkflowMode = common.WorkflowModeStep
+		if wfSpec.Mode != "" {
+			appfile.WorkflowMode = wfSpec.Mode
+		} else {
+			appfile.WorkflowMode = common.WorkflowModeStep
+		}
 		appfile.WorkflowSteps = wfSpec.Steps
 	}
 	appfile.WorkflowSteps, err = step.NewChainWorkflowStepGenerator(


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add `mode` in workflow like below, the `mode` can be `StepByStep` or `DAG`.
If not specified, the default mode in workflow is `StepByStep`. 

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: export-config
  namespace: default
spec:
  components:
  - name: express-server
    type: webservice
    properties:
      image: crccheck/hello-world
      port: 8000
  workflow:
    mode: DAG
    steps:
      - name: apply-server
        type: apply-component
        properties:
          component: express-server
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

/cc @wonderflow @leejanee 