### PR TITLE
Fix: add error message when the image doesn't exist

### DIFF
--- a/pkg/apiserver/domain/service/project.go
+++ b/pkg/apiserver/domain/service/project.go
@@ -657,12 +657,15 @@ func validateImage(ctx context.Context, k8sClient client.Client, project, imageN
 		}
 	}
 
+	var errMsg string
 	existed, err := image.IsExisted(username, password, imageName)
 	if err != nil {
-		return nil, err
+		errMsg = err.Error()
 	}
+
 	return &apisv1.ImageResponse{
 		Existed: existed,
 		Secret:  imagePullSecret,
+		Message: errMsg,
 	}, nil
 }

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -214,6 +214,7 @@ type Config struct {
 type ImageResponse struct {
 	Existed bool   `json:"existed"`
 	Secret  string `json:"secret"`
+	Message string `json:"message"`
 }
 
 // AccessKeyRequest request parameters to access cloud provider


### PR DESCRIPTION
Do not return error directly when the image doesn't exist

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->