### PR TITLE
Feat: vela kube delete

### DIFF
--- a/references/cli/kube.go
+++ b/references/cli/kube.go
@@ -25,11 +25,17 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	velacmd "github.com/oam-dev/kubevela/pkg/cmd"
@@ -52,6 +58,7 @@ func KubeCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command 
 		},
 	}
 	cmd.AddCommand(NewKubeApplyCommand(f, streams))
+	cmd.AddCommand(NewKubeDeleteCommand(f, streams))
 	return cmd
 }
 
@@ -211,6 +218,145 @@ func NewKubeApplyCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Comma
 			velacmd.UsageOption("The namespace to apply objects. If empty, the namespace declared in the YAML will be used."),
 		).
 		WithClusterFlag(velacmd.UsageOption("The cluster to apply objects. Setting multiple clusters will apply objects in order.")).
+		WithStreams(streams).
+		WithResponsiveWriter().
+		Build()
+}
+
+// KubeDeleteOptions options for kube delete
+type KubeDeleteOptions struct {
+	clusters     []string
+	namespace    string
+	deleteAll    bool
+	resource     string
+	resourceName string
+
+	util.IOStreams
+}
+
+var (
+	kubeDeleteLong = templates.LongDesc(i18n.T(`
+		Delete Kubernetes objects in clusters
+
+		Delete Kubernetes objects in multiple clusters. Use --clusters to specify which clusters to
+		delete. Use -n/--namespace flags to specify which cluster the target resource locates.
+
+		Use --all flag to delete all this kind of objects in the target namespace and clusters.`))
+
+	kubeDeleteExample = templates.Examples(i18n.T(`
+		# Delete the deployment nginx in default namespace in cluster-1
+		vela kube delete deployment nginx --cluster cluster-1
+
+		# Delete the deployment nginx in demo namespace in cluster-1 and cluster-2
+		vela kube delete deployment nginx -n demo --cluster cluster-1 --cluster cluster-2
+
+		# Delete all deployments in demo namespace in cluster-1
+		vela kube delete deployment --all -n demo --cluster cluster-1`))
+)
+
+// Complete .
+func (opt *KubeDeleteOptions) Complete(f velacmd.Factory, cmd *cobra.Command, args []string) {
+	opt.namespace = velacmd.GetNamespace(f, cmd)
+	if opt.namespace == "" {
+		opt.namespace = metav1.NamespaceDefault
+	}
+	opt.clusters = velacmd.GetClusters(cmd)
+	opt.resource = args[0]
+	if len(args) == 2 {
+		opt.resourceName = args[1]
+	}
+}
+
+// Validate .
+func (opt *KubeDeleteOptions) Validate() error {
+	if opt.resourceName == "" && !opt.deleteAll {
+		return fmt.Errorf("either resource name or flag --all should be set")
+	}
+	if opt.resourceName != "" && opt.deleteAll {
+		return fmt.Errorf("cannot set resource name and flag --all at the same time")
+	}
+	return nil
+}
+
+// Run .
+func (opt *KubeDeleteOptions) Run(f velacmd.Factory, cmd *cobra.Command) error {
+	gvks, err := f.Client().RESTMapper().KindsFor(schema.GroupVersionResource{Resource: opt.resource})
+	if err != nil {
+		return fmt.Errorf("failed to find kinds for resource %s: %w", opt.resource, err)
+	}
+	if len(gvks) == 0 {
+		return fmt.Errorf("no kinds found for resource %s", opt.resource)
+	}
+	gvk := gvks[0]
+	mappings, err := f.Client().RESTMapper().RESTMappings(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return fmt.Errorf("failed to get mappings for resource %s: %w", opt.resource, err)
+	}
+	if len(mappings) == 0 {
+		return fmt.Errorf("no mappings found for resource %s", opt.resource)
+	}
+	mapping := mappings[0]
+	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
+	for _, cluster := range opt.clusters {
+		ctx := multicluster.ContextWithClusterName(cmd.Context(), cluster)
+		objs, obj := &unstructured.UnstructuredList{}, &unstructured.Unstructured{}
+		objs.SetGroupVersionKind(gvk)
+		obj.SetGroupVersionKind(gvk)
+		switch {
+		case opt.deleteAll && namespaced:
+			err = f.Client().List(ctx, objs, client.InNamespace(opt.namespace))
+		case opt.deleteAll && !namespaced:
+			err = f.Client().List(ctx, objs)
+		case !opt.deleteAll && namespaced:
+			err = f.Client().Get(ctx, apitypes.NamespacedName{Namespace: opt.namespace, Name: opt.resourceName}, obj)
+		case !opt.deleteAll && !namespaced:
+			err = f.Client().Get(ctx, apitypes.NamespacedName{Name: opt.resourceName}, obj)
+		}
+		if err != nil && !apierrors.IsNotFound(err) && !runtime.IsNotRegisteredError(err) && !meta.IsNoMatchError(err) {
+			return fmt.Errorf("failed to retrieve %s in cluster %s: %w", opt.resource, cluster, err)
+		}
+		for _, toDel := range append(objs.Items, *obj) {
+			key := toDel.GetName()
+			if key == "" {
+				continue
+			}
+			if namespaced {
+				key = toDel.GetNamespace() + "/" + key
+			}
+			if err = f.Client().Delete(ctx, toDel.DeepCopy()); err != nil {
+				return fmt.Errorf("failed to delete %s %s in cluster %s: %w", opt.resource, key, cluster, err)
+			}
+			_, _ = fmt.Fprintf(opt.IOStreams.Out, "%s %s in cluster %s deleted.\n", opt.resource, key, cluster)
+		}
+	}
+	return nil
+}
+
+// NewKubeDeleteCommand kube delete command
+func NewKubeDeleteCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+	o := &KubeDeleteOptions{IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   i18n.T("Delete resources in clusters."),
+		Long:    kubeDeleteLong,
+		Example: kubeDeleteExample,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCD,
+		},
+		Args: cobra.RangeArgs(1, 2),
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Complete(f, cmd, args)
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run(f, cmd))
+		},
+	}
+	cmd.Flags().BoolVarP(&o.deleteAll, "all", "", o.deleteAll, "Setting this flag will delete all this kind of resources.")
+	return velacmd.NewCommandBuilder(f, cmd).
+		WithNamespaceFlag(
+			velacmd.NamespaceFlagDisableEnvOption{},
+			velacmd.UsageOption("The namespace to delete objects. If empty, the default namespace will be used."),
+		).
+		WithClusterFlag(velacmd.UsageOption("The cluster to delete objects. Setting multiple clusters will delete objects in order.")).
 		WithStreams(streams).
 		WithResponsiveWriter().
 		Build()


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support `vela kube delete <resourceType> <resourceName> --cluster <clusterName>` to delete resources in clusters.

Usage:
```
  # Delete the deployment nginx in default namespace in cluster-1
  vela kube delete deployment nginx --cluster cluster-1
  
  # Delete the deployment nginx in demo namespace in cluster-1 and cluster-2
  vela kube delete deployment nginx -n demo --cluster cluster-1 --cluster cluster-2
  
  # Delete all deployments in demo namespace in cluster-1
  vela kube delete deployment --all -n demo --cluster cluster-1
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
