### PR TITLE
Fix: remove the tcp protocol prefix in the endpoint string

### DIFF
--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -960,12 +960,12 @@ options: {
 			fmt.Sprintf("http://%s:30229", gatewayIP),
 			"http://10.10.10.10",
 			"http://text.example.com",
-			"tcp://10.10.10.10:81",
-			"tcp://text.example.com:81",
+			"10.10.10.10:81",
+			"text.example.com:81",
 			// helmRelease
 			fmt.Sprintf("http://%s:30002", gatewayIP),
 			"http://ingress.domain.helm",
-			"tcp://1.1.1.1:80/seldon/test",
+			"1.1.1.1:80/seldon/test",
 		}
 		endValue, err := v.Field("list")
 		Expect(err).Should(BeNil())

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -58,6 +58,9 @@ func (s *ServiceEndpoint) String() string {
 	if (protocol == HTTPS && s.Endpoint.Port == 443) || (protocol == HTTP && s.Endpoint.Port == 80) {
 		return fmt.Sprintf("%s://%s%s", protocol, s.Endpoint.Host, path)
 	}
+	if protocol == "tcp" {
+		return fmt.Sprintf("%s:%d%s", s.Endpoint.Host, s.Endpoint.Port, path)
+	}
 	return fmt.Sprintf("%s://%s:%d%s", protocol, s.Endpoint.Host, s.Endpoint.Port, path)
 }
 

--- a/references/cli/velaql_test.go
+++ b/references/cli/velaql_test.go
@@ -393,8 +393,8 @@ var _ = Describe("Test velaQL", func() {
 			fmt.Sprintf("http://%s:30229", gatewayIP),
 			"http://10.10.10.10",
 			"http://text.example.com",
-			"tcp://10.10.10.10:81",
-			"tcp://text.example.com:81",
+			"10.10.10.10:81",
+			"text.example.com:81",
 			// helmRelease
 			fmt.Sprintf("http://%s:30002", gatewayIP),
 			"http://ingress.domain.helm",


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

For the TCP protocol, remove the prefix in the endpoint string.

before:
```
tcp://10.101.2.1:8089
```
after:
```
10.101.2.1:8089
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### Special notes for your reviewer

/cc @wonderflow 