### PR TITLE
Fix: sensitive field of addon registry is exposed

### DIFF
--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -83,6 +83,55 @@ type HelmSource struct {
 	Password string `json:"password,omitempty"`
 }
 
+// SafeCopier is an interface to copy Struct without sensitive fields, such as Token, Username, Password
+type SafeCopier interface {
+	SafeCopy() interface{}
+}
+
+// SafeCopy hides field Token
+func (g *GitAddonSource) SafeCopy() *GitAddonSource {
+	if g == nil {
+		return nil
+	}
+	return &GitAddonSource{
+		URL:  g.URL,
+		Path: g.Path,
+	}
+}
+
+// SafeCopy hides field Token
+func (g *GiteeAddonSource) SafeCopy() *GiteeAddonSource {
+	if g == nil {
+		return nil
+	}
+	return &GiteeAddonSource{
+		URL:  g.URL,
+		Path: g.Path,
+	}
+}
+
+// SafeCopy hides field Token
+func (g *GitlabAddonSource) SafeCopy() *GitlabAddonSource {
+	if g == nil {
+		return nil
+	}
+	return &GitlabAddonSource{
+		URL:  g.URL,
+		Repo: g.Repo,
+		Path: g.Path,
+	}
+}
+
+// SafeCopy hides field Username, Password
+func (h *HelmSource) SafeCopy() *HelmSource {
+	if h == nil {
+		return nil
+	}
+	return &HelmSource{
+		URL: h.URL,
+	}
+}
+
 // Item is a partial interface for github.RepositoryContent
 type Item interface {
 	// GetType return "dir" or "file"

--- a/pkg/addon/source_test.go
+++ b/pkg/addon/source_test.go
@@ -115,3 +115,42 @@ func TestConvert2OssItem(t *testing.T) {
 	assert.Equal(t, expectItemCase, addonMetas)
 
 }
+
+func TestSafeCopy(t *testing.T) {
+	var git *GitAddonSource
+	sgit := git.SafeCopy()
+	assert.Nil(t, sgit)
+	git = &GitAddonSource{URL: "http://github.com/kubevela", Path: "addons", Token: "123456"}
+	sgit = git.SafeCopy()
+	assert.Empty(t, sgit.Token)
+	assert.Equal(t, "http://github.com/kubevela", sgit.URL)
+	assert.Equal(t, "addons", sgit.Path)
+
+	var gitee *GiteeAddonSource
+	sgitee := gitee.SafeCopy()
+	assert.Nil(t, sgitee)
+	gitee = &GiteeAddonSource{URL: "http://gitee.com/kubevela", Path: "addons", Token: "123456"}
+	sgitee = gitee.SafeCopy()
+	assert.Empty(t, sgitee.Token)
+	assert.Equal(t, "http://gitee.com/kubevela", sgitee.URL)
+	assert.Equal(t, "addons", sgitee.Path)
+
+	var gitlab *GitlabAddonSource
+	sgitlab := gitlab.SafeCopy()
+	assert.Nil(t, sgitlab)
+	gitlab = &GitlabAddonSource{URL: "http://gitlab.com/kubevela", Repo: "vela", Path: "addons", Token: "123456"}
+	sgitlab = gitlab.SafeCopy()
+	assert.Empty(t, sgitlab.Token)
+	assert.Equal(t, "http://gitlab.com/kubevela", sgitlab.URL)
+	assert.Equal(t, "addons", sgitlab.Path)
+	assert.Equal(t, "vela", sgitlab.Repo)
+
+	var helm *HelmSource
+	shelm := helm.SafeCopy()
+	assert.Nil(t, shelm)
+	helm = &HelmSource{URL: "https://hub.vela.com/chartrepo/addons", Username: "user123", Password: "pass456"}
+	shelm = helm.SafeCopy()
+	assert.Empty(t, shelm.Username)
+	assert.Empty(t, shelm.Password)
+	assert.Equal(t, "https://hub.vela.com/chartrepo/addons", shelm.URL)
+}

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -314,11 +314,11 @@ func (u *defaultAddonHandler) CreateAddonRegistry(ctx context.Context, req apis.
 func convertAddonRegistry(r pkgaddon.Registry) *apis.AddonRegistry {
 	return &apis.AddonRegistry{
 		Name:   r.Name,
-		Git:    r.Git,
-		Gitee:  r.Gitee,
+		Git:    r.Git.SafeCopy(),
+		Gitee:  r.Gitee.SafeCopy(),
 		OSS:    r.OSS,
-		Helm:   r.Helm,
-		Gitlab: r.Gitlab,
+		Helm:   r.Helm.SafeCopy(),
+		Gitlab: r.Gitlab.SafeCopy(),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

1. vela-apiserver only responses safe fields to caller

Fixes #3836 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->