### PR TITLE
Fix: add some default permissions about the configuration

### DIFF
--- a/pkg/apiserver/domain/service/rbac.go
+++ b/pkg/apiserver/domain/service/rbac.go
@@ -72,6 +72,14 @@ var defaultProjectPermissionTemplate = []*model.PermissionTemplate{
 		Effect:    "Allow",
 		Scope:     "project",
 	},
+	{
+		Name:      "configuration-read",
+		Alias:     "Environment Management",
+		Resources: []string{"project:{projectName}/config:*"},
+		Actions:   []string{"list", "detail"},
+		Effect:    "Allow",
+		Scope:     "project",
+	},
 }
 
 var defaultPlatformPermission = []*model.PermissionTemplate{
@@ -119,6 +127,14 @@ var defaultPlatformPermission = []*model.PermissionTemplate{
 		Name:      "role-management",
 		Alias:     "Platform Role Management",
 		Resources: []string{"role:*", "permission:*"},
+		Actions:   []string{"*"},
+		Effect:    "Allow",
+		Scope:     "platform",
+	},
+	{
+		Name:      "integration-management",
+		Alias:     "Integration Management",
+		Resources: []string{"config:*", "configType:*"},
 		Actions:   []string{"*"},
 		Effect:    "Allow",
 		Scope:     "platform",
@@ -182,7 +198,7 @@ var ResourceMaps = map[string]resourceMetadata{
 				pathName: "userName",
 			},
 			"applicationTemplate": {},
-			"configs":             {},
+			"config":              {},
 			"image":               {},
 		},
 		pathName: "projectName",
@@ -754,12 +770,12 @@ func (p *rbacServiceImpl) InitDefaultRoleAndUsersForProject(ctx context.Context,
 	batchData = append(batchData, &model.Role{
 		Name:        "app-developer",
 		Alias:       "App Developer",
-		Permissions: []string{"project-read", "app-management", "env-management"},
+		Permissions: []string{"project-read", "app-management", "env-management", "configuration-read"},
 		Project:     project.Name,
 	}, &model.Role{
 		Name:        "project-admin",
 		Alias:       "Project Admin",
-		Permissions: []string{"project-read", "app-management", "env-management", "role-management"},
+		Permissions: []string{"project-read", "app-management", "env-management", "role-management", "configuration-read"},
 		Project:     project.Name,
 	})
 	if project.Owner != "" {

--- a/pkg/apiserver/domain/service/rbac_test.go
+++ b/pkg/apiserver/domain/service/rbac_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test rbac service", func() {
 		Expect(err).Should(BeNil())
 		policies, err := rbacService.ListPermissions(context.TODO(), "")
 		Expect(err).Should(BeNil())
-		Expect(len(policies)).Should(BeEquivalentTo(int64(7)))
+		Expect(len(policies)).Should(BeEquivalentTo(int64(8)))
 	})
 
 	It("Test checkPerm by admin user", func() {
@@ -194,7 +194,7 @@ var _ = Describe("Test rbac service", func() {
 
 		policies, err := rbacService.ListPermissions(context.TODO(), "init-test")
 		Expect(err).Should(BeNil())
-		Expect(len(policies)).Should(BeEquivalentTo(int64(4)))
+		Expect(len(policies)).Should(BeEquivalentTo(int64(5)))
 	})
 
 	It("Test UpdatePermission", func() {

--- a/pkg/apiserver/interfaces/api/config.go
+++ b/pkg/apiserver/interfaces/api/config.go
@@ -65,7 +65,7 @@ func (s *configAPIInterface) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.POST("/{configType}").To(s.createConfig).
 		Doc("create or update a config").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(s.RbacService.CheckPerm("configType", "create")).
+		Filter(s.RbacService.CheckPerm("configType/config", "create")).
 		Param(ws.PathParameter("configType", "identifier of the config type").DataType("string")).
 		Reads(apis.CreateConfigRequest{}).
 		Returns(200, "OK", apis.EmptyResponse{}).
@@ -76,7 +76,7 @@ func (s *configAPIInterface) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{configType}/configs").To(s.getConfigs).
 		Doc("get configs from a config type").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(s.RbacService.CheckPerm("config", "list")).
+		Filter(s.RbacService.CheckPerm("configType/config", "list")).
 		Param(ws.PathParameter("configType", "identifier of the config").DataType("string")).
 		Returns(200, "OK", []*apis.Config{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
@@ -85,7 +85,7 @@ func (s *configAPIInterface) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{configType}/configs/{name}").To(s.getConfig).
 		Doc("get a config from a config type").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(s.RbacService.CheckPerm("config", "get")).
+		Filter(s.RbacService.CheckPerm("configType/config", "get")).
 		Param(ws.PathParameter("configType", "identifier of the config type").DataType("string")).
 		Param(ws.PathParameter("name", "identifier of the config").DataType("string")).
 		Returns(200, "OK", []*apis.Config{}).
@@ -95,7 +95,7 @@ func (s *configAPIInterface) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.DELETE("/{configType}/configs/{name}").To(s.deleteConfig).
 		Doc("delete a config").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(s.RbacService.CheckPerm("config", "delete")).
+		Filter(s.RbacService.CheckPerm("configType/config", "delete")).
 		Param(ws.PathParameter("configType", "identifier of the config type").DataType("string")).
 		Param(ws.PathParameter("name", "identifier of the config").DataType("string")).
 		Returns(200, "OK", apis.EmptyResponse{}).

--- a/pkg/apiserver/interfaces/api/project.go
+++ b/pkg/apiserver/interfaces/api/project.go
@@ -179,7 +179,7 @@ func (n *projectAPIInterface) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{projectName}/configs").To(n.getConfigs).
 		Doc("get configs which are in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(n.RbacService.CheckPerm("project/configs", "list")).
+		Filter(n.RbacService.CheckPerm("project/config", "list")).
 		Param(ws.QueryParameter("configType", "config type").DataType("string")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string")).
 		Returns(200, "OK", []*apis.Config{}).


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Fixes the issue that the project admin user can not get the configurations.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.