### PR TITLE
Fix: error message of `vela init env` is not clear

### DIFF
--- a/pkg/utils/env/env_test.go
+++ b/pkg/utils/env/env_test.go
@@ -15,3 +15,84 @@ limitations under the License.
 */
 
 package env
+
+import (
+	"testing"
+	"time"
+
+	"path/filepath"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+)
+
+var testEnv *envtest.Environment
+var cfg *rest.Config
+var rawClient client.Client
+var testScheme = runtime.NewScheme()
+
+func TestCreateEnv(t *testing.T) {
+
+	testEnv = &envtest.Environment{
+		ControlPlaneStartTimeout: time.Minute,
+		ControlPlaneStopTimeout:  time.Minute,
+		CRDDirectoryPaths: []string{
+			filepath.Join("../../..", "charts/vela-core/crds"), // this has all the required CRDs,
+		},
+	}
+	var err error
+	cfg, err = testEnv.Start()
+	assert.NoError(t, err)
+	assert.NoError(t, clientgoscheme.AddToScheme(testScheme))
+
+	rawClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	assert.NoError(t, err)
+
+	type want struct {
+		data string
+	}
+	testcases := []struct {
+		name    string
+		envMeta *types.EnvMeta
+		want    want
+	}{
+		{
+			name: "env-application",
+			envMeta: &types.EnvMeta{
+				Name:      "env-application",
+				Namespace: "default",
+			},
+			want: want{
+				data: "",
+			},
+		},
+		{
+			name: "default",
+			envMeta: &types.EnvMeta{
+				Name:      "default",
+				Namespace: "default",
+			},
+			want: want{
+				data: "the namespace default was already assigned to env env-application",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := common.SetGlobalClient(rawClient)
+			assert.NoError(t, err)
+			err = CreateEnv(tc.envMeta)
+			if err != nil && cmp.Diff(tc.want.data, err.Error()) != "" {
+				t.Errorf("CreateEnv(...): \n -want: \n%s,\n +got:\n%s", tc.want.data, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -97,6 +97,16 @@ func CreateNamespace(ctx context.Context, kubeClient client.Client, name string,
 	return kubeClient.Create(ctx, obj)
 }
 
+// GetNamespace will return a namespace with mutate option
+func GetNamespace(ctx context.Context, kubeClient client.Client, name string) (*corev1.Namespace, error) {
+	obj := &corev1.Namespace{}
+	err := kubeClient.Get(ctx, client.ObjectKey{Name: name}, obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
 // UpdateNamespace will update a namespace with mutate option
 func UpdateNamespace(ctx context.Context, kubeClient client.Client, name string, options ...MutateOption) error {
 	var namespace corev1.Namespace


### PR DESCRIPTION
Signed-off-by: Xiangbo Ma <maxiangboo@cmbchina.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3947
Error message of `vela init env` is not clear
I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->