### PR TITLE
Feat: vela auth grant-privileges

### DIFF
--- a/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
@@ -147,4 +147,7 @@ subjects:
   - kind: Group
     name: cluster-gateway-accessor
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: kubevela:client
+    apiGroup: rbac.authorization.k8s.io
 {{ end }}

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -111,3 +111,18 @@ func (identity *Identity) Validate() error {
 	}
 	return nil
 }
+
+// Subjects return rbac subjects
+func (identity *Identity) Subjects() []rbacv1.Subject {
+	var subs []rbacv1.Subject
+	if identity.User != "" {
+		subs = append(subs, rbacv1.Subject{Kind: rbacv1.UserKind, APIGroup: rbacv1.GroupName, Name: identity.User})
+	}
+	for _, group := range identity.Groups {
+		subs = append(subs, rbacv1.Subject{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: group})
+	}
+	if identity.ServiceAccount != "" {
+		subs = append(subs, rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: identity.ServiceAccount, Namespace: identity.ServiceAccountNamespace})
+	}
+	return subs
+}

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -26,12 +26,12 @@ import (
 
 // GetTokenSubject extract the subject field from the jwt token
 func GetTokenSubject(token string) (string, error) {
-	claims := jwt.MapClaims{}
-	if _, err := jwt.ParseWithClaims(token, claims, nil); err != nil {
-		return "", err
+	claims, sub := jwt.MapClaims{}, ""
+	_, err := jwt.ParseWithClaims(token, claims, nil)
+	if len(claims) > 0 {
+		sub, _ = claims["sub"].(string)
 	}
-	sub, _ := claims["sub"].(string)
-	return sub, nil
+	return sub, err
 }
 
 // GetCertificateSubject extract Subject from Certificate

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -34,11 +35,13 @@ import (
 	"github.com/oam-dev/kubevela/pkg/auth"
 	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
 // MutatingHandler adding user info to application annotations
 type MutatingHandler struct {
-	Decoder *admission.Decoder
+	skipUsers []string
+	Decoder   *admission.Decoder
 }
 
 var _ admission.Handler = &MutatingHandler{}
@@ -49,7 +52,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Patched("")
 	}
 
-	if slices.Contains(req.UserInfo.Groups, common.Group) {
+	if slices.Contains(req.UserInfo.Groups, common.Group) || slices.Contains(h.skipUsers, req.UserInfo.Username) {
 		return admission.Patched("")
 	}
 
@@ -61,6 +64,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	if metav1.HasAnnotation(app.ObjectMeta, oam.AnnotationApplicationServiceAccountName) {
 		return admission.Errored(http.StatusBadRequest, errors.New("service-account annotation is not permitted when authentication enabled"))
 	}
+	klog.Infof("[ApplicationMutatingHandler] Setting UserInfo into Application, UserInfo: %v, Application: %s/%s", req.UserInfo, app.GetNamespace(), app.GetName())
 	auth.SetUserInfoInAnnotation(&app.ObjectMeta, req.UserInfo)
 
 	bs, err := json.Marshal(app)
@@ -81,5 +85,12 @@ func (h *MutatingHandler) InjectDecoder(d *admission.Decoder) error {
 // RegisterMutatingHandler will register component mutation handler to the webhook
 func RegisterMutatingHandler(mgr manager.Manager) {
 	server := mgr.GetWebhookServer()
-	server.Register("/mutating-core-oam-dev-v1beta1-applications", &webhook.Admission{Handler: &MutatingHandler{}})
+	handler := &MutatingHandler{}
+	if !utilfeature.DefaultMutableFeatureGate.Enabled(features.ControllerAutoImpersonation) {
+		if userInfo := utils.GetUserInfoFromConfig(mgr.GetConfig()); userInfo != nil {
+			klog.Infof("[ApplicationMutatingHandler] add skip user %s", userInfo.Username)
+			handler.skipUsers = []string{userInfo.Username}
+		}
+	}
+	server.Register("/mutating-core-oam-dev-v1beta1-applications", &webhook.Admission{Handler: handler})
 }

--- a/references/cli/auth.go
+++ b/references/cli/auth.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -34,6 +37,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/auth"
 	velacmd "github.com/oam-dev/kubevela/pkg/cmd"
 	cmdutil "github.com/oam-dev/kubevela/pkg/cmd/util"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
@@ -48,6 +52,7 @@ func AuthCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command 
 	}
 	cmd.AddCommand(NewGenKubeConfigCommand(f, streams))
 	cmd.AddCommand(NewListPrivilegesCommand(f, streams))
+	cmd.AddCommand(NewGrantPrivilegesCommand(f, streams))
 	return cmd
 }
 
@@ -201,8 +206,8 @@ func (opt *ListPrivilegesOptions) Validate(f velacmd.Factory, cmd *cobra.Command
 }
 
 // Run .
-func (opt *ListPrivilegesOptions) Run(f velacmd.Factory) error {
-	ctx := context.Background()
+func (opt *ListPrivilegesOptions) Run(f velacmd.Factory, cmd *cobra.Command) error {
+	ctx := cmd.Context()
 	m, err := auth.ListPrivileges(ctx, f.Client(), opt.Clusters, &opt.Identity)
 	if err != nil {
 		return err
@@ -270,7 +275,7 @@ func NewListPrivilegesCommand(f velacmd.Factory, streams util.IOStreams) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Complete(f, cmd)
 			cmdutil.CheckErr(o.Validate(f, cmd))
-			cmdutil.CheckErr(o.Run(f))
+			cmdutil.CheckErr(o.Run(f, cmd))
 		},
 	}
 	cmd.Flags().StringVarP(&o.User, "user", "u", o.User, "The user to list privileges.")
@@ -289,6 +294,177 @@ func NewListPrivilegesCommand(f velacmd.Factory, streams util.IOStreams) *cobra.
 	return velacmd.NewCommandBuilder(f, cmd).
 		WithNamespaceFlag(velacmd.UsageOption("The namespace of the serviceaccount. This flag only works when `--serviceaccount` is set.")).
 		WithClusterFlag(velacmd.UsageOption("The cluster to list privileges. If not set, the command will list privileges in the control plane.")).
+		WithStreams(streams).
+		WithResponsiveWriter().
+		Build()
+}
+
+// GrantPrivilegesOptions options for grant privileges
+type GrantPrivilegesOptions struct {
+	auth.Identity
+	KubeConfig      string
+	GrantNamespaces []string
+	GrantClusters   []string
+	ReadOnly        bool
+	CreateNamespace bool
+
+	util.IOStreams
+}
+
+// Complete .
+func (opt *GrantPrivilegesOptions) Complete(f velacmd.Factory, cmd *cobra.Command) {
+	if opt.KubeConfig != "" {
+		identity, err := auth.ReadIdentityFromKubeConfig(opt.KubeConfig)
+		cmdutil.CheckErr(err)
+		opt.Identity = *identity
+		opt.Identity.Groups = nil
+	}
+	if opt.Identity.ServiceAccount != "" {
+		opt.Identity.ServiceAccountNamespace = velacmd.GetNamespace(f, cmd)
+	}
+	opt.Regularize()
+	if len(opt.GrantClusters) == 0 {
+		opt.GrantClusters = []string{types.ClusterLocalName}
+	}
+}
+
+// Validate .
+func (opt *GrantPrivilegesOptions) Validate(f velacmd.Factory, cmd *cobra.Command) error {
+	if opt.User == "" && len(opt.Groups) == 0 && opt.ServiceAccount == "" {
+		return fmt.Errorf("at least one idenity (user/group/serviceaccount) should be set")
+	}
+	for _, cluster := range opt.GrantClusters {
+		if _, err := prismclusterv1alpha1.NewClusterClient(f.Client()).Get(cmd.Context(), cluster); err != nil {
+			return fmt.Errorf("failed to find cluster %s: %w", cluster, err)
+		}
+		if !opt.CreateNamespace {
+			for _, namespace := range opt.GrantNamespaces {
+				if err := f.Client().Get(multicluster.ContextWithClusterName(cmd.Context(), cluster), apitypes.NamespacedName{Name: namespace}, &corev1.Namespace{}); err != nil {
+					return fmt.Errorf("failed to find namespace %s in cluster %s: %w", namespace, cluster, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Run .
+func (opt *GrantPrivilegesOptions) Run(f velacmd.Factory, cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	if opt.CreateNamespace {
+		for _, cluster := range opt.GrantClusters {
+			if _, err := prismclusterv1alpha1.NewClusterClient(f.Client()).Get(cmd.Context(), cluster); err != nil {
+				return fmt.Errorf("failed to find cluster %s: %w", cluster, err)
+			}
+			for _, namespace := range opt.GrantNamespaces {
+				_ctx := multicluster.ContextWithClusterName(cmd.Context(), cluster)
+				ns := &corev1.Namespace{}
+				if err := f.Client().Get(_ctx, apitypes.NamespacedName{Name: namespace}, ns); err != nil {
+					if kerrors.IsNotFound(err) {
+						ns.SetName(namespace)
+						if err = f.Client().Create(_ctx, ns); err != nil {
+							return fmt.Errorf("failed to create namespace %s in cluster %s: %w", namespace, cluster, err)
+						}
+						continue
+					}
+					return fmt.Errorf("failed to find namespace %s in cluster %s: %w", namespace, cluster, err)
+				}
+			}
+		}
+	}
+	var privileges []auth.PrivilegeDescription
+	for _, cluster := range opt.GrantClusters {
+		for _, namespace := range opt.GrantNamespaces {
+			privileges = append(privileges, &auth.ScopedPrivilege{Cluster: cluster, Namespace: namespace, ReadOnly: opt.ReadOnly})
+		}
+	}
+	if err := auth.GrantPrivileges(ctx, f.Client(), privileges, &opt.Identity, opt.IOStreams.Out); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(opt.IOStreams.Out, "Privileges granted.\n")
+	return nil
+}
+
+var (
+	grantPrivilegesLong = templates.LongDesc(i18n.T(`
+		Grant privileges for user
+
+		Grant privileges to user/group/serviceaccount. By using --for-namespace and --for-cluster,
+		you can grant all read/write privileges for all resources in the specified namespace and 
+		cluster. If --for-namespace is not set, the privileges will be granted cluster-wide. 
+
+		Setting --create-namespace will automatically create namespace if the namespace of the
+		granted privilege does not exists. By default, this flag is not enabled and errors will be
+		returned if the namespace is not found in the corresponding cluster.
+
+		Setting --readonly will only grant read privileges for all resources in the destination. This
+		can be useful if you want to give somebody the privileges to view resources but do not want to
+		allow them to edit any resource.
+		
+		If multiple identity information are set, all the identity information will be bond to the
+		intended privileges respectively.
+
+		If --kubeconfig is set, the user/serviceaccount information in the kubeconfig will be used as
+		the identity to grant privileges. Groups will be ignored.`))
+
+	grantPrivilegesExample = templates.Examples(i18n.T(`
+		# Grant privileges for User alice in the namespace demo of the control plane
+		vela auth grant-privileges --user alice --for-namespace demo
+
+		# Grant privileges for User alice in the namespace demo in cluster-1, create demo namespace if not exist
+		vela auth grant-privileges --user alice --for-namespace demo --for-cluster cluster-1 --create-namespace
+		
+		# Grant cluster-scoped privileges for Group org:dev-team in the control plane
+		vela auth grant-privileges --group org:dev-team
+
+		# Grant privileges for Group org:dev-team and org:test-team in the namespace test on the control plane and managed cluster example-cluster
+		vela auth grant-privileges --group org:dev-team --group org:test-team --for-namespace test --for-cluster local --for-cluster example-cluster
+		
+		# Grant read privileges for ServiceAccount observer in test namespace on the control plane
+		vela auth grant-privileges --serviceaccount observer -n test --for-namespace test --readonly
+
+		# Grant privileges for identity in kubeconfig in cluster-1
+		vela auth grant-privileges --kubeconfig ./example.kubeconfig --for-cluster cluster-1`))
+)
+
+// NewGrantPrivilegesCommand grant privileges to given identity
+func NewGrantPrivilegesCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+	o := &GrantPrivilegesOptions{IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:                   "grant-privileges",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Grant privileges for user/group/serviceaccount"),
+		Long:                  grantPrivilegesLong,
+		Example:               grantPrivilegesExample,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCD,
+		},
+		Args: cobra.ExactValidArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Complete(f, cmd)
+			cmdutil.CheckErr(o.Validate(f, cmd))
+			cmdutil.CheckErr(o.Run(f, cmd))
+		},
+	}
+	cmd.Flags().StringVarP(&o.User, "user", "u", o.User, "The user to grant privileges.")
+	cmd.Flags().StringSliceVarP(&o.Groups, "group", "g", o.Groups, "The group to grant privileges.")
+	cmd.Flags().StringVarP(&o.ServiceAccount, "serviceaccount", "", o.ServiceAccount, "The serviceaccount to grant privileges.")
+	cmd.Flags().StringVarP(&o.KubeConfig, "kubeconfig", "", o.KubeConfig, "The kubeconfig to grant privileges. If set, it will override all the other identity flags.")
+	cmd.Flags().StringSliceVarP(&o.GrantClusters, "for-cluster", "", o.GrantClusters, "The clusters privileges to grant. If empty, the control plane will be used.")
+	cmd.Flags().StringSliceVarP(&o.GrantNamespaces, "for-namespace", "", o.GrantNamespaces, "The namespaces privileges to grant. If empty, cluster-scoped privileges will be granted.")
+	cmd.Flags().BoolVarP(&o.ReadOnly, "readonly", "", o.ReadOnly, "If set, only read privileges of resources will be granted. Otherwise, read/write privileges will be granted.")
+	cmd.Flags().BoolVarP(&o.CreateNamespace, "create-namespace", "", o.CreateNamespace, "If set, non-exist namespace will be created automatically.")
+	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"serviceaccount", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if strings.TrimSpace(o.User) != "" {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			namespace := velacmd.GetNamespace(f, cmd)
+			return velacmd.GetServiceAccountForCompletion(cmd.Context(), f, namespace, toComplete)
+		}))
+
+	return velacmd.NewCommandBuilder(f, cmd).
+		WithNamespaceFlag(velacmd.UsageOption("The namespace of the serviceaccount. This flag only works when `--serviceaccount` is set.")).
 		WithStreams(streams).
 		WithResponsiveWriter().
 		Build()

--- a/references/cli/kube.go
+++ b/references/cli/kube.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/strings/slices"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	velacmd "github.com/oam-dev/kubevela/pkg/cmd"
@@ -151,7 +150,7 @@ func (opt *KubeApplyOptions) Run(f velacmd.Factory, cmd *cobra.Command) error {
 			if err = copiedObj.UnmarshalJSON(bs); err != nil {
 				return err
 			}
-			res, err := controllerutil.CreateOrPatch(ctx, f.Client(), copiedObj, nil)
+			res, err := utils.CreateOrUpdate(ctx, f.Client(), copiedObj)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support `vela auth grant-privileges` to grant privileges to users across clusters.

Usage:
```
  # Grant privileges for User alice in the namespace demo of the control plane
  vela auth grant-privileges --user alice --for-namespace demo
  
  # Grant privileges for User alice in the namespace demo in cluster-1, create demo namespace if not exist
  vela auth grant-privileges --user alice --for-namespace demo --for-cluster cluster-1 --create-namespace
  
  # Grant cluster-scoped privileges for Group org:dev-team in the control plane
  vela auth grant-privileges --group org:dev-team
  
  # Grant privileges for Group org:dev-team and org:test-team in the namespace test on the control plane and managed
cluster example-cluster
  vela auth grant-privileges --group org:dev-team --group org:test-team --for-namespace test --for-cluster local
--for-cluster example-cluster
  
  # Grant read privileges for ServiceAccount observer in test namespace on the control plane
  vela auth grant-privileges --serviceaccount observer -n test --for-namespace test --readonly
  
  # Grant privileges for identity in kubeconfig in cluster-1
  vela auth grant-privileges --kubeconfig ./example.kubeconfig --for-cluster cluster-1
```

Solves #3933 partially. Only support internal pre-configured privilege sets now. More extensions or abstracts could be done in the future. Extension interfaces are reserved in this PR.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

P.S. This PR also embeds tiny fixes to the authentication in vela-core. When `ControllerAutoImpersonation` is disabled, filter the application mutating requests in the ApplicationMutatingWebhook depending on the source controller's identity. 