### PR TITLE
Feat: add the component name field for the trigger

### DIFF
--- a/pkg/apiserver/model/application.go
+++ b/pkg/apiserver/model/application.go
@@ -379,6 +379,7 @@ type ApplicationTrigger struct {
 	Token         string `json:"token"`
 	Type          string `json:"type"`
 	PayloadType   string `json:"payloadType"`
+	ComponentName string `json:"componentName"`
 }
 
 const (

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -403,6 +403,7 @@ func (c *applicationUsecaseImpl) CreateApplication(ctx context.Context, req apis
 		if err != nil {
 			return nil, err
 		}
+		// For the custom payload, no need assign the component name
 		if _, err := c.CreateApplicationTrigger(ctx, &application, apisv1.CreateApplicationTriggerRequest{
 			Name:         fmt.Sprintf("%s-%s", application.Name, "default"),
 			PayloadType:  model.PayloadTypeCustom,
@@ -434,6 +435,7 @@ func (c *applicationUsecaseImpl) CreateApplicationTrigger(ctx context.Context, a
 		Description:   req.Description,
 		Type:          req.Type,
 		PayloadType:   req.PayloadType,
+		ComponentName: req.ComponentName,
 		Token:         genWebhookToken(),
 	}
 	if err := c.ds.Add(ctx, trigger); err != nil {
@@ -449,7 +451,7 @@ func (c *applicationUsecaseImpl) CreateApplicationTrigger(ctx context.Context, a
 		Type:          req.Type,
 		PayloadType:   req.PayloadType,
 		Token:         trigger.Token,
-		ComponentName: req.ComponentName,
+		ComponentName: trigger.ComponentName,
 		CreateTime:    trigger.CreateTime,
 		UpdateTime:    trigger.UpdateTime,
 	}, nil
@@ -489,15 +491,16 @@ func (c *applicationUsecaseImpl) ListApplicationTriggers(ctx context.Context, ap
 		trigger, ok := raw.(*model.ApplicationTrigger)
 		if ok {
 			resp = append(resp, &apisv1.ApplicationTriggerBase{
-				WorkflowName: trigger.WorkflowName,
-				Name:         trigger.Name,
-				Alias:        trigger.Alias,
-				Description:  trigger.Description,
-				Type:         trigger.Type,
-				PayloadType:  trigger.PayloadType,
-				Token:        trigger.Token,
-				UpdateTime:   trigger.UpdateTime,
-				CreateTime:   trigger.CreateTime,
+				WorkflowName:  trigger.WorkflowName,
+				Name:          trigger.Name,
+				Alias:         trigger.Alias,
+				Description:   trigger.Description,
+				Type:          trigger.Type,
+				PayloadType:   trigger.PayloadType,
+				Token:         trigger.Token,
+				UpdateTime:    trigger.UpdateTime,
+				CreateTime:    trigger.CreateTime,
+				ComponentName: trigger.ComponentName,
 			})
 		}
 	}

--- a/pkg/apiserver/rest/usecase/application_test.go
+++ b/pkg/apiserver/rest/usecase/application_test.go
@@ -177,6 +177,12 @@ var _ = Describe("Test application usecase function", func() {
 			Name: "trigger-name",
 		})
 		Expect(err).Should(BeNil())
+		base, err := appUsecase.CreateApplicationTrigger(context.TODO(), appModel, v1.CreateApplicationTriggerRequest{
+			Name:          "trigger-name-2",
+			ComponentName: "trigger-component",
+		})
+		Expect(err).Should(BeNil())
+		Expect(base.ComponentName).Should(Equal("trigger-component"))
 	})
 
 	It("Test ListTriggers function", func() {
@@ -184,7 +190,7 @@ var _ = Describe("Test application usecase function", func() {
 		Expect(err).Should(BeNil())
 		triggers, err := appUsecase.ListApplicationTriggers(context.TODO(), appModel)
 		Expect(err).Should(BeNil())
-		Expect(len(triggers)).Should(Equal(2))
+		Expect(len(triggers)).Should(Equal(3))
 	})
 
 	It("Test DeleteTrigger function", func() {
@@ -192,7 +198,7 @@ var _ = Describe("Test application usecase function", func() {
 		Expect(err).Should(BeNil())
 		triggers, err := appUsecase.ListApplicationTriggers(context.TODO(), appModel)
 		Expect(err).Should(BeNil())
-		Expect(len(triggers)).Should(Equal(2))
+		Expect(len(triggers)).Should(Equal(3))
 		var trigger *v1.ApplicationTriggerBase
 		for _, t := range triggers {
 			if t.Name == "trigger-name" {
@@ -204,7 +210,7 @@ var _ = Describe("Test application usecase function", func() {
 		Expect(appUsecase.DeleteApplicationTrigger(context.TODO(), appModel, trigger.Token)).Should(BeNil())
 		triggers, err = appUsecase.ListApplicationTriggers(context.TODO(), appModel)
 		Expect(err).Should(BeNil())
-		Expect(len(triggers)).Should(Equal(1))
+		Expect(len(triggers)).Should(Equal(2))
 		trigger = nil
 		for _, t := range triggers {
 			if t.Name == "trigger-name" {


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

For the trigger, In addition to the custom payload type, we should support setting the component name, whose image address needs to be changed by the trigger.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.