### PR TITLE
Fix(cli): avoid incorrect addon name when using dot as local addon path

### DIFF
--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Addon Test", func() {
 			}, 60*time.Second).Should(Succeed())
 		})
 
-		It("Enable local addon with . as path", func() {
-			output, err := e2e.LongTimeExec("vela addon enable ./e2e/addon/mock/testdata/sample/.", 600*time.Second)
+		FIt("Enable local addon with . as path", func() {
+			output, err := e2e.LongTimeExec("vela addon enable ../../e2e/addon/mock/testdata/sample/.", 600*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("sample enabled successfully."))
 			Expect(output).To(ContainSubstring("access sample from"))

--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -84,10 +84,10 @@ var _ = Describe("Addon Test", func() {
 		})
 
 		It("Enable local addon with . as path", func() {
-			output, err := e2e.LongTimeExec("vela addon enable ./e2e/addon/mock/testdata/test-addon/.", 600*time.Second)
+			output, err := e2e.LongTimeExec("vela addon enable ./e2e/addon/mock/testdata/sample/.", 600*time.Second)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("test-addon enabled successfully."))
-			Expect(output).To(ContainSubstring("access test-addon from"))
+			Expect(output).To(ContainSubstring("sample enabled successfully."))
+			Expect(output).To(ContainSubstring("access sample from"))
 		})
 
 		It("Test Change default namespace can work", func() {

--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -83,6 +83,13 @@ var _ = Describe("Addon Test", func() {
 			}, 60*time.Second).Should(Succeed())
 		})
 
+		It("Enable local addon with . as path", func() {
+			output, err := e2e.LongTimeExec("vela addon enable ./e2e/addon/mock/testdata/test-addon/.", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("test-addon enabled successfully."))
+			Expect(output).To(ContainSubstring("access test-addon from"))
+		})
+
 		It("Test Change default namespace can work", func() {
 			output, err := e2e.LongTimeExecWithEnv("vela addon list", 600*time.Second, []string{"DEFAULT_VELA_NS=test-vela"})
 			Expect(err).NotTo(HaveOccurred())

--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Addon Test", func() {
 			}, 60*time.Second).Should(Succeed())
 		})
 
-		FIt("Enable local addon with . as path", func() {
+		It("Enable local addon with . as path", func() {
 			output, err := e2e.LongTimeExec("vela addon enable ../../e2e/addon/mock/testdata/sample/.", 600*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("sample enabled successfully."))

--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -49,13 +49,13 @@ var _ = Describe("Addon Test", func() {
 		It("Enable addon test-addon", func() {
 			output, err := e2e.Exec("vela addon enable test-addon")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("enabled Successfully."))
+			Expect(output).To(ContainSubstring("enabled successfully."))
 		})
 
 		It("Upgrade addon test-addon", func() {
 			output, err := e2e.Exec("vela addon upgrade test-addon")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("enabled Successfully."))
+			Expect(output).To(ContainSubstring("enabled successfully."))
 		})
 
 		It("Disable addon test-addon", func() {
@@ -71,7 +71,7 @@ var _ = Describe("Addon Test", func() {
 		It("Enable addon with input", func() {
 			output, err := e2e.LongTimeExec("vela addon enable test-addon example=redis", 300*time.Second)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("enabled Successfully."))
+			Expect(output).To(ContainSubstring("enabled successfully."))
 		})
 
 		It("Disable addon test-addon", func() {
@@ -98,7 +98,7 @@ var _ = Describe("Addon Test", func() {
 
 			output, err = e2e.LongTimeExecWithEnv("vela addon enable test-addon", 600*time.Second, []string{"DEFAULT_VELA_NS=test-vela"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("enabled Successfully."))
+			Expect(output).To(ContainSubstring("enabled successfully."))
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "addon-test-addon", Namespace: "test-vela"}, &v1beta1.Application{})).Should(BeNil())

--- a/e2e/addon/mock/testdata/sample/metadata.yaml
+++ b/e2e/addon/mock/testdata/sample/metadata.yaml
@@ -1,0 +1,15 @@
+name: sample
+version: 1.0.1
+description: This is a test sample addon
+icon: https://www.terraform.io/assets/images/logo-text-8c3ba8a6.svg
+url: https://terraform.io/
+
+tags: []
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies: []
+
+invisible: false

--- a/e2e/addon/mock/testdata/sample/resources/parameter.cue
+++ b/e2e/addon/mock/testdata/sample/resources/parameter.cue
@@ -1,0 +1,3 @@
+parameter: {
+	example: *"default" | string
+}

--- a/e2e/cli.go
+++ b/e2e/cli.go
@@ -76,6 +76,8 @@ func asyncExec(cli string) (*gexec.Session, error) {
 	c := strings.Fields(cli)
 	commandName := path.Join(rudrPath, c[0])
 	command := exec.Command(commandName, c[1:]...)
+	// Use project root as working directory
+	command.Dir = path.Join(rudrPath, "..")
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	return session, err
 }

--- a/e2e/cli.go
+++ b/e2e/cli.go
@@ -76,8 +76,6 @@ func asyncExec(cli string) (*gexec.Session, error) {
 	c := strings.Fields(cli)
 	commandName := path.Join(rudrPath, c[0])
 	command := exec.Command(commandName, c[1:]...)
-	// Use project root as working directory
-	command.Dir = path.Join(rudrPath, "..")
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	return session, err
 }

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -166,7 +166,11 @@ Enable addon for specific clusters, (local means control plane):
 				}
 				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
 				// args[0] is a local path install with local dir, use base dir name as addonName
-				name = filepath.Base(addonOrDir)
+				abs, err := filepath.Abs(addonOrDir)
+				if err != nil {
+					return errors.Wrapf(err, "cannot open directory %s", addonOrDir)
+				}
+				name = filepath.Base(abs)
 				err = enableAddonByLocal(ctx, name, addonOrDir, k8sClient, dc, config, addonArgs)
 				if err != nil {
 					return err
@@ -181,7 +185,7 @@ Enable addon for specific clusters, (local means control plane):
 					return err
 				}
 			}
-			fmt.Printf("Addon: %s enabled Successfully.\n", name)
+			fmt.Printf("Addon %s enabled successfully.\n", name)
 			AdditionalEndpointPrinter(ctx, c, k8sClient, name, false)
 			return nil
 		},
@@ -194,7 +198,7 @@ Enable addon for specific clusters, (local means control plane):
 
 // AdditionalEndpointPrinter will print endpoints
 func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient client.Client, name string, isUpgrade bool) {
-	fmt.Printf("Please access the %s from the following endpoints:\n", name)
+	fmt.Printf("Please access %s from the following endpoints:\n", name)
 	err := printAppEndpoints(ctx, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, Filter{}, c)
 	if err != nil {
 		fmt.Println("Get application endpoints error:", err)
@@ -255,7 +259,11 @@ Upgrade addon for specific clusters, (local means control plane):
 				}
 				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
 				// args[0] is a local path install with local dir
-				name = filepath.Base(addonOrDir)
+				abs, err := filepath.Abs(addonOrDir)
+				if err != nil {
+					return errors.Wrapf(err, "cannot open directory %s", addonOrDir)
+				}
+				name = filepath.Base(abs)
 				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)
 				if err != nil {
 					return errors.Wrapf(err, "cannot fetch addon related addon %s", name)
@@ -279,7 +287,7 @@ Upgrade addon for specific clusters, (local means control plane):
 				}
 			}
 
-			fmt.Printf("Addon: %s\n enabled Successfully.", name)
+			fmt.Printf("Addon %s enabled successfully.", name)
 			AdditionalEndpointPrinter(ctx, c, k8sClient, name, true)
 			return nil
 		},

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -168,7 +168,7 @@ Enable addon for specific clusters, (local means control plane):
 				// args[0] is a local path install with local dir, use base dir name as addonName
 				abs, err := filepath.Abs(addonOrDir)
 				if err != nil {
-					return errors.Wrapf(err, "cannot open directory %s", addonOrDir)
+					return errors.Wrapf(err, "directory %s is invalid", addonOrDir)
 				}
 				name = filepath.Base(abs)
 				err = enableAddonByLocal(ctx, name, addonOrDir, k8sClient, dc, config, addonArgs)

--- a/references/cli/test-data/addon/sample/resources/parameter.cue
+++ b/references/cli/test-data/addon/sample/resources/parameter.cue
@@ -1,3 +1,3 @@
 parameter: {
-	example: *"default"
+	example: *"default" | string
 }

--- a/test/e2e-addon-test/addon_test.go
+++ b/test/e2e-addon-test/addon_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Addon tests", func() {
 			fmt.Println("exit code error:", string(ee.Stderr))
 		}
 		Expect(err).Should(BeNil())
-		Expect(string(output)).Should(ContainSubstring("enabled Successfully"))
+		Expect(string(output)).Should(ContainSubstring("enabled successfully"))
 
 		By("Checking Provider")
 		Eventually(func() error {
@@ -130,6 +130,6 @@ var _ = Describe("Addon tests", func() {
 			fmt.Println("exit code error:", string(ee.Stderr))
 		}
 		Expect(err).Should(BeNil())
-		Expect(string(output)).Should(ContainSubstring("enabled Successfully"))
+		Expect(string(output)).Should(ContainSubstring("enabled successfully"))
 	})
 })


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

When we use `.` to enable local addons, cli will use `.` as the addon name to print endpoints, which will cause errors.
Example: `vela addon enable .` or `vela addon enable ./some/path/.`

Notice the last three (or five) lines. (`.` is used as addon name, and `addon-.` invalid labels)
```console
$ vela addon enable .
enable addon by local dir: . 
I0607 22:14:37.470277  705624 apply.go:107] "creating object" name="canary-rollout" resource="core.oam.dev/v1beta1, Kind=WorkflowStepDefinition"
I0607 22:14:37.535854  705624 apply.go:107] "creating object" name="istio-gateway" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:14:37.597845  705624 apply.go:107] "creating object" name="canary-rollback" resource="core.oam.dev/v1beta1, Kind=WorkflowStepDefinition"
I0607 22:14:37.659132  705624 apply.go:107] "creating object" name="canary-traffic" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:14:37.721066  705624 apply.go:107] "creating object" name="istio-destinationrule" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:14:37.787186  705624 apply.go:107] "creating object" name="istio-vs" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:14:37.849421  705624 apply.go:107] "creating object" name="addon-secret-istio" resource="/v1, Kind=Secret"
Addon: . enabled Successfully.
Please access the . from the following endpoints:
I0607 22:14:38.091826  705624 utils.go:156] find cluster gateway service vela-system/kubevela-cluster-gateway-service:9443
E0607 22:14:38.210538  705624 task.go:238] "do steps" err="step resources: run step(provider=query,do=collectServiceEndpoints): unable to parse requirement: values[0][app.oam.dev/name]: Invalid value: \"addon-.\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')" step_name="service-endpoints-view-status" step_type="service-endpoints-view" spanID="i-rkb7duwf"
Get application endpoints error: failed to query the view step resources: run step(provider=query,do=collectServiceEndpoints): unable to parse requirement: values[0][app.oam.dev/name]: Invalid value: "addon-.": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
This has been fixed by correctly finding out directory name. (Also fixed some typos.)
```console
$ vela addon enable .
enable addon by local dir: . 
I0607 22:37:17.553323  751092 apply.go:107] "patching object" name="canary-rollout" resource="core.oam.dev/v1beta1, Kind=WorkflowStepDefinition"
I0607 22:37:17.617073  751092 apply.go:107] "patching object" name="istio-gateway" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:37:17.682554  751092 apply.go:107] "patching object" name="canary-rollback" resource="core.oam.dev/v1beta1, Kind=WorkflowStepDefinition"
I0607 22:37:17.746558  751092 apply.go:107] "patching object" name="canary-traffic" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:37:17.812260  751092 apply.go:107] "patching object" name="istio-destinationrule" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:37:17.881306  751092 apply.go:107] "patching object" name="istio-vs" resource="core.oam.dev/v1beta1, Kind=TraitDefinition"
I0607 22:37:17.945046  751092 apply.go:107] "patching object" name="addon-secret-istio" resource="/v1, Kind=Secret"
Addon istio enabled successfully.
Please access the istio from the following endpoints:
I0607 22:37:18.267096  751092 utils.go:156] find cluster gateway service vela-system/kubevela-cluster-gateway-service:9443
+---------+-----------+-------------------------------------------+------------------------+
| CLUSTER | COMPONENT |         REF(KIND/NAMESPACE/NAME)          |        ENDPOINT        |
+---------+-----------+-------------------------------------------+------------------------+
| local   | istio     | Service/istio-system/istio-ingressgateway | 123.57.xxx.xxx:15021   |
| local   | istio     | Service/istio-system/istio-ingressgateway | http://123.57.xxx.xxx  |
| local   | istio     | Service/istio-system/istio-ingressgateway | https://123.57.xxx.xxx |
+---------+-----------+-------------------------------------------+------------------------+

```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
e2e tests have been added


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->