### PR TITLE
Feat: velaql provider for get application resource-tree

### DIFF
--- a/charts/vela-core/templates/velaql/resourceTree.yaml
+++ b/charts/vela-core/templates/velaql/resourceTree.yaml
@@ -1,0 +1,31 @@
+apiVersion: "v1"
+kind:       "ConfigMap"
+metadata:
+  name:      "application-resource-tree-view"
+  namespace: {{ include "systemDefinitionNamespace" . }}
+data:
+  template: |
+    import (
+        "vela/ql"
+    )
+    parameter: {
+        appName:    string
+        appNs:      string
+    }
+    response: ql.#GetApplicationTree & {
+        app: {
+            name:      parameter.appName
+            namespace: parameter.appNs
+        }
+    }
+
+    if response.err == _|_ {
+        status: {
+            resources: response.list
+        }
+    }
+    if response.err != _|_ {
+        status: {
+            error: response.err
+        }
+    }

--- a/charts/vela-core/templates/velaql/resourceTree.yaml
+++ b/charts/vela-core/templates/velaql/resourceTree.yaml
@@ -11,11 +11,25 @@ data:
     parameter: {
         appName:    string
         appNs:      string
+        name?:      string
+        cluster?:   string
+        clusterNs?: string
     }
     response: ql.#GetApplicationTree & {
         app: {
             name:      parameter.appName
             namespace: parameter.appNs
+            filter: {
+                if parameter.cluster != _|_ {
+                    cluster: parameter.cluster
+                }
+                if parameter.clusterNs != _|_ {
+                    clusterNamespace: parameter.clusterNs
+                }
+                if parameter.name != _|_ {
+                    components: [parameter.name]
+                }
+            }
         }
     }
 

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -133,20 +133,20 @@
 		namespace: string
 	}
 	list?: [...{
-  		name:             string
-  		namespace?:       string
-  		cluster?:         string
-  		component?:       string
-  		trait?:           string
-  		kind?:            string
-  		uid?:             string
-  		apiVersion?:      string
-  		resourceVersion?: string
-  		publishVersion?:  string
-  		deployVersion?:   string
-  		revision?:        string
-  		latest?:          bool
-  		...
-  }]
+		name:             string
+		namespace?:       string
+		cluster?:         string
+		component?:       string
+		trait?:           string
+		kind?:            string
+		uid?:             string
+		apiVersion?:      string
+		resourceVersion?: string
+		publishVersion?:  string
+		deployVersion?:   string
+		revision?:        string
+		latest?:          bool
+		...
+	}]
 	...
 }

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -124,3 +124,29 @@
 	}]
 	...
 }
+
+#GetApplicationTree: {
+	#do:       "getApplicationTree"
+	#provider: "query"
+	app: {
+		name:      string
+		namespace: string
+	}
+	list?: [...{
+  		name:             string
+  		namespace?:       string
+  		cluster?:         string
+  		component?:       string
+  		trait?:           string
+  		kind?:            string
+  		uid?:             string
+  		apiVersion?:      string
+  		resourceVersion?: string
+  		publishVersion?:  string
+  		deployVersion?:   string
+  		revision?:        string
+  		latest?:          bool
+  		...
+  }]
+	...
+}

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -131,6 +131,11 @@
 	app: {
 		name:      string
 		namespace: string
+		filter?: {
+			cluster?:          string
+			clusterNamespace?: string
+			components?: [...string]
+		}
 	}
 	list?: [...{
 		name:             string

--- a/pkg/stdlib/ql.cue
+++ b/pkg/stdlib/ql.cue
@@ -15,3 +15,5 @@
 #CollectLogsInPod: query.#CollectLogsInPod
 
 #CollectServiceEndpoints: query.#CollectServiceEndpoints
+
+#GetApplicationTree: query.#GetApplicationTree

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -90,21 +90,21 @@ func (c *AppCollector) CollectResourceFromApp() ([]Resource, error) {
 }
 
 // ListApplicationResources list application applied resources from tracker
-func (c *AppCollector) ListApplicationResources(app *v1beta1.Application) ([]types.AppliedResource, error) {
+func (c *AppCollector) ListApplicationResources(app *v1beta1.Application) ([]*types.AppliedResource, error) {
 	ctx := context.Background()
 	rootRT, currentRT, historyRTs, _, err := resourcetracker.ListApplicationResourceTrackers(ctx, c.k8sClient, app)
 	if err != nil {
 		return nil, err
 	}
 
-	var managedResources []types.AppliedResource
+	var managedResources []*types.AppliedResource
 	for _, rt := range append(historyRTs, rootRT, currentRT) {
 		if rt != nil {
 			for _, managedResource := range rt.Spec.ManagedResources {
 				if isResourceInTargetCluster(c.opt.Filter, managedResource.ClusterObjectReference) &&
 					isResourceInTargetComponent(c.opt.Filter, managedResource.Component) &&
 					isResourceMatchKindAndVersion(c.opt.Filter, managedResource.Kind, managedResource.APIVersion) {
-					managedResources = append(managedResources, types.AppliedResource{
+					managedResources = append(managedResources, &types.AppliedResource{
 						Cluster:         managedResource.Cluster,
 						Kind:            managedResource.Kind,
 						Component:       managedResource.Component,

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -136,6 +136,53 @@ func (h *provider) ListAppliedResources(ctx wfContext.Context, v *value.Value, a
 	return v.FillObject(appResList, "list")
 }
 
+// ListAppliedResources list applied resource from tracker
+func (h *provider) GetApplicationResourceTree(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	val, err := v.LookupValue("app")
+	if err != nil {
+		return err
+	}
+	opt := Option{}
+	if err = val.UnmarshalTo(&opt); err != nil {
+		return err
+	}
+	collector := NewAppCollector(h.cli, opt)
+	app := new(v1beta1.Application)
+	appKey := client.ObjectKey{Name: opt.Name, Namespace: opt.Namespace}
+	if err := h.cli.Get(context.Background(), appKey, app); err != nil {
+		return v.FillObject(err.Error(), "err")
+	}
+	appResList, err := collector.ListApplicationResources(app)
+	if err != nil {
+		return v.FillObject(err.Error(), "err")
+	}
+	for _, resource := range appResList {
+		root := querytypes.ResourceTreeNode{
+			APIVersion: resource.APIVersion,
+			Kind:       resource.Kind,
+			Cluster:    resource.Cluster,
+			Namespace:  resource.Namespace,
+			Name:       resource.Name,
+			UID:        resource.UID,
+		}
+		root.ChildrenResources, err = iteratorChildResources(context.Background(), resource.Cluster, h.cli, root)
+		if err != nil {
+			return v.FillObject(err.Error(), "err")
+		}
+		rootObject, err := fetchObjectWithResourceTreeNode(context.Background(), resource.Cluster, h.cli, root)
+		if err != nil {
+			return v.FillObject(err.Error(), "err")
+		}
+		rootStatus, err := checkResourceStatus(*rootObject)
+		if err != nil {
+			return v.FillObject(err.Error(), "err")
+		}
+		root.ResourceHealthStatus = *rootStatus
+		resource.ResourceTree = root
+	}
+	return v.FillObject(appResList, "list")
+}
+
 func (h *provider) CollectPods(ctx wfContext.Context, v *value.Value, act types.Action) error {
 	val, err := v.LookupValue("value")
 	if err != nil {
@@ -426,6 +473,7 @@ func Install(p providers.Providers, cli client.Client, cfg *rest.Config) {
 		"searchEvents":            prd.SearchEvents,
 		"collectLogsInPod":        prd.CollectLogsInPod,
 		"collectServiceEndpoints": prd.GeneratorServiceEndpoints,
+		"getApplicationTree":      prd.GetApplicationResourceTree,
 	})
 }
 

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -165,7 +165,7 @@ func (h *provider) GetApplicationResourceTree(ctx wfContext.Context, v *value.Va
 			Name:       resource.Name,
 			UID:        resource.UID,
 		}
-		root.ChildrenResources, err = iteratorChildResources(context.Background(), resource.Cluster, h.cli, root)
+		root.LeafNodes, err = iteratorChildResources(context.Background(), resource.Cluster, h.cli, root, 1)
 		if err != nil {
 			return v.FillObject(err.Error(), "err")
 		}
@@ -177,7 +177,7 @@ func (h *provider) GetApplicationResourceTree(ctx wfContext.Context, v *value.Va
 		if err != nil {
 			return v.FillObject(err.Error(), "err")
 		}
-		root.ResourceHealthStatus = *rootStatus
+		root.HealthStatus = *rootStatus
 		resource.ResourceTree = root
 	}
 	return v.FillObject(appResList, "list")

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oam-dev/kubevela/pkg/apiserver/log"
+	"github.com/oam-dev/kubevela/pkg/apiserver/utils/log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -214,14 +214,14 @@ var checkPodStatus = func(obj unstructured.Unstructured) (*types.HealthStatus, e
 	case v12.PodFailed:
 		if pod.Status.Message != "" {
 			// Pod has a nice error message. Use that.
-			return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: pod.Status.Message}, nil
+			return &types.HealthStatus{Status: types.HealthStatusUnHealthy, Message: pod.Status.Message}, nil
 		}
 		for _, ctr := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
 			if msg := getFailMessage(ctr.DeepCopy()); msg != "" {
-				return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: msg}, nil
+				return &types.HealthStatus{Status: types.HealthStatusUnHealthy, Message: msg}, nil
 			}
 		}
-		return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: ""}, nil
+		return &types.HealthStatus{Status: types.HealthStatusUnHealthy, Message: ""}, nil
 	default:
 	}
 	return &types.HealthStatus{

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -1,0 +1,439 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package query
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	types2 "k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubectl/pkg/util/podutils"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+)
+
+// globalRule define the whole relationShip rule
+var globalRule map[GroupResourceType]ChildrenResourcesRule
+
+func init() {
+	globalRule = make(map[GroupResourceType]ChildrenResourcesRule)
+	globalRule[GroupResourceType{Group: "apps", Kind: "Deployment"}] = ChildrenResourcesRule{
+		CareResource: map[ResourceType]genListOptionFunc{
+			{APIVersion: "apps/v1", Kind: "ReplicaSet"}: deploy2RsLabelListOption,
+		},
+	}
+	globalRule[GroupResourceType{Group: "apps", Kind: "ReplicaSet"}] = ChildrenResourcesRule{
+		CareResource: map[ResourceType]genListOptionFunc{
+			{APIVersion: "v1", Kind: "Pod"}: rs2PodLabelListOption,
+		},
+	}
+	globalRule[GroupResourceType{Group: "apps", Kind: "StatefulSet"}] = ChildrenResourcesRule{
+		CareResource: map[ResourceType]genListOptionFunc{
+			{APIVersion: "v1", Kind: "Pod"}: statefulSet2PodListOption,
+		},
+	}
+	globalRule[GroupResourceType{Group: "helm.toolkit.fluxcd.io", Kind: "HelmRelease"}] = ChildrenResourcesRule{
+		CareResource: map[ResourceType]genListOptionFunc{
+			{APIVersion: "apps/v1", Kind: "Deployment"}:           nil,
+			{APIVersion: "apps/v1", Kind: "StatefulSet"}:          nil,
+			{APIVersion: "v1", Kind: "ConfigMap"}:                 nil,
+			{APIVersion: "v1", Kind: "Secret"}:                    nil,
+			{APIVersion: "v1", Kind: "Service"}:                   nil,
+			{APIVersion: "networking.k8s.io/v1", Kind: "Ingress"}: nil,
+		},
+		DefaultGenListOptionFunc: helmRelease2AnyListOption,
+	}
+}
+
+// GroupResourceType define the parent resource type
+type GroupResourceType struct {
+	Group string `json:"group"`
+	Kind  string `json:"kind"`
+}
+
+// ResourceType define the children resource type
+type ResourceType struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+}
+
+// ChildrenResourcesRule define the relationShip between parentObject and children resource
+type ChildrenResourcesRule struct {
+	// every subResourceType can have a specified genListOptionFunc.
+	CareResource map[ResourceType]genListOptionFunc
+	// if specified genListOptionFunc is nil will use use default genListOptionFunc to generate listOption.
+	DefaultGenListOptionFunc genListOptionFunc
+}
+
+type genListOptionFunc func(unstructured.Unstructured) (client.ListOptions, error)
+
+var deploy2RsLabelListOption = func(obj unstructured.Unstructured) (client.ListOptions, error) {
+	deploy := appsv1.Deployment{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	deploySelector, err := v1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	return client.ListOptions{Namespace: deploy.Namespace, LabelSelector: deploySelector}, nil
+}
+
+var rs2PodLabelListOption = func(obj unstructured.Unstructured) (client.ListOptions, error) {
+	rs := appsv1.ReplicaSet{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &rs)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	rsSelector, err := v1.LabelSelectorAsSelector(rs.Spec.Selector)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	return client.ListOptions{Namespace: rs.Namespace, LabelSelector: rsSelector}, nil
+}
+
+var statefulSet2PodListOption = func(obj unstructured.Unstructured) (client.ListOptions, error) {
+	sts := appsv1.StatefulSet{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &sts)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	stsSelector, err := v1.LabelSelectorAsSelector(sts.Spec.Selector)
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	return client.ListOptions{Namespace: sts.Namespace, LabelSelector: stsSelector}, nil
+}
+
+var helmRelease2AnyListOption = func(obj unstructured.Unstructured) (client.ListOptions, error) {
+	hrSelector, err := v1.LabelSelectorAsSelector(&v1.LabelSelector{MatchLabels: map[string]string{
+		"helm.toolkit.fluxcd.io/name":      obj.GetName(),
+		"helm.toolkit.fluxcd.io/namespace": obj.GetNamespace(),
+	}})
+	if err != nil {
+		return client.ListOptions{}, err
+	}
+	return client.ListOptions{LabelSelector: hrSelector}, nil
+}
+
+type healthyCheckFunc func(obj unstructured.Unstructured) (*types.HealthStatus, error)
+
+var checkPodStatus = func(obj unstructured.Unstructured) (*types.HealthStatus, error) {
+	var pod v12.Pod
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured Pod to typed: %w", err)
+	}
+
+	getFailMessage := func(ctr *v12.ContainerStatus) string {
+		if ctr.State.Terminated != nil {
+			if ctr.State.Terminated.Message != "" {
+				return ctr.State.Terminated.Message
+			}
+			if ctr.State.Terminated.Reason == "OOMKilled" {
+				return ctr.State.Terminated.Reason
+			}
+			if ctr.State.Terminated.ExitCode != 0 {
+				return fmt.Sprintf("container %q failed with exit code %d", ctr.Name, ctr.State.Terminated.ExitCode)
+			}
+		}
+		return ""
+	}
+
+	switch pod.Status.Phase {
+	case v12.PodSucceeded:
+		return &types.HealthStatus{
+			Status:  types.HealthStatusHealthy,
+			Reason:  pod.Status.Reason,
+			Message: pod.Status.Message,
+		}, nil
+	case v12.PodRunning:
+		switch pod.Spec.RestartPolicy {
+		case v12.RestartPolicyAlways:
+			// if pod is ready, it is automatically healthy
+			if podutils.IsPodReady(&pod) {
+				return &types.HealthStatus{
+					Status: types.HealthStatusHealthy,
+					Reason: "all containers are ready",
+				}, nil
+			}
+			// if it's not ready, check to see if any container terminated, if so, it's unhealthy
+			for _, ctrStatus := range pod.Status.ContainerStatuses {
+				if ctrStatus.LastTerminationState.Terminated != nil {
+					return &types.HealthStatus{
+						Status:  types.HealthStatusUnHealthy,
+						Reason:  pod.Status.Reason,
+						Message: pod.Status.Message,
+					}, nil
+				}
+			}
+			// otherwise we are progressing towards a ready state
+			return &types.HealthStatus{
+				Status:  types.HealthStatusProgressing,
+				Reason:  pod.Status.Reason,
+				Message: pod.Status.Message,
+			}, nil
+		case v12.RestartPolicyOnFailure, v12.RestartPolicyNever:
+			// pods set with a restart policy of OnFailure or Never, have a finite life.
+			// These pods are typically resource hooks. Thus, we consider these as Progressing
+			// instead of healthy.
+			return &types.HealthStatus{
+				Status:  types.HealthStatusProgressing,
+				Reason:  pod.Status.Reason,
+				Message: pod.Status.Message,
+			}, nil
+		}
+	case v12.PodPending:
+		return &types.HealthStatus{
+			Status:  types.HealthStatusProgressing,
+			Message: pod.Status.Message,
+		}, nil
+	case v12.PodFailed:
+		if pod.Status.Message != "" {
+			// Pod has a nice error message. Use that.
+			return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: pod.Status.Message}, nil
+		}
+		for _, ctr := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+			if msg := getFailMessage(ctr.DeepCopy()); msg != "" {
+				return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: msg}, nil
+			}
+		}
+		return &types.HealthStatus{Status: types.HealthStatusHealthy, Message: ""}, nil
+	default:
+	}
+	return &types.HealthStatus{
+		Status:  types.HealthStatusUnKnown,
+		Reason:  string(pod.Status.Phase),
+		Message: pod.Status.Message,
+	}, nil
+}
+
+var checkReplicaSetStatus = func(obj unstructured.Unstructured) (*types.HealthStatus, error) {
+	replicaSet := appsv1.ReplicaSet{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &replicaSet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured ReplicaSet to typed: %w", err)
+	}
+	if replicaSet.Generation <= replicaSet.Status.ObservedGeneration {
+		cond := getAppsv1ReplicaSetCondition(replicaSet.Status, appsv1.ReplicaSetReplicaFailure)
+		if cond != nil && cond.Status == v12.ConditionTrue {
+			return &types.HealthStatus{
+				Status:  types.HealthStatusUnHealthy,
+				Reason:  cond.Reason,
+				Message: cond.Message,
+			}, nil
+		} else if replicaSet.Spec.Replicas != nil && replicaSet.Status.AvailableReplicas < *replicaSet.Spec.Replicas {
+			return &types.HealthStatus{
+				Status:  types.HealthStatusProgressing,
+				Message: fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas are available...", replicaSet.Status.AvailableReplicas, *replicaSet.Spec.Replicas),
+			}, nil
+		}
+	} else {
+		return &types.HealthStatus{
+			Status:  types.HealthStatusProgressing,
+			Message: "Waiting for rollout to finish: observed replica set generation less then desired generation",
+		}, nil
+	}
+
+	return &types.HealthStatus{
+		Status: types.HealthStatusHealthy,
+	}, nil
+}
+
+func getAppsv1ReplicaSetCondition(status appsv1.ReplicaSetStatus, condType appsv1.ReplicaSetConditionType) *appsv1.ReplicaSetCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
+var checkPVCHealthStatus = func(obj unstructured.Unstructured) (*types.HealthStatus, error) {
+	pvc := v12.PersistentVolumeClaim{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &pvc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured PVC to typed: %w", err)
+	}
+	var status types.HealthStatusCode
+	switch pvc.Status.Phase {
+	case v12.ClaimLost:
+		status = types.HealthStatusUnHealthy
+	case v12.ClaimPending:
+		status = types.HealthStatusProgressing
+	case v12.ClaimBound:
+		status = types.HealthStatusHealthy
+	default:
+		status = types.HealthStatusUnKnown
+	}
+	return &types.HealthStatus{Status: status}, nil
+}
+
+var checkServiceStatus = func(obj unstructured.Unstructured) (*types.HealthStatus, error) {
+	svc := v12.Service{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &svc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured service to typed: %w", err)
+	}
+	health := types.HealthStatus{Status: types.HealthStatusHealthy}
+	if svc.Spec.Type == v12.ServiceTypeLoadBalancer {
+		if len(svc.Status.LoadBalancer.Ingress) > 0 {
+			health.Status = types.HealthStatusHealthy
+		} else {
+			health.Status = types.HealthStatusProgressing
+		}
+	}
+	return &health, nil
+}
+
+func checkResourceStatus(obj unstructured.Unstructured) (*types.HealthStatus, error) {
+	group := obj.GroupVersionKind().Group
+	kind := obj.GroupVersionKind().Kind
+	var checkFunc healthyCheckFunc
+	switch group {
+	case "":
+		switch kind {
+		case "Pod":
+			checkFunc = checkPodStatus
+		case "Service":
+			checkFunc = checkServiceStatus
+		case "PersistentVolumeClaim":
+			checkFunc = checkPVCHealthStatus
+		}
+	case "apps":
+		switch kind {
+		case "ReplicaSet":
+			checkFunc = checkReplicaSetStatus
+		default:
+		}
+	}
+	if checkFunc != nil {
+		return checkFunc(obj)
+	}
+	return &types.HealthStatus{Status: types.HealthStatusHealthy}, nil
+}
+
+func fetchObjectWithResourceTreeNode(ctx context.Context, cluster string, k8sClient client.Client, resource types.ResourceTreeNode) (*unstructured.Unstructured, error) {
+	o := unstructured.Unstructured{}
+	o.SetAPIVersion(resource.APIVersion)
+	o.SetKind(resource.Kind)
+	o.SetNamespace(resource.Namespace)
+	o.SetName(resource.Name)
+	err := k8sClient.Get(multicluster.ContextWithClusterName(ctx, cluster), types2.NamespacedName{Namespace: resource.Namespace, Name: resource.Name}, &o)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func listItemByRule(clusterCTX context.Context, k8sClient client.Client, resource ResourceType,
+	parentObject unstructured.Unstructured, specifiedFunc genListOptionFunc, defaultFunc genListOptionFunc) ([]unstructured.Unstructured, error) {
+
+	itemList := unstructured.UnstructuredList{}
+	itemList.SetAPIVersion(resource.APIVersion)
+	itemList.SetKind(fmt.Sprintf("%sList", resource.Kind))
+	var err error
+	if specifiedFunc == nil && defaultFunc == nil {
+		// if the relationShip between parent and child hasn't defined by any genListOption, list all subResource and filter by ownerReference UID
+		err = k8sClient.List(clusterCTX, &itemList)
+		if err != nil {
+			return nil, err
+		}
+		var res []unstructured.Unstructured
+		for _, item := range itemList.Items {
+			for _, reference := range item.GetOwnerReferences() {
+				if reference.UID == parentObject.GetUID() {
+					res = append(res, item)
+				}
+			}
+		}
+		return res, nil
+	}
+	var listOptions client.ListOptions
+	if specifiedFunc != nil {
+		//  specified func will override the default func
+		listOptions, err = specifiedFunc(parentObject)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		listOptions, err = defaultFunc(parentObject)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = k8sClient.List(clusterCTX, &itemList, &listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return itemList.Items, nil
+}
+
+func iteratorChildResources(ctx context.Context, cluster string, k8sClient client.Client, parentResource types.ResourceTreeNode) ([]types.ResourceTreeNode, error) {
+	parentObject, err := fetchObjectWithResourceTreeNode(ctx, cluster, k8sClient, parentResource)
+	if err != nil {
+		return nil, err
+	}
+	group := parentObject.GetObjectKind().GroupVersionKind().Group
+	kind := parentObject.GetObjectKind().GroupVersionKind().Kind
+
+	if rules, ok := globalRule[GroupResourceType{Group: group, Kind: kind}]; ok {
+		var resList []types.ResourceTreeNode
+		for resource, specifiedFunc := range rules.CareResource {
+			clusterCTX := multicluster.ContextWithClusterName(ctx, cluster)
+			items, err := listItemByRule(clusterCTX, k8sClient, resource, *parentObject, specifiedFunc, rules.DefaultGenListOptionFunc)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				rtn := types.ResourceTreeNode{
+					APIVersion: item.GetAPIVersion(),
+					Kind:       item.GroupVersionKind().Kind,
+					Namespace:  item.GetNamespace(),
+					Name:       item.GetName(),
+					UID:        item.GetUID(),
+					Cluster:    cluster,
+				}
+				if _, ok := globalRule[GroupResourceType{Group: item.GetObjectKind().GroupVersionKind().Group, Kind: item.GetObjectKind().GroupVersionKind().Kind}]; ok {
+					childrenRes, err := iteratorChildResources(ctx, cluster, k8sClient, rtn)
+					if err != nil {
+						return nil, err
+					}
+					rtn.ChildrenResources = childrenRes
+				}
+				healthStatus, err := checkResourceStatus(item)
+				if err != nil {
+					return nil, err
+				}
+				rtn.ResourceHealthStatus = *healthStatus
+				resList = append(resList, rtn)
+			}
+		}
+		return resList, nil
+	}
+	return nil, nil
+}

--- a/pkg/velaql/providers/query/tree_test.go
+++ b/pkg/velaql/providers/query/tree_test.go
@@ -760,11 +760,11 @@ var _ = Describe("unit-test to e2e test", func() {
 			Name:       "deploy1",
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
-		})
+		}, 1)
 		Expect(err).Should(BeNil())
 		Expect(len(tn)).Should(BeEquivalentTo(2))
-		Expect(len(tn[0].ChildrenResources)).Should(BeEquivalentTo(1))
-		Expect(len(tn[1].ChildrenResources)).Should(BeEquivalentTo(1))
+		Expect(len(tn[0].LeafNodes)).Should(BeEquivalentTo(1))
+		Expect(len(tn[1].LeafNodes)).Should(BeEquivalentTo(1))
 	})
 
 	It("test provider handler func", func() {

--- a/pkg/velaql/providers/query/tree_test.go
+++ b/pkg/velaql/providers/query/tree_test.go
@@ -1,0 +1,805 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package query
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/oam"
+
+	types2 "k8s.io/apimachinery/pkg/types"
+
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/stretchr/testify/assert"
+
+	v12 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+)
+
+func TestPodStatus(t *testing.T) {
+	succeedPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"}, Status: v1.PodStatus{
+		Phase: v1.PodSucceeded,
+	}}
+
+	runningReadyPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+			Phase: v1.PodRunning,
+		}}
+
+	runningUnHealthyPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode: 127,
+						},
+					},
+				},
+			},
+			Phase: v1.PodRunning,
+		}}
+
+	runningProgressingPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
+		Status: v1.PodStatus{
+			Phase:  v1.PodRunning,
+			Reason: "ContainerCreating",
+		}}
+
+	restartNeverPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		}}
+
+	pendingPod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "Pod"},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+		}, Status: v1.PodStatus{Phase: v1.PodPending},
+	}
+
+	testCases := map[string]struct {
+		intput v1.Pod
+		result types.HealthStatus
+	}{
+		"succeedPod": {
+			intput: succeedPod,
+			result: types.HealthStatus{Status: types.HealthStatusHealthy},
+		},
+		"runningReadyPod": {
+			intput: runningReadyPod,
+			result: types.HealthStatus{Status: types.HealthStatusHealthy, Reason: "all containers are ready"},
+		},
+		"runningUnHealthyPod": {
+			intput: runningUnHealthyPod,
+			result: types.HealthStatus{Status: types.HealthStatusUnHealthy},
+		},
+		"runningProgressingPod": {
+			intput: runningProgressingPod,
+			result: types.HealthStatus{Status: types.HealthStatusProgressing, Reason: "ContainerCreating"},
+		},
+		"restartNeverPod": {
+			intput: restartNeverPod,
+			result: types.HealthStatus{Status: types.HealthStatusProgressing},
+		},
+		"pendingPod": {
+			intput: pendingPod,
+			result: types.HealthStatus{Status: types.HealthStatusUnKnown, Reason: "Pending"},
+		},
+	}
+	for _, s := range testCases {
+		pod := s.intput.DeepCopy()
+		p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
+		assert.NoError(t, err)
+		res, err := checkPodStatus(unstructured.Unstructured{Object: p})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, *res, s.result)
+	}
+}
+
+func TestServiceStatus(t *testing.T) {
+	lbHealthSvc := v1.Service{Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer}, Status: v1.ServiceStatus{
+		LoadBalancer: v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{
+				{
+					IP: "198.1.1.1",
+				},
+			},
+		},
+	}}
+	lbProgressingSvc := v1.Service{Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer}, Status: v1.ServiceStatus{}}
+	testCases := map[string]struct {
+		input v1.Service
+		res   types.HealthStatus
+	}{
+		"health": {
+			input: lbHealthSvc,
+			res:   types.HealthStatus{Status: types.HealthStatusHealthy},
+		},
+		"progressing": {
+			input: lbProgressingSvc,
+			res:   types.HealthStatus{Status: types.HealthStatusProgressing},
+		},
+	}
+	for _, s := range testCases {
+		svc := s.input.DeepCopy()
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&svc)
+		assert.NoError(t, err)
+		res, err := checkServiceStatus(unstructured.Unstructured{Object: u})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, s.res, *res)
+	}
+}
+
+func TestPVCStatus(t *testing.T) {
+	heathyPVC := v1.PersistentVolumeClaim{Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound}}
+	unHeathyPVC := v1.PersistentVolumeClaim{Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimLost}}
+	progressingPVC := v1.PersistentVolumeClaim{Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimPending}}
+	heathyUnkown := v1.PersistentVolumeClaim{Status: v1.PersistentVolumeClaimStatus{}}
+	testCases := map[string]struct {
+		input v1.PersistentVolumeClaim
+		res   types.HealthStatus
+	}{
+		"health": {
+			input: heathyPVC,
+			res:   types.HealthStatus{Status: types.HealthStatusHealthy},
+		},
+		"progressing": {
+			input: progressingPVC,
+			res:   types.HealthStatus{Status: types.HealthStatusProgressing},
+		},
+		"unHealthy": {
+			input: unHeathyPVC,
+			res:   types.HealthStatus{Status: types.HealthStatusUnHealthy},
+		},
+		"unknown": {
+			input: heathyUnkown,
+			res:   types.HealthStatus{Status: types.HealthStatusUnKnown},
+		},
+	}
+	for _, s := range testCases {
+		pvc := s.input.DeepCopy()
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
+		assert.NoError(t, err)
+		res, err := checkPVCHealthStatus(unstructured.Unstructured{Object: u})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, s.res, *res)
+	}
+}
+
+func TestGetReplicaSetCondition(t *testing.T) {
+	rs := v12.ReplicaSet{Status: v12.ReplicaSetStatus{
+		Conditions: []v12.ReplicaSetCondition{{
+			Type: v12.ReplicaSetReplicaFailure,
+		}},
+	}}
+	c := getAppsv1ReplicaSetCondition(rs.Status, v12.ReplicaSetReplicaFailure)
+	assert.NotNil(t, c)
+}
+
+func TestReplicaSetStatus(t *testing.T) {
+	unhealthyReplicaSet := v12.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 2,
+		},
+		Status: v12.ReplicaSetStatus{ObservedGeneration: 2,
+			Conditions: []v12.ReplicaSetCondition{{
+				Type:   v12.ReplicaSetReplicaFailure,
+				Status: v1.ConditionTrue,
+			}}},
+	}
+	progressingPodReplicaSet := v12.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 2,
+		},
+		Spec: v12.ReplicaSetSpec{Replicas: pointer.Int32(3)},
+		Status: v12.ReplicaSetStatus{
+			ObservedGeneration: 2,
+			ReadyReplicas:      2,
+			AvailableReplicas:  2,
+		},
+	}
+	progressingRollingReplicaSet := v12.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 2,
+		},
+		Spec: v12.ReplicaSetSpec{Replicas: pointer.Int32(3)},
+		Status: v12.ReplicaSetStatus{
+			ObservedGeneration: 1,
+		},
+	}
+	testCases := map[string]struct {
+		input v12.ReplicaSet
+		res   types.HealthStatus
+	}{
+		"unHealth": {
+			input: unhealthyReplicaSet,
+			res:   types.HealthStatus{Status: types.HealthStatusUnHealthy},
+		},
+		"progressing": {
+			input: progressingPodReplicaSet,
+			res:   types.HealthStatus{Status: types.HealthStatusProgressing, Message: "Waiting for rollout to finish: 2 out of 3 new replicas are available..."},
+		},
+		"rolling": {
+			input: progressingRollingReplicaSet,
+			res:   types.HealthStatus{Status: types.HealthStatusProgressing, Message: "Waiting for rollout to finish: observed replica set generation less then desired generation"},
+		},
+	}
+	for d, s := range testCases {
+		fmt.Println(d)
+		rs := s.input.DeepCopy()
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rs)
+		assert.NoError(t, err)
+		res, err := checkReplicaSetStatus(unstructured.Unstructured{Object: u})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, s.res, *res)
+	}
+}
+
+func TestGenListOption(t *testing.T) {
+	resLabel, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"testKey": "testVal"}})
+	assert.NoError(t, err)
+	listOption := client.ListOptions{LabelSelector: resLabel, Namespace: "test"}
+
+	deploy := v12.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "test"}, Spec: v12.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"testKey": "testVal"}}}}
+	du, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&deploy)
+	assert.NoError(t, err)
+	assert.NotNil(t, du)
+	dls, err := deploy2RsLabelListOption(unstructured.Unstructured{Object: du})
+	assert.NoError(t, err)
+	assert.Equal(t, listOption, dls)
+
+	rs := v12.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Namespace: "test"}, Spec: v12.ReplicaSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"testKey": "testVal"}}}}
+	rsu, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rs)
+	assert.NoError(t, err)
+	assert.NotNil(t, du)
+	rsls, err := rs2PodLabelListOption(unstructured.Unstructured{Object: rsu})
+	assert.NoError(t, err)
+	assert.Equal(t, listOption, rsls)
+
+	sts := v12.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: "test"}, Spec: v12.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"testKey": "testVal"}}}}
+	stsu, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&sts)
+	assert.NoError(t, err)
+	assert.NotNil(t, stsu)
+	stsls, err := statefulSet2PodListOption(unstructured.Unstructured{Object: stsu})
+	assert.NoError(t, err)
+	assert.Equal(t, listOption, stsls)
+
+	helmRelease := unstructured.Unstructured{}
+	helmRelease.SetName("test-helm")
+	helmRelease.SetNamespace("test-ns")
+	hrll, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"helm.toolkit.fluxcd.io/name": "test-helm", "helm.toolkit.fluxcd.io/namespace": "test-ns"}})
+	assert.NoError(t, err)
+
+	hrls, err := helmRelease2AnyListOption(helmRelease)
+	assert.NoError(t, err)
+	assert.Equal(t, hrls, client.ListOptions{LabelSelector: hrll})
+}
+
+var _ = Describe("unit-test to e2e test", func() {
+	deploy1 := v12.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy1",
+			Namespace: "test-namespace",
+		},
+		Spec: v12.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy1",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy1",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deploy2 := v12.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy2",
+			Namespace: "test-namespace",
+		},
+		Spec: v12.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy2",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy2",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rs1 := v12.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "ReplicaSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy1",
+			},
+		},
+		Spec: v12.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy1",
+					"rs":  "rs1",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy1",
+						"rs":  "rs1",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rs2 := v12.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "ReplicaSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs2",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy1",
+			},
+		},
+		Spec: v12.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy1",
+					"rs":  "rs2",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy1",
+						"rs":  "rs2",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rs3 := v12.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "ReplicaSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs3",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy2",
+			},
+		},
+		Spec: v12.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy2",
+					"rs":  "rs3",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy2",
+						"rs":  "rs3",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod1 := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy1",
+				"rs":  "rs1",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "nginx",
+					Name:  "nginx",
+				},
+			},
+		},
+	}
+
+	pod2 := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy1",
+				"rs":  "rs2",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "nginx",
+					Name:  "nginx",
+				},
+			},
+		},
+	}
+
+	pod3 := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod3",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy2",
+				"rs":  "rs3",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "nginx",
+					Name:  "nginx",
+				},
+			},
+		},
+	}
+
+	rs4 := v12.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "ReplicaSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs4",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy3",
+			},
+		},
+		Spec: v12.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "deploy3",
+					"rs":  "rs4",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "deploy3",
+						"rs":  "rs4",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "nginx",
+							Name:  "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod4 := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod4",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "deploy3",
+				"rs":  "rs4",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "nginx",
+					Name:  "nginx",
+				},
+			},
+		},
+	}
+
+	var objectList []client.Object
+	objectList = append(objectList, &deploy1, &deploy1, &rs1, &rs2, &rs3, &rs4, &pod1, &pod2, &pod3, &rs4, &pod4)
+	BeforeEach(func() {
+		Expect(k8sClient.Create(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}})).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, deploy1.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, deploy2.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, rs1.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, rs2.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, rs3.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, pod1.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, pod2.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		Expect(k8sClient.Create(ctx, pod3.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+
+		cRs4 := rs4.DeepCopy()
+		Expect(k8sClient.Create(ctx, cRs4)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		cPod4 := pod4.DeepCopy()
+		cPod4.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       cRs4.Name,
+				UID:        cRs4.UID,
+			},
+		})
+		Expect(k8sClient.Create(ctx, cPod4)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		for _, object := range objectList {
+			Expect(k8sClient.Delete(ctx, object))
+		}
+	})
+
+	It("test fetchObjectWithResourceTreeNode func", func() {
+		rtn := types.ResourceTreeNode{
+			Name:       "deploy1",
+			Namespace:  "test-namespace",
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		}
+		u, err := fetchObjectWithResourceTreeNode(ctx, "", k8sClient, rtn)
+		Expect(err).Should(BeNil())
+		Expect(u).ShouldNot(BeNil())
+		Expect(u.GetName()).Should(BeEquivalentTo("deploy1"))
+	})
+
+	It("test list item by rule", func() {
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy1.DeepCopy())
+		Expect(err).Should(BeNil())
+		items, err := listItemByRule(ctx, k8sClient, ResourceType{APIVersion: "apps/v1", Kind: "ReplicaSet"}, unstructured.Unstructured{Object: u},
+			deploy2RsLabelListOption, nil)
+		Expect(err).Should(BeNil())
+		Expect(len(items)).Should(BeEquivalentTo(2))
+
+		u2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy2.DeepCopy())
+		Expect(err).Should(BeNil())
+		items2, err := listItemByRule(ctx, k8sClient, ResourceType{APIVersion: "apps/v1", Kind: "ReplicaSet"}, unstructured.Unstructured{Object: u2},
+			nil, deploy2RsLabelListOption)
+		Expect(len(items2)).Should(BeEquivalentTo(1))
+
+		// test use ownerReference UId to filter
+		u3 := unstructured.Unstructured{}
+		u3.SetNamespace(rs4.Namespace)
+		u3.SetName(rs4.Name)
+		u3.SetAPIVersion("apps/v1")
+		u3.SetKind("ReplicaSet")
+		Expect(k8sClient.Get(ctx, types2.NamespacedName{Namespace: u3.GetNamespace(), Name: u3.GetName()}, &u3))
+		Expect(err).Should(BeNil())
+		items3, err := listItemByRule(ctx, k8sClient, ResourceType{APIVersion: "v1", Kind: "Pod"}, u3,
+			nil, nil)
+		Expect(err).Should(BeNil())
+		Expect(len(items3)).Should(BeEquivalentTo(1))
+	})
+
+	It("iterate resource", func() {
+		tn, err := iteratorChildResources(ctx, "", k8sClient, types.ResourceTreeNode{
+			Cluster:    "",
+			Namespace:  "test-namespace",
+			Name:       "deploy1",
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		})
+		Expect(err).Should(BeNil())
+		Expect(len(tn)).Should(BeEquivalentTo(2))
+		Expect(len(tn[0].ChildrenResources)).Should(BeEquivalentTo(1))
+		Expect(len(tn[1].ChildrenResources)).Should(BeEquivalentTo(1))
+	})
+
+	It("test provider handler func", func() {
+		app := v1beta1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app",
+				Namespace: "test-namespace",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{},
+			},
+		}
+
+		rt := v1beta1.ResourceTracker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-test-v1-namespace",
+				Labels: map[string]string{
+					oam.LabelAppName:      "app",
+					oam.LabelAppNamespace: "test-namespace",
+				},
+				Annotations: map[string]string{
+					oam.AnnotationPublishVersion: "v1",
+				},
+			},
+			Spec: v1beta1.ResourceTrackerSpec{
+				Type: v1beta1.ResourceTrackerTypeVersioned,
+				ManagedResources: []v1beta1.ManagedResource{
+					{
+						ClusterObjectReference: common.ClusterObjectReference{
+							Cluster: "",
+							ObjectReference: v1.ObjectReference{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+								Namespace:  "test-namespace",
+								Name:       "deploy1",
+							},
+						},
+						OAMObjectReference: common.OAMObjectReference{
+							Component: "deploy1",
+						},
+					},
+					{
+						ClusterObjectReference: common.ClusterObjectReference{
+							Cluster: "",
+							ObjectReference: v1.ObjectReference{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+								Namespace:  "test-namespace",
+								Name:       "deploy2",
+							},
+						},
+						OAMObjectReference: common.OAMObjectReference{
+							Component: "deploy2",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &rt)).Should(BeNil())
+
+		prd := provider{cli: k8sClient}
+		opt := `app: {
+				name: "app"
+				namespace: "test-namespace"
+			}`
+		v, err := value.NewValue(opt, nil, "")
+		Expect(err).Should(BeNil())
+		Expect(prd.GetApplicationResourceTree(nil, v, nil)).Should(BeNil())
+		type Res struct {
+			List []types.AppliedResource `json:"list"`
+		}
+		var res Res
+		err = v.UnmarshalTo(&res)
+		Expect(err).Should(BeNil())
+		Expect(len(res.List)).Should(Equal(2))
+	})
+})

--- a/pkg/velaql/providers/query/types/health_status.go
+++ b/pkg/velaql/providers/query/types/health_status.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+// HealthStatusCode Represents resource health status
+type HealthStatusCode string
+
+const (
+	// HealthStatusHealthy  resource is healthy
+	HealthStatusHealthy HealthStatusCode = "HealthStatusHealthy"
+	// HealthStatusUnHealthy resource is unhealthy
+	HealthStatusUnHealthy HealthStatusCode = "HealthStatusUnHealthy"
+	// HealthStatusProgressing resource is still progressing
+	HealthStatusProgressing HealthStatusCode = "HealthStatusProgressing"
+	// HealthStatusUnKnown health status is unknown
+	HealthStatusUnKnown HealthStatusCode = "HealthStatusUnKnown"
+)
+
+// HealthStatus the resource health status
+type HealthStatus struct {
+	Status  HealthStatusCode `json:"statusCode"`
+	Reason  string           `json:"reason"`
+	Message string           `json:"message"`
+}

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -105,14 +105,14 @@ type AppliedResource struct {
 
 // ResourceTreeNode is the tree node of every resource
 type ResourceTreeNode struct {
-	Cluster              string             `json:"cluster"`
-	APIVersion           string             `json:"apiVersion,omitempty"`
-	Kind                 string             `json:"kind"`
-	Namespace            string             `json:"namespace,omitempty"`
-	Name                 string             `json:"name,omitempty"`
-	UID                  types.UID          `json:"uid,omitempty"`
-	ResourceHealthStatus HealthStatus       `json:"resourceHealthStatus,omitempty"`
-	ChildrenResources    []ResourceTreeNode `json:"childrenResources,omitempty"`
+	Cluster      string             `json:"cluster"`
+	APIVersion   string             `json:"apiVersion,omitempty"`
+	Kind         string             `json:"kind"`
+	Namespace    string             `json:"namespace,omitempty"`
+	Name         string             `json:"name,omitempty"`
+	UID          types.UID          `json:"uid,omitempty"`
+	HealthStatus HealthStatus       `json:"healthStatus,omitempty"`
+	LeafNodes    []ResourceTreeNode `json:"leafNodes,omitempty"`
 }
 
 // GroupVersionKind returns the stored group, version, and kind of an object

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -87,19 +87,32 @@ type Endpoint struct {
 
 // AppliedResource resource metadata
 type AppliedResource struct {
-	Cluster         string    `json:"cluster"`
-	Component       string    `json:"component"`
-	Trait           string    `json:"trait"`
-	Kind            string    `json:"kind"`
-	Namespace       string    `json:"namespace,omitempty"`
-	Name            string    `json:"name,omitempty"`
-	UID             types.UID `json:"uid,omitempty"`
-	APIVersion      string    `json:"apiVersion,omitempty"`
-	ResourceVersion string    `json:"resourceVersion,omitempty"`
-	DeployVersion   string    `json:"deployVersion,omitempty"`
-	PublishVersion  string    `json:"publishVersion,omitempty"`
-	Revision        string    `json:"revision,omitempty"`
-	Latest          bool      `json:"latest"`
+	Cluster         string           `json:"cluster"`
+	Component       string           `json:"component"`
+	Trait           string           `json:"trait"`
+	Kind            string           `json:"kind"`
+	Namespace       string           `json:"namespace,omitempty"`
+	Name            string           `json:"name,omitempty"`
+	UID             types.UID        `json:"uid,omitempty"`
+	APIVersion      string           `json:"apiVersion,omitempty"`
+	ResourceVersion string           `json:"resourceVersion,omitempty"`
+	DeployVersion   string           `json:"deployVersion,omitempty"`
+	PublishVersion  string           `json:"publishVersion,omitempty"`
+	Revision        string           `json:"revision,omitempty"`
+	Latest          bool             `json:"latest"`
+	ResourceTree    ResourceTreeNode `json:"resourceTree,omitempty"`
+}
+
+// ResourceTreeNode is the tree node of every resource
+type ResourceTreeNode struct {
+	Cluster              string             `json:"cluster"`
+	APIVersion           string             `json:"apiVersion,omitempty"`
+	Kind                 string             `json:"kind"`
+	Namespace            string             `json:"namespace,omitempty"`
+	Name                 string             `json:"name,omitempty"`
+	UID                  types.UID          `json:"uid,omitempty"`
+	ResourceHealthStatus HealthStatus       `json:"resourceHealthStatus,omitempty"`
+	ChildrenResources    []ResourceTreeNode `json:"childrenResources,omitempty"`
 }
 
 // GroupVersionKind returns the stored group, version, and kind of an object


### PR DESCRIPTION
implementation for get application resourceTree with velaql

eg: When access the endpoint: http://127.0.0.1:8000/api/v1/query/?velaql=application-resource-tree-view{appName="addon-kruise-rollout",appNs="vela-system",}.status . The result is
```json
{
    "resources": [
        {
            "apiVersion": "source.toolkit.fluxcd.io/v1beta1",
            "cluster": "",
            "component": "kruise-rollout",
            "kind": "HelmRepository",
            "latest": true,
            "name": "kruise-rollout",
            "namespace": "vela-system",
            "resourceTree": {
                "apiVersion": "source.toolkit.fluxcd.io/v1beta1",
                "cluster": "",
                "kind": "HelmRepository",
                "name": "kruise-rollout",
                "namespace": "vela-system",
                "resourceHealthStatus": {
                    "message": "",
                    "reason": "",
                    "statusCode": "HealthStatusHealthy"
                }
            },
            "revision": "addon-kruise-rollout-v1",
            "trait": ""
        },
        {
            "apiVersion": "helm.toolkit.fluxcd.io/v2beta1",
            "cluster": "",
            "component": "kruise-rollout",
            "kind": "HelmRelease",
            "latest": true,
            "name": "kruise-rollout",
            "namespace": "vela-system",
            "resourceTree": {
                "apiVersion": "helm.toolkit.fluxcd.io/v2beta1",
                "childrenResources": [
                    {
                        "apiVersion": "v1",
                        "cluster": "",
                        "kind": "Service",
                        "name": "kruise-rollout-webhook-service",
                        "namespace": "kruise-rollout",
                        "resourceHealthStatus": {
                            "message": "",
                            "reason": "",
                            "statusCode": "HealthStatusHealthy"
                        },
                        "uid": "a80aa2bc-92aa-48a1-bd30-db88a53218b4"
                    },
                    {
                        "apiVersion": "apps/v1",
                        "childrenResources": [
                            {
                                "apiVersion": "apps/v1",
                                "childrenResources": [
                                    {
                                        "apiVersion": "v1",
                                        "cluster": "",
                                        "kind": "Pod",
                                        "name": "kruise-rollout-controller-manager-696bdb76f8-626cv",
                                        "namespace": "kruise-rollout",
                                        "resourceHealthStatus": {
                                            "message": "",
                                            "reason": "",
                                            "statusCode": "HealthStatusHealthy"
                                        },
                                        "uid": "3f11c45f-cf5b-4e20-bad2-9f4bcaccead9"
                                    },
                                    {
                                        "apiVersion": "v1",
                                        "cluster": "",
                                        "kind": "Pod",
                                        "name": "kruise-rollout-controller-manager-696bdb76f8-7g4jj",
                                        "namespace": "kruise-rollout",
                                        "resourceHealthStatus": {
                                            "message": "",
                                            "reason": "",
                                            "statusCode": "HealthStatusHealthy"
                                        },
                                        "uid": "6b942769-ae38-4751-863e-2c99bf0929a7"
                                    }
                                ],
                                "cluster": "",
                                "kind": "ReplicaSet",
                                "name": "kruise-rollout-controller-manager-696bdb76f8",
                                "namespace": "kruise-rollout",
                                "resourceHealthStatus": {
                                    "message": "",
                                    "reason": "",
                                    "statusCode": "HealthStatusHealthy"
                                },
                                "uid": "96414447-a222-4301-a122-86f417d9af48"
                            }
                        ],
                        "cluster": "",
                        "kind": "Deployment",
                        "name": "kruise-rollout-controller-manager",
                        "namespace": "kruise-rollout",
                        "resourceHealthStatus": {
                            "message": "",
                            "reason": "",
                            "statusCode": "HealthStatusHealthy"
                        },
                        "uid": "a0935033-d0b6-4b32-a20f-59a60ee5ded4"
                    }
                ],
                "cluster": "",
                "kind": "HelmRelease",
                "name": "kruise-rollout",
                "namespace": "vela-system",
                "resourceHealthStatus": {
                    "message": "",
                    "reason": "",
                    "statusCode": "HealthStatusHealthy"
                }
            },
            "revision": "addon-kruise-rollout-v1",
            "trait": "AuxiliaryWorkload"
        }
    ]
}
```

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3886 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->