### PR TITLE
Feat: Add description column to vela trait and component command

### DIFF
--- a/references/cli/components.go
+++ b/references/cli/components.go
@@ -226,7 +226,7 @@ func PrintInstalledCompDef(c common2.Args, io cmdutil.IOStreams, filter filterFu
 	}
 
 	table := newUITable()
-	table.AddRow("NAME", "DEFINITION")
+	table.AddRow("NAME", "DEFINITION", "DESCRIPTION")
 
 	for _, cd := range list.Items {
 		data, err := json.Marshal(cd)
@@ -242,7 +242,7 @@ func PrintInstalledCompDef(c common2.Args, io cmdutil.IOStreams, filter filterFu
 		if filter != nil && !filter(capa) {
 			continue
 		}
-		table.AddRow(capa.Name, capa.CrdName)
+		table.AddRow(capa.Name, capa.CrdName, capa.Description)
 	}
 	io.Info(table.String())
 	return nil

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -228,6 +228,7 @@ func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterF
 
 	table := newUITable()
 	table.AddRow("NAME", "APPLIES-TO")
+	table.AddRow("NAME", "APPLIES-TO", "DESCRIPTION")
 
 	for _, td := range list.Items {
 		data, err := json.Marshal(td)
@@ -243,7 +244,7 @@ func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterF
 		if filter != nil && !filter(capa) {
 			continue
 		}
-		table.AddRow(capa.Name, capa.AppliesTo)
+		table.AddRow(capa.Name, capa.AppliesTo, capa.Description)
 	}
 	io.Info(table.String())
 	return nil


### PR DESCRIPTION
### Description of your changes
Using  the `description` field in the component and trait definition, show it now as an 3rd column in the vela cli command `vela components` and `vela traits`.


