### PR TITLE
Chore: fix potential bot failures

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -15,7 +15,17 @@ jobs:
           repository: "oam-dev/kubevela-github-actions"
           path: ./actions
           ref: v0.4.2
-      - name: Install Actions
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('./actions/package-lock.json') }}
+          restore-keys: npm-
+      - name: Install Dependencies
         run: npm ci --production --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -16,15 +16,11 @@ jobs:
           path: ./actions
           ref: v0.4.2
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('./actions/package-lock.json') }}
-          restore-keys: npm-
+          cache: 'npm'
+          cache-dependency-path: ./actions/package-lock.json
       - name: Install Dependencies
         run: npm ci --production --prefix ./actions
       - name: Run Commands

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

KubeVela bot sometimes will fail and the log shows that it is caused by an inconsistent lockfile.

However the lockfile itself is fine, and I suspect it is caused by node version changes (as it uses the version bundled with `ubuntu-latest`, which just updated recently with npm `v8.5.5` -> `v8.11.0` and causing this issue). 

Using `latest` tag does no good, which will often cause problems when software version changes. 

It is a good practice to fix node versions (also npm versions).

So I did the following:
- fixed node version to `v14` (instead of node `v16` + npm `v8.11.0` bundled with `ubuntu-latest`; that specific `v8.11.0` version doesn't work and will fail)
- fixed ubuntu version to 20.04, just for good measure
- (btw) added cache to speed up workflow runs

<img width="950" alt="Screen Shot 2022-06-09 at 6 16 02 PM" src="https://user-images.githubusercontent.com/55270174/172824203-21072c4b-8ffd-41ca-995d-82e36561a635.png">

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Since I used my repo to double check it can successfully install dependencies using GitHub Actions now, but I don't have the necessary token to run the entire job, I will continue to check how it actually works in real environments after being merged.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->