### PR TITLE
Feat: vela auth list-privileges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/tidwall/gjson v1.9.3
 	github.com/wercker/stern v0.0.0-20190705090245-4fa46dd6987f
 	github.com/wonderflow/cert-manager-api v1.0.3
+	github.com/xlab/treeprint v1.1.0
 	go.mongodb.org/mongo-driver v1.5.1
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
@@ -259,7 +260,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	github.com/zclconf/go-cty v1.8.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1911,8 +1911,9 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
-github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
+github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
+github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yeya24/promlinter v0.1.0/go.mod h1:rs5vtZzeBHqqMwXqFScncpCF6u06lezhZepno9AB1Oc=

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/utils/strings/slices"
+)
+
+// Identity the kubernetes identity
+type Identity struct {
+	User                    string
+	Groups                  []string
+	ServiceAccount          string
+	ServiceAccountNamespace string
+}
+
+// String .
+func (identity *Identity) String() string {
+	var tokens []string
+	if identity.User != "" {
+		tokens = append(tokens, "User="+identity.User)
+	}
+	if len(identity.Groups) > 0 {
+		tokens = append(tokens, "Groups="+strings.Join(identity.Groups, ","))
+	}
+	if identity.ServiceAccount != "" {
+		tokens = append(tokens, "SA="+serviceaccount.MakeUsername(identity.ServiceAccountNamespace, identity.ServiceAccount))
+	}
+	return strings.Join(tokens, " ")
+}
+
+// Match validate if identity matches rbac subject
+func (identity *Identity) Match(subject rbacv1.Subject) bool {
+	switch subject.Kind {
+	case rbacv1.UserKind:
+		return subject.Name == identity.User
+	case rbacv1.GroupKind:
+		return slices.Contains(identity.Groups, subject.Name)
+	case rbacv1.ServiceAccountKind:
+		return serviceaccount.MatchesUsername(subject.Namespace, subject.Name,
+			serviceaccount.MakeUsername(identity.ServiceAccountNamespace, identity.ServiceAccount))
+	default:
+		return false
+	}
+}
+
+// MatchAny validate if identity matches any one of the rbac subjects
+func (identity *Identity) MatchAny(subjects []rbacv1.Subject) bool {
+	for _, subject := range subjects {
+		if identity.Match(subject) {
+			return true
+		}
+	}
+	return false
+}
+
+// Regularize clean up input info
+func (identity *Identity) Regularize() {
+	identity.User = strings.TrimSpace(identity.User)
+	groupMap := map[string]struct{}{}
+	var groups []string
+	for _, group := range identity.Groups {
+		group = strings.TrimSpace(group)
+		if _, found := groupMap[group]; !found {
+			groupMap[group] = struct{}{}
+			groups = append(groups, group)
+		}
+	}
+	identity.Groups = groups
+	identity.ServiceAccount = strings.TrimSpace(identity.ServiceAccount)
+	if identity.ServiceAccount != "" {
+		if identity.ServiceAccountNamespace == "" {
+			identity.ServiceAccountNamespace = corev1.NamespaceDefault
+		}
+	}
+}
+
+// Validate check if identity is valid
+func (identity *Identity) Validate() error {
+	if identity.User == "" && identity.ServiceAccount == "" {
+		return fmt.Errorf("either `user` or `serviceaccount` should be set")
+	}
+	if identity.User != "" && identity.ServiceAccount != "" {
+		return fmt.Errorf("cannot set `user` and `serviceaccount` at the same time")
+	}
+	if len(identity.Groups) > 0 && identity.ServiceAccount != "" {
+		return fmt.Errorf("cannot set `group` and `serviceaccount` at the same time")
+	}
+	if identity.ServiceAccount == "" && identity.ServiceAccountNamespace != "" {
+		return fmt.Errorf("cannot set serviceaccount namespace when serviceaccount is not set")
+	}
+	return nil
+}

--- a/pkg/auth/privileges.go
+++ b/pkg/auth/privileges.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/gosuri/uitable/util/wordwrap"
+	"github.com/xlab/treeprint"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
+	"github.com/oam-dev/kubevela/pkg/utils/parallel"
+)
+
+// PrivilegeInfo describes one privilege in Kubernetes. Either one ClusterRole or
+// one Role is referenced. Related PolicyRules that describes the resource level
+// admissions are included. The RoleBindingRefs records where this RoleRef comes
+// from (from which ClusterRoleBinding or RoleBinding).
+type PrivilegeInfo struct {
+	Rules           []rbacv1.PolicyRule `json:"rules,omitempty"`
+	RoleRef         `json:"roleRef,omitempty"`
+	RoleBindingRefs []RoleBindingRef `json:"roleBindingRefs,omitempty"`
+}
+
+type authObjRef struct {
+	Kind      string `json:"kind,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// FullName the namespaced name string
+func (ref authObjRef) FullName() string {
+	if ref.Namespace == "" {
+		return ref.Name
+	}
+	return ref.Namespace + "/" + ref.Name
+}
+
+// RoleRef the references to ClusterRole or Role
+type RoleRef authObjRef
+
+// RoleBindingRef the reference to ClusterRoleBinding or RoleBinding
+type RoleBindingRef authObjRef
+
+// ListPrivileges retrieve privilege information in specified clusters
+func ListPrivileges(ctx context.Context, cli client.Client, clusters []string, identity *Identity) (map[string][]PrivilegeInfo, error) {
+	var m sync.Map
+	errs := parallel.Run(func(cluster string) error {
+		info, err := listPrivilegesInCluster(ctx, cli, cluster, identity)
+		if err != nil {
+			return err
+		}
+		m.Store(cluster, info)
+		return nil
+	}, clusters, parallel.DefaultParallelism)
+	if err := velaerrors.AggregateErrors(errs.([]error)); err != nil {
+		return nil, err
+	}
+	privilegesMap := make(map[string][]PrivilegeInfo)
+	m.Range(func(key, value interface{}) bool {
+		privilegesMap[key.(string)] = value.([]PrivilegeInfo)
+		return true
+	})
+	return privilegesMap, nil
+}
+
+func listPrivilegesInCluster(ctx context.Context, cli client.Client, cluster string, identity *Identity) ([]PrivilegeInfo, error) {
+	ctx = multicluster.ContextWithClusterName(ctx, cluster)
+	clusterRoleBindings := &rbacv1.ClusterRoleBindingList{}
+	roleBindings := &rbacv1.RoleBindingList{}
+	if err := cli.List(ctx, clusterRoleBindings); err != nil {
+		return nil, err
+	}
+	roleRefMap := make(map[RoleRef][]RoleBindingRef)
+	for _, clusterRoleBinding := range clusterRoleBindings.Items {
+		if identity.MatchAny(clusterRoleBinding.Subjects) {
+			roleRef := RoleRef{
+				Kind: clusterRoleBinding.RoleRef.Kind,
+				Name: clusterRoleBinding.RoleRef.Name,
+			}
+			roleRefMap[roleRef] = append(roleRefMap[roleRef], RoleBindingRef{
+				Kind: "ClusterRoleBinding",
+				Name: clusterRoleBinding.Name})
+		}
+	}
+	if err := cli.List(ctx, roleBindings); err != nil {
+		return nil, err
+	}
+	for _, roleBinding := range roleBindings.Items {
+		for i := range roleBinding.Subjects {
+			roleBinding.Subjects[i].Namespace = roleBinding.Namespace
+		}
+		if identity.MatchAny(roleBinding.Subjects) {
+			roleRef := RoleRef{
+				Kind: roleBinding.RoleRef.Kind,
+				Name: roleBinding.RoleRef.Name,
+			}
+			if roleRef.Kind == "Role" {
+				roleRef.Namespace = roleBinding.Namespace
+			}
+			roleRefMap[roleRef] = append(roleRefMap[roleRef], RoleBindingRef{
+				Kind:      "RoleBinding",
+				Name:      roleBinding.Name,
+				Namespace: roleBinding.Namespace})
+		}
+	}
+
+	var infos []PrivilegeInfo
+	for roleRef, roleBindingRefs := range roleRefMap {
+		infos = append(infos, PrivilegeInfo{RoleRef: roleRef, RoleBindingRefs: roleBindingRefs})
+	}
+	var m sync.Map
+	errs := parallel.Run(func(info PrivilegeInfo) error {
+		key := types.NamespacedName{Namespace: info.RoleRef.Namespace, Name: info.RoleRef.Name}
+		var rules []rbacv1.PolicyRule
+		if info.RoleRef.Kind == "Role" {
+			role := &rbacv1.Role{}
+			if err := cli.Get(ctx, key, role); err != nil {
+				return err
+			}
+			rules = role.Rules
+		} else {
+			clusterRole := &rbacv1.ClusterRole{}
+			if err := cli.Get(ctx, key, clusterRole); err != nil {
+				return err
+			}
+			rules = clusterRole.Rules
+		}
+		m.Store(authObjRef(info.RoleRef).FullName(), rules)
+		return nil
+	}, infos, parallel.DefaultParallelism)
+	if err := velaerrors.AggregateErrors(errs.([]error)); err != nil {
+		return nil, err
+	}
+	for i, info := range infos {
+		obj, ok := m.Load(authObjRef(info.RoleRef).FullName())
+		if ok {
+			infos[i].Rules = obj.([]rbacv1.PolicyRule)
+		}
+	}
+	return infos, nil
+}
+
+func printPolicyRule(rule rbacv1.PolicyRule, lim uint) string {
+	var rows []string
+	addRow := func(name string, values []string) {
+		values = slices.Filter(nil, values, func(s string) bool {
+			return len(s) > 0
+		})
+		if len(values) > 0 {
+			s := wordwrap.WrapString(strings.Join(values, ", "), lim)
+			for i, line := range strings.Split(s, "\n") {
+				prefix := []byte(name + " ")
+				if i > 0 {
+					for j := range prefix {
+						prefix[j] = ' '
+					}
+				}
+				rows = append(rows, string(prefix)+line)
+			}
+		}
+	}
+	addRow("APIGroups:      ", rule.APIGroups)
+	addRow("Resources:      ", rule.Resources)
+	addRow("ResourceNames:  ", rule.ResourceNames)
+	addRow("NonResourceURLs:", rule.NonResourceURLs)
+	addRow("Verb:           ", rule.Verbs)
+	return strings.Join(rows, "\n")
+}
+
+// PrettyPrintPrivileges print cluster privileges map in tree format
+func PrettyPrintPrivileges(identity *Identity, privilegesMap map[string][]PrivilegeInfo, clusters []string, lim uint) string {
+	tree := treeprint.New()
+	tree.SetValue(identity.String())
+	for _, cluster := range clusters {
+		privileges, exists := privilegesMap[cluster]
+		if !exists {
+			continue
+		}
+		root := tree.AddMetaBranch("Cluster", cluster)
+		for _, info := range privileges {
+			branch := root.AddMetaBranch(info.RoleRef.Kind, authObjRef(info.RoleRef).FullName())
+			bindingsBranch := branch.AddMetaBranch("Bindings", "")
+			for _, ref := range info.RoleBindingRefs {
+				bindingsBranch.AddMetaNode(ref.Kind, authObjRef(ref).FullName())
+			}
+			rulesBranch := branch.AddMetaBranch("PolicyRules", "")
+			for _, rule := range info.Rules {
+				rulesBranch.AddNode(printPolicyRule(rule, lim))
+			}
+		}
+		if len(privileges) == 0 {
+			root.AddNode("no privilege found")
+		}
+	}
+	return tree.String()
+}

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	prismclusterv1alpha1 "github.com/kubevela/prism/pkg/apis/cluster/v1alpha1"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
@@ -78,4 +80,19 @@ func GetApplicationsForCompletion(ctx context.Context, f Factory, namespace stri
 		options = append(options, client.InNamespace(namespace))
 	}
 	return listObjectNamesForCompletion(ctx, f, v1beta1.SchemeGroupVersion.WithKind(v1beta1.ApplicationKind), options, toComplete)
+}
+
+// GetClustersForCompletion auto-complete the cluster
+func GetClustersForCompletion(ctx context.Context, f Factory, toComplete string) ([]string, cobra.ShellCompDirective) {
+	clusters, err := prismclusterv1alpha1.NewClusterClient(f.Client()).List(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var candidates []string
+	for _, obj := range clusters.Items {
+		if name := obj.GetName(); strings.HasPrefix(name, toComplete) {
+			candidates = append(candidates, name)
+		}
+	}
+	return candidates, cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -17,10 +17,15 @@ limitations under the License.
 package cmd
 
 import (
+	"sync"
+
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cmdutil "github.com/oam-dev/kubevela/pkg/cmd/util"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
 
 // Factory client factory for running command
@@ -35,26 +40,62 @@ type ClientGetter func() (client.Client, error)
 // ConfigGetter function for getting config
 type ConfigGetter func() (*rest.Config, error)
 
-type defaultFactory struct {
+type delegateFactory struct {
 	ClientGetter
 	ConfigGetter
 }
 
 // Client return the client for command line use, interrupt if error encountered
-func (f *defaultFactory) Client() client.Client {
+func (f *delegateFactory) Client() client.Client {
 	cli, err := f.ClientGetter()
 	cmdutil.CheckErr(err)
 	return cli
 }
 
 // Config return the kubeConfig for command line use
-func (f *defaultFactory) Config() *rest.Config {
+func (f *delegateFactory) Config() *rest.Config {
 	cfg, err := f.ConfigGetter()
 	cmdutil.CheckErr(err)
 	return cfg
 }
 
+// NewDelegateFactory create a factory based on getter function
+func NewDelegateFactory(clientGetter ClientGetter, configGetter ConfigGetter) Factory {
+	return &delegateFactory{ClientGetter: clientGetter, ConfigGetter: configGetter}
+}
+
+var (
+	// DefaultRateLimiter default rate limiter for cmd client
+	DefaultRateLimiter = flowcontrol.NewTokenBucketRateLimiter(100, 200)
+)
+
+type defaultFactory struct {
+	sync.Mutex
+	cfg *rest.Config
+	cli client.Client
+}
+
+// Client return the client for command line use, interrupt if error encountered
+func (f *defaultFactory) Client() client.Client {
+	f.Lock()
+	defer f.Unlock()
+	if f.cli == nil {
+		var err error
+		f.cli, err = client.New(f.cfg, client.Options{Scheme: common.Scheme})
+		cmdutil.CheckErr(err)
+	}
+	return f.cli
+}
+
+// Config return the kubeConfig for command line use
+func (f *defaultFactory) Config() *rest.Config {
+	return f.cfg
+}
+
 // NewDefaultFactory create a factory based on client getter function
-func NewDefaultFactory(clientGetter ClientGetter, configGetter ConfigGetter) Factory {
-	return &defaultFactory{ClientGetter: clientGetter, ConfigGetter: configGetter}
+func NewDefaultFactory(cfg *rest.Config) Factory {
+	copiedCfg := *cfg
+	copiedCfg.RateLimiter = DefaultRateLimiter
+	copiedCfg.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
+	return &defaultFactory{cfg: &copiedCfg}
 }

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -109,7 +109,7 @@ func UpdateNamespace(ctx context.Context, kubeClient client.Client, name string,
 	return kubeClient.Update(ctx, &namespace)
 }
 
-// GetServiceAccountSubjectFromConfig extract ServiceAccount subject from token
+// GetServiceAccountSubjectFromConfig extract ServiceAccountName subject from token
 func GetServiceAccountSubjectFromConfig(cfg *rest.Config) string {
 	sub, _ := GetTokenSubject(cfg.BearerToken)
 	return sub

--- a/pkg/utils/parallel/parallel.go
+++ b/pkg/utils/parallel/parallel.go
@@ -20,6 +20,11 @@ import (
 	"reflect"
 )
 
+const (
+	// DefaultParallelism default parallelism
+	DefaultParallelism int = 5
+)
+
 // ParInput input for parallel execution
 type ParInput interface{}
 

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	velacmd "github.com/oam-dev/kubevela/pkg/cmd"
@@ -70,7 +71,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 	commandArgs := common.Args{
 		Schema: common.Scheme,
 	}
-	f := velacmd.NewDefaultFactory(commandArgs.GetClient, commandArgs.GetConfig)
+	f := velacmd.NewDefaultFactory(config.GetConfigOrDie())
 
 	if err := system.InitDirs(); err != nil {
 		fmt.Println("InitDir err", err)

--- a/references/cli/up_test.go
+++ b/references/cli/up_test.go
@@ -129,7 +129,7 @@ spec:
 			}))
 
 			var buf bytes.Buffer
-			cmd := NewUpCommand(velacmd.NewDefaultFactory(args.GetClient, args.GetConfig), "", args, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+			cmd := NewUpCommand(velacmd.NewDelegateFactory(args.GetClient, args.GetConfig), "", args, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 			cmd.SetArgs([]string{})
 			cmd.SetOut(&buf)
 			cmd.SetErr(&buf)

--- a/test/e2e-multicluster-test/multicluster_auth_test.go
+++ b/test/e2e-multicluster-test/multicluster_auth_test.go
@@ -37,6 +37,27 @@ var _ = Describe("Test multicluster Auth commands", func() {
 			Expect(outputs).Should(ContainSubstring("ServiceAccount vela-system/default found."))
 		})
 
+		It("Test vela list-privileges for user", func() {
+			outputs, err := execCommand("auth", "list-privileges", "--user", "example", "--group", "kubevela:dev-team", "--group", "kubevela:test-team")
+			Expect(err).Should(Succeed())
+			Expect(outputs).Should(ContainSubstring("local"))
+		})
+
+		It("Test vela list-privileges for ServiceAccount", func() {
+			outputs, err := execCommand("auth", "list-privileges", "--serviceaccount", "node-controller", "-n", "kube-system", "--cluster", "local", "--cluster", WorkerClusterName)
+			Expect(err).Should(Succeed())
+			Expect(outputs).Should(SatisfyAny(
+				ContainSubstring(WorkerClusterName),
+				ContainSubstring("nodes/status"),
+			))
+		})
+
+		It("Test vela list-privileges for kubeconfig", func() {
+			outputs, err := execCommand("auth", "list-privileges", "--kubeconfig", WorkerClusterKubeConfigPath, "--cluster", "local")
+			Expect(err).Should(Succeed())
+			Expect(outputs).Should(ContainSubstring("cluster-admin"))
+		})
+
 	})
 
 })


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support `vela auth list-privileges`. This command can show the privileges of given User/Group/ServiceAccount across multiple clusters.

Detail usage:
```
  # List privileges for User alice in the control plane
  vela auth list-privileges --user alice
  
  # List privileges for Group org:dev-team in the control plane
  vela auth list-privileges --group org:dev-team
  
  # List privileges for User bob with Groups org:dev-team and org:test-team in the control plane and managed cluster
example-cluster
  vela auth list-privileges --user bob --group org:dev-team --group org:test-team --cluster local --cluster
example-cluster
  
  # List privileges for ServiceAccount example-sa in demo namespace in multiple managed clusters
  vela auth list-privileges --serviceaccount example-sa -n demo --cluster cluster-1 --cluster cluster-2
  
  # List privileges for identity in kubeconfig
  vela auth list-privileges --kubeconfig ./example.kubeconfig --cluster local --cluster cluster-1
```

Example:
```
$ vela auth list-privileges --user somefive --cluster velad-002 --cluster velad-003                                                
User=somefive                                                                  
├── [Cluster]  velad-002                                                                                                                                      
│   ├── [ClusterRole]  cluster-admin                                           
│   │   ├── [Bindings]                                                                                                                                        
│   │   │   └── [ClusterRoleBinding]  somefive:root-cluster-admin-binding                                                                                     
│   │   └── [PolicyRules]                                                                                                                                     
│   │       ├── APIGroups:       *                                                                                                                            
│   │       │   Resources:       *                                             
│   │       │   Verb:            *                                             
│   │       └── NonResourceURLs: *                                             
│   │           Verb:            *                                             
│   └── [ClusterRole]  view                                                    
│       ├── [Bindings]                                                         
│       │   └── [ClusterRoleBinding]  somefive:view                            
│       └── [PolicyRules]                                                      
│           ├── Resources:       configmaps, endpoints, persistentvolumeclaims, persistentvolumeclaims/status, pods, replicationcontrollers,
│           │                    replicationcontrollers/scale, serviceaccounts, services, services/status
│           │   Verb:            get, list, watch
│           ├── Resources:       bindings, events, limitranges, namespaces/status, pods/log, pods/status, replicationcontrollers/status,
│           │                    resourcequotas, resourcequotas/status                                                                                        
│           │   Verb:            get, list, watch
│           ├── Resources:       namespaces                                                                                                                   
│           │   Verb:            get, list, watch                                                                                                             
│           ├── APIGroups:       apps                                          
│           │   Resources:       controllerrevisions, daemonsets, daemonsets/status, deployments, deployments/scale, deployments/status, replicasets,
│           │                    replicasets/scale, replicasets/status, statefulsets, statefulsets/scale, statefulsets/status
│           │   Verb:            get, list, watch                              
│           ├── APIGroups:       autoscaling      
│           │   Resources:       horizontalpodautoscalers, horizontalpodautoscalers/status
│           │   Verb:            get, list, watch                              
│           ├── APIGroups:       batch                                                                                                                        
│           │   Resources:       cronjobs, cronjobs/status, jobs, jobs/status
│           │   Verb:            get, list, watch                              
│           ├── APIGroups:       extensions                                    
│           │   Resources:       daemonsets, daemonsets/status, deployments, deployments/scale, deployments/status, ingresses, ingresses/status,
│           │                    networkpolicies, replicasets, replicasets/scale, replicasets/status, replicationcontrollers/scale
│           │   Verb:            get, list, watch                              
│           ├── APIGroups:       policy                                        
│           │   Resources:       poddisruptionbudgets, poddisruptionbudgets/status
│           │   Verb:            get, list, watch                                                                                                             
│           ├── APIGroups:       networking.k8s.io                                                                                                                                                                                                                                                                          
│           │   Resources:       ingresses, ingresses/status, networkpolicies                                                                                                                                                                                                                                               
│           │   Verb:            get, list, watch                                                                                                             
│           └── APIGroups:       metrics.k8s.io      
│               Resources:       pods, nodes                                   
│               Verb:            get, list, watch                                                                                                             
└── [Cluster]  velad-003                                                       
    ├── [ClusterRole]  cluster-admin                                           
    │   ├── [Bindings]                                                         
    │   │   └── [ClusterRoleBinding]  somefive:root-cluster-admin-binding
    │   └── [PolicyRules]                                                      
    │       ├── APIGroups:       *                                             
    │       │   Resources:       *                                             
    │       │   Verb:            *                                             
    │       └── NonResourceURLs: *                                             
    │           Verb:            *                                             
    └── [Role]  demo/deployment-reader                                         
        ├── [Bindings]                                                         
        │   └── [RoleBinding]  demo/somefive:deployment-reader
        └── [PolicyRules]                                                      
            └── APIGroups:       apps                                          
                Resources:       deployments
                Verb:            get, list, watch
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

The `ListPrivileges` function in pkg/auth/privileges.go can be reused in velaux apiserver as well.  

The `ListPrivileges` function needs to make multiple requests across clusters. The implementation parallelizes most of the requests to speed up.  