### PR TITLE
Fix: load the provider subcommands on demand

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -73,7 +73,6 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 	}
 	f := velacmd.NewDeferredFactory(config.GetConfig)
 
-	_, _ = commandArgs, f
 	if err := system.InitDirs(); err != nil {
 		fmt.Println("InitDir err", err)
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

/cc @wonderflow  @zzxwill 