### PR TITLE
Chore: hide some definitions in VelaUX

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/container-image.yaml
+++ b/charts/vela-core/templates/defwithtemplate/container-image.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Set the image of the container.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: container-image
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
@@ -5,6 +5,8 @@ kind: WorkflowStepDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Deploy env binding component to target env
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: deploy2env
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/json-merge-patch.yaml
+++ b/charts/vela-core/templates/defwithtemplate/json-merge-patch.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Patch the output following Json Merge Patch strategy, following RFC 7396.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: json-merge-patch
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/json-patch.yaml
+++ b/charts/vela-core/templates/defwithtemplate/json-patch.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Patch the output following Json Patch strategy, following RFC 6902.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: json-patch
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
@@ -5,6 +5,8 @@ kind: ComponentDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Ref-objects allow users to specify ref objects to use. Notice that this component type have special handle logic.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: ref-objects
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/step-group.yaml
+++ b/charts/vela-core/templates/defwithtemplate/step-group.yaml
@@ -5,6 +5,8 @@ kind: WorkflowStepDefinition
 metadata:
   annotations:
     definition.oam.dev/description: step group
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: step-group
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/container-image.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/container-image.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Set the image of the container.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: container-image
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/json-merge-patch.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/json-merge-patch.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Patch the output following Json Merge Patch strategy, following RFC 7396.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: json-merge-patch
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/json-patch.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/json-patch.yaml
@@ -5,6 +5,8 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Patch the output following Json Patch strategy, following RFC 6902.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: json-patch
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
@@ -5,6 +5,8 @@ kind: ComponentDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Ref-objects allow users to specify ref objects to use. Notice that this component type have special handle logic.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: ref-objects
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/step-group.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/step-group.yaml
@@ -5,6 +5,8 @@ kind: WorkflowStepDefinition
 metadata:
   annotations:
     definition.oam.dev/description: step group
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
   name: step-group
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/vela-templates/definitions/internal/component/ref-objects.cue
+++ b/vela-templates/definitions/internal/component/ref-objects.cue
@@ -1,7 +1,9 @@
 "ref-objects": {
 	type: "component"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "Ref-objects allow users to specify ref objects to use. Notice that this component type have special handle logic."
 	attributes: {
 		workload: type: "autodetects.core.oam.dev"

--- a/vela-templates/definitions/internal/trait/container-image.cue
+++ b/vela-templates/definitions/internal/trait/container-image.cue
@@ -1,7 +1,9 @@
 "container-image": {
 	type: "trait"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "Set the image of the container."
 	attributes: {
 		podDisruptive: true

--- a/vela-templates/definitions/internal/trait/json-merge-patch.cue
+++ b/vela-templates/definitions/internal/trait/json-merge-patch.cue
@@ -1,7 +1,9 @@
 "json-merge-patch": {
 	type: "trait"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "Patch the output following Json Merge Patch strategy, following RFC 7396."
 	attributes: {
 		podDisruptive: true

--- a/vela-templates/definitions/internal/trait/json-patch.cue
+++ b/vela-templates/definitions/internal/trait/json-patch.cue
@@ -1,7 +1,9 @@
 "json-patch": {
 	type: "trait"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "Patch the output following Json Patch strategy, following RFC 6902."
 	attributes: {
 		podDisruptive: true

--- a/vela-templates/definitions/internal/workflowstep/deploy2env.cue
+++ b/vela-templates/definitions/internal/workflowstep/deploy2env.cue
@@ -5,7 +5,9 @@ import (
 "deploy2env": {
 	type: "workflow-step"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "Deploy env binding component to target env"
 }
 template: {

--- a/vela-templates/definitions/internal/workflowstep/step-group.cue
+++ b/vela-templates/definitions/internal/workflowstep/step-group.cue
@@ -1,7 +1,9 @@
 "step-group": {
 	type: "workflow-step"
 	annotations: {}
-	labels: {}
+	labels: {
+		"ui-hidden": "true"
+	}
 	description: "step group"
 }
 template: {


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Some definitions did not generate the UI schema, we provisionally hid them. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### Special notes for your reviewer

/cc @Somefive @wonderflow 