### PR TITLE
Fix: kustomize can not read environment variables

### DIFF
--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -60,7 +60,10 @@ KUSTOMIZE_VERSION ?= 4.5.4
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize:
-ifeq (, $(shell $(KUSTOMIZE) version | grep $(KUSTOMIZE_VERSION)))
+ifneq (, $(shell kustomize version | grep $(KUSTOMIZE_VERSION)))
+KUSTOMIZE=$(shell which kustomize)
+else ifneq (, $(shell $(KUSTOMIZE) version | grep $(KUSTOMIZE_VERSION)))
+else
 	@{ \
 	set -eo pipefail ;\
     echo "installing kustomize-v$(KUSTOMIZE_VERSION) into $(shell pwd)/bin" ;\


### PR DESCRIPTION
Signed-off-by: Xiangbo Ma <maxiangboo@cmbchina.com>


### Description of your changes

Kustomize can not read environment variables

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->