### PR TITLE
Feat: render color for outputs of vela up command

### DIFF
--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -237,7 +237,7 @@ func (opt *UpCommandOptions) deployApplicationFromFile(f velacmd.Factory, cmd *c
 	if err != nil {
 		return err
 	}
-	cmd.Printf("Application %s/%s applied.\n", app.Namespace, app.Name)
+	cmd.Printf("Application %s applied.\n", green.Sprintf("%s/%s", app.Namespace, app.Name))
 	return nil
 }
 

--- a/references/common/application.go
+++ b/references/common/application.go
@@ -465,13 +465,14 @@ func (o *AppfileOptions) apply(app *corev1beta1.Application, scopes []oam.Object
 
 // Info shows the status of each service in the Appfile
 func Info(app *corev1beta1.Application) string {
+	yellow := color.New(color.FgYellow)
 	appName := app.Name
 	var appUpMessage = "✅ App has been deployed 🚀🚀🚀\n" +
-		fmt.Sprintf("    Port forward: vela port-forward %s\n", appName) +
-		fmt.Sprintf("             SSH: vela exec %s\n", appName) +
-		fmt.Sprintf("         Logging: vela logs %s\n", appName) +
-		fmt.Sprintf("      App status: vela status %s\n", appName) +
-		fmt.Sprintf("        Endpoint: vela status %s --endpoint\n", appName)
+		"    Port forward: " + yellow.Sprintf("vela port-forward %s\n", appName) +
+		"             SSH: " + yellow.Sprintf("vela exec %s\n", appName) +
+		"         Logging: " + yellow.Sprintf("vela logs %s\n", appName) +
+		"      App status: " + yellow.Sprintf("vela status %s\n", appName) +
+		"        Endpoint: " + yellow.Sprintf("vela status %s --endpoint\n", appName)
 	return appUpMessage
 }
 


### PR DESCRIPTION
Signed-off-by: huangminjie <minjie.huang@daocloud.io>

render color for outputs of vela up command (#3903 )


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3903 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->