### PR TITLE
Fix: vela port-forward not working and kustomize not read environment…

### DIFF
--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -57,15 +57,17 @@ CUE=$(shell which cue)
 endif
 
 KUSTOMIZE_VERSION ?= 4.5.4
-KUSTOMIZE = $(shell pwd)/bin/kustomize
+KUSTOMIZE_HOME = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize:
-ifeq (, $(shell $(KUSTOMIZE) version | grep $(KUSTOMIZE_VERSION)))
+ifneq (, $(shell kustomize version | grep $(KUSTOMIZE_VERSION)))
+else ifneq (, $(shell $(KUSTOMIZE_HOME) version | grep $(KUSTOMIZE_VERSION)))
+else
 	@{ \
 	set -eo pipefail ;\
     echo "installing kustomize-v$(KUSTOMIZE_VERSION) into $(shell pwd)/bin" ;\
     mkdir -p $(shell pwd)/bin ;\
-    rm -f $(KUSTOMIZE) ;\
+    rm -f $(KUSTOMIZE_HOME) ;\
 	curl -sS https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s $(KUSTOMIZE_VERSION) $(shell pwd)/bin;\
 	echo 'Install succeed' ;\
     }

--- a/references/cli/portforward.go
+++ b/references/cli/portforward.go
@@ -293,25 +293,28 @@ func (o *VelaPortForwardOptions) Complete() error {
 		var found bool
 		_, configs := appfile.GetApplicationSettings(o.App, compName)
 		for k, v := range configs {
-			if k == "port" {
-				var val string
-				switch pv := v.(type) {
-				case int:
-					val = strconv.Itoa(pv)
-				case string:
-					val = pv
-				case float64:
-					val = strconv.Itoa(int(pv))
-				default:
-					return fmt.Errorf("invalid type '%s' of port %v", reflect.TypeOf(v), k)
+			if k == "ports" {
+				portArray := v.([]interface{})
+				for _, p := range portArray {
+					var val string
+					switch pv := p.(map[string]interface{})["port"].(type) {
+					case int:
+						val = strconv.Itoa(pv)
+					case string:
+						val = pv
+					case float64:
+						val = strconv.Itoa(int(pv))
+					default:
+						return fmt.Errorf("invalid type '%s' of port %v", reflect.TypeOf(v), k)
+					}
+					if val == "80" {
+						val = "8080:80"
+					} else if val == "443" {
+						val = "8443:443"
+					}
+					o.Args = append(o.Args, val)
+					found = true
 				}
-				if val == "80" {
-					val = "8080:80"
-				} else if val == "443" {
-					val = "8443:443"
-				}
-				o.Args = append(o.Args, val)
-				found = true
 			}
 		}
 		if !found {

--- a/references/cli/portforward_test.go
+++ b/references/cli/portforward_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	util2 "github.com/oam-dev/kubevela/pkg/oam/util"
+	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+var _ = Describe("Test port-forward cli", func() {
+
+	When("test port-forward cli", func() {
+
+		It("should not have err", func() {
+			app := v1beta1.Application{}
+			Expect(yaml.Unmarshal([]byte(appWithNginx), &app)).Should(BeNil())
+			Expect(k8sClient.Create(context.Background(), &app)).Should(SatisfyAny(BeNil(), util2.AlreadyExistMatcher{}))
+			arg := common2.Args{}
+			arg.SetClient(k8sClient)
+			buffer := bytes.NewBuffer(nil)
+			ioStreams := util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer}
+			cmd := NewPortForwardCommand(arg, "nginx", ioStreams)
+			Expect(cmd.Execute()).Should(BeNil())
+			buf, ok := ioStreams.Out.(*bytes.Buffer)
+			Expect(ok).Should(BeTrue())
+			Expect(strings.Contains(buf.String(), "error")).Should(BeFalse())
+		})
+	})
+})
+
+const (
+	appWithNginx = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: nginx
+  namespace: default
+spec:
+  components:
+  - name: nginx
+    type: webservice
+    properties:
+      image: nginx
+      ports:
+      - expose: true
+        port: 80
+        protocol: TCP
+    traits:
+    - properties:
+        replicas: 1
+      type: scaler
+`
+)


### PR DESCRIPTION
… variables

Signed-off-by: Xiangbo Ma <maxiangboo@cmbchina.com>


### Description of your changes
FIx vela port-forward not working for webservice component and kustomize not read environment variables.


Fixes #3885 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.



### Special notes for your reviewer

ping @wonderflow 