### PR TITLE
Fix: vela provider delete command's example is wrong

### DIFF
--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -338,7 +338,7 @@ func prepareProviderDeleteCommand(c common.Args, ioStreams cmdutil.IOStreams) (*
 		Aliases: []string{"rm", "del"},
 		Short:   "Delete Terraform Cloud Provider",
 		Long:    "Delete Terraform Cloud Provider",
-		Example: "vela provider delete <provider-type> -name <provider-name>",
+		Example: "vela provider delete <provider-type> --name <provider-name>",
 	}
 
 	deleteSubCommands, err := prepareProviderDeleteSubCommand(c, ioStreams)


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4093 


Before:
```
Examples:
vela provider delete <provider-type> -name <provider-name>

```

After:
```
Examples:
vela provider delete <provider-type> --name <provider-name>


```


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->