### PR TITLE
Fix: optimized the version comparison

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -61,6 +61,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/apiserver/utils/log"
 	utils2 "github.com/oam-dev/kubevela/pkg/controller/utils"
 	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
@@ -1418,13 +1419,29 @@ func checkSemVer(actual string, require string) (bool, error) {
 	l := strings.ReplaceAll(require, "v", " ")
 	constraint, err := semver.NewConstraint(l)
 	if err != nil {
+		log.Logger.Errorf("fail to new constraint: %s", err.Error())
 		return false, err
 	}
 	v, err := semver.NewVersion(smeVer)
 	if err != nil {
+		log.Logger.Errorf("fail to new version %s: %s", smeVer, err.Error())
 		return false, err
 	}
-	return constraint.Check(v), nil
+	if constraint.Check(v) {
+		return true, nil
+	}
+	if strings.Contains(actual, "-") && !strings.Contains(require, "-") {
+		smeVer := strings.TrimPrefix(actual[:strings.Index(actual, "-")], "v")
+		v, err := semver.NewVersion(smeVer)
+		if err != nil {
+			log.Logger.Errorf("fail to new version %s: %s", smeVer, err.Error())
+			return false, err
+		}
+		if constraint.Check(v) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func fetchVelaCoreImageTag(ctx context.Context, k8sClient client.Client) (string, error) {

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -763,6 +763,21 @@ func TestCheckSemVer(t *testing.T) {
 			require: ">=v1.3.0-beta.2",
 			res:     true,
 		},
+		{
+			actual:  "v1.4.0-beta.1",
+			require: ">=v1.3.0",
+			res:     true,
+		},
+		{
+			actual:  "v1.4.0",
+			require: ">=v1.3.0-beta.2",
+			res:     true,
+		},
+		{
+			actual:  "1.2.4-beta.2",
+			require: ">=v1.2.4-beta.3",
+			res:     false,
+		},
 	}
 	for _, testCase := range testCases {
 		result, err := checkSemVer(testCase.actual, testCase.require)


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

```
Error: addon terraform-alibaba system requirement miss match: vela cli/ux version: v1.4.0-beta.1  require: >=v1.3.0
 addon terraform-alibaba cannot enable 
```

If can not compare the version with beta or alpha, try to remove the suffix and make it as pass as possible.

Fixes #3950

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.



### Special notes for your reviewer

/cc @wangyikewxgm 