### PR TITLE
Fix(makefile): update kustomize version to be available for darwin-arm64

### DIFF
--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -55,10 +55,14 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -74,14 +78,18 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level
+                        scopes the format is <scope-type:scope-instance-name> pairs,
+                        the key represents type of `ScopeDefinition` while the value
+                        represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type must be array to keep the order.
+                      description: Traits define the trait of one component, the type
+                        must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -102,16 +110,24 @@ spec:
                   type: object
                 type: array
               rolloutPlan:
-                description: RolloutPlan is the details on how to rollout the resources The controller simply replace the old resources with the new one if there is no rollout plan involved
+                description: RolloutPlan is the details on how to rollout the resources
+                  The controller simply replace the old resources with the new one
+                  if there is no rollout plan involved
                 properties:
                   batchPartition:
-                    description: All pods in the batches up to the batchPartition (included) will have the target resource specification while the rest still have the source resource This is designed for the operators to manually rollout Default is the the number of batches which will rollout all the batches
+                    description: All pods in the batches up to the batchPartition
+                      (included) will have the target resource specification while
+                      the rest still have the source resource This is designed for
+                      the operators to manually rollout Default is the the number
+                      of batches which will rollout all the batches
                     format: int32
                     type: integer
                   canaryMetric:
-                    description: CanaryMetric provides a way for the rollout process to automatically check certain metrics before complete the process
+                    description: CanaryMetric provides a way for the rollout process
+                      to automatically check certain metrics before complete the process
                     items:
-                      description: CanaryMetric holds the reference to metrics used for canary analysis
+                      description: CanaryMetric holds the reference to metrics used
+                        for canary analysis
                       properties:
                         interval:
                           description: Interval represents the windows size
@@ -142,7 +158,18 @@ spec:
                               description: API version of the referent.
                               type: string
                             fieldPath:
-                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
                               type: string
                             kind:
                               description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -151,10 +178,12 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             namespace:
-                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                               type: string
                             resourceVersion:
-                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                               type: string
                             uid:
                               description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -172,17 +201,26 @@ spec:
                     description: Paused the rollout, default is false
                     type: boolean
                   rolloutBatches:
-                    description: The exact distribution among batches. its size has to be exactly the same as the NumBatches (if set) The total number cannot exceed the targetSize or the size of the source resource We will IGNORE the last batch's replica field if it's a percentage since round errors can lead to inaccurate sum We highly recommend to leave the last batch's replica field empty
+                    description: The exact distribution among batches. its size has
+                      to be exactly the same as the NumBatches (if set) The total
+                      number cannot exceed the targetSize or the size of the source
+                      resource We will IGNORE the last batch's replica field if it's
+                      a percentage since round errors can lead to inaccurate sum We
+                      highly recommend to leave the last batch's replica field empty
                     items:
-                      description: RolloutBatch is used to describe how the each batch rollout should be
+                      description: RolloutBatch is used to describe how the each batch
+                        rollout should be
                       properties:
                         batchRolloutWebhooks:
-                          description: RolloutWebhooks provides a way for the batch rollout to interact with an external process
+                          description: RolloutWebhooks provides a way for the batch
+                            rollout to interact with an external process
                           items:
-                            description: RolloutWebhook holds the reference to external checks used for canary analysis
+                            description: RolloutWebhook holds the reference to external
+                              checks used for canary analysis
                             properties:
                               expectedStatus:
-                                description: ExpectedStatus contains all the expected http status code that we will accept as success
+                                description: ExpectedStatus contains all the expected
+                                  http status code that we will accept as success
                                 items:
                                   type: integer
                                 type: array
@@ -192,7 +230,8 @@ spec:
                                 description: Metadata (key-value pairs) for this webhook
                                 type: object
                               method:
-                                description: Method the HTTP call method, default is POST
+                                description: Method the HTTP call method, default
+                                  is POST
                                 type: string
                               name:
                                 description: Name of this webhook
@@ -210,9 +249,12 @@ spec:
                             type: object
                           type: array
                         canaryMetric:
-                          description: CanaryMetric provides a way for the batch rollout process to automatically check certain metrics before moving to the next batch
+                          description: CanaryMetric provides a way for the batch rollout
+                            process to automatically check certain metrics before
+                            moving to the next batch
                           items:
-                            description: CanaryMetric holds the reference to metrics used for canary analysis
+                            description: CanaryMetric holds the reference to metrics
+                              used for canary analysis
                             properties:
                               interval:
                                 description: Interval represents the windows size
@@ -237,28 +279,48 @@ spec:
                                 description: Name of the metric
                                 type: string
                               templateRef:
-                                description: TemplateRef references a metric template object
+                                description: TemplateRef references a metric template
+                                  object
                                 properties:
                                   apiVersion:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -266,17 +328,23 @@ spec:
                             type: object
                           type: array
                         instanceInterval:
-                          description: The wait time, in seconds, between instances upgrades, default = 0
+                          description: The wait time, in seconds, between instances
+                            upgrades, default = 0
                           format: int32
                           type: integer
                         maxUnavailable:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: MaxUnavailable is the max allowed number of pods that is unavailable during the upgrade. We will mark the batch as ready as long as there are less or equal number of pods unavailable than this number. default = 0
+                          description: MaxUnavailable is the max allowed number of
+                            pods that is unavailable during the upgrade. We will mark
+                            the batch as ready as long as there are less or equal
+                            number of pods unavailable than this number. default =
+                            0
                           x-kubernetes-int-or-string: true
                         podList:
-                          description: The list of Pods to get upgraded it is mutually exclusive with the Replicas field
+                          description: The list of Pods to get upgraded it is mutually
+                            exclusive with the Replicas field
                           items:
                             type: string
                           type: array
@@ -284,20 +352,28 @@ spec:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Replicas is the number of pods to upgrade in this batch it can be an absolute number (ex: 5) or a percentage of total pods we will ignore the percentage of the last batch to just fill the gap it is mutually exclusive with the PodList field'
+                          description: 'Replicas is the number of pods to upgrade
+                            in this batch it can be an absolute number (ex: 5) or
+                            a percentage of total pods we will ignore the percentage
+                            of the last batch to just fill the gap it is mutually
+                            exclusive with the PodList field'
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
                   rolloutStrategy:
-                    description: RolloutStrategy defines strategies for the rollout plan The default is IncreaseFirstRolloutStrategyType
+                    description: RolloutStrategy defines strategies for the rollout
+                      plan The default is IncreaseFirstRolloutStrategyType
                     type: string
                   rolloutWebhooks:
-                    description: RolloutWebhooks provide a way for the rollout to interact with an external process
+                    description: RolloutWebhooks provide a way for the rollout to
+                      interact with an external process
                     items:
-                      description: RolloutWebhook holds the reference to external checks used for canary analysis
+                      description: RolloutWebhook holds the reference to external
+                        checks used for canary analysis
                       properties:
                         expectedStatus:
-                          description: ExpectedStatus contains all the expected http status code that we will accept as success
+                          description: ExpectedStatus contains all the expected http
+                            status code that we will accept as success
                           items:
                             type: integer
                           type: array
@@ -325,7 +401,8 @@ spec:
                       type: object
                     type: array
                   targetSize:
-                    description: The size of the target resource. The default is the same as the size of the source resource.
+                    description: The size of the target resource. The default is the
+                      same as the size of the source resource.
                     format: int32
                     type: integer
                 type: object
@@ -336,9 +413,11 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               appliedResources:
-                description: AppliedResources record the resources that the  workflow step apply.
+                description: AppliedResources record the resources that the  workflow
+                  step apply.
                 items:
-                  description: ClusterObjectReference defines the object reference with cluster.
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -349,7 +428,17 @@ spec:
                       description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -361,7 +450,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -369,15 +459,50 @@ spec:
                   type: object
                 type: array
               components:
-                description: Components record the related Components created by Application Controller
+                description: Components record the related Components created by Application
+                  Controller
                 items:
-                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -389,7 +514,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -402,20 +528,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -433,7 +564,8 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of
+                      ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -463,7 +595,8 @@ spec:
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status of App component
+                  description: ApplicationComponentStatus record the health status
+                    of App component
                   properties:
                     cluster:
                       type: string
@@ -479,13 +612,50 @@ spec:
                       type: string
                     scopes:
                       items:
-                        description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                        description: 'ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs.  1. Ignored
+                          fields.  It includes many fields which are not generally
+                          honored.  For instance, ResourceVersion and FieldPath are
+                          both very rarely valid in actual usage.  2. Invalid usage
+                          help.  It is impossible to add specific help for individual
+                          usage.  In most embedded usages, there are particular     restrictions
+                          like, "must refer only to types A and B" or "UID not honored"
+                          or "name must be restricted".     Those cannot be well described
+                          when embedded.  3. Inconsistent validation.  Because the
+                          usages are different, the validation rules are different
+                          by usage, which makes it hard for users to predict what
+                          will happen.  4. The fields are both imprecise and overly
+                          precise.  Kind is not a precise mapping to a URL. This can
+                          produce ambiguity     during interpretation and require
+                          a REST mapping.  In most cases, the dependency is on the
+                          group,resource tuple     and the version of the actual struct
+                          is irrelevant.  5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type     will affect numerous schemas.  Don''t make new
+                          APIs embed an underspecified API type they do not control.
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          .'
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
                             type: string
                           kind:
                             description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -497,7 +667,8 @@ spec:
                             description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                             type: string
                           uid:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -506,7 +677,8 @@ spec:
                       type: array
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health status
+                        description: ApplicationTraitStatus records the trait health
+                          status
                         properties:
                           healthy:
                             type: boolean
@@ -520,7 +692,8 @@ spec:
                         type: object
                       type: array
                     workloadDefinition:
-                      description: WorkloadDefinition is the definition of a WorkloadDefinition, such as deployments/apps.v1
+                      description: WorkloadDefinition is the definition of a WorkloadDefinition,
+                        such as deployments/apps.v1
                       properties:
                         apiVersion:
                           type: string
@@ -536,7 +709,8 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of an application at the current time
+                description: ApplicationPhase is a label for the condition of an application
+                  at the current time
                 type: string
               workflow:
                 description: Workflow record the status of workflow
@@ -544,13 +718,47 @@ spec:
                   appRevision:
                     type: string
                   contextBackend:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -562,7 +770,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -580,31 +789,38 @@ spec:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStepStatus record the status of a workflow step
+                      description: WorkflowStepStatus record the status of a workflow
+                        step
                       properties:
                         firstExecuteTime:
-                          description: FirstExecuteTime is the first time this step execution.
+                          description: FirstExecuteTime is the first time this step
+                            execution.
                           format: date-time
                           type: string
                         id:
                           type: string
                         lastExecuteTime:
-                          description: LastExecuteTime is the last time this step execution.
+                          description: LastExecuteTime is the last time this step
+                            execution.
                           format: date-time
                           type: string
                         message:
-                          description: A human readable message indicating details about why the workflowStep is in this state.
+                          description: A human readable message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         name:
                           type: string
                         phase:
-                          description: WorkflowStepPhase describes the phase of a workflow step.
+                          description: WorkflowStepPhase describes the phase of a
+                            workflow step.
                           type: string
                         reason:
-                          description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                          description: A brief CamelCase message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         subSteps:
-                          description: SubStepsStatus record the status of workflow steps.
+                          description: SubStepsStatus record the status of workflow
+                            steps.
                           properties:
                             mode:
                               description: WorkflowMode describes the mode of workflow
@@ -613,20 +829,26 @@ spec:
                               type: integer
                             steps:
                               items:
-                                description: WorkflowSubStepStatus record the status of a workflow step
+                                description: WorkflowSubStepStatus record the status
+                                  of a workflow step
                                 properties:
                                   id:
                                     type: string
                                   message:
-                                    description: A human readable message indicating details about why the workflowStep is in this state.
+                                    description: A human readable message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   name:
                                     type: string
                                   phase:
-                                    description: WorkflowStepPhase describes the phase of a workflow step.
+                                    description: WorkflowStepPhase describes the phase
+                                      of a workflow step.
                                     type: string
                                   reason:
-                                    description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                                    description: A brief CamelCase message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   type:
                                     type: string
@@ -684,10 +906,14 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -739,11 +965,15 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level
+                        scopes the format is <scope-type:scope-instance-name> pairs,
+                        the key represents type of `ScopeDefinition` while the value
+                        represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type must be array to keep the order.
+                      description: Traits define the trait of one component, the type
+                        must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -764,9 +994,13 @@ spec:
                   type: object
                 type: array
               policies:
-                description: Policies defines the global policies for all components in the app, e.g. security, metrics, gitops, multi-cluster placement rules, etc. Policies are applied after components are rendered and before workflow steps are executed.
+                description: Policies defines the global policies for all components
+                  in the app, e.g. security, metrics, gitops, multi-cluster placement
+                  rules, etc. Policies are applied after components are rendered and
+                  before workflow steps are executed.
                 items:
-                  description: AppPolicy defines a global policy for all components in the app.
+                  description: AppPolicy defines a global policy for all components
+                    in the app.
                   properties:
                     name:
                       description: Name is the unique name of the policy.
@@ -782,13 +1016,18 @@ spec:
                   type: object
                 type: array
               workflow:
-                description: 'Workflow defines how to customize the control logic. If workflow is specified, Vela won''t apply any resource, but provide rendered output in AppRevision. Workflow steps are executed in array order, and each step: - will have a context in annotation. - should mark "finish" phase in status.conditions.'
+                description: 'Workflow defines how to customize the control logic.
+                  If workflow is specified, Vela won''t apply any resource, but provide
+                  rendered output in AppRevision. Workflow steps are executed in array
+                  order, and each step: - will have a context in annotation. - should
+                  mark "finish" phase in status.conditions.'
                 properties:
                   ref:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStep defines how to execute a workflow step.
+                      description: WorkflowStep defines how to execute a workflow
+                        step.
                       properties:
                         dependsOn:
                           items:
@@ -841,9 +1080,11 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               appliedResources:
-                description: AppliedResources record the resources that the  workflow step apply.
+                description: AppliedResources record the resources that the  workflow
+                  step apply.
                 items:
-                  description: ClusterObjectReference defines the object reference with cluster.
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -854,7 +1095,17 @@ spec:
                       description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -866,7 +1117,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -874,15 +1126,50 @@ spec:
                   type: object
                 type: array
               components:
-                description: Components record the related Components created by Application Controller
+                description: Components record the related Components created by Application
+                  Controller
                 items:
-                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -894,7 +1181,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -907,20 +1195,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -938,7 +1231,8 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of
+                      ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -968,7 +1262,8 @@ spec:
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status of App component
+                  description: ApplicationComponentStatus record the health status
+                    of App component
                   properties:
                     cluster:
                       type: string
@@ -984,13 +1279,50 @@ spec:
                       type: string
                     scopes:
                       items:
-                        description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                        description: 'ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs.  1. Ignored
+                          fields.  It includes many fields which are not generally
+                          honored.  For instance, ResourceVersion and FieldPath are
+                          both very rarely valid in actual usage.  2. Invalid usage
+                          help.  It is impossible to add specific help for individual
+                          usage.  In most embedded usages, there are particular     restrictions
+                          like, "must refer only to types A and B" or "UID not honored"
+                          or "name must be restricted".     Those cannot be well described
+                          when embedded.  3. Inconsistent validation.  Because the
+                          usages are different, the validation rules are different
+                          by usage, which makes it hard for users to predict what
+                          will happen.  4. The fields are both imprecise and overly
+                          precise.  Kind is not a precise mapping to a URL. This can
+                          produce ambiguity     during interpretation and require
+                          a REST mapping.  In most cases, the dependency is on the
+                          group,resource tuple     and the version of the actual struct
+                          is irrelevant.  5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type     will affect numerous schemas.  Don''t make new
+                          APIs embed an underspecified API type they do not control.
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          .'
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
                             type: string
                           kind:
                             description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1002,7 +1334,8 @@ spec:
                             description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                             type: string
                           uid:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1011,7 +1344,8 @@ spec:
                       type: array
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health status
+                        description: ApplicationTraitStatus records the trait health
+                          status
                         properties:
                           healthy:
                             type: boolean
@@ -1025,7 +1359,8 @@ spec:
                         type: object
                       type: array
                     workloadDefinition:
-                      description: WorkloadDefinition is the definition of a WorkloadDefinition, such as deployments/apps.v1
+                      description: WorkloadDefinition is the definition of a WorkloadDefinition,
+                        such as deployments/apps.v1
                       properties:
                         apiVersion:
                           type: string
@@ -1041,7 +1376,8 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of an application at the current time
+                description: ApplicationPhase is a label for the condition of an application
+                  at the current time
                 type: string
               workflow:
                 description: Workflow record the status of workflow
@@ -1049,13 +1385,47 @@ spec:
                   appRevision:
                     type: string
                   contextBackend:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1067,7 +1437,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1085,31 +1456,38 @@ spec:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStepStatus record the status of a workflow step
+                      description: WorkflowStepStatus record the status of a workflow
+                        step
                       properties:
                         firstExecuteTime:
-                          description: FirstExecuteTime is the first time this step execution.
+                          description: FirstExecuteTime is the first time this step
+                            execution.
                           format: date-time
                           type: string
                         id:
                           type: string
                         lastExecuteTime:
-                          description: LastExecuteTime is the last time this step execution.
+                          description: LastExecuteTime is the last time this step
+                            execution.
                           format: date-time
                           type: string
                         message:
-                          description: A human readable message indicating details about why the workflowStep is in this state.
+                          description: A human readable message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         name:
                           type: string
                         phase:
-                          description: WorkflowStepPhase describes the phase of a workflow step.
+                          description: WorkflowStepPhase describes the phase of a
+                            workflow step.
                           type: string
                         reason:
-                          description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                          description: A brief CamelCase message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         subSteps:
-                          description: SubStepsStatus record the status of workflow steps.
+                          description: SubStepsStatus record the status of workflow
+                            steps.
                           properties:
                             mode:
                               description: WorkflowMode describes the mode of workflow
@@ -1118,20 +1496,26 @@ spec:
                               type: integer
                             steps:
                               items:
-                                description: WorkflowSubStepStatus record the status of a workflow step
+                                description: WorkflowSubStepStatus record the status
+                                  of a workflow step
                                 properties:
                                   id:
                                     type: string
                                   message:
-                                    description: A human readable message indicating details about why the workflowStep is in this state.
+                                    description: A human readable message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   name:
                                     type: string
                                   phase:
-                                    description: WorkflowStepPhase describes the phase of a workflow step.
+                                    description: WorkflowStepPhase describes the phase
+                                      of a workflow step.
                                     type: string
                                   reason:
-                                    description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                                    description: A brief CamelCase message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   type:
                                     type: string

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -55,10 +55,14 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -74,14 +78,18 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level
+                        scopes the format is <scope-type:scope-instance-name> pairs,
+                        the key represents type of `ScopeDefinition` while the value
+                        represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type must be array to keep the order.
+                      description: Traits define the trait of one component, the type
+                        must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -102,16 +110,24 @@ spec:
                   type: object
                 type: array
               rolloutPlan:
-                description: RolloutPlan is the details on how to rollout the resources The controller simply replace the old resources with the new one if there is no rollout plan involved
+                description: RolloutPlan is the details on how to rollout the resources
+                  The controller simply replace the old resources with the new one
+                  if there is no rollout plan involved
                 properties:
                   batchPartition:
-                    description: All pods in the batches up to the batchPartition (included) will have the target resource specification while the rest still have the source resource This is designed for the operators to manually rollout Default is the the number of batches which will rollout all the batches
+                    description: All pods in the batches up to the batchPartition
+                      (included) will have the target resource specification while
+                      the rest still have the source resource This is designed for
+                      the operators to manually rollout Default is the the number
+                      of batches which will rollout all the batches
                     format: int32
                     type: integer
                   canaryMetric:
-                    description: CanaryMetric provides a way for the rollout process to automatically check certain metrics before complete the process
+                    description: CanaryMetric provides a way for the rollout process
+                      to automatically check certain metrics before complete the process
                     items:
-                      description: CanaryMetric holds the reference to metrics used for canary analysis
+                      description: CanaryMetric holds the reference to metrics used
+                        for canary analysis
                       properties:
                         interval:
                           description: Interval represents the windows size
@@ -142,7 +158,18 @@ spec:
                               description: API version of the referent.
                               type: string
                             fieldPath:
-                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
                               type: string
                             kind:
                               description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -151,10 +178,12 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             namespace:
-                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                               type: string
                             resourceVersion:
-                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                               type: string
                             uid:
                               description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -172,17 +201,26 @@ spec:
                     description: Paused the rollout, default is false
                     type: boolean
                   rolloutBatches:
-                    description: The exact distribution among batches. its size has to be exactly the same as the NumBatches (if set) The total number cannot exceed the targetSize or the size of the source resource We will IGNORE the last batch's replica field if it's a percentage since round errors can lead to inaccurate sum We highly recommend to leave the last batch's replica field empty
+                    description: The exact distribution among batches. its size has
+                      to be exactly the same as the NumBatches (if set) The total
+                      number cannot exceed the targetSize or the size of the source
+                      resource We will IGNORE the last batch's replica field if it's
+                      a percentage since round errors can lead to inaccurate sum We
+                      highly recommend to leave the last batch's replica field empty
                     items:
-                      description: RolloutBatch is used to describe how the each batch rollout should be
+                      description: RolloutBatch is used to describe how the each batch
+                        rollout should be
                       properties:
                         batchRolloutWebhooks:
-                          description: RolloutWebhooks provides a way for the batch rollout to interact with an external process
+                          description: RolloutWebhooks provides a way for the batch
+                            rollout to interact with an external process
                           items:
-                            description: RolloutWebhook holds the reference to external checks used for canary analysis
+                            description: RolloutWebhook holds the reference to external
+                              checks used for canary analysis
                             properties:
                               expectedStatus:
-                                description: ExpectedStatus contains all the expected http status code that we will accept as success
+                                description: ExpectedStatus contains all the expected
+                                  http status code that we will accept as success
                                 items:
                                   type: integer
                                 type: array
@@ -192,7 +230,8 @@ spec:
                                 description: Metadata (key-value pairs) for this webhook
                                 type: object
                               method:
-                                description: Method the HTTP call method, default is POST
+                                description: Method the HTTP call method, default
+                                  is POST
                                 type: string
                               name:
                                 description: Name of this webhook
@@ -210,9 +249,12 @@ spec:
                             type: object
                           type: array
                         canaryMetric:
-                          description: CanaryMetric provides a way for the batch rollout process to automatically check certain metrics before moving to the next batch
+                          description: CanaryMetric provides a way for the batch rollout
+                            process to automatically check certain metrics before
+                            moving to the next batch
                           items:
-                            description: CanaryMetric holds the reference to metrics used for canary analysis
+                            description: CanaryMetric holds the reference to metrics
+                              used for canary analysis
                             properties:
                               interval:
                                 description: Interval represents the windows size
@@ -237,28 +279,48 @@ spec:
                                 description: Name of the metric
                                 type: string
                               templateRef:
-                                description: TemplateRef references a metric template object
+                                description: TemplateRef references a metric template
+                                  object
                                 properties:
                                   apiVersion:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -266,17 +328,23 @@ spec:
                             type: object
                           type: array
                         instanceInterval:
-                          description: The wait time, in seconds, between instances upgrades, default = 0
+                          description: The wait time, in seconds, between instances
+                            upgrades, default = 0
                           format: int32
                           type: integer
                         maxUnavailable:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: MaxUnavailable is the max allowed number of pods that is unavailable during the upgrade. We will mark the batch as ready as long as there are less or equal number of pods unavailable than this number. default = 0
+                          description: MaxUnavailable is the max allowed number of
+                            pods that is unavailable during the upgrade. We will mark
+                            the batch as ready as long as there are less or equal
+                            number of pods unavailable than this number. default =
+                            0
                           x-kubernetes-int-or-string: true
                         podList:
-                          description: The list of Pods to get upgraded it is mutually exclusive with the Replicas field
+                          description: The list of Pods to get upgraded it is mutually
+                            exclusive with the Replicas field
                           items:
                             type: string
                           type: array
@@ -284,20 +352,28 @@ spec:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Replicas is the number of pods to upgrade in this batch it can be an absolute number (ex: 5) or a percentage of total pods we will ignore the percentage of the last batch to just fill the gap it is mutually exclusive with the PodList field'
+                          description: 'Replicas is the number of pods to upgrade
+                            in this batch it can be an absolute number (ex: 5) or
+                            a percentage of total pods we will ignore the percentage
+                            of the last batch to just fill the gap it is mutually
+                            exclusive with the PodList field'
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
                   rolloutStrategy:
-                    description: RolloutStrategy defines strategies for the rollout plan The default is IncreaseFirstRolloutStrategyType
+                    description: RolloutStrategy defines strategies for the rollout
+                      plan The default is IncreaseFirstRolloutStrategyType
                     type: string
                   rolloutWebhooks:
-                    description: RolloutWebhooks provide a way for the rollout to interact with an external process
+                    description: RolloutWebhooks provide a way for the rollout to
+                      interact with an external process
                     items:
-                      description: RolloutWebhook holds the reference to external checks used for canary analysis
+                      description: RolloutWebhook holds the reference to external
+                        checks used for canary analysis
                       properties:
                         expectedStatus:
-                          description: ExpectedStatus contains all the expected http status code that we will accept as success
+                          description: ExpectedStatus contains all the expected http
+                            status code that we will accept as success
                           items:
                             type: integer
                           type: array
@@ -325,7 +401,8 @@ spec:
                       type: object
                     type: array
                   targetSize:
-                    description: The size of the target resource. The default is the same as the size of the source resource.
+                    description: The size of the target resource. The default is the
+                      same as the size of the source resource.
                     format: int32
                     type: integer
                 type: object
@@ -336,9 +413,11 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               appliedResources:
-                description: AppliedResources record the resources that the  workflow step apply.
+                description: AppliedResources record the resources that the  workflow
+                  step apply.
                 items:
-                  description: ClusterObjectReference defines the object reference with cluster.
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -349,7 +428,17 @@ spec:
                       description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -361,7 +450,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -369,15 +459,50 @@ spec:
                   type: object
                 type: array
               components:
-                description: Components record the related Components created by Application Controller
+                description: Components record the related Components created by Application
+                  Controller
                 items:
-                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -389,7 +514,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -402,20 +528,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -433,7 +564,8 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of
+                      ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -463,7 +595,8 @@ spec:
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status of App component
+                  description: ApplicationComponentStatus record the health status
+                    of App component
                   properties:
                     cluster:
                       type: string
@@ -479,13 +612,50 @@ spec:
                       type: string
                     scopes:
                       items:
-                        description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                        description: 'ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs.  1. Ignored
+                          fields.  It includes many fields which are not generally
+                          honored.  For instance, ResourceVersion and FieldPath are
+                          both very rarely valid in actual usage.  2. Invalid usage
+                          help.  It is impossible to add specific help for individual
+                          usage.  In most embedded usages, there are particular     restrictions
+                          like, "must refer only to types A and B" or "UID not honored"
+                          or "name must be restricted".     Those cannot be well described
+                          when embedded.  3. Inconsistent validation.  Because the
+                          usages are different, the validation rules are different
+                          by usage, which makes it hard for users to predict what
+                          will happen.  4. The fields are both imprecise and overly
+                          precise.  Kind is not a precise mapping to a URL. This can
+                          produce ambiguity     during interpretation and require
+                          a REST mapping.  In most cases, the dependency is on the
+                          group,resource tuple     and the version of the actual struct
+                          is irrelevant.  5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type     will affect numerous schemas.  Don''t make new
+                          APIs embed an underspecified API type they do not control.
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          .'
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
                             type: string
                           kind:
                             description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -497,7 +667,8 @@ spec:
                             description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                             type: string
                           uid:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -506,7 +677,8 @@ spec:
                       type: array
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health status
+                        description: ApplicationTraitStatus records the trait health
+                          status
                         properties:
                           healthy:
                             type: boolean
@@ -520,7 +692,8 @@ spec:
                         type: object
                       type: array
                     workloadDefinition:
-                      description: WorkloadDefinition is the definition of a WorkloadDefinition, such as deployments/apps.v1
+                      description: WorkloadDefinition is the definition of a WorkloadDefinition,
+                        such as deployments/apps.v1
                       properties:
                         apiVersion:
                           type: string
@@ -536,7 +709,8 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of an application at the current time
+                description: ApplicationPhase is a label for the condition of an application
+                  at the current time
                 type: string
               workflow:
                 description: Workflow record the status of workflow
@@ -544,13 +718,47 @@ spec:
                   appRevision:
                     type: string
                   contextBackend:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -562,7 +770,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -580,31 +789,38 @@ spec:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStepStatus record the status of a workflow step
+                      description: WorkflowStepStatus record the status of a workflow
+                        step
                       properties:
                         firstExecuteTime:
-                          description: FirstExecuteTime is the first time this step execution.
+                          description: FirstExecuteTime is the first time this step
+                            execution.
                           format: date-time
                           type: string
                         id:
                           type: string
                         lastExecuteTime:
-                          description: LastExecuteTime is the last time this step execution.
+                          description: LastExecuteTime is the last time this step
+                            execution.
                           format: date-time
                           type: string
                         message:
-                          description: A human readable message indicating details about why the workflowStep is in this state.
+                          description: A human readable message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         name:
                           type: string
                         phase:
-                          description: WorkflowStepPhase describes the phase of a workflow step.
+                          description: WorkflowStepPhase describes the phase of a
+                            workflow step.
                           type: string
                         reason:
-                          description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                          description: A brief CamelCase message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         subSteps:
-                          description: SubStepsStatus record the status of workflow steps.
+                          description: SubStepsStatus record the status of workflow
+                            steps.
                           properties:
                             mode:
                               description: WorkflowMode describes the mode of workflow
@@ -613,20 +829,26 @@ spec:
                               type: integer
                             steps:
                               items:
-                                description: WorkflowSubStepStatus record the status of a workflow step
+                                description: WorkflowSubStepStatus record the status
+                                  of a workflow step
                                 properties:
                                   id:
                                     type: string
                                   message:
-                                    description: A human readable message indicating details about why the workflowStep is in this state.
+                                    description: A human readable message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   name:
                                     type: string
                                   phase:
-                                    description: WorkflowStepPhase describes the phase of a workflow step.
+                                    description: WorkflowStepPhase describes the phase
+                                      of a workflow step.
                                     type: string
                                   reason:
-                                    description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                                    description: A brief CamelCase message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   type:
                                     type: string
@@ -684,10 +906,14 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -739,11 +965,15 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level
+                        scopes the format is <scope-type:scope-instance-name> pairs,
+                        the key represents type of `ScopeDefinition` while the value
+                        represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type must be array to keep the order.
+                      description: Traits define the trait of one component, the type
+                        must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -764,9 +994,13 @@ spec:
                   type: object
                 type: array
               policies:
-                description: Policies defines the global policies for all components in the app, e.g. security, metrics, gitops, multi-cluster placement rules, etc. Policies are applied after components are rendered and before workflow steps are executed.
+                description: Policies defines the global policies for all components
+                  in the app, e.g. security, metrics, gitops, multi-cluster placement
+                  rules, etc. Policies are applied after components are rendered and
+                  before workflow steps are executed.
                 items:
-                  description: AppPolicy defines a global policy for all components in the app.
+                  description: AppPolicy defines a global policy for all components
+                    in the app.
                   properties:
                     name:
                       description: Name is the unique name of the policy.
@@ -782,13 +1016,18 @@ spec:
                   type: object
                 type: array
               workflow:
-                description: 'Workflow defines how to customize the control logic. If workflow is specified, Vela won''t apply any resource, but provide rendered output in AppRevision. Workflow steps are executed in array order, and each step: - will have a context in annotation. - should mark "finish" phase in status.conditions.'
+                description: 'Workflow defines how to customize the control logic.
+                  If workflow is specified, Vela won''t apply any resource, but provide
+                  rendered output in AppRevision. Workflow steps are executed in array
+                  order, and each step: - will have a context in annotation. - should
+                  mark "finish" phase in status.conditions.'
                 properties:
                   ref:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStep defines how to execute a workflow step.
+                      description: WorkflowStep defines how to execute a workflow
+                        step.
                       properties:
                         dependsOn:
                           items:
@@ -841,9 +1080,11 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               appliedResources:
-                description: AppliedResources record the resources that the  workflow step apply.
+                description: AppliedResources record the resources that the  workflow
+                  step apply.
                 items:
-                  description: ClusterObjectReference defines the object reference with cluster.
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -854,7 +1095,17 @@ spec:
                       description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -866,7 +1117,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -874,15 +1126,50 @@ spec:
                   type: object
                 type: array
               components:
-                description: Components record the related Components created by Application Controller
+                description: Components record the related Components created by Application
+                  Controller
                 items:
-                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -894,7 +1181,8 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -907,20 +1195,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -938,7 +1231,8 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of
+                      ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -968,7 +1262,8 @@ spec:
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status of App component
+                  description: ApplicationComponentStatus record the health status
+                    of App component
                   properties:
                     cluster:
                       type: string
@@ -984,13 +1279,50 @@ spec:
                       type: string
                     scopes:
                       items:
-                        description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                        description: 'ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs.  1. Ignored
+                          fields.  It includes many fields which are not generally
+                          honored.  For instance, ResourceVersion and FieldPath are
+                          both very rarely valid in actual usage.  2. Invalid usage
+                          help.  It is impossible to add specific help for individual
+                          usage.  In most embedded usages, there are particular     restrictions
+                          like, "must refer only to types A and B" or "UID not honored"
+                          or "name must be restricted".     Those cannot be well described
+                          when embedded.  3. Inconsistent validation.  Because the
+                          usages are different, the validation rules are different
+                          by usage, which makes it hard for users to predict what
+                          will happen.  4. The fields are both imprecise and overly
+                          precise.  Kind is not a precise mapping to a URL. This can
+                          produce ambiguity     during interpretation and require
+                          a REST mapping.  In most cases, the dependency is on the
+                          group,resource tuple     and the version of the actual struct
+                          is irrelevant.  5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type     will affect numerous schemas.  Don''t make new
+                          APIs embed an underspecified API type they do not control.
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          .'
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
                             type: string
                           kind:
                             description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1002,7 +1334,8 @@ spec:
                             description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                             type: string
                           uid:
                             description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1011,7 +1344,8 @@ spec:
                       type: array
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health status
+                        description: ApplicationTraitStatus records the trait health
+                          status
                         properties:
                           healthy:
                             type: boolean
@@ -1025,7 +1359,8 @@ spec:
                         type: object
                       type: array
                     workloadDefinition:
-                      description: WorkloadDefinition is the definition of a WorkloadDefinition, such as deployments/apps.v1
+                      description: WorkloadDefinition is the definition of a WorkloadDefinition,
+                        such as deployments/apps.v1
                       properties:
                         apiVersion:
                           type: string
@@ -1041,7 +1376,8 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of an application at the current time
+                description: ApplicationPhase is a label for the condition of an application
+                  at the current time
                 type: string
               workflow:
                 description: Workflow record the status of workflow
@@ -1049,13 +1385,47 @@ spec:
                   appRevision:
                     type: string
                   contextBackend:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1067,7 +1437,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1085,31 +1456,38 @@ spec:
                     type: string
                   steps:
                     items:
-                      description: WorkflowStepStatus record the status of a workflow step
+                      description: WorkflowStepStatus record the status of a workflow
+                        step
                       properties:
                         firstExecuteTime:
-                          description: FirstExecuteTime is the first time this step execution.
+                          description: FirstExecuteTime is the first time this step
+                            execution.
                           format: date-time
                           type: string
                         id:
                           type: string
                         lastExecuteTime:
-                          description: LastExecuteTime is the last time this step execution.
+                          description: LastExecuteTime is the last time this step
+                            execution.
                           format: date-time
                           type: string
                         message:
-                          description: A human readable message indicating details about why the workflowStep is in this state.
+                          description: A human readable message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         name:
                           type: string
                         phase:
-                          description: WorkflowStepPhase describes the phase of a workflow step.
+                          description: WorkflowStepPhase describes the phase of a
+                            workflow step.
                           type: string
                         reason:
-                          description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                          description: A brief CamelCase message indicating details
+                            about why the workflowStep is in this state.
                           type: string
                         subSteps:
-                          description: SubStepsStatus record the status of workflow steps.
+                          description: SubStepsStatus record the status of workflow
+                            steps.
                           properties:
                             mode:
                               description: WorkflowMode describes the mode of workflow
@@ -1118,20 +1496,26 @@ spec:
                               type: integer
                             steps:
                               items:
-                                description: WorkflowSubStepStatus record the status of a workflow step
+                                description: WorkflowSubStepStatus record the status
+                                  of a workflow step
                                 properties:
                                   id:
                                     type: string
                                   message:
-                                    description: A human readable message indicating details about why the workflowStep is in this state.
+                                    description: A human readable message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   name:
                                     type: string
                                   phase:
-                                    description: WorkflowStepPhase describes the phase of a workflow step.
+                                    description: WorkflowStepPhase describes the phase
+                                      of a workflow step.
                                     type: string
                                   reason:
-                                    description: A brief CamelCase message indicating details about why the workflowStep is in this state.
+                                    description: A brief CamelCase message indicating
+                                      details about why the workflowStep is in this
+                                      state.
                                     type: string
                                   type:
                                     type: string

--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -56,7 +56,7 @@ else
 CUE=$(shell which cue)
 endif
 
-KUSTOMIZE_VERSION ?= 3.8.2
+KUSTOMIZE_VERSION ?= 4.5.4	
 
 .PHONY: kustomize
 kustomize:


### PR DESCRIPTION
### Description of your changes

Update kustomize to the last version available.  The previous pinned version was not available for darwin-arm64. 

[Fixes #3807](https://github.com/kubevela/kubevela/issues/3807)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

In a darwin-ar64 machine, execute:

```
make manifests
```

If there is another kustomize version installed in $HOME/go/bin, you will need to remove it before compiling with the new makefile
```
make manifests
installing kustomize-v4.5.4	 into ...go/bin
.../go/bin/kustomize exists. Remove it first.
make: *** [kustomize] Error 1
```
### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->