### PR TITLE
Fix: resolve locally installed addons not being displayed

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -451,7 +451,7 @@ func listAddons(ctx context.Context, clt client.Client, registry string) error {
 	if err != nil {
 		return err
 	}
-	onlineAddon := map[string]bool{}
+
 	for _, r := range registries {
 		if registry != "" && r.Name != registry {
 			continue
@@ -481,6 +481,7 @@ func listAddons(ctx context.Context, clt client.Client, registry string) error {
 	table.AddRow("NAME", "REGISTRY", "DESCRIPTION", "AVAILABLE-VERSIONS", "STATUS")
 
 	// get locally installed addons first
+	locallyInstalledAddons := map[string]bool{}
 	appList := v1alpha2.ApplicationList{}
 	if err := clt.List(ctx, &appList, client.MatchingLabels{oam.LabelAddonRegistry: pkgaddon.LocalAddonRegistryName}); err != nil {
 		return err
@@ -490,12 +491,12 @@ func listAddons(ctx context.Context, clt client.Client, registry string) error {
 		addonName := labels[oam.LabelAddonName]
 		addonVersion := labels[oam.LabelAddonVersion]
 		table.AddRow(addonName, app.GetLabels()[oam.LabelAddonRegistry], "", genAvailableVersionInfo([]string{addonVersion}, addonVersion), statusEnabled)
-		onlineAddon[addonName] = true
+		locallyInstalledAddons[addonName] = true
 	}
 
 	for _, addon := range addons {
 		// if the addon with same name has already installed locally, display the registry one as not installed
-		if onlineAddon[addon.Name] {
+		if locallyInstalledAddons[addon.Name] {
 			table.AddRow(addon.Name, addon.RegistryName, addon.Description, addon.AvailableVersions, "disabled")
 			continue
 		}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -127,11 +127,11 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 		Long:  "enable an addon in cluster.",
 		Example: `\
 Enable addon by:
-    vela addon enable <addon-name>
+	vela addon enable <addon-name>
 Enable addon with specify version:
-    vela addon enable <addon-name> --version <addon-version>
+	vela addon enable <addon-name> --version <addon-version>
 Enable addon for specific clusters, (local means control plane):
-    vela addon enable <addon-name> --clusters={local,cluster1,cluster2}
+	vela addon enable <addon-name> --clusters={local,cluster1,cluster2}
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -218,11 +218,11 @@ func NewAddonUpgradeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Co
 		Long:  "upgrade an addon in cluster.",
 		Example: `\
 Upgrade addon by:
-    vela addon upgrade <addon-name>
+	vela addon upgrade <addon-name>
 Upgrade addon with specify version:
-    vela addon upgrade <addon-name> --version <addon-version>
+	vela addon upgrade <addon-name> --version <addon-version>
 Upgrade addon for specific clusters, (local means control plane):
-    vela addon upgrade <addon-name> --clusters={local,cluster1,cluster2}
+	vela addon upgrade <addon-name> --clusters={local,cluster1,cluster2}
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
@@ -619,49 +619,49 @@ func transClusters(cstr string) []string {
 
 // TODO(wangyike) addon can support multi-tenancy, an addon can be enabled multi times and will create many times
 // func checkWhetherTerraformProviderExist(ctx context.Context, k8sClient client.Client, addonName string, args map[string]string) (string, bool, error) {
-//  _, providerName := getTerraformProviderArgumentValue(addonName, args)
+//	_, providerName := getTerraformProviderArgumentValue(addonName, args)
 //
-//  providerNames, err := getTerraformProviderNames(ctx, k8sClient)
-//  if err != nil {
-//      return "", false, err
-//  }
-//  for _, name := range providerNames {
-//      if providerName == name {
-//          return providerName, true, nil
-//      }
-//  }
-//  return providerName, false, nil
+//	providerNames, err := getTerraformProviderNames(ctx, k8sClient)
+//	if err != nil {
+//		return "", false, err
+//	}
+//	for _, name := range providerNames {
+//		if providerName == name {
+//			return providerName, true, nil
+//		}
+//	}
+//	return providerName, false, nil
 // }
 
 //  func getTerraformProviderNames(ctx context.Context, k8sClient client.Client) ([]string, error) {
-//  var names []string
-//  providerList := &terraformv1beta1.ProviderList{}
-//  err := k8sClient.List(ctx, providerList, client.InNamespace(AddonTerraformProviderNamespace))
-//  if err != nil {
-//      if apimeta.IsNoMatchError(err) || kerrors.IsNotFound(err) {
-//          return nil, nil
-//      }
-//      return nil, err
-//  }
-//  for _, provider := range providerList.Items {
-//      names = append(names, provider.Name)
-//  }
-//  return names, nil
+//	var names []string
+//	providerList := &terraformv1beta1.ProviderList{}
+//	err := k8sClient.List(ctx, providerList, client.InNamespace(AddonTerraformProviderNamespace))
+//	if err != nil {
+//		if apimeta.IsNoMatchError(err) || kerrors.IsNotFound(err) {
+//			return nil, nil
+//		}
+//		return nil, err
+//	}
+//	for _, provider := range providerList.Items {
+//		names = append(names, provider.Name)
+//	}
+//	return names, nil
 // }
 //
 // Get the value of argument AddonTerraformProviderNameArgument
 // func getTerraformProviderArgumentValue(addonName string, args map[string]string) (map[string]string, string) {
-//  providerName, ok := args[AddonTerraformProviderNameArgument]
-//  if !ok {
-//      switch addonName {
-//      case "terraform-alibaba":
-//          providerName = "default"
-//      case "terraform-aws":
-//          providerName = "aws"
-//      case "terraform-azure":
-//          providerName = "azure"
-//      }
-//      args[AddonTerraformProviderNameArgument] = providerName
-//  }
-//  return args, providerName
+//	providerName, ok := args[AddonTerraformProviderNameArgument]
+//	if !ok {
+//		switch addonName {
+//		case "terraform-alibaba":
+//			providerName = "default"
+//		case "terraform-aws":
+//			providerName = "aws"
+//		case "terraform-azure":
+//			providerName = "azure"
+//		}
+//		args[AddonTerraformProviderNameArgument] = providerName
+//	}
+//	return args, providerName
 // }

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Output of listing addons tests", func() {
 
 	When("there is no addons installed", func() {
 		It("should not have any enabled addon", func() {
-			Expect(len(actualTable.Rows) > 1).To(BeTrue())
+			Expect(actualTable.Rows).ToNot(HaveLen(0))
 			for idx, row := range actualTable.Rows {
 				// Skip header
 				if idx == 0 {
@@ -80,7 +80,7 @@ var _ = Describe("Output of listing addons tests", func() {
 
 		It("should print fluxcd addon as local", func() {
 			matchedRows := getRowsByName("fluxcd")
-			Expect(len(matchedRows) > 0).To(BeTrue())
+			Expect(matchedRows).ToNot(HaveLen(0))
 			// Only use first row (local first), check column REGISTRY(1) = local
 			Expect(matchedRows[0].Cells[1].Data).To(Equal("local"))
 			Eventually(func() error {

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -99,6 +99,8 @@ var _ = Describe("Output of listing addons tests", func() {
 
 		It("should print fluxcd in the registry as disabled", func() {
 			matchedRows := getRowsByName("fluxcd")
+			// There should be a local one and a registry one
+			Expect(len(matchedRows)).To(Equal(2))
 			for idx, row := range matchedRows {
 				// Skip local addon
 				if idx == 0 {

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cli
 
 import (

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+
+	"github.com/fatih/color"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
+
+	"github.com/gosuri/uitable"
+)
+
+var _ = Describe("Output of listing addons tests", func() {
+	// Output of function listAddons to test
+	var actualTable *uitable.Table
+
+	// getRowsByName extracts every rows with its NAME matching name
+	getRowsByName := func(name string) []*uitable.Row {
+		matchedRows := []*uitable.Row{}
+		for _, row := range actualTable.Rows {
+			// Check column NAME(0) = name
+			if row.Cells[0].Data == name {
+				matchedRows = append(matchedRows, row)
+			}
+		}
+		return matchedRows
+	}
+
+	BeforeEach(func() {
+		// Prepare KubeVela registry
+		reg := &pkgaddon.Registry{
+			Name: "KubeVela",
+			Helm: &pkgaddon.HelmSource{
+				URL: "https://addons.kubevela.net",
+			},
+		}
+		ds := pkgaddon.NewRegistryDataStore(k8sClient)
+		Expect(ds.AddRegistry(context.Background(), *reg)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		// Print addon list to table for later comparison
+		ret, err := listAddons(context.Background(), k8sClient, "")
+		Expect(err).Should(BeNil())
+		actualTable = ret
+	})
+
+	When("there is no addons installed", func() {
+		It("should not have any enabled addon", func() {
+			Expect(len(actualTable.Rows) > 1).To(BeTrue())
+			for idx, row := range actualTable.Rows {
+				// Skip header
+				if idx == 0 {
+					continue
+				}
+				// Check column STATUS(4) = disabled
+				Expect(row.Cells[4].Data).To(Equal("disabled"))
+			}
+		})
+	})
+
+	When("there is locally installed addons", func() {
+		BeforeEach(func() {
+			// Install fluxcd locally
+			fluxcd := v1beta1.Application{}
+			err := yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)
+			Expect(err).Should(BeNil())
+			Expect(k8sClient.Create(context.Background(), &fluxcd)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		})
+
+		It("should print fluxcd addon as local", func() {
+			matchedRows := getRowsByName("fluxcd")
+			Expect(len(matchedRows) > 0).To(BeTrue())
+			// Only use first row (local first), check column REGISTRY(1) = local
+			Expect(matchedRows[0].Cells[1].Data).To(Equal("local"))
+			Eventually(func() error {
+				matchedRows = getRowsByName("fluxcd")
+				// Check column STATUS(4) = enabled
+				if matchedRows[0].Cells[4].Data != "enabled" {
+					return fmt.Errorf("fluxcd is not enabled yet")
+				}
+				// Check column AVAILABLE-VERSIONS(3) = 1.1.0
+				if versionString := matchedRows[0].Cells[3].Data; versionString != fmt.Sprintf("[%s]", color.New(color.Bold, color.FgGreen).Sprintf("1.1.0")) {
+					return fmt.Errorf("fluxcd version string is incorrect: %s", versionString)
+				}
+				return nil
+			}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+		})
+
+		It("should print fluxcd in the registry as disabled", func() {
+			matchedRows := getRowsByName("fluxcd")
+			for idx, row := range matchedRows {
+				// Skip local addon
+				if idx == 0 {
+					continue
+				}
+				Expect(row.Cells[1].Data).To(Equal("KubeVela"))
+				Expect(row.Cells[4].Data).To(Equal("disabled"))
+			}
+		})
+	})
+})

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -101,14 +101,9 @@ var _ = Describe("Output of listing addons tests", func() {
 			matchedRows := getRowsByName("fluxcd")
 			// There should be a local one and a registry one
 			Expect(len(matchedRows)).To(Equal(2))
-			for idx, row := range matchedRows {
-				// Skip local addon
-				if idx == 0 {
-					continue
-				}
-				Expect(row.Cells[1].Data).To(Equal("KubeVela"))
-				Expect(row.Cells[4].Data).To(Equal("disabled"))
-			}
+			// The registry one should be disabled
+			Expect(matchedRows[1].Cells[1].Data).To(Equal("KubeVela"))
+			Expect(matchedRows[1].Cells[4].Data).To(Equal("disabled"))
 		})
 	})
 })

--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -225,7 +225,7 @@ func TestGenerateAvailableVersions(t *testing.T) {
 		},
 	}
 	for _, s := range testcases {
-		re := genAvailableVersionInfo(s.c.versions, pkgaddon.Status{InstalledVersion: s.c.inVersion})
+		re := genAvailableVersionInfo(s.c.versions, s.c.inVersion)
 		assert.Equal(t, re, s.res)
 	}
 }

--- a/references/cli/uninstall_test.go
+++ b/references/cli/uninstall_test.go
@@ -70,7 +70,9 @@ metadata:
   name: addon-fluxcd
   namespace: vela-system
   labels:
-     addons.oam.dev/name: fluxcd
+    addons.oam.dev/name: fluxcd
+    addons.oam.dev/registry: local
+    addons.oam.dev/version: 1.1.0
 spec:
   components:
   - name: ns-flux-system


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Addressed an issue where locally installed addons being displayed as the registry one if there is an addon with the same name is in the registry.

#### Before

Notice the `dex` addon, which is installed from local sources, but displayed as the one in the registry.

<img width="1580" alt="Screen Shot 2022-05-07 at 7 40 04 PM" src="https://user-images.githubusercontent.com/55270174/167252711-cba9faf6-1858-4607-8b38-f65547ca4b21.png">

#### After

It is now displayed properly as locally installed (the one in  KubeVela registry is not affected).

<img width="1585" alt="Screen Shot 2022-05-07 at 7 41 52 PM" src="https://user-images.githubusercontent.com/55270174/167252758-f93d729d-31eb-46ae-866c-3d10e27acb19.png">



I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Changes that need to apply to existing unit tests have been added.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->