### PR TITLE
Feat:  mechanism to let user add relationship  mapping rule by configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,10 +110,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 )
 
-require (
-	github.com/google/go-containerregistry v0.9.0
-	gopkg.in/yaml.v2 v2.4.0
-)
+require github.com/google/go-containerregistry v0.9.0
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
@@ -300,6 +297,7 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	istio.io/api v0.0.0-20210128181506-0c4b8e54850f // indirect
 	istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a // indirect
 	oras.land/oras-go v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,10 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 )
 
-require github.com/google/go-containerregistry v0.9.0
+require (
+	github.com/google/go-containerregistry v0.9.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
@@ -297,7 +300,6 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	istio.io/api v0.0.0-20210128181506-0c4b8e54850f // indirect
 	istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a // indirect
 	oras.land/oras-go v0.4.0 // indirect

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -96,6 +96,8 @@ const (
 
 	// LabelProject recorde the project the resource belong to
 	LabelProject = "core.oam.dev/project"
+
+	LabelResourceRules = "rules.oam.dev/resources"
 )
 
 const (

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -156,6 +156,11 @@ func (h *provider) GetApplicationResourceTree(ctx wfContext.Context, v *value.Va
 	if err != nil {
 		return v.FillObject(err.Error(), "err")
 	}
+	// merge user defined customize rule before every request.
+	err = mergeCustomRules(context.Background(), h.cli)
+	if err != nil {
+		return err
+	}
 	for _, resource := range appResList {
 		root := querytypes.ResourceTreeNode{
 			APIVersion: resource.APIVersion,

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -740,7 +740,7 @@ options: {
 				Name: "vela-system",
 			},
 		})
-		Expect(err).Should(BeNil())
+		Expect(err).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 		for _, s := range testServicelist {
 			ns := "default"
 			if s["namespace"] != nil {

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -91,14 +91,10 @@ type ResourceType struct {
 	Kind       string `json:"kind,omitempty"`
 }
 
-// CustomRules define the customize rule created by user
-type CustomRule struct {
+// customRule define the customize rule created by user
+type customRule struct {
 	ParentResourceType   *GroupResourceType `json:"parentResourceType,omitempty"`
 	ChildrenResourceType []ResourceType     `json:"childrenResourceType,omitempty"`
-}
-
-type CustomRules struct {
-	CustomRules []CustomRule `json:"customRules"`
 }
 
 // ChildrenResourcesRule define the relationShip between parentObject and children resource
@@ -472,10 +468,11 @@ func mergeCustomRules(ctx context.Context, k8sClient client.Client) error {
 	}
 	for _, item := range rulesList.Items {
 		ruleStr := item.Data[relationshipKey]
-		var customRules []*CustomRule
+		var customRules []*customRule
 		err := yaml.Unmarshal([]byte(ruleStr), &customRules)
 		if err != nil {
-			return err
+			// don't let one miss-config configmap brake whole process
+			log.Logger.Errorf("relationship rule configamp %s miss config %v", item.Name, err)
 		}
 		for _, rule := range customRules {
 			if cResource, ok := globalRule[*rule.ParentResourceType]; ok {

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	velatypes "github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/oam"
+
 	"github.com/oam-dev/kubevela/pkg/apiserver/utils/log"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,10 +34,14 @@ import (
 	"k8s.io/kubectl/pkg/util/podutils"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
 )
+
+// relationshipKey is the configmap key of relationShip rule
+var relationshipKey = "rules"
 
 // set the iterator max depth is 5
 var maxDepth = 5
@@ -82,6 +89,16 @@ type GroupResourceType struct {
 type ResourceType struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Kind       string `json:"kind,omitempty"`
+}
+
+// CustomRules define the customize rule created by user
+type CustomRule struct {
+	ParentResourceType   *GroupResourceType `json:"parentResourceType,omitempty"`
+	ChildrenResourceType []ResourceType     `json:"childrenResourceType,omitempty"`
+}
+
+type CustomRules struct {
+	CustomRules []CustomRule `json:"customRules"`
 }
 
 // ChildrenResourcesRule define the relationShip between parentObject and children resource
@@ -445,4 +462,36 @@ func iteratorChildResources(ctx context.Context, cluster string, k8sClient clien
 		return resList, nil
 	}
 	return nil, nil
+}
+
+// mergeCustomRules merge the customize
+func mergeCustomRules(ctx context.Context, k8sClient client.Client) error {
+	rulesList := v12.ConfigMapList{}
+	if err := k8sClient.List(ctx, &rulesList, client.InNamespace(velatypes.DefaultKubeVelaNS), client.HasLabels{oam.LabelResourceRules}); err != nil {
+		return err
+	}
+	for _, item := range rulesList.Items {
+		ruleStr := item.Data[relationshipKey]
+		var customRules []*CustomRule
+		err := yaml.Unmarshal([]byte(ruleStr), &customRules)
+		if err != nil {
+			return err
+		}
+		for _, rule := range customRules {
+			if cResource, ok := globalRule[*rule.ParentResourceType]; ok {
+				for _, resourceType := range rule.ChildrenResourceType {
+					if _, ok := cResource.CareResource[resourceType]; !ok {
+						cResource.CareResource[resourceType] = nil
+					}
+				}
+			} else {
+				caredResources := map[ResourceType]genListOptionFunc{}
+				for _, resourceType := range rule.ChildrenResourceType {
+					caredResources[resourceType] = nil
+				}
+				globalRule[*rule.ParentResourceType] = ChildrenResourcesRule{DefaultGenListOptionFunc: nil, CareResource: caredResources}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/velaql/providers/query/tree_test.go
+++ b/pkg/velaql/providers/query/tree_test.go
@@ -904,9 +904,5 @@ var _ = Describe("test merge globalRules", func() {
 		crSpecifyFunc, ok := childrenResources.CareResource[ResourceType{APIVersion: "apps/v1", Kind: "ControllerRevision"}]
 		Expect(ok).Should(BeTrue())
 		Expect(crSpecifyFunc).Should(BeNil())
-
-		Expect(k8sClient.Delete(ctx, &cloneSetConfigMap)).Should(BeNil())
-		Expect(k8sClient.Delete(ctx, &daemonSetConfigMap)).Should(BeNil())
-		Expect(k8sClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vela-system"}})).Should(BeNil())
 	})
 })


### PR DESCRIPTION
mechanism to  relation-rule between parent and children resource

You can apply this configmap to create the relationship between cronjob, job and pod
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: clone-set-relation
  namespace: vela-system
  labels:
    "rules.oam.dev/resources": "true"
data:
  rules: |-
    - parentResourceType:
        group: batch
        kind: CronJob
      childrenResourceType:
        - apiVersion: batch/v1
          kind: Job
    - parentResourceType:
         group: batch
         kind: Job
      childrenResourceType:
         - apiVersion: v1
           kind: Pod
```
then you request the application resource tree will get
```json
{
  "resources": [
    {
      "apiVersion": "batch/v1beta1",
      "cluster": "",
      "component": "nacos",
      "kind": "CronJob",
      "latest": true,
      "name": "nacos",
      "namespace": "default",
      "resourceTree": {
        "apiVersion": "batch/v1beta1",
        "cluster": "",
        "healthStatus": {
          "message": "",
          "reason": "",
          "statusCode": "HealthStatusHealthy"
        },
        "kind": "CronJob",
        "leafNodes": [
          {
            "apiVersion": "batch/v1",
            "cluster": "",
            "healthStatus": {
              "message": "",
              "reason": "",
              "statusCode": "HealthStatusHealthy"
            },
            "kind": "Job",
            "leafNodes": [
              {
                "apiVersion": "v1",
                "cluster": "",
                "healthStatus": {
                  "message": "",
                  "reason": "",
                  "statusCode": "HealthStatusProgressing"
                },
                "kind": "Pod",
                "name": "nacos-27556371--1-nws5t",
                "namespace": "default",
                "uid": "a6e7617f-8182-4735-91c0-53e6d5b35426"
              }
            ],
            "name": "nacos-27556371",
            "namespace": "default",
            "uid": "706714cc-911c-42a3-a181-9ee9442672f8"
          },
          {
            "apiVersion": "batch/v1",
            "cluster": "",
            "healthStatus": {
              "message": "",
              "reason": "",
              "statusCode": "HealthStatusHealthy"
            },
            "kind": "Job",
            "leafNodes": [
              {
                "apiVersion": "v1",
                "cluster": "",
                "healthStatus": {
                  "message": "",
                  "reason": "",
                  "statusCode": "HealthStatusProgressing"
                },
                "kind": "Pod",
                "name": "nacos-27556389--1-d4zgz",
                "namespace": "default",
                "uid": "4d83377d-f240-4f86-8830-cf3d1ef3ae6e"
              }
            ],
            "name": "nacos-27556389",
            "namespace": "default",
            "uid": "02c8c28d-c16d-4955-819f-d29a9e85feb0"
          }
        ],
        "name": "nacos",
        "namespace": "default"
      },
      "revision": "wordpress-v2",
      "trait": ""
    }
  ]
}
```


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->