### PR TITLE
Fix: useless \n is printed in log message

### DIFF
--- a/pkg/apiserver/rest/usecase/user.go
+++ b/pkg/apiserver/rest/usecase/user.go
@@ -94,7 +94,7 @@ func (u *userUsecaseImpl) Init(ctx context.Context) error {
 				return err
 			}
 			// print default password of admin user in log
-			log.Logger.Infof("initialized admin username and password: admin / %s\n", initAdminPassword)
+			log.Logger.Infof("initialized admin username and password: admin / %s", initAdminPassword)
 		} else {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3790 

How to fix it?
Just remove "\n" in log message.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->