### PR TITLE
Fix: Improve vela provider add response

### DIFF
--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	providerNameParam       = "name"
-	errAuthenticateProvider = "failed to authenticate Terraform cloud provider %s"
+	errAuthenticateProvider = "failed to authenticate Terraform cloud provider %s err: %w"
 )
 
 // NewProviderCommand create `addon` command
@@ -188,11 +188,11 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 				}
 				data, err := json.Marshal(properties)
 				if err != nil {
-					return fmt.Errorf(errAuthenticateProvider, providerType)
+					return fmt.Errorf(errAuthenticateProvider, providerType, err)
 				}
 
 				if err := config.CreateApplication(ctx, k8sClient, name, providerType, string(data), config.UIParam{}); err != nil {
-					return fmt.Errorf(errAuthenticateProvider, providerType)
+					return fmt.Errorf(errAuthenticateProvider, providerType, err)
 				}
 				ioStreams.Infof("Successfully authenticate provider %s for %s\n", name, providerType)
 				return nil

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"log"
 	"math/rand"
+	"os"
 	"time"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -37,6 +37,6 @@ func main() {
 	command := cli.NewCommand()
 
 	if err := command.Execute(); err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

Print the detail error for provider add failure

Fixes #3936 

Before:
```
➜  bin git:(fix-terr) ✗ vela provider add terraform-alibaba --ALICLOUD_ACCESS_KEY xxxxx --ALICLOUD_SECRET_KEY xxxxx   --ALICLOUD_REGION cn-hangzhou
Error: failed to authenticate Terraform cloud provider terraform-alibaba
2022/05/30 14:41:29 failed to authenticate Terraform cloud provider terraform-alibaba

```

After:
```
➜  bin git:(fix-terr) ✗  ./vela provider add terraform-alibaba --ALICLOUD_ACCESS_KEY xxxxxx --ALICLOUD_SECRET_KEY xxxxx   --ALICLOUD_REGION cn-hangzhou
Error: failed to authenticate Terraform cloud provider terraform-alibaba err: terraform provider default for terraform-alibaba already exists
2022/05/30 14:46:37 failed to authenticate Terraform cloud provider terraform-alibaba err: terraform provider default for terraform-alibaba already exists
➜  bin git:(fix-terr) ✗ 

```



I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->