### PR TITLE
Feat(cli): added the offline flag to the dry-run command

### DIFF
--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -297,12 +297,7 @@ func DryRunTemplateLoader(defs []oam.Object) TemplateLoaderFn {
 			}
 		}
 		// not found in provided cap definitions
-		// then try to retrieve from cluster if not in offline mode where reader will be nil
-		if r == nil {
-			return nil, fmt.Errorf("cannot load template %q from provided ones", capName)
-		}
-
-		// Now attempt to load template from cluster
+		// then try to retrieve from cluster
 		tmpl, err := LoadTemplate(ctx, dm, r, capName, capType)
 		if err != nil {
 			return nil, errors.WithMessagef(err, "cannot load template %q from cluster and provided ones", capName)

--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -297,7 +297,12 @@ func DryRunTemplateLoader(defs []oam.Object) TemplateLoaderFn {
 			}
 		}
 		// not found in provided cap definitions
-		// then try to retrieve from cluster
+		// then try to retrieve from cluster if not in offline mode where reader will be nil
+		if r == nil {
+			return nil, fmt.Errorf("cannot load template %q from provided ones", capName)
+		}
+
+		// Now attempt to load template from cluster
 		tmpl, err := LoadTemplate(ctx, dm, r, capName, capType)
 		if err != nil {
 			return nil, errors.WithMessagef(err, "cannot load template %q from cluster and provided ones", capName)


### PR DESCRIPTION
### Description of your changes


Fixes #3865

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Made a sample `definition.yaml` file and a `app.yaml` and run the `vela dry-run` command with the `-d` `-f` and `--offline` flags.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->