### PR TITLE
Fix: initialize kube config multiple times

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -109,19 +109,13 @@ type Server struct {
 func (s *Server) run(ctx context.Context, errChan chan error) error {
 	log.Logger.Infof("KubeVela information: version: %v, gitRevision: %v", version.VelaVersion, version.GitRevision)
 
-	server, err := apiserver.New(s.serverConfig)
-	if err != nil {
-		return fmt.Errorf("create apiserver failed : %w ", err)
-	}
+	server := apiserver.New(s.serverConfig)
 
 	return server.Run(ctx, errChan)
 }
 
 func (s *Server) buildSwagger() (*spec.Swagger, error) {
-	server, err := apiserver.New(s.serverConfig)
-	if err != nil {
-		return nil, err
-	}
+	server := apiserver.New(s.serverConfig)
 	config, err := server.BuildRestfulConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/apiserver/domain/service/project.go
+++ b/pkg/apiserver/domain/service/project.go
@@ -363,6 +363,12 @@ func (p *projectServiceImpl) UpdateProject(ctx context.Context, projectName stri
 			}
 			return nil, err
 		}
+		if _, err := p.AddProjectUser(ctx, projectName, apisv1.AddProjectUserRequest{
+			UserName:  req.Owner,
+			UserRoles: []string{"project-admin"},
+		}); err != nil && !errors.Is(err, bcode.ErrProjectUserExist) {
+			return nil, err
+		}
 		project.Owner = req.Owner
 	}
 	err = p.Store.Put(ctx, project)

--- a/pkg/apiserver/domain/service/project_test.go
+++ b/pkg/apiserver/domain/service/project_test.go
@@ -189,6 +189,27 @@ var _ = Describe("Test project service functions", func() {
 		Expect(base.Description).Should(BeEquivalentTo("Change description"))
 		Expect(base.Owner.Alias).Should(BeEquivalentTo("Administrator"))
 
+		user := &model.User{
+			Name:     "admin-2",
+			Alias:    "Administrator2",
+			Password: "ddddd",
+			Disabled: false,
+		}
+		err = projectService.Store.Add(context.TODO(), user)
+		Expect(err).Should(BeNil())
+		base, err = projectService.UpdateProject(context.TODO(), "test-project", apisv1.UpdateProjectRequest{
+			Alias:       "Change alias",
+			Description: "Change description",
+			Owner:       "admin-2",
+		})
+		Expect(err).Should(BeNil())
+		Expect(base.Alias).Should(BeEquivalentTo("Change alias"))
+		Expect(base.Description).Should(BeEquivalentTo("Change description"))
+		Expect(base.Owner.Alias).Should(BeEquivalentTo("Administrator2"))
+		res, err := projectService.ListProjectUser(context.TODO(), "test-project", 0, 0)
+		Expect(err).Should(BeNil())
+		Expect(res.Total).Should(Equal(int64(2)))
+
 		_, err = projectService.UpdateProject(context.TODO(), "test-project", apisv1.UpdateProjectRequest{
 			Alias:       "Change alias",
 			Description: "Change description",

--- a/pkg/apiserver/domain/service/rbac.go
+++ b/pkg/apiserver/domain/service/rbac.go
@@ -51,7 +51,7 @@ var defaultProjectPermissionTemplate = []*model.PermissionTemplate{
 	{
 		Name:      "app-management",
 		Alias:     "App Management",
-		Resources: []string{"project:{projectName}/application:*/*", "definition:*"},
+		Resources: []string{"project:{projectName}/application:*/*", "definition:list", "definition:detail"},
 		Actions:   []string{"*"},
 		Effect:    "Allow",
 		Scope:     "project",

--- a/pkg/apiserver/infrastructure/clients/kubeclient.go
+++ b/pkg/apiserver/infrastructure/clients/kubeclient.go
@@ -18,6 +18,7 @@ package clients
 
 import (
 	"errors"
+	"fmt"
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -57,11 +58,7 @@ func GetKubeClient() (client.Client, error) {
 		return kubeClient, nil
 	}
 	if kubeConfig == nil {
-		conf, err := config.GetConfig()
-		if err != nil {
-			return nil, err
-		}
-		kubeConfig = conf
+		return nil, fmt.Errorf("please call SetKubeConfig first")
 	}
 	var err error
 	kubeClient, err = multicluster.Initialize(kubeConfig, false)
@@ -81,10 +78,8 @@ func GetKubeClient() (client.Client, error) {
 
 // GetKubeConfig create/get kube runtime config
 func GetKubeConfig() (*rest.Config, error) {
-	var err error
 	if kubeConfig == nil {
-		kubeConfig, err = config.GetConfig()
-		return kubeConfig, err
+		return nil, fmt.Errorf("please call SetKubeConfig first")
 	}
 	return kubeConfig, nil
 }

--- a/pkg/velaql/providers/query/types/health_status.go
+++ b/pkg/velaql/providers/query/types/health_status.go
@@ -21,13 +21,13 @@ type HealthStatusCode string
 
 const (
 	// HealthStatusHealthy  resource is healthy
-	HealthStatusHealthy HealthStatusCode = "HealthStatusHealthy"
+	HealthStatusHealthy HealthStatusCode = "Healthy"
 	// HealthStatusUnHealthy resource is unhealthy
-	HealthStatusUnHealthy HealthStatusCode = "HealthStatusUnHealthy"
+	HealthStatusUnHealthy HealthStatusCode = "UnHealthy"
 	// HealthStatusProgressing resource is still progressing
-	HealthStatusProgressing HealthStatusCode = "HealthStatusProgressing"
+	HealthStatusProgressing HealthStatusCode = "Progressing"
 	// HealthStatusUnKnown health status is unknown
-	HealthStatusUnKnown HealthStatusCode = "HealthStatusUnKnown"
+	HealthStatusUnKnown HealthStatusCode = "UnKnown"
 )
 
 // HealthStatus the resource health status

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -56,12 +56,6 @@ func TestE2eApiserverTest(t *testing.T) {
 
 // Suite test in e2e-apiserver-test relies on the pre-setup kubernetes environment
 var _ = BeforeSuite(func() {
-	By("new kube client")
-	var err error
-	k8sClient, err = clients.GetKubeClient()
-	Expect(err).Should(BeNil())
-	Expect(k8sClient).ToNot(BeNil())
-	By("new kube client success")
 
 	ctx := context.Background()
 
@@ -72,6 +66,8 @@ var _ = BeforeSuite(func() {
 			Database: "kubevela",
 		},
 		AddonCacheTime: 10 * time.Minute,
+		KubeQPS:        100,
+		KubeBurst:      300,
 	}
 	cfg.LeaderConfig.ID = uuid.New().String()
 	cfg.LeaderConfig.LockName = "apiserver-lock"
@@ -80,7 +76,7 @@ var _ = BeforeSuite(func() {
 	server := apiserver.New(cfg)
 	Expect(server).ShouldNot(BeNil())
 	go func() {
-		err = server.Run(ctx, make(chan error))
+		err := server.Run(ctx, make(chan error))
 		Expect(err).ShouldNot(HaveOccurred())
 	}()
 	By("wait for api server to start")
@@ -113,6 +109,9 @@ var _ = BeforeSuite(func() {
 			Expect(err).Should(BeNil())
 			return fmt.Errorf("rest service not ready code:%d message:%s", resp.StatusCode, code.Message)
 		}, time.Second*10, time.Millisecond*200).Should(BeNil())
+	var err error
+	k8sClient, err = clients.GetKubeClient()
+	Expect(err).ShouldNot(HaveOccurred())
 	By("api server started")
 })
 

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -77,8 +77,7 @@ var _ = BeforeSuite(func() {
 	cfg.LeaderConfig.LockName = "apiserver-lock"
 	cfg.LeaderConfig.Duration = time.Second * 10
 
-	server, err := apiserver.New(cfg)
-	Expect(err).ShouldNot(HaveOccurred())
+	server := apiserver.New(cfg)
 	Expect(server).ShouldNot(BeNil())
 	go func() {
 		err = server.Run(ctx, make(chan error))


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

Adjust the order in which the kube conf is created, there is must only one kube config instance. 

Others: Fixes #3967

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->