### PR TITLE
Fix: hold the force uninstalling process untill the last addon been deleted

### DIFF
--- a/references/cli/uninstall.go
+++ b/references/cli/uninstall.go
@@ -211,7 +211,7 @@ func forceDisableAddon(ctx context.Context, kubeClient client.Client, config *re
 		}
 		timeConsumed = time.Now()
 		for {
-			if time.Now().After(timeConsumed.Add(2 * time.Minute)) {
+			if time.Now().After(timeConsumed.Add(5 * time.Minute)) {
 				return errors.New("timeout disable fluxcd addon, please disable the addon manually")
 			}
 			addons, err := checkInstallAddon(kubeClient)
@@ -221,8 +221,8 @@ func forceDisableAddon(ctx context.Context, kubeClient client.Client, config *re
 			if len(addons) == 0 {
 				break
 			}
-			fmt.Println("Waiting delete the fluxcd addon......")
-			time.Sleep(5 * time.Second)
+			fmt.Printf("Waiting delete the fluxcd addon, timeout left %s \r\n", 5*time.Minute-time.Since(timeConsumed))
+			time.Sleep(2 * time.Second)
 		}
 	}
 	return nil

--- a/references/cli/uninstall.go
+++ b/references/cli/uninstall.go
@@ -209,6 +209,21 @@ func forceDisableAddon(ctx context.Context, kubeClient client.Client, config *re
 		if err := pkgaddon.DisableAddon(ctx, kubeClient, "fluxcd", config, true); err != nil {
 			return err
 		}
+		timeConsumed = time.Now()
+		for {
+			if time.Now().After(timeConsumed.Add(2 * time.Minute)) {
+				return errors.New("timeout disable fluxcd addon, please disable the addon manually")
+			}
+			addons, err := checkInstallAddon(kubeClient)
+			if err != nil {
+				return err
+			}
+			if len(addons) == 0 {
+				break
+			}
+			fmt.Println("Waiting delete the fluxcd addon......")
+			time.Sleep(5 * time.Second)
+		}
 	}
 	return nil
 }

--- a/references/cli/uninstall.go
+++ b/references/cli/uninstall.go
@@ -221,7 +221,7 @@ func forceDisableAddon(ctx context.Context, kubeClient client.Client, config *re
 			if len(addons) == 0 {
 				break
 			}
-			fmt.Printf("Waiting delete the fluxcd addon, timeout left %s \r\n", 5*time.Minute-time.Since(timeConsumed))
+			fmt.Printf("Waiting delete the fluxcd addon, timeout left %s . \r\n", 5*time.Minute-time.Since(timeConsumed))
 			time.Sleep(2 * time.Second)
 		}
 	}


### PR DESCRIPTION
A bug generated when fluxcd addon has been enabled, then use `uninstall -f`

The uninstall process begin to remove the vela core controller and vela-system namespace while fluxcd addon is  been deleting. This will cause a dead clock to block whole uninstall and re-install process.

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->