### PR TITLE
Feat: support filter the resource by kind or apiVersion

### DIFF
--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -1264,11 +1264,8 @@ func (c *applicationUsecaseImpl) DeleteComponent(ctx context.Context, app *model
 		log.Logger.Warnf("delete app component %s failure %s", app.PrimaryKey(), err.Error())
 		return err
 	}
-	// update the workflow if added a first cloud resource component
-	if component.WorkloadType.Type == TerraformWorkloadType {
-		if err := UpdateAppEnvWorkflow(ctx, c.kubeClient, c.ds, app); err != nil {
-			return bcode.ErrEnvBindingUpdateWorkflow
-		}
+	if err := UpdateAppEnvWorkflow(ctx, c.kubeClient, c.ds, app); err != nil {
+		return bcode.ErrEnvBindingUpdateWorkflow
 	}
 	return nil
 }

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -8,7 +8,10 @@
 			cluster?:          string
 			clusterNamespace?: string
 			components?: [...string]
+			kind?:       string
+			apiVersion?: string
 		}
+		withStatus?: bool
 	}
 	list?: [...{
 		cluster:   string
@@ -29,6 +32,8 @@
 			cluster?:          string
 			clusterNamespace?: string
 			components?: [...string]
+			kind?:       string
+			apiVersion?: string
 		}
 	}
 	list?: [...{

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -81,6 +81,9 @@ type Option struct {
 	Name      string       `json:"name"`
 	Namespace string       `json:"namespace"`
 	Filter    FilterOption `json:"filter,omitempty"`
+	// WithStatus means query the object from the cluster and get the latest status
+	// This field only suitable for ListResourcesInApp
+	WithStatus bool `json:"withStatus,omitempty"`
 }
 
 // FilterOption filter resource created by component
@@ -88,9 +91,11 @@ type FilterOption struct {
 	Cluster          string   `json:"cluster,omitempty"`
 	ClusterNamespace string   `json:"clusterNamespace,omitempty"`
 	Components       []string `json:"components,omitempty"`
+	APIVersion       string   `json:"apiVersion,omitempty"`
+	Kind             string   `json:"kind,omitempty"`
 }
 
-// ListResourcesInApp lists CRs created by Application
+// ListResourcesInApp lists CRs created by Application, this provider queries the object data.
 func (h *provider) ListResourcesInApp(ctx wfContext.Context, v *value.Value, act types.Action) error {
 	val, err := v.LookupValue("app")
 	if err != nil {
@@ -108,7 +113,7 @@ func (h *provider) ListResourcesInApp(ctx wfContext.Context, v *value.Value, act
 	return v.FillObject(appResList, "list")
 }
 
-// ListAppliedResources list applied resource from tracker
+// ListAppliedResources list applied resource from tracker, this provider only queries the metadata.
 func (h *provider) ListAppliedResources(ctx wfContext.Context, v *value.Value, act types.Action) error {
 	val, err := v.LookupValue("app")
 	if err != nil {

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -298,9 +298,10 @@ var _ = Describe("Test Query Provider", func() {
 							ClusterObjectReference: common.ClusterObjectReference{
 								Cluster: "",
 								ObjectReference: corev1.ObjectReference{
-									Kind:      "Deployment",
-									Namespace: "default",
-									Name:      "web",
+									Kind:       "Deployment",
+									APIVersion: "apps/v1",
+									Namespace:  "default",
+									Name:       "web",
 								},
 							},
 							OAMObjectReference: common.OAMObjectReference{
@@ -311,9 +312,10 @@ var _ = Describe("Test Query Provider", func() {
 							ClusterObjectReference: common.ClusterObjectReference{
 								Cluster: "",
 								ObjectReference: corev1.ObjectReference{
-									Kind:      "Service",
-									Namespace: "default",
-									Name:      "web",
+									Kind:       "Service",
+									APIVersion: "v1",
+									Namespace:  "default",
+									Name:       "web",
 								},
 							},
 							OAMObjectReference: common.OAMObjectReference{
@@ -344,6 +346,41 @@ var _ = Describe("Test Query Provider", func() {
 			err = v.UnmarshalTo(&res)
 			Expect(err).Should(BeNil())
 			Expect(len(res.List)).Should(Equal(2))
+
+			By("test filter with the apiVersion and kind")
+			optWithVersion := `app: {
+				name: "test-applied"
+				namespace: "default"
+				filter: {
+					components: ["web"]
+					apiVersion: "apps/v1"
+				}
+			}`
+			valueWithVersion, err := value.NewValue(optWithVersion, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListAppliedResources(nil, valueWithVersion, nil)).Should(BeNil())
+			var res2 Res
+			err = valueWithVersion.UnmarshalTo(&res2)
+			Expect(err).Should(BeNil())
+			Expect(len(res2.List)).Should(Equal(1))
+			Expect(res2.List[0].Kind).Should(Equal("Deployment"))
+
+			optWithKind := `app: {
+				name: "test-applied"
+				namespace: "default"
+				filter: {
+					components: ["web"]
+					kind: "Service"
+				}
+			}`
+			valueWithKind, err := value.NewValue(optWithKind, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListAppliedResources(nil, valueWithKind, nil)).Should(BeNil())
+			var res3 Res
+			err = valueWithKind.UnmarshalTo(&res3)
+			Expect(err).Should(BeNil())
+			Expect(len(res3.List)).Should(Equal(1))
+			Expect(res3.List[0].Kind).Should(Equal("Service"))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

There are two changes:

1. add kind or apiVersion as a filter option, this is useful for querying one kind resource of application.  for an example:

original:

```
apiVersion: "terraform.core.oam.dev/v1beta1"
kind:       "Configuration"

resources: ql.#ListResourcesInApp & {
        app: {
                name:      parameter.appName
                namespace: parameter.appNs
        }
}
status: {
        if resources.err == _|_ {
                "cloud-resources": [ for i, resource in resources.list if resource.object.apiVersion == apiVersion && resource.object.kind == kind {
                        resource.object
                }]
        }
        if resources.err != _|_ {
                error: resources.err
        }
}
```

now:

```
resources: ql.#ListResourcesInApp & {
        app: {
                name:      parameter.appName
                namespace: parameter.appNs
                filter: {
                    "apiVersion": "terraform.core.oam.dev/v1beta1"
                    "kind": "Configuration"
                }
                withStatus: true
        }
}
status: {
        if resources.err == _|_ {
                "cloud-resources": [ for i, resource in resources.list {
                        resource.object
                }]
        }
        if resources.err != _|_ {
                error: resources.err
        }
}
```

2. add the `withStatus` field as a query option, we default query the resource object from RT, set withStatus is true will query the object from the cluster. take the example above.


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.