### PR TITLE
Feat: add if in workflow

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -401,8 +401,6 @@ const (
 	WorkflowStepPhaseSucceeded WorkflowStepPhase = "succeeded"
 	// WorkflowStepPhaseFailed will report error in `message`.
 	WorkflowStepPhaseFailed WorkflowStepPhase = "failed"
-	// WorkflowStepPhaseFailedAfterRetries will report error in `message` and stop retrying the step.
-	WorkflowStepPhaseFailedAfterRetries WorkflowStepPhase = "failedAfterRetries"
 	// WorkflowStepPhaseSkipped will make the controller skip the step.
 	WorkflowStepPhaseSkipped WorkflowStepPhase = "skipped"
 	// WorkflowStepPhaseStopped will make the controller stop the workflow.

--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -366,6 +366,8 @@ type WorkflowSubStep struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Properties *runtime.RawExtension `json:"properties,omitempty"`
 
+	If string `json:"if,omitempty"`
+
 	DependsOn []string `json:"dependsOn,omitempty"`
 
 	Inputs StepInputs `json:"inputs,omitempty"`

--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -347,6 +347,8 @@ type WorkflowStep struct {
 
 	SubSteps []WorkflowSubStep `json:"subSteps,omitempty"`
 
+	If string `json:"if,omitempty"`
+
 	DependsOn []string `json:"dependsOn,omitempty"`
 
 	Inputs StepInputs `json:"inputs,omitempty"`
@@ -397,6 +399,10 @@ const (
 	WorkflowStepPhaseSucceeded WorkflowStepPhase = "succeeded"
 	// WorkflowStepPhaseFailed will report error in `message`.
 	WorkflowStepPhaseFailed WorkflowStepPhase = "failed"
+	// WorkflowStepPhaseFailedAfterRetries will report error in `message` and stop retrying the step.
+	WorkflowStepPhaseFailedAfterRetries WorkflowStepPhase = "failedAfterRetries"
+	// WorkflowStepPhaseSkipped will make the controller skip the step.
+	WorkflowStepPhaseSkipped WorkflowStepPhase = "skipped"
 	// WorkflowStepPhaseStopped will make the controller stop the workflow.
 	WorkflowStepPhaseStopped WorkflowStepPhase = "stopped"
 	// WorkflowStepPhaseRunning will make the controller continue the workflow.

--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -53,11 +53,12 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 ### KubeVela workflow parameters
 
-| Name                                   | Description                                            | Value |
-| -------------------------------------- | ------------------------------------------------------ | ----- |
-| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`  |
-| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300` |
-| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`  |
+| Name                                   | Description                                            | Value   |
+| -------------------------------------- | ------------------------------------------------------ | ------- |
+| `workflow.enableSuspendFailedWorkflow` | Enable suspend failed workflow                         | `false` |
+| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`    |
+| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300`   |
+| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`    |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -55,7 +55,7 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 | Name                                   | Description                                            | Value   |
 | -------------------------------------- | ------------------------------------------------------ | ------- |
-| `workflow.enableSuspendFailedWorkflow` | Enable suspend failed workflow                         | `false` |
+| `workflow.enableSuspendOnFailure`      | Enable suspend on workflow failure                     | `false` |
 | `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`    |
 | `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300`   |
 | `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`    |

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -2209,6 +2209,8 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                if:
+                                  type: string
                                 inputs:
                                   description: StepInputs defines variable input of
                                     WorkflowStep
@@ -3954,6 +3956,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -2255,6 +2255,8 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      if:
+                                        type: string
                                       inputs:
                                         description: StepInputs defines variable input
                                           of WorkflowStep
@@ -3999,6 +4001,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -1020,6 +1020,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -1063,6 +1063,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/charts/vela-core/crds/core.oam.dev_workflows.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workflows.yaml
@@ -42,6 +42,8 @@ spec:
                   items:
                     type: string
                   type: array
+                if:
+                  type: string
                 inputs:
                   description: StepInputs defines variable input of WorkflowStep
                   items:
@@ -147,6 +149,8 @@ spec:
                   items:
                     type: string
                   type: array
+                if:
+                  type: string
                 inputs:
                   description: StepInputs defines variable input of WorkflowStep
                   items:

--- a/charts/vela-core/crds/core.oam.dev_workflows.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workflows.yaml
@@ -85,6 +85,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      if:
+                        type: string
                       inputs:
                         description: StepInputs defines variable input of WorkflowStep
                         items:
@@ -192,6 +194,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      if:
+                        type: string
                       inputs:
                         description: StepInputs defines variable input of WorkflowStep
                         items:

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -169,6 +169,7 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.burst }}"
+            - "--enable-suspend-failed-workflow={{ .Values.workflow.enableSuspendFailedWorkflow }}"
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -172,7 +172,7 @@ spec:
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
-            - "--feature-gates=EnableSuspendFailedWorkflow={{- .Values.workflow.enableSuspendFailedWorkflow | toString -}}"
+            - "--feature-gates=EnableSuspendOnFailure={{- .Values.workflow.enableSuspendOnFailure | toString -}}"
             - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -169,10 +169,10 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.burst }}"
-            - "--enable-suspend-failed-workflow={{ .Values.workflow.enableSuspendFailedWorkflow }}"
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
+            - "--feature-gates=EnableSuspendFailedWorkflow={{- .Values.workflow.enableSuspendFailedWorkflow | toString -}}"
             - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -35,12 +35,12 @@ dependCheckWait: 30s
 
 ## @section KubeVela workflow parameters
 
-## @param workflow.enableSuspendFailedWorkflow Enable suspend failed workflow
+## @param workflow.enableSuspendOnFailure Enable suspend on workflow failure
 ## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
 ## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
 ## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
 workflow:
-  enableSuspendFailedWorkflow: false
+  enableSuspendOnFailure: false
   backoff:
     maxTime:
       waitState: 60

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -35,10 +35,12 @@ dependCheckWait: 30s
 
 ## @section KubeVela workflow parameters
 
+## @param workflow.enableSuspendFailedWorkflow Enable suspend failed workflow
 ## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
 ## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
 ## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
 workflow:
+  enableSuspendFailedWorkflow: false
   backoff:
     maxTime:
       waitState: 60

--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -74,7 +74,7 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 
 | Name                                   | Description                                            | Value   |
 | -------------------------------------- | ------------------------------------------------------ | ------- |
-| `workflow.enableSuspendFailedWorkflow` | Enable suspend failed workflow                         | `false` |
+| `workflow.enableSuspendOnFailure`      | Enable suspend on workflow failure                     | `false` |
 | `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`    |
 | `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300`   |
 | `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`    |

--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -72,11 +72,12 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 
 ### KubeVela workflow parameters
 
-| Name                                   | Description                                            | Value |
-| -------------------------------------- | ------------------------------------------------------ | ----- |
-| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`  |
-| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300` |
-| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`  |
+| Name                                   | Description                                            | Value   |
+| -------------------------------------- | ------------------------------------------------------ | ------- |
+| `workflow.enableSuspendFailedWorkflow` | Enable suspend failed workflow                         | `false` |
+| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`    |
+| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300`   |
+| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`    |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -2209,6 +2209,8 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                if:
+                                  type: string
                                 inputs:
                                   description: StepInputs defines variable input of
                                     WorkflowStep
@@ -3954,6 +3956,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -2255,6 +2255,8 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      if:
+                                        type: string
                                       inputs:
                                         description: StepInputs defines variable input
                                           of WorkflowStep
@@ -3999,6 +4001,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -1020,6 +1020,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -1063,6 +1063,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -142,7 +142,7 @@ spec:
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
-            - "--feature-gates=EnableSuspendFailedWorkflow={{- .Values.workflow.enableSuspendFailedWorkflow | toString -}}"
+            - "--feature-gates=EnableSuspendOnFailure={{- .Values.workflow.enableSuspendOnFailure | toString -}}"
             - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -139,10 +139,10 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.burst }}"
-            - "--enable-suspend-failed-workflow={{ .Values.workflow.enableSuspendFailedWorkflow }}"
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
+            - "--feature-gates=EnableSuspendFailedWorkflow={{- .Values.workflow.enableSuspendFailedWorkflow | toString -}}"
             - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -139,6 +139,7 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.burst }}"
+            - "--enable-suspend-failed-workflow={{ .Values.workflow.enableSuspendFailedWorkflow }}"
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -38,12 +38,12 @@ dependCheckWait: 30s
 
 ## @section KubeVela workflow parameters
 
-## @param workflow.enableSuspendFailedWorkflow Enable suspend failed workflow
+## @param workflow.enableSuspendOnFailure Enable suspend on workflow failure
 ## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
 ## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
 ## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
 workflow:
-  enableSuspendFailedWorkflow: false
+  enableSuspendOnFailure: false
   backoff:
     maxTime:
       waitState: 60

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -38,10 +38,12 @@ dependCheckWait: 30s
 
 ## @section KubeVela workflow parameters
 
+## @param workflow.enableSuspendFailedWorkflow Enable suspend failed workflow
 ## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
 ## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
 ## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
 workflow:
+  enableSuspendFailedWorkflow: false
   backoff:
     maxTime:
       waitState: 60

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -144,6 +144,7 @@ func main() {
 	flag.IntVar(&workflow.MaxWorkflowWaitBackoffTime, "max-workflow-wait-backoff-time", 60, "Set the max workflow wait backoff time, default is 60")
 	flag.IntVar(&workflow.MaxWorkflowFailedBackoffTime, "max-workflow-failed-backoff-time", 300, "Set the max workflow wait backoff time, default is 300")
 	flag.IntVar(&custom.MaxWorkflowStepErrorRetryTimes, "max-workflow-step-error-retry-times", 10, "Set the max workflow step error retry times, default is 10")
+	flag.BoolVar(&custom.EnableSuspendFailedWorkflow, "enable-suspend-failed-workflow", false, "Enable suspend failed workflow, defaults to false, if set to true, the if capability in workflow is disabled")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(flag.CommandLine)
 
 	flag.Parse()

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -144,7 +144,6 @@ func main() {
 	flag.IntVar(&workflow.MaxWorkflowWaitBackoffTime, "max-workflow-wait-backoff-time", 60, "Set the max workflow wait backoff time, default is 60")
 	flag.IntVar(&workflow.MaxWorkflowFailedBackoffTime, "max-workflow-failed-backoff-time", 300, "Set the max workflow wait backoff time, default is 300")
 	flag.IntVar(&custom.MaxWorkflowStepErrorRetryTimes, "max-workflow-step-error-retry-times", 10, "Set the max workflow step error retry times, default is 10")
-	flag.BoolVar(&custom.EnableSuspendFailedWorkflow, "enable-suspend-failed-workflow", false, "Enable suspend failed workflow, defaults to false, if set to true, the if capability in workflow is disabled")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(flag.CommandLine)
 
 	flag.Parse()

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -2209,6 +2209,8 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                if:
+                                  type: string
                                 inputs:
                                   description: StepInputs defines variable input of
                                     WorkflowStep
@@ -3954,6 +3956,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -2255,6 +2255,8 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      if:
+                                        type: string
                                       inputs:
                                         description: StepInputs defines variable input
                                           of WorkflowStep
@@ -3999,6 +4001,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -1064,6 +1064,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              if:
+                                type: string
                               inputs:
                                 description: StepInputs defines variable input of
                                   WorkflowStep

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -1021,6 +1021,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        if:
+                          type: string
                         inputs:
                           description: StepInputs defines variable input of WorkflowStep
                           items:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
@@ -42,6 +42,8 @@ spec:
                   items:
                     type: string
                   type: array
+                if:
+                  type: string
                 inputs:
                   description: StepInputs defines variable input of WorkflowStep
                   items:
@@ -147,6 +149,8 @@ spec:
                   items:
                     type: string
                   type: array
+                if:
+                  type: string
                 inputs:
                   description: StepInputs defines variable input of WorkflowStep
                   items:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
@@ -85,6 +85,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      if:
+                        type: string
                       inputs:
                         description: StepInputs defines variable input of WorkflowStep
                         items:
@@ -192,6 +194,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      if:
+                        type: string
                       inputs:
                         description: StepInputs defines variable input of WorkflowStep
                         items:

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -578,7 +578,7 @@ func (w *workflowServiceImpl) TerminateRecord(ctx context.Context, appModel *mod
 		return err
 	}
 
-	if err := TerminateWorkflow(w.KubeClient, oamApp); err != nil {
+	if err := TerminateWorkflow(ctx, w.KubeClient, oamApp); err != nil {
 		return err
 	}
 	if err := w.syncWorkflowStatus(ctx, oamApp, recordName, oamApp.Name); err != nil {
@@ -589,7 +589,7 @@ func (w *workflowServiceImpl) TerminateRecord(ctx context.Context, appModel *mod
 }
 
 // TerminateWorkflow terminate workflow
-func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
+func TerminateWorkflow(ctx context.Context, kubecli client.Client, app *v1beta1.Application) error {
 	// set the workflow terminated to true
 	app.Status.Workflow.Terminated = true
 	steps := app.Status.Workflow.Steps
@@ -618,7 +618,7 @@ func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 		}
 	}
 
-	if err := kubecli.Status().Patch(context.TODO(), app, client.Merge); err != nil {
+	if err := kubecli.Status().Patch(ctx, app, client.Merge); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -43,6 +43,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	utils2 "github.com/oam-dev/kubevela/pkg/utils"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
+	"github.com/oam-dev/kubevela/references/cli"
 )
 
 // WorkflowService workflow manage api
@@ -577,8 +578,7 @@ func (w *workflowServiceImpl) TerminateRecord(ctx context.Context, appModel *mod
 		return err
 	}
 
-	oamApp.Status.Workflow.Terminated = true
-	if err := w.KubeClient.Status().Patch(ctx, oamApp, client.Merge); err != nil {
+	if err := cli.TerminateWorkflow(w.KubeClient, oamApp); err != nil {
 		return err
 	}
 	if err := w.syncWorkflowStatus(ctx, oamApp, recordName, oamApp.Name); err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -241,9 +241,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err := r.doWorkflowFinish(app, wf); err != nil {
 			return r.endWithNegativeCondition(ctx, app, condition.ErrorCondition(common.WorkflowCondition.String(), errors.WithMessage(err, "DoWorkflowFinish")), common.ApplicationRunningWorkflow)
 		}
-		if !workflow.IsFailedAfterRetry(app) {
-			r.stateKeep(logCtx, handler, app)
-		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowTerminated, false, true)
 	case common.WorkflowStateExecuting:
 		logCtx.Info("Workflow return state=Executing")

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -29,6 +29,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,7 @@ import (
 	common2 "github.com/oam-dev/kubevela/pkg/controller/common"
 	core "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
+	"github.com/oam-dev/kubevela/pkg/features"
 	monitorContext "github.com/oam-dev/kubevela/pkg/monitor/context"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -56,7 +58,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/resourcetracker"
 	"github.com/oam-dev/kubevela/pkg/workflow"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
-	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 	"github.com/oam-dev/kubevela/version"
 )
 
@@ -230,7 +231,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			handler.app.Status.Workflow.SuspendState = ""
 			return r.gcResourceTrackers(logCtx, handler, common.ApplicationRunningWorkflow, false, false)
 		}
-		if !workflow.IsFailedAfterRetry(app) || !custom.EnableSuspendFailedWorkflow {
+		if !workflow.IsFailedAfterRetry(app) || !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
 			r.stateKeep(logCtx, handler, app)
 		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowSuspending, false, true)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -231,7 +231,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			handler.app.Status.Workflow.SuspendState = ""
 			return r.gcResourceTrackers(logCtx, handler, common.ApplicationRunningWorkflow, false, false)
 		}
-		if !workflow.IsFailedAfterRetry(app) || !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+		if !workflow.IsFailedAfterRetry(app) || !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 			r.stateKeep(logCtx, handler, app)
 		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowSuspending, false, true)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/resourcetracker"
 	"github.com/oam-dev/kubevela/pkg/workflow"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
+	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 	"github.com/oam-dev/kubevela/version"
 )
 
@@ -228,6 +229,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			handler.app.Status.Workflow.Suspend = false
 			handler.app.Status.Workflow.SuspendState = ""
 			return r.gcResourceTrackers(logCtx, handler, common.ApplicationRunningWorkflow, false, false)
+		}
+		if !workflow.IsFailedAfterRetry(app) || !custom.EnableSuspendFailedWorkflow {
+			r.stateKeep(logCtx, handler, app)
 		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowSuspending, false, true)
 	case common.WorkflowStateTerminated:

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -229,15 +229,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			handler.app.Status.Workflow.SuspendState = ""
 			return r.gcResourceTrackers(logCtx, handler, common.ApplicationRunningWorkflow, false, false)
 		}
-		if !workflow.IsFailedAfterRetry(app) {
-			r.stateKeep(logCtx, handler, app)
-		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowSuspending, false, true)
 	case common.WorkflowStateTerminated:
 		logCtx.Info("Workflow return state=Terminated")
 		handler.UpdateApplicationRevisionStatus(logCtx, handler.latestAppRev, false, app.Status.Workflow)
 		if err := r.doWorkflowFinish(app, wf); err != nil {
 			return r.endWithNegativeCondition(ctx, app, condition.ErrorCondition(common.WorkflowCondition.String(), errors.WithMessage(err, "DoWorkflowFinish")), common.ApplicationRunningWorkflow)
+		}
+		if !workflow.IsFailedAfterRetry(app) {
+			r.stateKeep(logCtx, handler, app)
 		}
 		return r.gcResourceTrackers(logCtx, handler, common.ApplicationWorkflowTerminated, false, true)
 	case common.WorkflowStateExecuting:

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1864,6 +1864,7 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with dag workflow failed after retries", func() {
+		custom.EnableSuspendFailedWorkflow = true
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dag-failed-after-retries",
@@ -1906,7 +1907,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageInitializingWorkflow))
 
-		By("verify the first twenty reconciles")
+		By("verify the first ten reconciles")
 		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes; i++ {
 			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 			Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
@@ -1916,12 +1917,11 @@ var _ = Describe("Test Application Controller", func() {
 		}
 
 		By("application should be suspended after failed max reconciles")
-		custom.EnableSuspendFailedWorkflow = true
 		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
 
 		By("resume the suspended application")
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
@@ -1953,7 +1953,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
 
-		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes+1; i++ {
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes-1; i++ {
 			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 			Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 			Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
@@ -1961,9 +1961,17 @@ var _ = Describe("Test Application Controller", func() {
 			Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
 			Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 		}
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
+		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(string(common.WorkflowStateExecuting)))
+		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
 	})
 
 	It("application with step by step workflow failed after retries", func() {
+		custom.EnableSuspendFailedWorkflow = true
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "step-by-step-failed-after-retries",
@@ -2034,7 +2042,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
 
 		By("resume the suspended application")
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
@@ -2101,7 +2109,7 @@ var _ = Describe("Test Application Controller", func() {
 								{
 									Name:       "myweb2-sub1",
 									Type:       "apply-component",
-									DependsOn:  []string{"myweb3"},
+									DependsOn:  []string{"myweb2-sub2"},
 									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
 								},
 								{
@@ -2158,6 +2166,241 @@ var _ = Describe("Test Application Controller", func() {
 		checkApp = &v1beta1.Application{}
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
+	})
+
+	It("application with if always in workflow", func() {
+		custom.EnableSuspendFailedWorkflow = false
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-if-always-workflow",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-if-always-workflow"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-if-always-workflow",
+				Namespace: "app-with-if-always-workflow",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+					{
+						Name:       "failed-step",
+						Type:       "k8s-objects",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"objects":[{"apiVersion":"v1","kind":"invalid","metadata":{"name":"test1"}}]}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name:       "failed-step",
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"failed-step"}`)},
+						},
+						{
+							Name:       "myweb1",
+							Type:       "apply-component",
+							If:         "always",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name:       "myweb2",
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("verify the first ten reconciles")
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes; i++ {
+			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		}
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(util.NotFoundMatcher{})
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowTerminated))
+	})
+
+	It("application with if always in workflow sub steps", func() {
+		custom.EnableSuspendFailedWorkflow = false
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-if-always-workflow-sub-steps",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-if-always-workflow-sub-steps"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-if-always-workflow-sub-steps",
+				Namespace: "app-with-if-always-workflow-sub-steps",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb3",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+					{
+						Name:       "failed-step",
+						Type:       "k8s-objects",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"objects":[{"apiVersion":"v1","kind":"invalid","metadata":{"name":"test1"}}]}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name: "myweb1",
+							Type: "step-group",
+							SubSteps: []common.WorkflowSubStep{
+								{
+									Name:       "myweb1-sub1",
+									Type:       "apply-component",
+									If:         "always",
+									DependsOn:  []string{"myweb1-sub2"},
+									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+								},
+								{
+									Name:       "myweb1-sub2",
+									Type:       "apply-component",
+									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"failed-step"}`)},
+								},
+								{
+									Name:       "myweb1-sub3",
+									Type:       "apply-component",
+									DependsOn:  []string{"myweb1-sub1"},
+									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+								},
+							},
+						},
+						{
+							Name:       "myweb2",
+							Type:       "apply-component",
+							If:         "always",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+						{
+							Name:       "myweb3",
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb3"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("verify the first ten reconciles")
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes; i++ {
+			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		}
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(util.NotFoundMatcher{})
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+		web3Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb3"}
+		Expect(k8sClient.Get(ctx, web3Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+		Expect(k8sClient.Get(ctx, web3Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(BeNil())
+		Expect(k8sClient.Get(ctx, web3Key, expDeployment)).Should(util.NotFoundMatcher{})
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowTerminated))
 	})
 
 	It("application with input/output run as dag workflow", func() {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -23,8 +23,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 	"time"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
@@ -50,6 +53,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	stdv1alpha1 "github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
 	velatypes "github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -1864,7 +1868,7 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with dag workflow failed after retries", func() {
-		custom.EnableSuspendFailedWorkflow = true
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dag-failed-after-retries",
@@ -1973,7 +1977,7 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with step by step workflow failed after retries", func() {
-		custom.EnableSuspendFailedWorkflow = true
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "step-by-step-failed-after-retries",
@@ -2172,7 +2176,6 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with if always in workflow", func() {
-		custom.EnableSuspendFailedWorkflow = false
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "app-with-if-always-workflow",
@@ -2272,7 +2275,6 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with if always in workflow sub steps", func() {
-		custom.EnableSuspendFailedWorkflow = false
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "app-with-if-always-workflow-sub-steps",

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -2047,6 +2047,119 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 	})
 
+	It("application with sub steps", func() {
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-sub-steps",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-sub-steps"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-sub-steps",
+				Namespace: "app-with-sub-steps",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+					{
+						Name:       "myweb3",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name:       "myweb1",
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name: "myweb2",
+							Type: "step-group",
+							SubSteps: []common.WorkflowSubStep{
+								{
+									Name:       "myweb2-sub1",
+									Type:       "apply-component",
+									DependsOn:  []string{"myweb3"},
+									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+								},
+								{
+									Name:       "myweb2-sub2",
+									Type:       "apply-component",
+									Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb3"}`)},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnceAfterFinalizer(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		expDeployment := &v1.Deployment{}
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+		web3Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb3"}
+		Expect(k8sClient.Get(ctx, web3Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+		Expect(k8sClient.Get(ctx, web3Key, expDeployment)).Should(BeNil())
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(BeNil())
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		checkApp = &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
+	})
+
 	It("application with input/output run as dag workflow", func() {
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1915,11 +1915,12 @@ var _ = Describe("Test Application Controller", func() {
 			Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 		}
 
-		By("application should be suspended after failed twenty reconciles")
+		By("application should be suspended after failed max reconciles")
+		custom.EnableSuspendFailedWorkflow = true
 		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
-		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageFailedAfterRetries))
+		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
 		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 
 		By("resume the suspended application")
@@ -2028,11 +2029,11 @@ var _ = Describe("Test Application Controller", func() {
 			Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 		}
 
-		By("application should be suspended after failed twenty reconciles")
+		By("application should be suspended after failed max reconciles")
 		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
-		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageFailedAfterRetries))
+		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
 		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
 
 		By("resume the suspended application")

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1921,7 +1921,8 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
+		Expect(checkApp.Status.Workflow.Steps[1].Reason).Should(BeEquivalentTo(custom.StatusReasonFailedAfterRetries))
 
 		By("resume the suspended application")
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
@@ -1967,7 +1968,8 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(string(common.WorkflowStateExecuting)))
 		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
+		Expect(checkApp.Status.Workflow.Steps[1].Reason).Should(BeEquivalentTo(custom.StatusReasonFailedAfterRetries))
 	})
 
 	It("application with step by step workflow failed after retries", func() {
@@ -2042,7 +2044,8 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageSuspendFailedAfterRetries))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailedAfterRetries))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseFailed))
+		Expect(checkApp.Status.Workflow.Steps[1].Reason).Should(BeEquivalentTo(custom.StatusReasonFailedAfterRetries))
 
 		By("resume the suspended application")
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1868,7 +1868,7 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with dag workflow failed after retries", func() {
-		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendOnFailure, true)()
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dag-failed-after-retries",
@@ -1977,7 +1977,7 @@ var _ = Describe("Test Application Controller", func() {
 	})
 
 	It("application with step by step workflow failed after retries", func() {
-		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendOnFailure, true)()
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "step-by-step-failed-after-retries",

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -122,6 +122,7 @@ func generateStep(ctx context.Context,
 				DependsOn:  subStep.DependsOn,
 				Inputs:     subStep.Inputs,
 				Outputs:    subStep.Outputs,
+				If:         subStep.If,
 			}
 			subTask, err := generateStep(ctx, app, workflowStep, taskDiscover, step.Name)
 			if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Test Workflow", func() {
 		Expect(appObj.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
 	})
 
-	It("test workflow terminate a suspend workflow", func() {
+	FIt("test workflow terminate a suspend workflow", func() {
 		suspendApp := appWithWorkflow.DeepCopy()
 		suspendApp.Name = "test-terminate-suspend-app"
 		suspendApp.Spec.Workflow.Steps = []oamcore.WorkflowStep{

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Test Workflow", func() {
 		Expect(appObj.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
 	})
 
-	FIt("test workflow terminate a suspend workflow", func() {
+	It("test workflow terminate a suspend workflow", func() {
 		suspendApp := appWithWorkflow.DeepCopy()
 		suspendApp.Name = "test-terminate-suspend-app"
 		suspendApp.Spec.Workflow.Steps = []oamcore.WorkflowStep{

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -33,8 +33,8 @@ const (
 	DeprecatedObjectLabelSelector featuregate.Feature = "DeprecatedObjectLabelSelector"
 	// LegacyResourceTrackerGC enable the gc of legacy resource tracker in managed clusters
 	LegacyResourceTrackerGC featuregate.Feature = "LegacyResourceTrackerGC"
-	// EnableSuspendFailedWorkflow enable suspend failed workflow
-	EnableSuspendFailedWorkflow featuregate.Feature = "EnableSuspendFailedWorkflow"
+	// EnableSuspendOnFailure enable suspend on workflow failure
+	EnableSuspendOnFailure featuregate.Feature = "EnableSuspendOnFailure"
 
 	// Edge Features
 
@@ -47,7 +47,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LegacyObjectTypeIdentifier:    {Default: false, PreRelease: featuregate.Alpha},
 	DeprecatedObjectLabelSelector: {Default: false, PreRelease: featuregate.Alpha},
 	LegacyResourceTrackerGC:       {Default: true, PreRelease: featuregate.Alpha},
-	EnableSuspendFailedWorkflow:   {Default: false, PreRelease: featuregate.Alpha},
+	EnableSuspendOnFailure:        {Default: false, PreRelease: featuregate.Alpha},
 	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -33,6 +33,8 @@ const (
 	DeprecatedObjectLabelSelector featuregate.Feature = "DeprecatedObjectLabelSelector"
 	// LegacyResourceTrackerGC enable the gc of legacy resource tracker in managed clusters
 	LegacyResourceTrackerGC featuregate.Feature = "LegacyResourceTrackerGC"
+	// EnableSuspendFailedWorkflow enable suspend failed workflow
+	EnableSuspendFailedWorkflow featuregate.Feature = "EnableSuspendFailedWorkflow"
 
 	// Edge Features
 
@@ -45,6 +47,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LegacyObjectTypeIdentifier:    {Default: false, PreRelease: featuregate.Alpha},
 	DeprecatedObjectLabelSelector: {Default: false, PreRelease: featuregate.Alpha},
 	LegacyResourceTrackerGC:       {Default: true, PreRelease: featuregate.Alpha},
+	EnableSuspendFailedWorkflow:   {Default: false, PreRelease: featuregate.Alpha},
 	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -28,18 +28,8 @@ import (
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 )
 
-const (
-	// ReadyComponent is the key for depends on in workflow context
-	ReadyComponent = "readyComponent__"
-)
-
 // Input set data to parameter.
 func Input(ctx wfContext.Context, paramValue *value.Value, step v1beta1.WorkflowStep) error {
-	for _, depend := range step.DependsOn {
-		if _, err := ctx.GetVar(ReadyComponent, depend); err != nil {
-			return errors.WithMessagef(err, "the depends on component [%s] is not ready", depend)
-		}
-	}
 	for _, input := range step.Inputs {
 		inputValue, err := ctx.GetVar(strings.Split(input.From, ".")...)
 		if err != nil {
@@ -64,13 +54,6 @@ func Output(ctx wfContext.Context, taskValue *value.Value, step v1beta1.Workflow
 				return err
 			}
 			if err := json.Unmarshal(js, &o); err != nil {
-				return err
-			}
-			ready, err := value.NewValue(`true`, nil, "")
-			if err != nil {
-				return err
-			}
-			if err := ctx.SetVar(ready, ReadyComponent, o.Name); err != nil {
 				return err
 			}
 		}

--- a/pkg/workflow/hooks/data_passing_test.go
+++ b/pkg/workflow/hooks/data_passing_test.go
@@ -43,10 +43,6 @@ func TestInput(t *testing.T) {
 	r.NoError(err)
 	err = wfCtx.SetVar(score, "foo")
 	r.NoError(err)
-	ready, err := value.NewValue(`true`, nil, "")
-	r.NoError(err)
-	err = wfCtx.SetVar(ready, ReadyComponent, "mystep")
-	r.NoError(err)
 	err = Input(wfCtx, paramValue, v1beta1.WorkflowStep{
 		DependsOn: []string{"mystep"},
 		Inputs: common.StepInputs{{
@@ -85,12 +81,6 @@ output: score: 99
 	s, err := result.String()
 	r.NoError(err)
 	r.Equal(s, `99
-`)
-	ready, err := wfCtx.GetVar(ReadyComponent, "mystep")
-	r.NoError(err)
-	s, err = ready.String()
-	r.NoError(err)
-	r.Equal(s, `true
 `)
 }
 

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -480,7 +480,7 @@ func SkipTaskRunner(options *SkipOptions) bool {
 	case "":
 		return options.DependsOnPhase != common.WorkflowStepPhaseSucceeded
 	default:
-		// TODO:(fog) support cue syntax in if
+		// TODO:(fog) support more if cases
 		return false
 	}
 }

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -466,6 +466,7 @@ func NewTaskLoader(lt LoadTaskTemplate, pkgDiscover *packages.PackageDiscover, h
 	}
 }
 
+// SkipOptions is the options of skip task runner
 type SkipOptions struct {
 	If             string
 	DependsOn      []string
@@ -496,6 +497,7 @@ func SkipTaskRunner(ctx wfContext.Context, options *SkipOptions) bool {
 	}
 }
 
+// CheckPending checks whether to pending task run
 func CheckPending(ctx wfContext.Context, step v1beta1.WorkflowStep, stepStatus map[string]common.WorkflowStepStatus) bool {
 	for _, depend := range step.DependsOn {
 		if status, ok := stepStatus[depend]; ok {

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -157,7 +157,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 			return CheckPending(ctx, wfStep, stepStatus)
 		}
 		tRunner.skip = func(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
-			if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+			if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 				return exec.status(), false
 			}
 			skip := SkipTaskRunner(&SkipOptions{
@@ -506,7 +506,7 @@ func CheckPending(ctx wfContext.Context, step v1beta1.WorkflowStep, stepStatus m
 
 // IsStepFinish will decide whether step is finish.
 func IsStepFinish(phase common.WorkflowStepPhase, reason string) bool {
-	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		return phase == common.WorkflowStepPhaseSucceeded
 	}
 	if phase == common.WorkflowStepPhaseFailed {

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -478,7 +478,7 @@ func SkipTaskRunner(options *SkipOptions) bool {
 	case "":
 		return options.DependsOnPhase != common.WorkflowStepPhaseSucceeded
 	default:
-		// TODO:(fog)
+		// TODO:(fog) support cue syntax in if
 		return false
 	}
 }

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -509,8 +509,14 @@ func IsStepFinish(phase common.WorkflowStepPhase, reason string) bool {
 	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		return phase == common.WorkflowStepPhaseSucceeded
 	}
-	if phase == common.WorkflowStepPhaseFailed {
+	switch phase {
+	case common.WorkflowStepPhaseFailed:
 		return reason == StatusReasonTerminate || reason == StatusReasonFailedAfterRetries
+	case common.WorkflowStepPhaseSkipped:
+		return true
+	case common.WorkflowStepPhaseSucceeded:
+		return true
+	default:
+		return false
 	}
-	return phase == common.WorkflowStepPhaseSucceeded || phase == common.WorkflowStepPhaseSkipped
 }

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -475,7 +475,9 @@ func TestPendingDependsOnCheck(t *testing.T) {
 	r.Equal(run.Pending(wfCtx, nil), true)
 	ss := map[string]common.WorkflowStepStatus{
 		"depend": {
-			Phase: common.WorkflowStepPhaseSucceeded,
+			StepStatus: common.StepStatus{
+				Phase: common.WorkflowStepPhaseSucceeded,
+			},
 		},
 	}
 	r.Equal(run.Pending(wfCtx, ss), false)

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -512,6 +512,7 @@ func TestSkip(t *testing.T) {
 		If:   "always",
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
+	r.NoError(err)
 	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
 	r.Equal(skip, false)
 }

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -268,7 +268,8 @@ close({
 			r.NoError(err)
 			r.Equal(operation.Waiting, false)
 			r.Equal(operation.FailedAfterRetries, true)
-			r.Equal(status.Phase, common.WorkflowStepPhaseFailedAfterRetries)
+			r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+			r.Equal(status.Reason, StatusReasonFailedAfterRetries)
 		default:
 			r.Equal(operation.Waiting, true)
 			r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
@@ -504,7 +505,7 @@ func TestSkip(t *testing.T) {
 	r.NoError(err)
 	runner, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
+	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, nil)
 	r.Equal(skip, true)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, StatusReasonSkip)
@@ -513,7 +514,7 @@ func TestSkip(t *testing.T) {
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
+	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, nil)
 	r.Equal(skip, false)
 }
 

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
-	"github.com/oam-dev/kubevela/pkg/workflow/hooks"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
 	"github.com/oam-dev/kubevela/pkg/workflow/types"
 )
@@ -438,14 +437,14 @@ func TestPendingInputCheck(t *testing.T) {
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx), true)
+	r.Equal(run.Pending(wfCtx, nil), true)
 	score, err := value.NewValue(`
 100
 `, nil, "")
 	r.NoError(err)
 	err = wfCtx.SetVar(score, "score")
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx), false)
+	r.Equal(run.Pending(wfCtx, nil), false)
 }
 
 func TestPendingDependsOnCheck(t *testing.T) {
@@ -473,12 +472,13 @@ func TestPendingDependsOnCheck(t *testing.T) {
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx), true)
-	ready, err := value.NewValue("true", nil, "")
-	r.NoError(err)
-	err = wfCtx.SetVar(ready, hooks.ReadyComponent, "depend")
-	r.NoError(err)
-	r.Equal(run.Pending(wfCtx), false)
+	r.Equal(run.Pending(wfCtx, nil), true)
+	ss := map[string]common.WorkflowStepStatus{
+		"depend": {
+			Phase: common.WorkflowStepPhaseSucceeded,
+		},
+	}
+	r.Equal(run.Pending(wfCtx, ss), false)
 }
 
 func newWorkflowContextForTest(t *testing.T) wfContext.Context {

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -268,7 +268,7 @@ close({
 			r.NoError(err)
 			r.Equal(operation.Waiting, false)
 			r.Equal(operation.FailedAfterRetries, true)
-			r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+			r.Equal(status.Phase, common.WorkflowStepPhaseFailedAfterRetries)
 		default:
 			r.Equal(operation.Waiting, true)
 			r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
@@ -473,11 +473,9 @@ func TestPendingDependsOnCheck(t *testing.T) {
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
 	r.Equal(run.Pending(wfCtx, nil), true)
-	ss := map[string]common.WorkflowStepStatus{
+	ss := map[string]common.StepStatus{
 		"depend": {
-			StepStatus: common.StepStatus{
-				Phase: common.WorkflowStepPhaseSucceeded,
-			},
+			Phase: common.WorkflowStepPhaseSucceeded,
 		},
 	}
 	r.Equal(run.Pending(wfCtx, ss), false)

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -163,7 +163,12 @@ func (tr *suspendTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common.W
 	if custom.EnableSuspendFailedWorkflow {
 		return status, false
 	}
-	skip := custom.SkipTaskRunner(ctx, tr.step, dependsOnPhase, stepStatus)
+	skip := custom.SkipTaskRunner(ctx, &custom.SkipOptions{
+		If:             tr.step.If,
+		DependsOn:      tr.step.DependsOn,
+		DependsOnPhase: dependsOnPhase,
+		StepStatus:     stepStatus,
+	})
 	if skip {
 		tr.skip = true
 		status.Phase = common.WorkflowStepPhaseSkipped
@@ -223,6 +228,8 @@ func (tr *stepGroupTaskRunner) Run(ctx wfContext.Context, options *types.TaskRun
 		phase = common.WorkflowStepPhaseStopped
 	case subStepPhases[common.WorkflowStepPhaseFailed] > 0:
 		phase = common.WorkflowStepPhaseFailed
+	case subStepPhases[common.WorkflowStepPhaseFailedAfterRetries] > 0:
+		phase = common.WorkflowStepPhaseFailedAfterRetries
 	default:
 		phase = common.WorkflowStepPhaseSucceeded
 	}

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -162,7 +162,7 @@ func (tr *suspendTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, stepS
 		Type:  types.WorkflowStepTypeSuspend,
 		Phase: tr.phase,
 	}
-	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		return status, false
 	}
 	skip := custom.SkipTaskRunner(&custom.SkipOptions{
@@ -199,7 +199,7 @@ func (tr *stepGroupTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, ste
 		Name: tr.step.Name,
 		Type: types.WorkflowStepTypeStepGroup,
 	}
-	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		return status, false
 	}
 	skip := custom.SkipTaskRunner(&custom.SkipOptions{

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -153,7 +153,7 @@ func (tr *suspendTaskRunner) Pending(ctx wfContext.Context, stepStatus map[strin
 	return custom.CheckPending(ctx, tr.step, stepStatus)
 }
 
-func (tr *suspendTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
+func (tr *suspendTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
 	status := common.StepStatus{
 		ID:    tr.id,
 		Name:  tr.step.Name,
@@ -163,11 +163,9 @@ func (tr *suspendTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common.W
 	if custom.EnableSuspendFailedWorkflow {
 		return status, false
 	}
-	skip := custom.SkipTaskRunner(ctx, &custom.SkipOptions{
+	skip := custom.SkipTaskRunner(&custom.SkipOptions{
 		If:             tr.step.If,
-		DependsOn:      tr.step.DependsOn,
 		DependsOnPhase: dependsOnPhase,
-		StepStatus:     stepStatus,
 	})
 	if skip {
 		status.Phase = common.WorkflowStepPhaseSkipped
@@ -193,7 +191,7 @@ func (tr *stepGroupTaskRunner) Pending(ctx wfContext.Context, stepStatus map[str
 	return custom.CheckPending(ctx, tr.step, stepStatus)
 }
 
-func (tr *stepGroupTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
+func (tr *stepGroupTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
 	status := common.StepStatus{
 		ID:   tr.id,
 		Name: tr.step.Name,
@@ -202,11 +200,9 @@ func (tr *stepGroupTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common
 	if custom.EnableSuspendFailedWorkflow {
 		return status, false
 	}
-	skip := custom.SkipTaskRunner(ctx, &custom.SkipOptions{
+	skip := custom.SkipTaskRunner(&custom.SkipOptions{
 		If:             tr.step.If,
-		DependsOn:      tr.step.DependsOn,
 		DependsOnPhase: dependsOnPhase,
-		StepStatus:     stepStatus,
 	})
 	if skip {
 		status.Phase = common.WorkflowStepPhaseSkipped

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -22,6 +22,7 @@ import (
 	builtintime "time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
+	"github.com/oam-dev/kubevela/pkg/features"
 	monitorContext "github.com/oam-dev/kubevela/pkg/monitor/context"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/velaql/providers/query"
@@ -160,7 +162,7 @@ func (tr *suspendTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, stepS
 		Type:  types.WorkflowStepTypeSuspend,
 		Phase: tr.phase,
 	}
-	if custom.EnableSuspendFailedWorkflow {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
 		return status, false
 	}
 	skip := custom.SkipTaskRunner(&custom.SkipOptions{
@@ -197,7 +199,7 @@ func (tr *stepGroupTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, ste
 		Name: tr.step.Name,
 		Type: types.WorkflowStepTypeStepGroup,
 	}
-	if custom.EnableSuspendFailedWorkflow {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
 		return status, false
 	}
 	skip := custom.SkipTaskRunner(&custom.SkipOptions{

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/cue/process"

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -85,7 +85,7 @@ func TestSuspendStep(t *testing.T) {
 	runner, err := gen(v1beta1.WorkflowStep{Name: "test"}, &types.GeneratorOptions{ID: "124"})
 	r.NoError(err)
 	r.Equal(runner.Name(), "test")
-	r.Equal(runner.Pending(nil), false)
+	r.Equal(runner.Pending(nil, nil), false)
 	status, act, err := runner.Run(nil, nil)
 	r.NoError(err)
 	r.Equal(act.Suspend, true)
@@ -130,7 +130,7 @@ func TestStepGroupStep(t *testing.T) {
 	runner, err := gen(v1beta1.WorkflowStep{Name: "test"}, &types.GeneratorOptions{ID: "124", SubTaskRunners: []types.TaskRunner{subRunner}})
 	r.NoError(err)
 	r.Equal(runner.Name(), "test")
-	r.Equal(runner.Pending(nil), false)
+	r.Equal(runner.Pending(nil, nil), false)
 
 	testCases := []struct {
 		name          string

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -108,6 +108,7 @@ func TestSuspendStep(t *testing.T) {
 		If:   "always",
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
+	r.NoError(err)
 	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
 	r.Equal(skip, false)
 
@@ -180,6 +181,7 @@ func TestStepGroupStep(t *testing.T) {
 		If:   "always",
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
+	r.NoError(err)
 	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, stepStatus)
 	r.Equal(skip, false)
 

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -100,7 +100,7 @@ func TestSuspendStep(t *testing.T) {
 	r.Equal(runner.Pending(nil, ss), false)
 
 	// test skip
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
+	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, nil)
 	r.Equal(skip, true)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, custom.StatusReasonSkip)
@@ -109,7 +109,7 @@ func TestSuspendStep(t *testing.T) {
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, nil)
+	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, nil)
 	r.Equal(skip, false)
 
 	// test run
@@ -172,7 +172,7 @@ func TestStepGroupStep(t *testing.T) {
 
 	// test skip
 	stepStatus := make(map[string]common.StepStatus)
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailedAfterRetries, stepStatus)
+	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, stepStatus)
 	r.Equal(skip, false)
 	r.Equal(stepStatus["test"].Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
@@ -182,7 +182,7 @@ func TestStepGroupStep(t *testing.T) {
 		Name: "test",
 	}, &types.GeneratorOptions{ID: "124"})
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailedAfterRetries, stepStatus)
+	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, stepStatus)
 	r.Equal(skip, false)
 
 	// test run

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -281,11 +281,9 @@ func TestPendingDependsOnCheck(t *testing.T) {
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
 	r.Equal(run.Pending(wfCtx, nil), true)
-	ss := map[string]common.WorkflowStepStatus{
+	ss := map[string]common.StepStatus{
 		"depend": {
-			StepStatus: common.StepStatus{
-				Phase: common.WorkflowStepPhaseSucceeded,
-			},
+			Phase: common.WorkflowStepPhaseSucceeded,
 		},
 	}
 	r.Equal(run.Pending(wfCtx, ss), false)

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -30,9 +30,9 @@ import (
 // TaskRunner is a task runner.
 type TaskRunner interface {
 	Name() string
-	Pending(ctx wfContext.Context, stepStatus map[string]common.WorkflowStepStatus) bool
+	Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
 	Run(ctx wfContext.Context, options *TaskRunOptions) (common.StepStatus, *Operation, error)
-	Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.WorkflowStepStatus) (common.StepStatus, bool)
+	Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool)
 }
 
 // TaskDiscover is the interface to obtain the TaskGenerator。

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -32,7 +32,7 @@ type TaskRunner interface {
 	Name() string
 	Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
 	Run(ctx wfContext.Context, options *TaskRunOptions) (common.StepStatus, *Operation, error)
-	Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool)
+	Skip(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool)
 }
 
 // TaskDiscover is the interface to obtain the TaskGenerator。

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -30,8 +30,9 @@ import (
 // TaskRunner is a task runner.
 type TaskRunner interface {
 	Name() string
-	Pending(ctx wfContext.Context) bool
+	Pending(ctx wfContext.Context, stepStatus map[string]common.WorkflowStepStatus) bool
 	Run(ctx wfContext.Context, options *TaskRunOptions) (common.StepStatus, *Operation, error)
+	Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.WorkflowStepStatus) (common.StepStatus, bool)
 }
 
 // TaskDiscover is the interface to obtain the TaskGenerator。
@@ -71,6 +72,7 @@ type Operation struct {
 	Suspend            bool
 	Terminated         bool
 	Waiting            bool
+	Skip               bool
 	FailedAfterRetries bool
 }
 

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -563,7 +563,7 @@ func (e *engine) steps(taskRunners []wfTypes.TaskRunner, dag bool) error {
 		var status common.StepStatus
 		operation := &wfTypes.Operation{}
 		skip := false
-		status, skip = runner.Skip(wfCtx, e.findDependPhase(taskRunners, index, dag), e.stepStatus)
+		status, skip = runner.Skip(e.findDependPhase(taskRunners, index, dag), e.stepStatus)
 		if !skip {
 			status, operation, err = runner.Run(wfCtx, options)
 			if err != nil {

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -540,9 +540,9 @@ func (e *engine) Run(taskRunners []wfTypes.TaskRunner, dag bool) error {
 
 func (e *engine) checkWorkflowStatusMessage(wfStatus *common.WorkflowStatus) {
 	switch {
-	case !e.waiting && e.failedAfterRetries && feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow):
+	case !e.waiting && e.failedAfterRetries && feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure):
 		e.status.Message = MessageSuspendFailedAfterRetries
-	case e.failedAfterRetries && !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow):
+	case e.failedAfterRetries && !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure):
 		e.status.Message = MessageTerminatedFailedAfterRetries
 	case wfStatus.Terminated:
 		e.status.Message = string(common.WorkflowStateTerminated)
@@ -695,16 +695,16 @@ func (e *engine) updateStepStatus(status common.StepStatus) {
 }
 
 func (e *engine) checkFailedAfterRetries() {
-	if !e.waiting && e.failedAfterRetries && feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if !e.waiting && e.failedAfterRetries && feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		e.status.Suspend = true
 	}
-	if e.failedAfterRetries && !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if e.failedAfterRetries && !feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		e.status.Terminated = true
 	}
 }
 
 func (e *engine) needStop() bool {
-	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+	if feature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 		e.checkFailedAfterRetries()
 	}
 	// if the workflow is terminated, we still need to execute all the remaining steps

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -523,7 +523,7 @@ var _ = Describe("Test Workflow", func() {
 
 	It("Workflow test for failed after retries with suspend", func() {
 		By("Test failed-after-retries in StepByStep mode with suspend")
-		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendOnFailure, true)()
 		app, runners := makeTestCase([]oamcore.WorkflowStep{
 			{
 				Name: "s1",
@@ -804,7 +804,7 @@ var _ = Describe("Test Workflow", func() {
 
 	It("Test failed after retries with sub steps", func() {
 		By("Test failed-after-retries with step group in StepByStep mode")
-		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendFailedWorkflow, true)()
+		defer featuregatetesting.SetFeatureGateDuringTest(&testing.T{}, utilfeature.DefaultFeatureGate, features.EnableSuspendOnFailure, true)()
 		app, runners := makeTestCase([]oamcore.WorkflowStep{
 			{
 				Name: "s1",
@@ -1399,7 +1399,7 @@ func makeRunner(name, tpy, ifDecl string, dependsOn []string, subTaskRunners []w
 			Name: name,
 			Type: tpy,
 		}
-		if utilfeature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendFailedWorkflow) {
+		if utilfeature.DefaultMutableFeatureGate.Enabled(features.EnableSuspendOnFailure) {
 			return status, false
 		}
 		skip := custom.SkipTaskRunner(&custom.SkipOptions{

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -1381,7 +1381,7 @@ var pending bool
 
 func makeRunner(name, tpy, ifDecl string, dependsOn []string, subTaskRunners []wfTypes.TaskRunner) wfTypes.TaskRunner {
 	var run func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error)
-	skip := func(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
+	skip := func(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
 		status := common.StepStatus{
 			Name: name,
 			Type: tpy,
@@ -1389,11 +1389,9 @@ func makeRunner(name, tpy, ifDecl string, dependsOn []string, subTaskRunners []w
 		if custom.EnableSuspendFailedWorkflow {
 			return status, false
 		}
-		skip := custom.SkipTaskRunner(ctx, &custom.SkipOptions{
+		skip := custom.SkipTaskRunner(&custom.SkipOptions{
 			If:             ifDecl,
-			DependsOn:      dependsOn,
 			DependsOnPhase: dependsOnPhase,
-			StepStatus:     stepStatus,
 		})
 		if skip {
 			status.Phase = common.WorkflowStepPhaseSkipped
@@ -1521,7 +1519,7 @@ type testTaskRunner struct {
 	name         string
 	run          func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error)
 	checkPending func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
-	skip         func(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool)
+	skip         func(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool)
 }
 
 // Name return step name.
@@ -1539,8 +1537,8 @@ func (tr *testTaskRunner) Pending(ctx wfContext.Context, stepStatus map[string]c
 	return tr.checkPending(ctx, stepStatus)
 }
 
-func (tr *testTaskRunner) Skip(ctx wfContext.Context, dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
-	return tr.skip(ctx, dependsOnPhase, stepStatus)
+func (tr *testTaskRunner) Skip(dependsOnPhase common.WorkflowStepPhase, stepStatus map[string]common.StepStatus) (common.StepStatus, bool) {
+	return tr.skip(dependsOnPhase, stepStatus)
 }
 
 func cleanStepTimeStamp(wfStatus *common.WorkflowStatus) {

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -270,9 +270,10 @@ var _ = Describe("Test Workflow", func() {
 			Message:     string(MessageTerminatedFailedAfterRetries),
 			Steps: []common.WorkflowStepStatus{{
 				StepStatus: common.StepStatus{
-					Name:  "s1",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s1",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}, {
 				StepStatus: common.StepStatus{
@@ -353,15 +354,17 @@ var _ = Describe("Test Workflow", func() {
 			Message:     string(MessageTerminatedFailedAfterRetries),
 			Steps: []common.WorkflowStepStatus{{
 				StepStatus: common.StepStatus{
-					Name:  "s1",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s1",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "step-group",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "step-group",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 				SubStepsStatus: []common.WorkflowSubStepStatus{{
 					StepStatus: common.StepStatus{
@@ -371,9 +374,10 @@ var _ = Describe("Test Workflow", func() {
 					},
 				}, {
 					StepStatus: common.StepStatus{
-						Name:  "s2-sub2",
-						Type:  "failed-after-retries",
-						Phase: common.WorkflowStepPhaseFailedAfterRetries,
+						Name:   "s2-sub2",
+						Type:   "failed-after-retries",
+						Phase:  common.WorkflowStepPhaseFailed,
+						Reason: custom.StatusReasonFailedAfterRetries,
 					},
 				}},
 			}, {
@@ -556,9 +560,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}},
 		})).Should(BeEquivalentTo(""))
@@ -604,9 +609,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}, {
 				StepStatus: common.StepStatus{
@@ -672,9 +678,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}, {
 				StepStatus: common.StepStatus{
@@ -757,9 +764,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 			}, {
 				StepStatus: common.StepStatus{
@@ -841,9 +849,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "step-group",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   "s2",
+					Type:   "step-group",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				},
 				SubStepsStatus: []common.WorkflowSubStepStatus{{
 					StepStatus: common.StepStatus{
@@ -853,9 +862,10 @@ var _ = Describe("Test Workflow", func() {
 					},
 				}, {
 					StepStatus: common.StepStatus{
-						Name:  "s2-sub2",
-						Type:  "failed-after-retries",
-						Phase: common.WorkflowStepPhaseFailedAfterRetries,
+						Name:   "s2-sub2",
+						Type:   "failed-after-retries",
+						Phase:  common.WorkflowStepPhaseFailed,
+						Reason: custom.StatusReasonFailedAfterRetries,
 					},
 				}},
 			}},
@@ -1439,9 +1449,10 @@ func makeRunner(name, tpy, ifDecl string, dependsOn []string, subTaskRunners []w
 	case "failed-after-retries":
 		run = func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error) {
 			return common.StepStatus{
-					Name:  name,
-					Type:  "failed-after-retries",
-					Phase: common.WorkflowStepPhaseFailedAfterRetries,
+					Name:   name,
+					Type:   "failed-after-retries",
+					Phase:  common.WorkflowStepPhaseFailed,
+					Reason: custom.StatusReasonFailedAfterRetries,
 				}, &wfTypes.Operation{
 					FailedAfterRetries: true,
 				}, nil

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -36,6 +36,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 	"github.com/oam-dev/kubevela/references/appfile"
 )
 
@@ -170,7 +171,7 @@ func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cob
 			if err != nil {
 				return err
 			}
-			err = terminateWorkflow(client, app)
+			err = TerminateWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -286,11 +287,34 @@ func resumeWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	return nil
 }
 
-func terminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
+func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	// set the workflow terminated to true
 	app.Status.Workflow.Terminated = true
+	steps := app.Status.Workflow.Steps
+	for i, step := range steps {
+		switch step.Phase {
+		case oamcommon.WorkflowStepPhaseFailed:
+			if step.Reason != custom.StatusReasonFailedAfterRetries {
+				steps[i].Reason = custom.StatusReasonTerminate
+			}
+		case oamcommon.WorkflowStepPhaseRunning:
+			steps[i].Phase = oamcommon.WorkflowStepPhaseFailed
+			steps[i].Reason = custom.StatusReasonTerminate
+		}
+		for j, sub := range step.SubStepsStatus {
+			switch sub.Phase {
+			case oamcommon.WorkflowStepPhaseFailed:
+				if sub.Reason != custom.StatusReasonFailedAfterRetries {
+					steps[i].SubStepsStatus[j].Phase = custom.StatusReasonTerminate
+				}
+			case oamcommon.WorkflowStepPhaseRunning:
+				steps[i].SubStepsStatus[j].Phase = oamcommon.WorkflowStepPhaseFailed
+				steps[i].SubStepsStatus[j].Reason = custom.StatusReasonTerminate
+			}
+		}
+	}
 
-	if err := kubecli.Status().Patch(context.TODO(), app, client.Merge); err != nil {
+	if err := kubecli.Status().Update(context.TODO(), app); err != nil {
 		return err
 	}
 

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -289,7 +289,7 @@ func resumeWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 
 // TerminateWorkflow terminate workflow
 func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
-	if err := service.TerminateWorkflow(kubecli, app); err != nil {
+	if err := service.TerminateWorkflow(context.TODO(), kubecli, app); err != nil {
 		return err
 	}
 

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -287,6 +287,7 @@ func resumeWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	return nil
 }
 
+// TerminateWorkflow terminate workflow
 func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	// set the workflow terminated to true
 	app.Status.Workflow.Terminated = true
@@ -300,6 +301,7 @@ func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 		case oamcommon.WorkflowStepPhaseRunning:
 			steps[i].Phase = oamcommon.WorkflowStepPhaseFailed
 			steps[i].Reason = custom.StatusReasonTerminate
+		default:
 		}
 		for j, sub := range step.SubStepsStatus {
 			switch sub.Phase {
@@ -310,11 +312,12 @@ func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 			case oamcommon.WorkflowStepPhaseRunning:
 				steps[i].SubStepsStatus[j].Phase = oamcommon.WorkflowStepPhaseFailed
 				steps[i].SubStepsStatus[j].Reason = custom.StatusReasonTerminate
+			default:
 			}
 		}
 	}
 
-	if err := kubecli.Status().Update(context.TODO(), app); err != nil {
+	if err := kubecli.Status().Patch(context.TODO(), app, client.Merge); err != nil {
 		return err
 	}
 

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -122,15 +122,15 @@ var _ = Describe("Application Normal tests", func() {
 			}, time.Second*5, time.Millisecond*500).Should(Succeed())
 	}
 
-	verifyApplicationWorkflowSuspending := func(ns, appName string) {
+	verifyApplicationWorkflowTerminated := func(ns, appName string) {
 		var testApp v1beta1.Application
 		Eventually(func() error {
 			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: appName}, &testApp)
 			if err != nil {
 				return err
 			}
-			if testApp.Status.Phase != oamcomm.ApplicationWorkflowSuspending {
-				return fmt.Errorf("application status wants %s, actually %s", oamcomm.ApplicationWorkflowSuspending, testApp.Status.Phase)
+			if testApp.Status.Phase != oamcomm.ApplicationWorkflowTerminated {
+				return fmt.Errorf("application status wants %s, actually %s", oamcomm.ApplicationWorkflowTerminated, testApp.Status.Phase)
 			}
 			return nil
 		}, 120*time.Second, time.Second).Should(BeNil())
@@ -335,7 +335,7 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 
 		By("check application status")
-		verifyApplicationWorkflowSuspending(newApp.Namespace, newApp.Name)
+		verifyApplicationWorkflowTerminated(newApp.Namespace, newApp.Name)
 	})
 
 	It("Test wait suspend", func() {
@@ -425,7 +425,7 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 
 		By("Checking an application status")
-		verifyApplicationWorkflowSuspending(newApp.Namespace, newApp.Name)
+		verifyApplicationWorkflowTerminated(newApp.Namespace, newApp.Name)
 	})
 
 	It("Test app with non-existence ServiceAccount", func() {
@@ -453,6 +453,6 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 
 		By("Checking an application status")
-		verifyApplicationWorkflowSuspending(newApp.Namespace, newApp.Name)
+		verifyApplicationWorkflowTerminated(newApp.Namespace, newApp.Name)
 	})
 })


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR adds `if` in both workflow steps and substeps.

In the KubeVela v1.3, if the step failed in workflow, after ten times retries, the workflow will suspend automatically.
After this PR is merged, if one step failed after retries, its reason is `FailedAfterRetries`, and the workflow will try to execute the following steps. For the steps that can't satisfy the execution conditions, their phase will be `skipped`. After all steps have been executed, the workflow's phase is `terminated`.

> Note that you can use --enable-suspend-failed-workflow flag to open the feature of suspend the failed workflow automatically, but with the feature, you can not use `if`.

Here's an example.

The workflow step spec is like this:
```yaml
  workflow:
    steps:
    - name: webhook-err
      type: webhook-err
    - name: notification
      type: notification
      if: always
    - name: notification2
      type: notification
```

And the status is like:
```yaml
    status: workflowTerminated
    workflow:
      finished: true
      message: The workflow terminates automatically because the failed times of steps
        have reached the limit
      mode: StepByStep
      steps:
      - firstExecuteTime: "2022-05-27T02:57:14Z"
        id: adkxovfvvi
        lastExecuteTime: "2022-05-27T02:58:06Z"
        message: 'step webhook: step http: run step(provider=http,do=do): invalid
          string argument, webhook.http.url: field "str" is optional'
        name: webhook-err
        phase: failed
        reason: FailedAfterRetries
        type: webhook-err
      - firstExecuteTime: "2022-05-27T02:58:06Z"
        id: nwwmr9ysa6
        lastExecuteTime: "2022-05-27T02:58:06Z"
        name: notification
        phase: succeeded
        type: notification
      - firstExecuteTime: "2022-05-27T02:58:06Z"
        id: pohtl28pwz
        lastExecuteTime: "2022-05-27T02:58:06Z"
        name: notification2
        phase: skipped
        reason: Skip
        type: notification
      suspend: false
      terminated: true
```

If you try to terminate a running workflow manually, the running step's phase will be `failed`, and its reason is `Terminated`. e.g.

```yaml
    status: workflowTerminated
    workflow:
      finished: true
      message: terminated
      mode: StepByStep
      steps:
      - firstExecuteTime: "2022-05-27T03:01:51Z"
        id: ijv8go9bsa
        lastExecuteTime: "2022-05-27T03:01:55Z"
        message: wait healthy
        name: apply
        phase: failed
        reason: Terminate
        type: apply-component
      - firstExecuteTime: "2022-05-27T03:01:56Z"
        id: 8jx3ke4kix
        lastExecuteTime: "2022-05-27T03:01:56Z"
        name: notification
       // this step is executed successfully because it's `if` is `always`.
        phase: succeeded
        type: notification
      - firstExecuteTime: "2022-05-27T03:01:56Z"
        id: 8gpmipwkz3
        lastExecuteTime: "2022-05-27T03:01:56Z"
        name: notification2
        phase: skipped
        reason: Skip
        type: notification
      suspend: false
      terminated: true
```

Fixes #3825

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->