### PR TITLE
Feat: vela auth gen-kubeconfig

### DIFF
--- a/pkg/auth/kubeconfig.go
+++ b/pkg/auth/kubeconfig.go
@@ -23,6 +23,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/pkg/errors"
@@ -35,43 +37,41 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/pointer"
-
-	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
-// KubeConfigCreateOptions options for create KubeConfig
-type KubeConfigCreateOptions struct {
-	X509           *KubeConfigCreateX509Options
-	ServiceAccount *KubeConfigCreateServiceAccountOptions
+// KubeConfigGenerateOptions options for create KubeConfig
+type KubeConfigGenerateOptions struct {
+	X509           *KubeConfigGenerateX509Options
+	ServiceAccount *KubeConfigGenerateServiceAccountOptions
 }
 
-// KubeConfigCreateX509Options options for create X509 based KubeConfig
-type KubeConfigCreateX509Options struct {
+// KubeConfigGenerateX509Options options for create X509 based KubeConfig
+type KubeConfigGenerateX509Options struct {
 	User           string
 	Groups         []string
 	ExpireTime     time.Duration
 	PrivateKeyBits int
 }
 
-// KubeConfigCreateServiceAccountOptions options for create ServiceAccount based KubeConfig
-type KubeConfigCreateServiceAccountOptions struct {
+// KubeConfigGenerateServiceAccountOptions options for create ServiceAccount based KubeConfig
+type KubeConfigGenerateServiceAccountOptions struct {
 	ServiceAccountName      string
 	ServiceAccountNamespace string
 }
 
-// KubeConfigWithUserCreateOption option for setting user in KubeConfig
-type KubeConfigWithUserCreateOption string
+// KubeConfigWithUserGenerateOption option for setting user in KubeConfig
+type KubeConfigWithUserGenerateOption string
 
 // ApplyToOptions .
-func (opt KubeConfigWithUserCreateOption) ApplyToOptions(options *KubeConfigCreateOptions) {
+func (opt KubeConfigWithUserGenerateOption) ApplyToOptions(options *KubeConfigGenerateOptions) {
 	options.X509.User = string(opt)
 }
 
-// KubeConfigWithGroupCreateOption option for setting group in KubeConfig
-type KubeConfigWithGroupCreateOption string
+// KubeConfigWithGroupGenerateOption option for setting group in KubeConfig
+type KubeConfigWithGroupGenerateOption string
 
 // ApplyToOptions .
-func (opt KubeConfigWithGroupCreateOption) ApplyToOptions(options *KubeConfigCreateOptions) {
+func (opt KubeConfigWithGroupGenerateOption) ApplyToOptions(options *KubeConfigGenerateOptions) {
 	for _, group := range options.X509.Groups {
 		if group == string(opt) {
 			return
@@ -80,26 +80,26 @@ func (opt KubeConfigWithGroupCreateOption) ApplyToOptions(options *KubeConfigCre
 	options.X509.Groups = append(options.X509.Groups, string(opt))
 }
 
-// KubeConfigWithServiceAccount option for setting service account in KubeConfig
-type KubeConfigWithServiceAccount types.NamespacedName
+// KubeConfigWithServiceAccountGenerateOption option for setting service account in KubeConfig
+type KubeConfigWithServiceAccountGenerateOption types.NamespacedName
 
 // ApplyToOptions .
-func (opt KubeConfigWithServiceAccount) ApplyToOptions(options *KubeConfigCreateOptions) {
+func (opt KubeConfigWithServiceAccountGenerateOption) ApplyToOptions(options *KubeConfigGenerateOptions) {
 	options.X509 = nil
-	options.ServiceAccount = &KubeConfigCreateServiceAccountOptions{
+	options.ServiceAccount = &KubeConfigGenerateServiceAccountOptions{
 		ServiceAccountName:      opt.Name,
 		ServiceAccountNamespace: opt.Namespace,
 	}
 }
 
-// KubeConfigCreateOption option for create KubeConfig
-type KubeConfigCreateOption interface {
-	ApplyToOptions(options *KubeConfigCreateOptions)
+// KubeConfigGenerateOption option for create KubeConfig
+type KubeConfigGenerateOption interface {
+	ApplyToOptions(options *KubeConfigGenerateOptions)
 }
 
-func newKubeConfigCreateOptions(options ...KubeConfigCreateOption) *KubeConfigCreateOptions {
-	opts := &KubeConfigCreateOptions{
-		X509: &KubeConfigCreateX509Options{
+func newKubeConfigGenerateOptions(options ...KubeConfigGenerateOption) *KubeConfigGenerateOptions {
+	opts := &KubeConfigGenerateOptions{
+		X509: &KubeConfigGenerateX509Options{
 			User:           user.Anonymous,
 			Groups:         []string{KubeVelaClientGroup},
 			ExpireTime:     time.Hour * 24 * 365,
@@ -118,18 +118,18 @@ const (
 	KubeVelaClientGroup = "kubevela:client"
 )
 
-// CreateKubeConfig create KubeConfig for users with given options
-func CreateKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, options ...KubeConfigCreateOption) (*clientcmdapi.Config, error) {
-	opts := newKubeConfigCreateOptions(options...)
+// GenerateKubeConfig generate KubeConfig for users with given options.
+func GenerateKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, writer io.Writer, options ...KubeConfigGenerateOption) (*clientcmdapi.Config, error) {
+	opts := newKubeConfigGenerateOptions(options...)
 	if opts.X509 != nil {
-		return createX509KubeConfig(ctx, cli, cfg, ioStream, opts.X509)
+		return generateX509KubeConfig(ctx, cli, cfg, writer, opts.X509)
 	} else if opts.ServiceAccount != nil {
-		return createServiceAccountKubeConfig(ctx, cli, cfg, ioStream, opts.ServiceAccount)
+		return generateServiceAccountKubeConfig(ctx, cli, cfg, writer, opts.ServiceAccount)
 	}
 	return nil, errors.New("either x509 or serviceaccount must be set for creating KubeConfig")
 }
 
-func generateKubeConfig(cfg *clientcmdapi.Config, authInfo *clientcmdapi.AuthInfo, caData []byte) *clientcmdapi.Config {
+func genKubeConfig(cfg *clientcmdapi.Config, authInfo *clientcmdapi.AuthInfo, caData []byte) *clientcmdapi.Config {
 	exportCfg := cfg.DeepCopy()
 	exportContext := cfg.Contexts[cfg.CurrentContext].DeepCopy()
 	exportCfg.Contexts = map[string]*clientcmdapi.Context{cfg.CurrentContext: exportContext}
@@ -142,14 +142,14 @@ func generateKubeConfig(cfg *clientcmdapi.Config, authInfo *clientcmdapi.AuthInf
 	return exportCfg
 }
 
-func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, opts *KubeConfigCreateX509Options) (*clientcmdapi.Config, error) {
+func generateX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, writer io.Writer, opts *KubeConfigGenerateX509Options) (*clientcmdapi.Config, error) {
 	// generate private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, opts.PrivateKeyBits)
 	if err != nil {
 		return nil, err
 	}
 	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-	ioStream.Infof("Private key generated.")
+	_, _ = fmt.Fprintf(writer, "Private key generated.\n")
 
 	template := &x509.CertificateRequest{
 		Subject: pkix.Name{
@@ -164,7 +164,7 @@ func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *cl
 		return nil, err
 	}
 	csrPemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
-	ioStream.Infof("Certificate request generated.")
+	_, _ = fmt.Fprintf(writer, "Certificate request generated.\n")
 
 	csr := &certificatesv1.CertificateSigningRequest{}
 	csr.Name = opts.User
@@ -175,7 +175,7 @@ func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *cl
 	if csr, err = cli.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{}); err != nil {
 		return nil, err
 	}
-	ioStream.Infof("Certificate signing request %s generated.", opts.User)
+	_, _ = fmt.Fprintf(writer, "Certificate signing request %s generated.\n", opts.User)
 	defer func() {
 		_ = cli.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, metav1.DeleteOptions{})
 	}()
@@ -189,7 +189,7 @@ func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *cl
 	if csr, err = cli.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, csr, metav1.UpdateOptions{}); err != nil {
 		return nil, err
 	}
-	ioStream.Infof("Certificate signing request %s approved.", opts.User)
+	_, _ = fmt.Fprintf(writer, "Certificate signing request %s approved.\n", opts.User)
 	if err = wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
 		if csr, err = cli.CertificatesV1().CertificateSigningRequests().Get(ctx, opts.User, metav1.GetOptions{}); err != nil {
 			return false, err
@@ -201,20 +201,20 @@ func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *cl
 	}); err != nil {
 		return nil, err
 	}
-	ioStream.Infof("Signed certificate retrieved.")
+	_, _ = fmt.Fprintf(writer, "Signed certificate retrieved.\n")
 
-	return generateKubeConfig(cfg, &clientcmdapi.AuthInfo{
+	return genKubeConfig(cfg, &clientcmdapi.AuthInfo{
 		ClientKeyData:         keyBytes,
 		ClientCertificateData: csr.Status.Certificate,
 	}, nil), nil
 }
 
-func createServiceAccountKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, opts *KubeConfigCreateServiceAccountOptions) (*clientcmdapi.Config, error) {
+func generateServiceAccountKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, writer io.Writer, opts *KubeConfigGenerateServiceAccountOptions) (*clientcmdapi.Config, error) {
 	sa, err := cli.CoreV1().ServiceAccounts(opts.ServiceAccountNamespace).Get(ctx, opts.ServiceAccountName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	ioStream.Infof("ServiceAccount %s/%s found.", opts.ServiceAccountNamespace, opts.ServiceAccountName)
+	_, _ = fmt.Fprintf(writer, "ServiceAccount %s/%s found.\n", opts.ServiceAccountNamespace, opts.ServiceAccountName)
 	if len(sa.Secrets) == 0 {
 		return nil, errors.Errorf("no secret found in serviceaccount %s/%s", opts.ServiceAccountNamespace, opts.ServiceAccountName)
 	}
@@ -226,12 +226,12 @@ func createServiceAccountKubeConfig(ctx context.Context, cli kubernetes.Interfac
 	if err != nil {
 		return nil, err
 	}
-	ioStream.Infof("ServiceAccount secret %s/%s found.", secretKey.Namespace, secret.Name)
+	_, _ = fmt.Fprintf(writer, "ServiceAccount secret %s/%s found.\n", secretKey.Namespace, secret.Name)
 	if len(secret.Data["token"]) == 0 {
 		return nil, errors.Errorf("no token found in secret %s/%s", secret.Namespace, secret.Name)
 	}
-	ioStream.Infof("ServiceAccount token found.")
-	return generateKubeConfig(cfg, &clientcmdapi.AuthInfo{
+	_, _ = fmt.Fprintf(writer, "ServiceAccount token found.\n")
+	return genKubeConfig(cfg, &clientcmdapi.AuthInfo{
 		Token: string(secret.Data["token"]),
 	}, secret.Data["ca.crt"]), nil
 }

--- a/pkg/auth/kubeconfig.go
+++ b/pkg/auth/kubeconfig.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"time"
+
+	"github.com/pkg/errors"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/pointer"
+
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+// KubeConfigCreateOptions options for create KubeConfig
+type KubeConfigCreateOptions struct {
+	X509           *KubeConfigCreateX509Options
+	ServiceAccount *KubeConfigCreateServiceAccountOptions
+}
+
+// KubeConfigCreateX509Options options for create X509 based KubeConfig
+type KubeConfigCreateX509Options struct {
+	User           string
+	Groups         []string
+	ExpireTime     time.Duration
+	PrivateKeyBits int
+}
+
+// KubeConfigCreateServiceAccountOptions options for create ServiceAccount based KubeConfig
+type KubeConfigCreateServiceAccountOptions struct {
+	ServiceAccountName      string
+	ServiceAccountNamespace string
+}
+
+// KubeConfigWithUserCreateOption option for setting user in KubeConfig
+type KubeConfigWithUserCreateOption string
+
+// ApplyToOptions .
+func (opt KubeConfigWithUserCreateOption) ApplyToOptions(options *KubeConfigCreateOptions) {
+	options.X509.User = string(opt)
+}
+
+// KubeConfigWithGroupCreateOption option for setting group in KubeConfig
+type KubeConfigWithGroupCreateOption string
+
+// ApplyToOptions .
+func (opt KubeConfigWithGroupCreateOption) ApplyToOptions(options *KubeConfigCreateOptions) {
+	for _, group := range options.X509.Groups {
+		if group == string(opt) {
+			return
+		}
+	}
+	options.X509.Groups = append(options.X509.Groups, string(opt))
+}
+
+// KubeConfigWithServiceAccount option for setting service account in KubeConfig
+type KubeConfigWithServiceAccount types.NamespacedName
+
+// ApplyToOptions .
+func (opt KubeConfigWithServiceAccount) ApplyToOptions(options *KubeConfigCreateOptions) {
+	options.X509 = nil
+	options.ServiceAccount = &KubeConfigCreateServiceAccountOptions{
+		ServiceAccountName:      opt.Name,
+		ServiceAccountNamespace: opt.Namespace,
+	}
+}
+
+// KubeConfigCreateOption option for create KubeConfig
+type KubeConfigCreateOption interface {
+	ApplyToOptions(options *KubeConfigCreateOptions)
+}
+
+func newKubeConfigCreateOptions(options ...KubeConfigCreateOption) *KubeConfigCreateOptions {
+	opts := &KubeConfigCreateOptions{
+		X509: &KubeConfigCreateX509Options{
+			User:           user.Anonymous,
+			Groups:         []string{KubeVelaClientGroup},
+			ExpireTime:     time.Hour * 24 * 365,
+			PrivateKeyBits: 2048,
+		},
+		ServiceAccount: nil,
+	}
+	for _, op := range options {
+		op.ApplyToOptions(opts)
+	}
+	return opts
+}
+
+const (
+	// KubeVelaClientGroup the default group to be added to the generated X509 KubeConfig
+	KubeVelaClientGroup = "kubevela:client"
+)
+
+// CreateKubeConfig create KubeConfig for users with given options
+func CreateKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, options ...KubeConfigCreateOption) (*clientcmdapi.Config, error) {
+	opts := newKubeConfigCreateOptions(options...)
+	if opts.X509 != nil {
+		return createX509KubeConfig(ctx, cli, cfg, ioStream, opts.X509)
+	} else if opts.ServiceAccount != nil {
+		return createServiceAccountKubeConfig(ctx, cli, cfg, ioStream, opts.ServiceAccount)
+	}
+	return nil, errors.New("either x509 or serviceaccount must be set for creating KubeConfig")
+}
+
+func generateKubeConfig(cfg *clientcmdapi.Config, authInfo *clientcmdapi.AuthInfo, caData []byte) *clientcmdapi.Config {
+	exportCfg := cfg.DeepCopy()
+	exportContext := cfg.Contexts[cfg.CurrentContext].DeepCopy()
+	exportCfg.Contexts = map[string]*clientcmdapi.Context{cfg.CurrentContext: exportContext}
+	exportCluster := cfg.Clusters[exportContext.Cluster].DeepCopy()
+	if caData != nil {
+		exportCluster.CertificateAuthorityData = caData
+	}
+	exportCfg.Clusters = map[string]*clientcmdapi.Cluster{exportContext.Cluster: exportCluster}
+	exportCfg.AuthInfos = map[string]*clientcmdapi.AuthInfo{exportContext.AuthInfo: authInfo}
+	return exportCfg
+}
+
+func createX509KubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, opts *KubeConfigCreateX509Options) (*clientcmdapi.Config, error) {
+	// generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, opts.PrivateKeyBits)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	ioStream.Infof("Private key generated.")
+
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   opts.User,
+			Organization: opts.Groups,
+		},
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+	if err != nil {
+		return nil, err
+	}
+	csrPemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	ioStream.Infof("Certificate request generated.")
+
+	csr := &certificatesv1.CertificateSigningRequest{}
+	csr.Name = opts.User
+	csr.Spec.SignerName = certificatesv1.KubeAPIServerClientSignerName
+	csr.Spec.Usages = []certificatesv1.KeyUsage{certificatesv1.UsageClientAuth}
+	csr.Spec.Request = csrPemBytes
+	csr.Spec.ExpirationSeconds = pointer.Int32(int32(opts.ExpireTime.Seconds()))
+	if csr, err = cli.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{}); err != nil {
+		return nil, err
+	}
+	ioStream.Infof("Certificate signing request %s generated.", opts.User)
+	defer func() {
+		_ = cli.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, metav1.DeleteOptions{})
+	}()
+	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+		Type:           certificatesv1.CertificateApproved,
+		Status:         corev1.ConditionTrue,
+		Reason:         "Self-generated and auto-approved by KubeVela",
+		Message:        "This CSR was approved by KubeVela",
+		LastUpdateTime: metav1.Now(),
+	})
+	if csr, err = cli.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, csr, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	}
+	ioStream.Infof("Certificate signing request %s approved.", opts.User)
+	if err = wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+		if csr, err = cli.CertificatesV1().CertificateSigningRequests().Get(ctx, opts.User, metav1.GetOptions{}); err != nil {
+			return false, err
+		}
+		if csr.Status.Certificate == nil {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+	ioStream.Infof("Signed certificate retrieved.")
+
+	return generateKubeConfig(cfg, &clientcmdapi.AuthInfo{
+		ClientKeyData:         keyBytes,
+		ClientCertificateData: csr.Status.Certificate,
+	}, nil), nil
+}
+
+func createServiceAccountKubeConfig(ctx context.Context, cli kubernetes.Interface, cfg *clientcmdapi.Config, ioStream util.IOStreams, opts *KubeConfigCreateServiceAccountOptions) (*clientcmdapi.Config, error) {
+	sa, err := cli.CoreV1().ServiceAccounts(opts.ServiceAccountNamespace).Get(ctx, opts.ServiceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ioStream.Infof("ServiceAccount %s/%s found.", opts.ServiceAccountNamespace, opts.ServiceAccountName)
+	if len(sa.Secrets) == 0 {
+		return nil, errors.Errorf("no secret found in serviceaccount %s/%s", opts.ServiceAccountNamespace, opts.ServiceAccountName)
+	}
+	secretKey := sa.Secrets[0]
+	if secretKey.Namespace == "" {
+		secretKey.Namespace = sa.Namespace
+	}
+	secret, err := cli.CoreV1().Secrets(secretKey.Namespace).Get(ctx, secretKey.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ioStream.Infof("ServiceAccount secret %s/%s found.", secretKey.Namespace, secret.Name)
+	if len(secret.Data["token"]) == 0 {
+		return nil, errors.Errorf("no token found in secret %s/%s", secret.Namespace, secret.Name)
+	}
+	ioStream.Infof("ServiceAccount token found.")
+	return generateKubeConfig(cfg, &clientcmdapi.AuthInfo{
+		Token: string(secret.Data["token"]),
+	}, secret.Data["ca.crt"]), nil
+}

--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubectl/pkg/util/term"
 
 	cmdutil "github.com/oam-dev/kubevela/pkg/cmd/util"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
 // Builder build command with factory
@@ -97,6 +98,14 @@ func (builder *Builder) WithNamespaceFlag(options ...NamespaceFlagOption) *Build
 // WithEnvFlag add env flag to the command
 func (builder *Builder) WithEnvFlag() *Builder {
 	builder.cmd.PersistentFlags().StringP(flagEnv, "e", "", usageEnv)
+	return builder
+}
+
+// WithStreams set the in/out/err streams for the command
+func (builder *Builder) WithStreams(streams util.IOStreams) *Builder {
+	builder.cmd.SetIn(streams.In)
+	builder.cmd.SetOut(streams.Out)
+	builder.cmd.SetErr(streams.ErrOut)
 	return builder
 }
 

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -50,6 +50,15 @@ func GetNamespacesForCompletion(ctx context.Context, f Factory, toComplete strin
 	return listObjectNamesForCompletion(ctx, f, corev1.SchemeGroupVersion.WithKind("Namespace"), nil, toComplete)
 }
 
+// GetServiceAccountForCompletion auto-complete serviceaccount
+func GetServiceAccountForCompletion(ctx context.Context, f Factory, namespace string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var options []client.ListOption
+	if namespace != "" {
+		options = append(options, client.InNamespace(namespace))
+	}
+	return listObjectNamesForCompletion(ctx, f, corev1.SchemeGroupVersion.WithKind("ServiceAccount"), options, toComplete)
+}
+
 // GetRevisionForCompletion auto-complete the revision according to the application
 func GetRevisionForCompletion(ctx context.Context, f Factory, appName string, namespace string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var options []client.ListOption

--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cmdutil "github.com/oam-dev/kubevela/pkg/cmd/util"
@@ -25,13 +26,18 @@ import (
 // Factory client factory for running command
 type Factory interface {
 	Client() client.Client
+	Config() *rest.Config
 }
 
 // ClientGetter function for getting client
 type ClientGetter func() (client.Client, error)
 
+// ConfigGetter function for getting config
+type ConfigGetter func() (*rest.Config, error)
+
 type defaultFactory struct {
 	ClientGetter
+	ConfigGetter
 }
 
 // Client return the client for command line use, interrupt if error encountered
@@ -41,7 +47,14 @@ func (f *defaultFactory) Client() client.Client {
 	return cli
 }
 
+// Config return the kubeConfig for command line use
+func (f *defaultFactory) Config() *rest.Config {
+	cfg, err := f.ConfigGetter()
+	cmdutil.CheckErr(err)
+	return cfg
+}
+
 // NewDefaultFactory create a factory based on client getter function
-func NewDefaultFactory(clientGetter ClientGetter) Factory {
-	return &defaultFactory{ClientGetter: clientGetter}
+func NewDefaultFactory(clientGetter ClientGetter, configGetter ConfigGetter) Factory {
+	return &defaultFactory{ClientGetter: clientGetter, ConfigGetter: configGetter}
 }

--- a/pkg/utils/util/cmd.go
+++ b/pkg/utils/util/cmd.go
@@ -17,8 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"os"
 )
 
 // IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
@@ -55,4 +57,15 @@ func (i *IOStreams) Errorf(format string, a ...interface{}) {
 // Error print error info
 func (i *IOStreams) Error(a ...interface{}) {
 	_, _ = i.ErrOut.Write([]byte(fmt.Sprintln(a...)))
+}
+
+// NewDefaultIOStreams return IOStreams with standard input/output/error
+func NewDefaultIOStreams() IOStreams {
+	return IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+}
+
+// NewTestIOStreams return IOStreams with empty input and combined buffered output
+func NewTestIOStreams() (IOStreams, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return IOStreams{In: &bytes.Buffer{}, Out: &buf, ErrOut: &buf}, &buf
 }

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -40,8 +40,11 @@ var assumeYes bool
 
 // NewCommand will contain all commands
 func NewCommand() *cobra.Command {
-	ioStream := util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	return NewCommandWithIOStreams(util.NewDefaultIOStreams())
+}
 
+// NewCommandWithIOStreams will contain all commands and initialize them with given ioStream
+func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:                "vela",
 		DisableFlagParsing: true,
@@ -67,7 +70,7 @@ func NewCommand() *cobra.Command {
 	commandArgs := common.Args{
 		Schema: common.Scheme,
 	}
-	f := velacmd.NewDefaultFactory(commandArgs.GetClient)
+	f := velacmd.NewDefaultFactory(commandArgs.GetClient, commandArgs.GetConfig)
 
 	if err := system.InitDirs(); err != nil {
 		fmt.Println("InitDir err", err)
@@ -107,6 +110,7 @@ func NewCommand() *cobra.Command {
 		NewTraitCommand(commandArgs, ioStream),
 		NewComponentsCommand(commandArgs, ioStream),
 		NewProviderCommand(commandArgs, "10", ioStream),
+		CreateCommandGroup(f, ioStream),
 
 		// System
 		NewInstallCommand(commandArgs, "1", ioStream),

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -110,7 +110,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 		NewTraitCommand(commandArgs, ioStream),
 		NewComponentsCommand(commandArgs, ioStream),
 		NewProviderCommand(commandArgs, "10", ioStream),
-		CreateCommandGroup(f, ioStream),
+		AuthCommandGroup(f, ioStream),
 
 		// System
 		NewInstallCommand(commandArgs, "1", ioStream),

--- a/references/cli/create.go
+++ b/references/cli/create.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/auth"
+	velacmd "github.com/oam-dev/kubevela/pkg/cmd"
+	cmdutil "github.com/oam-dev/kubevela/pkg/cmd/util"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+// CreateCommandGroup commands for create resources or configuration
+func CreateCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: i18n.T("Create resource or configuration"),
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCD,
+		},
+	}
+	cmd.AddCommand(NewCreateKubeConfigCommand(f, streams))
+	return cmd
+}
+
+// CreateKubeConfigOptions options for create kubeconfig
+type CreateKubeConfigOptions struct {
+	User                    string
+	Groups                  []string
+	ServiceAccountName      string
+	ServiceAccountNamespace string
+
+	util.IOStreams
+}
+
+func (opt *CreateKubeConfigOptions) options() []auth.KubeConfigCreateOption {
+	var opts []auth.KubeConfigCreateOption
+	if opt.User != "" {
+		opts = append(opts, auth.KubeConfigWithUserCreateOption(opt.User))
+	}
+	for _, group := range opt.Groups {
+		opts = append(opts, auth.KubeConfigWithGroupCreateOption(group))
+	}
+	if opt.ServiceAccountName != "" {
+		opts = append(opts, auth.KubeConfigWithServiceAccount{
+			Name:      opt.ServiceAccountName,
+			Namespace: opt.ServiceAccountNamespace,
+		})
+	}
+	return opts
+}
+
+// Complete .
+func (opt *CreateKubeConfigOptions) Complete(f velacmd.Factory, cmd *cobra.Command) {
+	opt.User = strings.TrimSpace(opt.User)
+	groupMap := map[string]struct{}{}
+	var groups []string
+	for _, group := range opt.Groups {
+		group = strings.TrimSpace(group)
+		if _, found := groupMap[group]; !found {
+			groupMap[group] = struct{}{}
+			groups = append(groups, group)
+		}
+	}
+	opt.Groups = groups
+	opt.ServiceAccountName = strings.TrimSpace(opt.ServiceAccountName)
+	if opt.ServiceAccountName != "" {
+		if ns := velacmd.GetNamespace(f, cmd); ns != "" {
+			opt.ServiceAccountNamespace = ns
+		} else {
+			opt.ServiceAccountNamespace = corev1.NamespaceDefault
+		}
+	}
+}
+
+// Validate .
+func (opt *CreateKubeConfigOptions) Validate() error {
+	if opt.User == "" && opt.ServiceAccountName == "" {
+		return errors.Errorf("either `user` or `serviceaccount` should be set")
+	}
+	if opt.User != "" && opt.ServiceAccountName != "" {
+		return errors.Errorf("cannot set `user` and `serviceaccount` at the same time")
+	}
+	if opt.User == "" && len(opt.Groups) > 0 {
+		return errors.Errorf("cannot set groups when user is not set")
+	}
+	if opt.ServiceAccountName == "" && opt.ServiceAccountNamespace != "" {
+		return errors.Errorf("cannot set serviceaccount namespace when serviceaccount is not set")
+	}
+	return nil
+}
+
+// Run .
+func (opt *CreateKubeConfigOptions) Run(f velacmd.Factory) error {
+	ctx := context.Background()
+	cli, err := kubernetes.NewForConfig(f.Config())
+	if err != nil {
+		return err
+	}
+	cfg, err := clientcmd.NewDefaultPathOptions().GetStartingConfig()
+	if err != nil {
+		return err
+	}
+	cfg, err = auth.CreateKubeConfig(ctx, cli, cfg, opt.IOStreams, opt.options()...)
+	if err != nil {
+		return err
+	}
+	bs, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return err
+	}
+	_, err = opt.Out.Write(bs)
+	return err
+}
+
+var (
+	createKubeConfigLong = templates.LongDesc(i18n.T(`
+		Create kubeconfig for user
+
+		Create a new kubeconfig with specified identity. By default, the generated kubeconfig 
+		will reuse the certificate-authority-data in the cluster config from the current used 
+		kubeconfig. All contexts, clusters and users that are not in use will not be included
+		in the generated kubeconfig.
+
+		To generate a new kubeconfig for given user and groups, use the --user and --group flag.
+		Multiple --group flags is allowed. The group kubevela:client is added to the groups by 
+		default. The identity in the current kubeconfig should be able to approve 
+		CertificateSigningRequest in the kubernetes cluster. See
+		https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
+		for details.
+
+		To generate a kubeconfig based on existing ServiceAccount in your cluster, use the 
+		--serviceaccount flag. The corresponding secret token and ca data will be embedded in 
+		the generated kubeconfig, which allows you to act as the serviceaccount.`))
+
+	createKubeConfigExample = templates.Examples(i18n.T(`
+		# Create a kubeconfig with provided user
+		vela create kubeconfig --user new-user
+		
+		# Create a kubeconfig with provided user and group
+		vela create kubeconfig --user new-user --group kubevela:developer
+		
+		# Create a kubeconfig with provided user and groups
+		vela create kubeconfig --user new-user --group kubevela:developer --group my-org:my-team
+
+		# Create a kubeconfig with provided serviceaccount
+		vela create kubeconfig --serviceaccount default -n demo`))
+)
+
+// NewCreateKubeConfigCommand create kubeconfig for given user and groups
+func NewCreateKubeConfigCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+	o := &CreateKubeConfigOptions{IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:                   "kubeconfig",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create kubeconfig for user"),
+		Long:                  createKubeConfigLong,
+		Example:               createKubeConfigExample,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCD,
+		},
+		Args: cobra.ExactValidArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Complete(f, cmd)
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run(f))
+		},
+	}
+	cmd.Flags().StringVarP(&o.User, "user", "u", o.User, "The user of the generated kubeconfig. If set, an X509-based kubeconfig will be intended to create. It will be embedded as the Subject in the X509 certificate.")
+	cmd.Flags().StringSliceVarP(&o.Groups, "group", "g", o.Groups, "The groups of the generated kubeconfig. This flag only works when `--user` is set. It will be embedded as the Organization in the X509 certificate.")
+	cmd.Flags().StringVarP(&o.ServiceAccountName, "serviceaccount", "", o.ServiceAccountName, "The serviceaccount of the generated kubeconfig. If set, a kubeconfig will be generated based on the secret token of the serviceaccount. Cannot be set when `--user` presents.")
+	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"serviceaccount", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if strings.TrimSpace(o.User) != "" {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			namespace := velacmd.GetNamespace(f, cmd)
+			return velacmd.GetServiceAccountForCompletion(cmd.Context(), f, namespace, toComplete)
+		}))
+
+	return velacmd.NewCommandBuilder(f, cmd).
+		WithNamespaceFlag(velacmd.NamespaceFlagUsageOption("The namespace of the serviceaccount. This flag only works when `--serviceaccount` is set.")).
+		WithStreams(streams).
+		WithResponsiveWriter().
+		Build()
+}

--- a/references/cli/up_test.go
+++ b/references/cli/up_test.go
@@ -129,7 +129,7 @@ spec:
 			}))
 
 			var buf bytes.Buffer
-			cmd := NewUpCommand(velacmd.NewDefaultFactory(args.GetClient), "", args, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+			cmd := NewUpCommand(velacmd.NewDefaultFactory(args.GetClient, args.GetConfig), "", args, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 			cmd.SetArgs([]string{})
 			cmd.SetOut(&buf)
 			cmd.SetErr(&buf)

--- a/test/e2e-multicluster-test/multicluster_auth_test.go
+++ b/test/e2e-multicluster-test/multicluster_auth_test.go
@@ -26,13 +26,13 @@ var _ = Describe("Test multicluster Auth commands", func() {
 	Context("Test vela auth commands", func() {
 
 		It("Test vela create kubeconfig for given user", func() {
-			outputs, err := execCommand("create", "kubeconfig", "--user", "kubevela", "--group", "kubevela:dev", "--group", "kubevela:test")
+			outputs, err := execCommand("auth", "gen-kubeconfig", "--user", "kubevela", "--group", "kubevela:dev", "--group", "kubevela:test")
 			Expect(err).Should(Succeed())
 			Expect(outputs).Should(ContainSubstring("Certificate signing request kubevela approved"))
 		})
 
 		It("Test vela create kubeconfig for serviceaccount", func() {
-			outputs, err := execCommand("create", "kubeconfig", "--serviceaccount", "default", "-n", "vela-system")
+			outputs, err := execCommand("auth", "gen-kubeconfig", "--serviceaccount", "default", "-n", "vela-system")
 			Expect(err).Should(Succeed())
 			Expect(outputs).Should(ContainSubstring("ServiceAccount vela-system/default found."))
 		})

--- a/test/e2e-multicluster-test/multicluster_auth_test.go
+++ b/test/e2e-multicluster-test/multicluster_auth_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_multicluster_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test multicluster Auth commands", func() {
+
+	Context("Test vela auth commands", func() {
+
+		It("Test vela create kubeconfig for given user", func() {
+			outputs, err := execCommand("create", "kubeconfig", "--user", "kubevela", "--group", "kubevela:dev", "--group", "kubevela:test")
+			Expect(err).Should(Succeed())
+			Expect(outputs).Should(ContainSubstring("Certificate signing request kubevela approved"))
+		})
+
+		It("Test vela create kubeconfig for serviceaccount", func() {
+			outputs, err := execCommand("create", "kubeconfig", "--serviceaccount", "default", "-n", "vela-system")
+			Expect(err).Should(Succeed())
+			Expect(outputs).Should(ContainSubstring("ServiceAccount vela-system/default found."))
+		})
+
+	})
+
+})

--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e_multicluster_test
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
 	"github.com/oam-dev/kubevela/references/cli"
 )
 
@@ -43,11 +43,11 @@ var (
 )
 
 func execCommand(args ...string) (string, error) {
-	command := cli.NewCommand()
+	ioStream, buf := util.NewTestIOStreams()
+	command := cli.NewCommandWithIOStreams(ioStream)
 	command.SetArgs(args)
-	var buf bytes.Buffer
-	command.SetOut(&buf)
-	command.SetErr(&buf)
+	command.SetOut(buf)
+	command.SetErr(buf)
 	err := command.Execute()
 	return buf.String(), err
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

`vela auth gen-kubeconfig` generate kubeconfig for users with given User/Groups or ServiceAccount.

For User/Groups, the command will generate a new private key, create a CertificateSigningRequest, approve itself and generate kubeconfig with the signed X.509 certificate.

For ServiceAccount, the command will find the serviceaccount secret and generate kubeconfig with the token inside the secret.

Example usage:

```                                                                                                                                                     
  # Generate a kubeconfig with provided user
  vela auth gen-kubeconfig --user new-user                                                                                                                    
                                                                                                                                                              
  # Generate a kubeconfig with provided user and group                                                                                                        
  vela auth gen-kubeconfig --user new-user --group kubevela:developer                                                                                         
   
  # Generate a kubeconfig with provided user and groups
  vela auth gen-kubeconfig --user new-user --group kubevela:developer --group my-org:my-team
                             
  # Generate a kubeconfig with provided serviceaccount
  vela auth gen-kubeconfig --serviceaccount default -n demo
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

Other commands that will be developed following this PR.
- `vela auth list-privileges --user <User> --group <Group> --serviceaccount <ServiceAccount> --namespace <Namespace> --cluster <Cluster>`