### PR TITLE
Fix: unknown field ignoreTerraformComponent

### DIFF
--- a/pkg/workflow/step/types.go
+++ b/pkg/workflow/step/types.go
@@ -29,4 +29,6 @@ type DeployWorkflowStepSpec struct {
 	Policies []string `json:"policies,omitempty"`
 	// Parallelism allows setting parallelism for the component deploy process
 	Parallelism *int `json:"parallelism,omitempty"`
+	// IgnoreTerraformComponent default is true, true means this step will apply the components without the terraform workload.
+	IgnoreTerraformComponent *bool `json:"ignoreTerraformComponent,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

```
"msg":"deploy app game2048 failure cannot patch object: admission webhook \"validating.core.oam.dev.v1beta1.applications\" denied the request: field \"spec\": Invalid value error encountered, failed to parsePolicies: invalid WorkflowStep default: json: unknown field \"ignoreTerraformComponent\"
```

New a field for the deploy workflow step must set both cue script and go struct.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### Special notes for your reviewer

/cc @Somefive 