### PR TITLE
Fix: enhance auth CLI output

### DIFF
--- a/references/cli/auth.go
+++ b/references/cli/auth.go
@@ -377,6 +377,9 @@ func (opt *GrantPrivilegesOptions) Run(f velacmd.Factory, cmd *cobra.Command) er
 		for _, namespace := range opt.GrantNamespaces {
 			privileges = append(privileges, &auth.ScopedPrivilege{Cluster: cluster, Namespace: namespace, ReadOnly: opt.ReadOnly})
 		}
+		if len(opt.GrantNamespaces) == 0 {
+			privileges = append(privileges, &auth.ScopedPrivilege{Cluster: cluster, ReadOnly: opt.ReadOnly})
+		}
 	}
 	if err := auth.GrantPrivileges(ctx, f.Client(), privileges, &opt.Identity, opt.IOStreams.Out); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. `auth grant-privileges` show cluster when displaying results.
```
$ vela auth grant-privileges --user bob --for-cluster=velad-002 --for-namespace=dev --readonly
RoleBinding dev/kubevela:reader:binding created in velad-002.
Privileges granted.
```
2. Fixes grant cluster-scoped privileges error. (Previously not correctly convert the input)
```
$ vela auth grant-privileges --user bob --for-cluster=velad-003           
ClusterRoleBinding kubevela:writer:binding created in velad-003.
Privileges granted.
```
3. Enhance the output of list-privileges. Converting "Binding" to "Scope" to be more clear.
```
$ vela auth list-privileges --user bob --cluster velad-002,velad-003                        
User=bob
├── [Cluster]  velad-002
│   └── [ClusterRole]  kubevela:reader
│       ├── [Scope]  
│       │   └── [Namespaced]  dev (RoleBinding kubevela:reader:binding)
│       └── [PolicyRules]  
│           ├── APIGroups:       *
│           │   Resources:       *
│           │   Verb:            get, list, watch
│           └── NonResourceURLs: *
│               Verb:            get, list, watch
└── [Cluster]  velad-003
    └── [ClusterRole]  kubevela:writer
        ├── [Scope]  
        │   └── [Cluster]  (ClusterRoleBinding kubevela:writer:binding)
        └── [PolicyRules]  
            ├── APIGroups:       *
            │   Resources:       *
            │   Verb:            get, list, watch, create, update, patch, delete
            └── NonResourceURLs: *
                Verb:            get, list, watch, create, update, patch, delete
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->