### PR TITLE
Fix: remove last-applied-config annotation for configmap and secret

### DIFF
--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -117,7 +117,7 @@ const (
 	AnnotationAppGeneration = "app.oam.dev/generation"
 
 	// AnnotationLastAppliedConfig records the previous configuration of a
-	// resource for use in a three way diff during a patching apply
+	// resource for use in a three-way diff during a patching apply
 	AnnotationLastAppliedConfig = "app.oam.dev/last-applied-configuration"
 
 	// AnnotationLastAppliedTime indicates the last applied time


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

This PR remove the last-applied-config annotation for configmap and secret, and allow users to disable it by fill `-` or `skip` into this annotation `app.oam.dev/last-applied-configuration`.

You can disable it by adding a annotation triat, or manuelly add this annotation on it.

```
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app
spec:
  components:
    - name: express-server
      type: webservice
      properties:
        image: oamdev/hello-world
        ports:
         - port: 8000
           expose: true
      traits:
        - type: annotations
          properties:
            app.oam.dev/last-applied-configuration: skip
```

Then the deployment won't have the `app.oam.dev/last-applied-configuration` filled:

![image](https://user-images.githubusercontent.com/2173670/169455237-02edc9cd-90f0-4718-ba7d-aafea899a0f6.png)


Fixes #3938

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->