### PR TITLE
Feat: add support for ApplicationResourceTracker

### DIFF
--- a/pkg/resourcetracker/app_test.go
+++ b/pkg/resourcetracker/app_test.go
@@ -25,12 +25,15 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -48,7 +51,7 @@ func TestCreateAndListResourceTrackers(t *testing.T) {
 	r.NoError(err)
 	var versionedRTs []*v1beta1.ResourceTracker
 	for i := 0; i < 10; i++ {
-		app.Status.LatestRevision = &common2.Revision{Name: fmt.Sprintf("app-v%d", i)}
+		app.Status.LatestRevision = &apicommon.Revision{Name: fmt.Sprintf("app-v%d", i)}
 		app.Generation = int64(i + 1)
 		currentRT, err := CreateCurrentResourceTracker(context.Background(), cli, app)
 		r.NoError(err)
@@ -148,4 +151,41 @@ func TestPublishedVersion(t *testing.T) {
 	r.NoError(err)
 	r.Nil(currentRT)
 	r.Equal(2, len(historyRTs))
+}
+
+func TestListApplicationResourceTrackers(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	rt := &unstructured.Unstructured{}
+	rt.SetGroupVersionKind(applicationResourceTrackerGroupVersionKind)
+	rt.SetName("rt")
+	rt.SetNamespace("example")
+	rt.SetLabels(map[string]string{oam.LabelAppName: "app"})
+	cli := &clientWithoutRTPermission{Client: fake.NewClientBuilder().WithScheme(common.Scheme).WithObjects(rt).Build()}
+	app := &v1beta1.Application{}
+	app.SetName("app")
+	app.SetNamespace("example")
+	_, err := listApplicationResourceTrackers(ctx, cli, app)
+	r.NotNil(err)
+	r.Contains(err.Error(), "no permission for ResourceTracker and vela-prism is not serving ApplicationResourceTracker")
+	cli.recognizeApplicationResourceTracker = true
+	rts, err := listApplicationResourceTrackers(ctx, cli, app)
+	r.NoError(err)
+	r.Equal(len(rts), 1)
+	r.Equal(rts[0].Name, "rt-example")
+}
+
+type clientWithoutRTPermission struct {
+	client.Client
+	recognizeApplicationResourceTracker bool
+}
+
+func (c *clientWithoutRTPermission) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, isRTList := list.(*v1beta1.ResourceTrackerList); isRTList {
+		return errors.NewForbidden(schema.GroupResource{}, "", nil)
+	}
+	if unsList, isUnsList := list.(*unstructured.UnstructuredList); isUnsList && unsList.GetKind() == applicationResourceTrackerGroupVersionKind.Kind && !c.recognizeApplicationResourceTracker {
+		return &apimeta.NoKindMatchError{}
+	}
+	return c.Client.List(ctx, list, opts...)
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support use ApplicationResourceTracker for list resource trackers when users do not have permissions to access cluster-scoped ResourceTracker.

This PR is a cherry-pick for #3768.
The server part is moved to [vela-prism](https://github.com/kubevela/prism).

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->