### PR TITLE
Fix: mongoDB datastore can't list special email user(#4104)

### DIFF
--- a/pkg/apiserver/domain/model/user.go
+++ b/pkg/apiserver/domain/model/user.go
@@ -70,10 +70,10 @@ func (u *User) PrimaryKey() string {
 func (u *User) Index() map[string]string {
 	index := make(map[string]string)
 	if u.Name != "" {
-		index["name"] = verifyUserValue(u.Name)
+		index["name"] = u.Name
 	}
 	if u.Email != "" {
-		index["email"] = verifyUserValue(u.Email)
+		index["email"] = u.Email
 	}
 	return index
 }

--- a/pkg/apiserver/domain/model/user.go
+++ b/pkg/apiserver/domain/model/user.go
@@ -18,7 +18,6 @@ package model
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/form3tech-oss/jwt-go"
@@ -63,7 +62,7 @@ func (u *User) ShortTableName() string {
 
 // PrimaryKey return custom primary key
 func (u *User) PrimaryKey() string {
-	return verifyUserValue(u.Name)
+	return u.Name
 }
 
 // Index return custom index
@@ -99,25 +98,19 @@ func (u *ProjectUser) ShortTableName() string {
 
 // PrimaryKey return custom primary key
 func (u *ProjectUser) PrimaryKey() string {
-	return fmt.Sprintf("%s-%s", u.ProjectName, verifyUserValue(u.Username))
+	return fmt.Sprintf("%s-%s", u.ProjectName, u.Username)
 }
 
 // Index return custom index
 func (u *ProjectUser) Index() map[string]string {
 	index := make(map[string]string)
 	if u.Username != "" {
-		index["username"] = verifyUserValue(u.Username)
+		index["username"] = u.Username
 	}
 	if u.ProjectName != "" {
 		index["projectName"] = u.ProjectName
 	}
 	return index
-}
-
-func verifyUserValue(v string) string {
-	s := strings.ReplaceAll(v, "@", "-")
-	s = strings.ReplaceAll(s, " ", "-")
-	return strings.ToLower(s)
 }
 
 // CustomClaims is the custom claims

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
@@ -360,7 +360,11 @@ func (m *kubeapi) List(ctx context.Context, entity datastore.Entity, op *datasto
 	}
 	if op != nil {
 		for _, inFilter := range op.In {
-			rq, err := labels.NewRequirement(inFilter.Key, selection.In, inFilter.Values)
+			var values []string
+			for _, value := range inFilter.Values {
+				values = append(values, verifyValue(value))
+			}
+			rq, err := labels.NewRequirement(inFilter.Key, selection.In, values)
 			if err != nil {
 				log.Logger.Errorf("new list requirement failure %s", err.Error())
 				return nil, datastore.ErrIndexInvalid

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
@@ -85,7 +85,7 @@ func (m *kubeapi) generateConfigMap(entity datastore.Entity) *corev1.ConfigMap {
 		labels = make(map[string]string)
 	}
 	for k, v := range labels {
-		labels[k] = verifyUserValue(v)
+		labels[k] = verifyValue(v)
 	}
 	labels["table"] = entity.TableName()
 	labels["primaryKey"] = entity.PrimaryKey()
@@ -180,7 +180,7 @@ func (m *kubeapi) Put(ctx context.Context, entity datastore.Entity) error {
 		labels = make(map[string]string)
 	}
 	for k, v := range labels {
-		labels[k] = verifyUserValue(v)
+		labels[k] = verifyValue(v)
 	}
 	labels["table"] = entity.TableName()
 	labels["primaryKey"] = entity.PrimaryKey()
@@ -351,7 +351,7 @@ func (m *kubeapi) List(ctx context.Context, entity datastore.Entity, op *datasto
 	selector = selector.Add(*rq)
 
 	for k, v := range entity.Index() {
-		rq, err := labels.NewRequirement(k, selection.Equals, []string{verifyUserValue(v)})
+		rq, err := labels.NewRequirement(k, selection.Equals, []string{verifyValue(v)})
 		if err != nil {
 			return nil, datastore.ErrIndexInvalid
 		}
@@ -437,7 +437,7 @@ func (m *kubeapi) Count(ctx context.Context, entity datastore.Entity, filterOpti
 		return 0, datastore.NewDBError(err)
 	}
 	for k, v := range entity.Index() {
-		rq, err := labels.NewRequirement(k, selection.Equals, []string{verifyUserValue(v)})
+		rq, err := labels.NewRequirement(k, selection.Equals, []string{verifyValue(v)})
 		if err != nil {
 			return 0, datastore.ErrIndexInvalid
 		}
@@ -480,7 +480,7 @@ func (m *kubeapi) Count(ctx context.Context, entity datastore.Entity, filterOpti
 	return int64(len(items)), nil
 }
 
-func verifyUserValue(v string) string {
+func verifyValue(v string) string {
 	s := strings.ReplaceAll(v, "@", "-")
 	s = strings.ReplaceAll(s, " ", "-")
 	return strings.ToLower(s)

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
@@ -75,6 +75,7 @@ func generateName(entity datastore.Entity) string {
 	// record the old ways here, it'll be migrated
 	// name := fmt.Sprintf("veladatabase-%s-%s", entity.TableName(), entity.PrimaryKey())
 	name := fmt.Sprintf("%s-%s", entity.ShortTableName(), entity.PrimaryKey())
+	name = verifyValue(name)
 	return strings.ReplaceAll(name, "_", "-")
 }
 
@@ -84,11 +85,11 @@ func (m *kubeapi) generateConfigMap(entity datastore.Entity) *corev1.ConfigMap {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
+	labels["table"] = entity.TableName()
+	labels["primaryKey"] = entity.PrimaryKey()
 	for k, v := range labels {
 		labels[k] = verifyValue(v)
 	}
-	labels["table"] = entity.TableName()
-	labels["primaryKey"] = entity.PrimaryKey()
 	var configMap = corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateName(entity),
@@ -179,11 +180,11 @@ func (m *kubeapi) Put(ctx context.Context, entity datastore.Entity) error {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
+	labels["table"] = entity.TableName()
+	labels["primaryKey"] = entity.PrimaryKey()
 	for k, v := range labels {
 		labels[k] = verifyValue(v)
 	}
-	labels["table"] = entity.TableName()
-	labels["primaryKey"] = entity.PrimaryKey()
 	entity.SetUpdateTime(time.Now())
 	var configMap corev1.ConfigMap
 	if err := m.kubeClient.Get(ctx, types.NamespacedName{Namespace: m.namespace, Name: generateName(entity)}, &configMap); err != nil {

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi.go
@@ -450,7 +450,11 @@ func (m *kubeapi) Count(ctx context.Context, entity datastore.Entity, filterOpti
 	}
 	if filterOptions != nil {
 		for _, inFilter := range filterOptions.In {
-			rq, err := labels.NewRequirement(inFilter.Key, selection.In, inFilter.Values)
+			var values []string
+			for _, value := range inFilter.Values {
+				values = append(values, verifyValue(value))
+			}
+			rq, err := labels.NewRequirement(inFilter.Key, selection.In, values)
 			if err != nil {
 				return 0, datastore.ErrIndexInvalid
 			}

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
@@ -39,8 +39,9 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 		err := kubeStore.Add(context.TODO(), &model.Application{Name: "kubevela-app", Description: "default"})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = kubeStore.Add(context.TODO(), &model.Application{Name: "cat@delete", Description: "this is for test special symbol"})
+		err = kubeStore.Add(context.TODO(), &model.Application{Name: "can@delete", Description: "this is for test special symbol"})
 		Expect(err).ToNot(HaveOccurred())
+
 	})
 
 	It("Test batch add function", func() {
@@ -248,5 +249,9 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 		err = kubeStore.Delete(context.TODO(), &app)
 		equal := cmp.Equal(err, datastore.ErrRecordNotExist, cmpopts.EquateErrors())
 		Expect(equal).Should(BeTrue())
+
+		app.Name = "can@delete"
+		err = kubeStore.Delete(context.TODO(), &app)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 })

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 	It("Test add function", func() {
 		err := kubeStore.Add(context.TODO(), &model.Application{Name: "kubevela-app", Description: "default"})
 		Expect(err).ToNot(HaveOccurred())
+
+		err = kubeStore.Add(context.TODO(), &model.Application{Name: "cat@delete", Description: "this is for test special symbol"})
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Test batch add function", func() {

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
@@ -248,20 +248,20 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 	})
 
 	It("Test verify index", func() {
-		var app = model.Application{Name: "can@delete", Description: "this is for test special symbol"}
-		err := kubeStore.Add(context.TODO(), &app)
+		var usr = model.User{Name: "can@delete", Email: "xxx@xx.com"}
+		err := kubeStore.Add(context.TODO(), &usr)
 		Expect(err).ToNot(HaveOccurred())
 
-		app.Description = "change"
-		err = kubeStore.Put(context.TODO(), &app)
+		usr.Email = "change"
+		err = kubeStore.Put(context.TODO(), &usr)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = kubeStore.Get(context.TODO(), &app)
+		err = kubeStore.Get(context.TODO(), &usr)
 		Expect(err).Should(BeNil())
-		diff := cmp.Diff(app.Description, "change")
+		diff := cmp.Diff(usr.Email, "change")
 		Expect(diff).Should(BeEmpty())
 
-		list, err := kubeStore.List(context.TODO(), &app, &datastore.ListOptions{FilterOptions: datastore.FilterOptions{In: []datastore.InQueryOption{
+		list, err := kubeStore.List(context.TODO(), &usr, &datastore.ListOptions{FilterOptions: datastore.FilterOptions{In: []datastore.InQueryOption{
 			{
 				Key:    "name",
 				Values: []string{"can@delete"},
@@ -271,7 +271,7 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 		diff = cmp.Diff(len(list), 1)
 		Expect(diff).Should(BeEmpty())
 
-		count, err := kubeStore.Count(context.TODO(), &app, &datastore.FilterOptions{In: []datastore.InQueryOption{
+		count, err := kubeStore.Count(context.TODO(), &usr, &datastore.FilterOptions{In: []datastore.InQueryOption{
 			{
 				Key:    "name",
 				Values: []string{"can@delete"},
@@ -280,8 +280,8 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(count).Should(Equal(int64(1)))
 
-		app.Name = "can@delete"
-		err = kubeStore.Delete(context.TODO(), &app)
+		usr.Name = "can@delete"
+		err = kubeStore.Delete(context.TODO(), &usr)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })

--- a/references/cli/components.go
+++ b/references/cli/components.go
@@ -226,7 +226,7 @@ func PrintInstalledCompDef(c common2.Args, io cmdutil.IOStreams, filter filterFu
 	}
 
 	table := newUITable()
-	table.AddRow("NAME", "DEFINITION")
+	table.AddRow("NAME", "DEFINITION", "DESCRIPTION")
 
 	for _, cd := range list.Items {
 		data, err := json.Marshal(cd)
@@ -242,7 +242,7 @@ func PrintInstalledCompDef(c common2.Args, io cmdutil.IOStreams, filter filterFu
 		if filter != nil && !filter(capa) {
 			continue
 		}
-		table.AddRow(capa.Name, capa.CrdName)
+		table.AddRow(capa.Name, capa.CrdName, capa.Description)
 	}
 	io.Info(table.String())
 	return nil

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -228,6 +228,7 @@ func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterF
 
 	table := newUITable()
 	table.AddRow("NAME", "APPLIES-TO")
+	table.AddRow("NAME", "APPLIES-TO", "DESCRIPTION")
 
 	for _, td := range list.Items {
 		data, err := json.Marshal(td)
@@ -243,7 +244,7 @@ func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterF
 		if filter != nil && !filter(capa) {
 			continue
 		}
-		table.AddRow(capa.Name, capa.AppliesTo)
+		table.AddRow(capa.Name, capa.AppliesTo, capa.Description)
 	}
 	io.Info(table.String())
 	return nil


### PR DESCRIPTION
Signed-off-by: fengkang <fengkangb@digitalchina.com>


### Description of your changes
I change the user model index function ,and replace symbol timing.
In the kubeapi datastore , the list function can get include Special characters("@"," ")filed "name" and "email",i use verifyUserValue function to replace the Special characters to make sure that can be used by k8s label
In the mongoDB datastore , this list funciton keep intact,so that the program can special a email to list the model user
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4104 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer
@FogDong 
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->