### PR TITLE
dependsOn cannot be an empty array

### DIFF
--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
@@ -372,5 +372,25 @@ var _ = Describe("Test Application Validator", func() {
 		}
 		resp = handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeFalse())
+
+		By("dependsOn cannot be an empty array")
+		req = admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"kind":"Application","metadata":{"name":"test-external-revision", "namespace":"default"},
+"spec":{"components":[{"name":"myworker","type":"worker",
+"dependsOn": [],
+"properties":{"image":"stefanprodan/podinfo:4.0.6"},
+"externalRevision":"external-comp2"}]}}
+`),
+				},
+			},
+		}
+		resp = handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeFalse())
+
 	})
 })

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
@@ -68,6 +68,9 @@ func (h *ValidatingHandler) validateExternalRevisionName(ctx context.Context, ap
 	var componentErrs field.ErrorList
 
 	for index, comp := range app.Spec.Components {
+		if comp.DependsOn != nil && len(comp.DependsOn) == 0 {
+			componentErrs = append(componentErrs, field.Invalid(field.NewPath(fmt.Sprintf("components[%d].dependsOn", index)), app, "empty array not allowed"))
+		}
 		if len(comp.ExternalRevision) == 0 {
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: clarechu [106218615@qq.com](mailto:106218615@qq.com)

### Description of your changes

When I updated the application resource of vela, I found that the deployment resource application was deleted by vela-core.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```yaml
kubectl apply -f -<<EOF
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: app1
spec:
  components:
    - name: comp-1
      type: webservice
      dependsOn: []
      properties:
        image: nginx
        ports:
          - expose: true
            port: 80
EOF
```

Response result is

```bash
Error from server: error when creating "STDIN": admission webhook "validating.core.oam.dev.v1beta1.applications" denied the request: field "components[0].dependsOn": Invalid value error encountered, empty array not allowed.
```

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->