### PR TITLE
Feat: controller auto-impersonation

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -207,10 +207,8 @@ func main() {
 	restConfig.Wrap(auth.NewImpersonatingRoundTripper)
 	if utilfeature.DefaultMutableFeatureGate.Enabled(features.ControllerAutoImpersonation) {
 		restConfig.Impersonate.UserName = types.VelaCoreName
-		if sub := pkgutils.GetServiceAccountSubjectFromConfig(restConfig); sub != "" {
-			restConfig.Impersonate.UserName = sub
-		}
 		restConfig.Impersonate.Groups = []string{apicommon.Group}
+		pkgutils.AutoSetSelfImpersonationInConfig(restConfig)
 	}
 	klog.InfoS("Kubernetes Config Loaded",
 		"UserAgent", restConfig.UserAgent,

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -46,7 +46,7 @@ import (
 	oamv1alpha2 "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
-	_ "github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/features"
 	_ "github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -205,15 +205,18 @@ func main() {
 	restConfig.QPS = float32(qps)
 	restConfig.Burst = burst
 	restConfig.Wrap(auth.NewImpersonatingRoundTripper)
-	restConfig.Impersonate.UserName = types.VelaCoreName
-	if sub := pkgutils.GetServiceAccountSubjectFromConfig(restConfig); sub != "" {
-		restConfig.Impersonate.UserName = sub
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.ControllerAutoImpersonation) {
+		restConfig.Impersonate.UserName = types.VelaCoreName
+		if sub := pkgutils.GetServiceAccountSubjectFromConfig(restConfig); sub != "" {
+			restConfig.Impersonate.UserName = sub
+		}
+		restConfig.Impersonate.Groups = []string{apicommon.Group}
 	}
-	restConfig.Impersonate.Groups = []string{apicommon.Group}
 	klog.InfoS("Kubernetes Config Loaded",
 		"UserAgent", restConfig.UserAgent,
 		"QPS", restConfig.QPS,
 		"Burst", restConfig.Burst,
+		"Auto-Impersonation", utilfeature.DefaultMutableFeatureGate.Enabled(features.ControllerAutoImpersonation),
 		"Impersonate-User", restConfig.Impersonate.UserName,
 		"Impersonate-Group", strings.Join(restConfig.Impersonate.Groups, ","),
 	)

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -36,6 +36,8 @@ const (
 
 	// Edge Features
 
+	// ControllerAutoImpersonation enable the auto impersonation for controller (to use explicit identity for requests)
+	ControllerAutoImpersonation featuregate.Feature = "ControllerAutoImpersonation"
 	// AuthenticateApplication enable the authentication for application
 	AuthenticateApplication featuregate.Feature = "AuthenticateApplication"
 )
@@ -45,6 +47,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LegacyObjectTypeIdentifier:    {Default: false, PreRelease: featuregate.Alpha},
 	DeprecatedObjectLabelSelector: {Default: false, PreRelease: featuregate.Alpha},
 	LegacyResourceTrackerGC:       {Default: true, PreRelease: featuregate.Alpha},
+	ControllerAutoImpersonation:   {Default: true, PreRelease: featuregate.Alpha},
 	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package utils
 
-import "github.com/form3tech-oss/jwt-go"
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+
+	"github.com/form3tech-oss/jwt-go"
+)
 
 // GetTokenSubject extract the subject field from the jwt token
 func GetTokenSubject(token string) (string, error) {
@@ -26,4 +32,20 @@ func GetTokenSubject(token string) (string, error) {
 	}
 	sub, _ := claims["sub"].(string)
 	return sub, nil
+}
+
+// GetCertificateSubject extract Subject from Certificate
+func GetCertificateSubject(certificate []byte) (*pkix.Name, error) {
+	if len(certificate) == 0 {
+		return nil, nil
+	}
+	blk, _ := pem.Decode(certificate)
+	if blk == nil {
+		return nil, nil
+	}
+	cert, err := x509.ParseCertificate(blk.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return &cert.Subject, nil
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR includes two changes:
1. Support auto-detect identity in X509 kubeconfig and let controller to impersonate as itself in this case. (Previously only ServiceAccount based kubeconfig is supported.)
2. Add a feature flag to controller impersonation. By default enabled.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->