### PR TITLE
Feat: add timeout in workflow step

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -349,6 +349,8 @@ type WorkflowStep struct {
 
 	If string `json:"if,omitempty"`
 
+	Timeout string `json:"timeout,omitempty"`
+
 	DependsOn []string `json:"dependsOn,omitempty"`
 
 	Inputs StepInputs `json:"inputs,omitempty"`
@@ -367,6 +369,8 @@ type WorkflowSubStep struct {
 	Properties *runtime.RawExtension `json:"properties,omitempty"`
 
 	If string `json:"if,omitempty"`
+
+	Timeout string `json:"timeout,omitempty"`
 
 	DependsOn []string `json:"dependsOn,omitempty"`
 

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -2292,6 +2292,8 @@ spec:
                                       properties:
                                         type: object
                                         x-kubernetes-preserve-unknown-fields: true
+                                      timeout:
+                                        type: string
                                       type:
                                         type: string
                                     required:
@@ -2299,6 +2301,8 @@ spec:
                                     - type
                                     type: object
                                   type: array
+                                timeout:
+                                  type: string
                                 type:
                                   type: string
                               required:
@@ -4038,6 +4042,8 @@ spec:
                               properties:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -4045,6 +4051,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -1100,6 +1100,8 @@ spec:
                               properties:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -1107,6 +1109,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/charts/vela-core/crds/core.oam.dev_workflows.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workflows.yaml
@@ -119,6 +119,8 @@ spec:
                       properties:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      timeout:
+                        type: string
                       type:
                         type: string
                     required:
@@ -126,6 +128,8 @@ spec:
                     - type
                     type: object
                   type: array
+                timeout:
+                  type: string
                 type:
                   type: string
               required:
@@ -228,6 +232,8 @@ spec:
                       properties:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      timeout:
+                        type: string
                       type:
                         type: string
                     required:
@@ -235,6 +241,8 @@ spec:
                     - type
                     type: object
                   type: array
+                timeout:
+                  type: string
                 type:
                   type: string
               required:

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -2292,6 +2292,8 @@ spec:
                                       properties:
                                         type: object
                                         x-kubernetes-preserve-unknown-fields: true
+                                      timeout:
+                                        type: string
                                       type:
                                         type: string
                                     required:
@@ -2299,6 +2301,8 @@ spec:
                                     - type
                                     type: object
                                   type: array
+                                timeout:
+                                  type: string
                                 type:
                                   type: string
                               required:
@@ -4038,6 +4042,8 @@ spec:
                               properties:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -4045,6 +4051,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -1100,6 +1100,8 @@ spec:
                               properties:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -1107,6 +1109,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -2292,6 +2292,8 @@ spec:
                                       properties:
                                         type: object
                                         
+                                      timeout:
+                                        type: string
                                       type:
                                         type: string
                                     required:
@@ -2299,6 +2301,8 @@ spec:
                                     - type
                                     type: object
                                   type: array
+                                timeout:
+                                  type: string
                                 type:
                                   type: string
                               required:
@@ -4038,6 +4042,8 @@ spec:
                               properties:
                                 type: object
                                 
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -4045,6 +4051,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -1101,6 +1101,8 @@ spec:
                               properties:
                                 type: object
                                 
+                              timeout:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -1108,6 +1110,8 @@ spec:
                             - type
                             type: object
                           type: array
+                        timeout:
+                          type: string
                         type:
                           type: string
                       required:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_workflows.yaml
@@ -119,6 +119,8 @@ spec:
                       properties:
                         type: object
                         
+                      timeout:
+                        type: string
                       type:
                         type: string
                     required:
@@ -126,6 +128,8 @@ spec:
                     - type
                     type: object
                   type: array
+                timeout:
+                  type: string
                 type:
                   type: string
               required:
@@ -228,6 +232,8 @@ spec:
                       properties:
                         type: object
                         
+                      timeout:
+                        type: string
                       type:
                         type: string
                     required:
@@ -235,6 +241,8 @@ spec:
                     - type
                     type: object
                   type: array
+                timeout:
+                  type: string
                 type:
                   type: string
               required:

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -612,6 +612,8 @@ func ResumeWorkflow(ctx context.Context, kubecli client.Client, app *v1beta1.App
 func TerminateWorkflow(ctx context.Context, kubecli client.Client, app *v1beta1.Application) error {
 	// set the workflow terminated to true
 	app.Status.Workflow.Terminated = true
+	// set the workflow suspend to false
+	app.Status.Workflow.Suspend = false
 	steps := app.Status.Workflow.Steps
 	for i, step := range steps {
 		switch step.Phase {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -123,6 +123,7 @@ func generateStep(ctx context.Context,
 				Inputs:     subStep.Inputs,
 				Outputs:    subStep.Outputs,
 				If:         subStep.If,
+				Timeout:    subStep.Timeout,
 			}
 			subTask, err := generateStep(ctx, app, workflowStep, taskDiscover, step.Name)
 			if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -313,6 +313,7 @@ var _ = Describe("Test Workflow", func() {
 
 		// terminate
 		appObj.Status.Workflow.Terminated = true
+		appObj.Status.Workflow.Suspend = false
 		appObj.Status.Workflow.Steps[0].Phase = common.WorkflowStepPhaseFailed
 		appObj.Status.Workflow.Steps[0].Reason = custom.StatusReasonTerminate
 		Expect(k8sClient.Status().Patch(ctx, appObj, client.Merge)).Should(BeNil())

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -40,6 +40,7 @@ import (
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 )
 
 var _ = Describe("Test Workflow", func() {
@@ -255,10 +256,11 @@ var _ = Describe("Test Workflow", func() {
 
 		Expect(appObj.Status.Workflow.Suspend).Should(BeTrue())
 		Expect(appObj.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowSuspending))
-		Expect(appObj.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseSucceeded))
+		Expect(appObj.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
 		Expect(appObj.Status.Workflow.Steps[0].ID).ShouldNot(BeEquivalentTo(""))
 		// resume
 		appObj.Status.Workflow.Suspend = false
+		appObj.Status.Workflow.Steps[0].Phase = common.WorkflowStepPhaseSucceeded
 		Expect(k8sClient.Status().Patch(ctx, appObj, client.Merge)).Should(BeNil())
 		Expect(k8sClient.Get(ctx, client.ObjectKey{
 			Name:      suspendApp.Name,
@@ -311,6 +313,8 @@ var _ = Describe("Test Workflow", func() {
 
 		// terminate
 		appObj.Status.Workflow.Terminated = true
+		appObj.Status.Workflow.Steps[0].Phase = common.WorkflowStepPhaseFailed
+		appObj.Status.Workflow.Steps[0].Reason = custom.StatusReasonTerminate
 		Expect(k8sClient.Status().Patch(ctx, appObj, client.Merge)).Should(BeNil())
 
 		tryReconcile(reconciler, suspendApp.Name, suspendApp.Namespace)
@@ -322,7 +326,7 @@ var _ = Describe("Test Workflow", func() {
 			Namespace: suspendApp.Namespace,
 		}, appObj)).Should(BeNil())
 
-		Expect(appObj.Status.Workflow.Suspend).Should(BeTrue())
+		Expect(appObj.Status.Workflow.Suspend).Should(BeFalse())
 		Expect(appObj.Status.Workflow.Terminated).Should(BeTrue())
 		Expect(appObj.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowTerminated))
 	})

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
@@ -134,14 +134,14 @@ var _ = Describe("Test Application Validator", func() {
 	})
 
 	It("Test Application Validator workflow step name duplicate [error]", func() {
-		By("test duplicate step name in workflow")
+		By("test duplicated step name in workflow")
 		req := admission.Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Create,
 				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1alpha2", Resource: "applications"},
 				Object: runtime.RawExtension{
 					Raw: []byte(`
-{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"webservice","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"suspend","type":"suspend"},{"name":"suspend","type":"suspend"}]}}}
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"suspend","type":"suspend"},{"name":"suspend","type":"suspend"}]}}}
 `),
 				},
 			},
@@ -149,14 +149,14 @@ var _ = Describe("Test Application Validator", func() {
 		resp := handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeFalse())
 
-		By("test duplicate sub step name in workflow")
+		By("test duplicated sub step name in workflow")
 		req = admission.Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Create,
 				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1alpha2", Resource: "applications"},
 				Object: runtime.RawExtension{
 					Raw: []byte(`
-{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"webservice","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"step-group","subSteps":[{"name":"sub","type":"suspend"},{"name":"sub","type":"suspend"}]}]}}}
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"step-group","subSteps":[{"name":"sub","type":"suspend"},{"name":"sub","type":"suspend"}]}]}}}
 `),
 				},
 			},
@@ -164,20 +164,52 @@ var _ = Describe("Test Application Validator", func() {
 		resp = handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeFalse())
 
-		By("test duplicate sub and parent step name in workflow")
+		By("test duplicated sub and parent step name in workflow")
 		req = admission.Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Create,
 				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1alpha2", Resource: "applications"},
 				Object: runtime.RawExtension{
 					Raw: []byte(`
-{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"webservice","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"step-group","subSteps":[{"name":"group","type":"suspend"},{"name":"sub","type":"suspend"}]}]}}}
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-duplicate","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"step-group","subSteps":[{"name":"group","type":"suspend"},{"name":"sub","type":"suspend"}]}]}}}
 `),
 				},
 			},
 		}
 		resp = handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	It("Test Application Validator workflow step invalid timeout [error]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1alpha2", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-timeout","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"suspend","timeout":"test"}]}}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	It("Test Application Validator workflow step invalid timeout [allow]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1alpha2", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"workflow-timeout","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"crccheck/hello-world"}}],"workflow":{"steps":[{"name":"group","type":"suspend","timeout":"1s"}]}}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
 	})
 
 	It("Test Application Validator external revision name [allow]", func() {

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
@@ -31,8 +31,29 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
-// ValidateCreate validates the Application on creation
-func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.Application) field.ErrorList {
+// ValidateWorkflow validates the Application workflow
+func (h *ValidatingHandler) ValidateWorkflow(ctx context.Context, app *v1beta1.Application) field.ErrorList {
+	var errs field.ErrorList
+	if app.Spec.Workflow != nil {
+		stepName := make(map[string]interface{})
+		for _, step := range app.Spec.Workflow.Steps {
+			if _, ok := stepName[step.Name]; ok {
+				errs = append(errs, field.Invalid(field.NewPath("spec", "workflow", "steps"), step.Name, "duplicate step name"))
+			}
+			stepName[step.Name] = nil
+			for _, sub := range step.SubSteps {
+				if _, ok := stepName[sub.Name]; ok {
+					errs = append(errs, field.Invalid(field.NewPath("spec", "workflow", "steps", "subSteps"), sub.Name, "duplicate step name"))
+				}
+				stepName[sub.Name] = nil
+			}
+		}
+	}
+	return errs
+}
+
+// ValidateComponents validates the Application components
+func (h *ValidatingHandler) ValidateComponents(ctx context.Context, app *v1beta1.Application) field.ErrorList {
 	var componentErrs field.ErrorList
 	// try to generate an app file
 	appParser := appfile.NewApplicationParser(h.Client, h.dm, h.pd)
@@ -56,12 +77,21 @@ func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.App
 	return componentErrs
 }
 
+// ValidateCreate validates the Application on creation
+func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.Application) field.ErrorList {
+	var errs field.ErrorList
+
+	errs = append(errs, h.ValidateWorkflow(ctx, app)...)
+	errs = append(errs, h.ValidateComponents(ctx, app)...)
+	return errs
+}
+
 // ValidateUpdate validates the Application on update
 func (h *ValidatingHandler) ValidateUpdate(ctx context.Context, newApp, oldApp *v1beta1.Application) field.ErrorList {
 	// check if the newApp is valid
-	componentErrs := h.ValidateCreate(ctx, newApp)
+	errs := h.ValidateCreate(ctx, newApp)
 	// TODO: add more validating
-	return componentErrs
+	return errs
 }
 
 func (h *ValidatingHandler) validateExternalRevisionName(ctx context.Context, app *v1beta1.Application) field.ErrorList {

--- a/pkg/workflow/interface.go
+++ b/pkg/workflow/interface.go
@@ -37,4 +37,6 @@ type Workflow interface {
 	GetBackoffWaitTime() time.Duration
 
 	HandleSuspendWait(ctx monitorContext.Context) (bool, time.Duration, error)
+
+	GetSuspendBackoffWaitTime() time.Duration
 }

--- a/pkg/workflow/interface.go
+++ b/pkg/workflow/interface.go
@@ -36,7 +36,5 @@ type Workflow interface {
 	// GetBackoffWaitTime returns the wait time for next retry.
 	GetBackoffWaitTime() time.Duration
 
-	HandleSuspendWait(ctx monitorContext.Context) (bool, time.Duration, error)
-
 	GetSuspendBackoffWaitTime() time.Duration
 }

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -176,8 +176,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 					return exec.status(), exec.operation(), nil
 				}
 				if result.Timeout {
-					exec.err(ctx, errors.New("timeout"), StatusReasonTimeout)
-					exec.terminated = true
+					exec.timeout("")
 					return exec.status(), exec.operation(), nil
 				}
 			}
@@ -314,6 +313,13 @@ func (exec *executor) Skip(message string) {
 	exec.skip = true
 	exec.wfStatus.Phase = common.WorkflowStepPhaseSkipped
 	exec.wfStatus.Reason = StatusReasonSkip
+	exec.wfStatus.Message = message
+}
+
+func (exec *executor) timeout(message string) {
+	exec.terminated = true
+	exec.wfStatus.Phase = common.WorkflowStepPhaseFailed
+	exec.wfStatus.Reason = StatusReasonTimeout
 	exec.wfStatus.Message = message
 }
 

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -65,7 +65,8 @@ const (
 	StatusReasonOutput = "Output"
 	// StatusReasonFailedAfterRetries is the reason of the workflow progress condition which is FailedAfterRetries.
 	StatusReasonFailedAfterRetries = "FailedAfterRetries"
-	StatusReasonTimeout            = "Timeout"
+	// StatusReasonTimeout is the reason of the workflow progress condition which is Timeout.
+	StatusReasonTimeout = "Timeout"
 )
 
 // LoadTaskTemplate gets the workflowStep definition from cluster and resolve it.
@@ -176,6 +177,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 				}
 				if result.Timeout {
 					exec.err(ctx, errors.New("timeout"), StatusReasonTimeout)
+					exec.terminated = true
 					return exec.status(), exec.operation(), nil
 				}
 			}

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -531,7 +531,7 @@ func TestTimeout(t *testing.T) {
 		Type: "ok",
 	}
 	pCtx := process.NewContext(process.ContextData{
-		AppName:         "myapp",
+		AppName:         "myapp-timeout",
 		CompName:        "mycomp",
 		Namespace:       "default",
 		AppRevisionName: "myapp-v1",

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -505,17 +505,53 @@ func TestSkip(t *testing.T) {
 	r.NoError(err)
 	runner, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, nil)
-	r.Equal(skip, true)
+	status, operations, err := runner.Run(nil, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Skip: true}, nil
+			},
+		},
+	})
+	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, StatusReasonSkip)
-	runner2, err := gen(v1beta1.WorkflowStep{
-		If:   "always",
-		Name: "test",
-	}, &types.GeneratorOptions{ID: "124"})
+	r.Equal(operations.Skip, true)
+}
+
+func TestTimeout(t *testing.T) {
+	r := require.New(t)
+	discover := providers.NewProviders()
+	discover.Register("test", map[string]providers.Handler{
+		"ok": func(ctx wfContext.Context, v *value.Value, act types.Action) error {
+			return nil
+		},
+	})
+	step := v1beta1.WorkflowStep{
+		Name: "timeout",
+		Type: "ok",
+	}
+	pCtx := process.NewContext(process.ContextData{
+		AppName:         "myapp",
+		CompName:        "mycomp",
+		Namespace:       "default",
+		AppRevisionName: "myapp-v1",
+	})
+	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover, 0, pCtx)
+	gen, err := tasksLoader.GetTaskGenerator(context.Background(), step.Type)
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, nil)
-	r.Equal(skip, false)
+	runner, err := gen(step, &types.GeneratorOptions{})
+	r.NoError(err)
+	ctx := newWorkflowContextForTest(t)
+	status, _, err := runner.Run(ctx, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Timeout: true}, nil
+			},
+		},
+	})
+	r.NoError(err)
+	r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+	r.Equal(status.Reason, StatusReasonTimeout)
 }
 
 func newWorkflowContextForTest(t *testing.T) wfContext.Context {

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -212,7 +212,8 @@ func (tr *stepGroupTaskRunner) Run(ctx wfContext.Context, options *types.TaskRun
 			status.Reason = custom.StatusReasonSkip
 			options.StepStatus[tr.step.Name] = status
 			break
-		} else if result.Timeout {
+		}
+		if result.Timeout {
 			status.Phase = common.WorkflowStepPhaseFailed
 			status.Reason = custom.StatusReasonTimeout
 			options.StepStatus[tr.step.Name] = status

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -110,6 +110,7 @@ func TestSuspendStep(t *testing.T) {
 	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, custom.StatusReasonSkip)
+	r.Equal(operations.Suspend, false)
 	r.Equal(operations.Skip, true)
 
 	// test timeout
@@ -123,6 +124,8 @@ func TestSuspendStep(t *testing.T) {
 	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
 	r.Equal(status.Reason, custom.StatusReasonTimeout)
+	r.Equal(operations.Suspend, false)
+	r.Equal(operations.Terminated, true)
 
 	// test run
 	status, act, err := runner.Run(nil, nil)
@@ -130,7 +133,7 @@ func TestSuspendStep(t *testing.T) {
 	r.Equal(act.Suspend, true)
 	r.Equal(status.ID, "124")
 	r.Equal(status.Name, "test")
-	r.Equal(status.Phase, common.WorkflowStepPhaseSucceeded)
+	r.Equal(status.Phase, common.WorkflowStepPhaseRunning)
 }
 
 type testEngine struct {
@@ -216,6 +219,7 @@ func TestStepGroupStep(t *testing.T) {
 	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
 	r.Equal(status.Reason, custom.StatusReasonTimeout)
+	r.Equal(operations.Terminated, true)
 
 	// test run
 	testCases := []struct {

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -100,17 +100,29 @@ func TestSuspendStep(t *testing.T) {
 	r.Equal(runner.Pending(nil, ss), false)
 
 	// test skip
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, nil)
-	r.Equal(skip, true)
+	status, operations, err := runner.Run(nil, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Skip: true}, nil
+			},
+		},
+	})
+	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, custom.StatusReasonSkip)
-	runner2, err := gen(v1beta1.WorkflowStep{
-		If:   "always",
-		Name: "test",
-	}, &types.GeneratorOptions{ID: "124"})
+	r.Equal(operations.Skip, true)
+
+	// test timeout
+	status, operations, err = runner.Run(nil, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Timeout: true}, nil
+			},
+		},
+	})
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, nil)
-	r.Equal(skip, false)
+	r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+	r.Equal(status.Reason, custom.StatusReasonTimeout)
 
 	// test run
 	status, act, err := runner.Run(nil, nil)
@@ -171,19 +183,39 @@ func TestStepGroupStep(t *testing.T) {
 	r.Equal(runner.Pending(nil, ss), false)
 
 	// test skip
-	stepStatus := make(map[string]common.StepStatus)
-	status, skip := runner.Skip(common.WorkflowStepPhaseFailed, stepStatus)
-	r.Equal(skip, false)
-	r.Equal(stepStatus["test"].Phase, common.WorkflowStepPhaseSkipped)
+	status, operations, err := runner.Run(nil, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Skip: true}, nil
+			},
+		},
+		StepStatus: map[string]common.StepStatus{},
+		Engine: &testEngine{
+			stepStatus: common.WorkflowStepStatus{},
+			operation:  &types.Operation{},
+		},
+	})
+	r.NoError(err)
 	r.Equal(status.Phase, common.WorkflowStepPhaseSkipped)
 	r.Equal(status.Reason, custom.StatusReasonSkip)
-	runner2, err := gen(v1beta1.WorkflowStep{
-		If:   "always",
-		Name: "test",
-	}, &types.GeneratorOptions{ID: "124"})
+	r.Equal(operations.Skip, true)
+
+	// test timeout
+	status, operations, err = runner.Run(nil, &types.TaskRunOptions{
+		PreCheckHooks: []types.TaskPreCheckHook{
+			func(step v1beta1.WorkflowStep) (*types.PreCheckResult, error) {
+				return &types.PreCheckResult{Timeout: true}, nil
+			},
+		},
+		StepStatus: map[string]common.StepStatus{},
+		Engine: &testEngine{
+			stepStatus: common.WorkflowStepStatus{},
+			operation:  &types.Operation{},
+		},
+	})
 	r.NoError(err)
-	_, skip = runner2.Skip(common.WorkflowStepPhaseFailed, stepStatus)
-	r.Equal(skip, false)
+	r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+	r.Equal(status.Reason, custom.StatusReasonTimeout)
 
 	// test run
 	testCases := []struct {

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -61,11 +61,13 @@ type TaskRunOptions struct {
 	Engine        Engine
 }
 
+// PreCheckResult is the result of pre check.
 type PreCheckResult struct {
 	Skip    bool
 	Timeout bool
 }
 
+// TaskPreCheckHook is the hook for pre check.
 type TaskPreCheckHook func(step v1beta1.WorkflowStep) (*PreCheckResult, error)
 
 // TaskPreStartHook run before task execution.

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -331,7 +331,7 @@ func handleSuspendBackoffTime(step oamcore.WorkflowStep, status common.StepStatu
 		if step.Timeout != "" {
 			duration, err := time.ParseDuration(step.Timeout)
 			if err != nil {
-				return 0
+				return min
 			}
 			timeout := status.FirstExecuteTime.Add(duration)
 			if time.Now().Before(timeout) {
@@ -344,7 +344,7 @@ func handleSuspendBackoffTime(step oamcore.WorkflowStep, status common.StepStatu
 
 		d, err := wfTasks.GetSuspendStepDurationWaiting(step)
 		if err != nil {
-			return 0
+			return min
 		}
 		if d != 0 && d < min {
 			min = d

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -171,7 +171,7 @@ func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cob
 			if err != nil {
 				return err
 			}
-			err = TerminateWorkflow(client, app)
+			err = terminateWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -276,10 +276,7 @@ func suspendWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 }
 
 func resumeWorkflow(kubecli client.Client, app *v1beta1.Application) error {
-	// set the workflow suspend to false
-	app.Status.Workflow.Suspend = false
-
-	if err := kubecli.Status().Patch(context.TODO(), app, client.Merge); err != nil {
+	if err := service.ResumeWorkflow(context.TODO(), kubecli, app); err != nil {
 		return err
 	}
 
@@ -287,8 +284,7 @@ func resumeWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	return nil
 }
 
-// TerminateWorkflow terminate workflow
-func TerminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
+func terminateWorkflow(kubecli client.Client, app *v1beta1.Application) error {
 	if err := service.TerminateWorkflow(context.TODO(), kubecli, app); err != nil {
 		return err
 	}

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -130,6 +130,11 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 			_app := &v1beta1.Application{}
 			g.Expect(k8sClient.Get(hubCtx, appKey, _app)).Should(Succeed())
 			_app.Status.Workflow.Suspend = false
+			for _, step := range _app.Status.Workflow.Steps {
+				if step.Type == "suspend" {
+					step.Phase = oamcomm.WorkflowStepPhaseSucceeded
+				}
+			}
 			g.Expect(k8sClient.Status().Update(hubCtx, _app)).Should(Succeed())
 		}, 15*time.Second).Should(Succeed())
 

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -130,9 +130,9 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 			_app := &v1beta1.Application{}
 			g.Expect(k8sClient.Get(hubCtx, appKey, _app)).Should(Succeed())
 			_app.Status.Workflow.Suspend = false
-			for _, step := range _app.Status.Workflow.Steps {
+			for i, step := range _app.Status.Workflow.Steps {
 				if step.Type == "suspend" {
-					step.Phase = oamcomm.WorkflowStepPhaseSucceeded
+					_app.Status.Workflow.Steps[i].Phase = oamcomm.WorkflowStepPhaseSucceeded
 				}
 			}
 			g.Expect(k8sClient.Status().Update(hubCtx, _app)).Should(Succeed())


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4020

This PR adds timeout in workflow step, you can use it like:
```yaml
  workflow:
    steps:
    - name: suspend
      type: suspend
      timeout: 15s
```

After 15s, if the workflow is still not resumed, then the status will be like:
```yaml
steps:
    - name: suspend
       type: suspend
       phase: failed
       reason: Timeout
```

**Note**: In the past version, the `suspend` step succeeded when executed. After this PR is merged, the `suspend` step' status is `running` when it was executed, and become `succeeded` if it's resumed.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

/cc @leejanee @wonderflow 

This PR also made some optimization to #3644 /cc @ArenaSu 