### PR TITLE
Fix: there are probability to report error when controlPlaneOnly=true

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -348,7 +348,8 @@ func getComponentResources(ctx context.Context, manifest *types.ComponentManifes
 
 	for _, trait := range manifest.Traits {
 		v := trait.DeepCopy()
-		if err := cli.Get(ctx, client.ObjectKeyFromObject(trait), v); err != nil {
+		remoteCtx := multicluster.ContextWithClusterName(ctx, oam.GetCluster(v))
+		if err := cli.Get(remoteCtx, client.ObjectKeyFromObject(trait), v); err != nil {
 			return workload, nil, err
 		}
 		traits = append(traits, v)


### PR DESCRIPTION
when controlPlaneOnly=true, There are probability to report error "resource not found"

Signed-off-by: Xiangbo Ma <maxiangboo@cmbchina.com>


### Description of your changes
After applycomponent, when waiting for health, the trace still checks the CR of the corresponding trace from the managedcluster corresponding to comp. At this time, the status of the CR should be checked from local
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->



I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.





