### PR TITLE
Feat: add the feature that views in addon are applied independently.(#3905)

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -80,6 +80,8 @@ const (
 	OpenapiV3JSONSchema string = "openapi-v3-json-schema"
 	// UISchema is the key to store ui custom schema
 	UISchema string = "ui-schema"
+	// VelaQLTemplate is the key to store velaql view
+	VelaQLTemplate string = "template"
 )
 
 // CapabilityCategory defines the category of a capability

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -94,6 +94,9 @@ const (
 	// DefSchemaName is the addon definition schemas dir name
 	DefSchemaName string = "schemas"
 
+	// ViewDirName is the addon views dir name
+	ViewDirName string = "views"
+
 	// AddonParameterDataKey is the key of parameter in addon args secrets
 	AddonParameterDataKey string = "addonParameterDataKey"
 
@@ -191,7 +194,7 @@ type Pattern struct {
 }
 
 // Patterns is the file pattern that the addon should be in
-var Patterns = []Pattern{{Value: ReadmeFileName}, {Value: MetadataFileName}, {Value: TemplateFileName}, {Value: ParameterFileName}, {IsDir: true, Value: ResourcesDirName}, {IsDir: true, Value: DefinitionsDirName}, {IsDir: true, Value: DefSchemaName}}
+var Patterns = []Pattern{{Value: ReadmeFileName}, {Value: MetadataFileName}, {Value: TemplateFileName}, {Value: ParameterFileName}, {IsDir: true, Value: ResourcesDirName}, {IsDir: true, Value: DefinitionsDirName}, {IsDir: true, Value: DefSchemaName}, {IsDir: true, Value: ViewDirName}}
 
 // GetPatternFromItem will check if the file path has a valid pattern, return empty string if it's invalid.
 // AsyncReader is needed to calculate relative path
@@ -306,6 +309,7 @@ func GetInstallPackageFromReader(r AsyncReader, meta *SourceMeta, uiData *UIData
 		TemplateFileName: readTemplate,
 		ResourcesDirName: readResFile,
 		DefSchemaName:    readDefSchemaFile,
+		ViewDirName:      readViewFile,
 	}
 	ptItems := ClassifyItemByPattern(meta, r)
 
@@ -405,6 +409,16 @@ func readDefFile(a *UIData, reader AsyncReader, readPath string) error {
 	default:
 		// skip other file formats
 	}
+	return nil
+}
+
+// readViewFile read single view file
+func readViewFile(a *InstallPackage, reader AsyncReader, readPath string) error {
+	b, err := reader.ReadFile(readPath)
+	if err != nil {
+		return err
+	}
+	a.Views = append(a.Views, ElementFile{Data: b, Name: filepath.Base(readPath)})
 	return nil
 }
 
@@ -809,6 +823,19 @@ func RenderDefinitionSchema(addon *InstallPackage) ([]*unstructured.Unstructured
 	return schemaConfigmaps, nil
 }
 
+// RenderViews will render views in addons.
+func RenderViews(addon *InstallPackage) ([]*unstructured.Unstructured, error) {
+	views := make([]*unstructured.Unstructured, 0)
+	for _, view := range addon.Views {
+		obj, err := renderCueView(view)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, obj)
+	}
+	return views, nil
+}
+
 func allocateDomainForAddon(ctx context.Context, k8sClient client.Client) ([]ObservabilityEnvironment, error) {
 	secrets, err := multicluster.ListExistingClusterSecrets(ctx, k8sClient)
 	if err != nil {
@@ -949,6 +976,16 @@ func renderSchemaConfigmap(elem ElementFile) (*unstructured.Unstructured, error)
 		ObjectMeta: metav1.ObjectMeta{Namespace: types.DefaultKubeVelaNS, Name: strings.Split(elem.Name, ".")[0]},
 		Data: map[string]string{
 			types.UISchema: string(jsonData),
+		}}
+	return util.Object2Unstructured(cm)
+}
+
+func renderCueView(elem ElementFile) (*unstructured.Unstructured, error) {
+	cm := v1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: types.DefaultKubeVelaNS, Name: strings.Split(elem.Name, ".")[0]},
+		Data: map[string]string{
+			types.VelaQLTemplate: elem.Data,
 		}}
 	return util.Object2Unstructured(cm)
 }
@@ -1248,6 +1285,11 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 		return errors.Wrap(err, "render addon definitions' schema fail")
 	}
 
+	views, err := RenderViews(addon)
+	if err != nil {
+		return errors.Wrap(err, "render addon views fail")
+	}
+
 	if err := passDefInAppAnnotation(defs, app); err != nil {
 		return errors.Wrapf(err, "cannot pass definition to addon app's annotation")
 	}
@@ -1267,6 +1309,14 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	for _, schema := range schemas {
 		addOwner(schema, app)
 		err = h.apply.Apply(h.ctx, schema, apply.DisableUpdateAnnotation())
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, view := range views {
+		addOwner(view, app)
+		err = h.apply.Apply(h.ctx, view, apply.DisableUpdateAnnotation())
 		if err != nil {
 			return err
 		}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -418,7 +418,12 @@ func readViewFile(a *InstallPackage, reader AsyncReader, readPath string) error 
 	if err != nil {
 		return err
 	}
-	a.Views = append(a.Views, ElementFile{Data: b, Name: filepath.Base(readPath)})
+	filename := path.Base(readPath)
+	switch filepath.Ext(filename) {
+	case ".cue":
+		a.Views = append(a.Views, ElementFile{Data: b, Name: filepath.Base(readPath)})
+	default:
+	}
 	return nil
 }
 

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -1042,6 +1042,35 @@ func TestReadDefFile(t *testing.T) {
 	assert.True(t, len(uiData.Definitions) == 1)
 }
 
+// Test readDefFile only accept .cue
+func TestReadViewFile(t *testing.T) {
+
+	// setup test data
+	testAddonName := "test-view"
+	testAddonDir := fmt.Sprintf("./testdata/%s", testAddonName)
+	reader := localReader{dir: testAddonDir, name: testAddonName}
+	metas, err := reader.ListAddonMeta()
+	testAddonMeta := metas[testAddonName]
+	assert.NoError(t, err)
+
+	// run test
+	var addon = &InstallPackage{}
+	ptItems := ClassifyItemByPattern(&testAddonMeta, reader)
+	items := ptItems[ViewDirName]
+
+	for _, it := range items {
+		err := readViewFile(addon, reader, reader.RelativePath(it))
+		if err != nil {
+			assert.NoError(t, err)
+		}
+	}
+	notExistErr := readViewFile(addon, reader, "not-exist.cue")
+	assert.Error(t, notExistErr)
+
+	// verify
+	assert.True(t, len(addon.Views) == 1)
+}
+
 func TestRenderCUETemplate(t *testing.T) {
 	fileDate, err := os.ReadFile("./testdata/example/resources/configmap.cue")
 	assert.NoError(t, err)

--- a/pkg/addon/testdata/test-view/metadata.yaml
+++ b/pkg/addon/testdata/test-view/metadata.yaml
@@ -1,0 +1,15 @@
+name: test-view
+version: 1.0.0
+description: test
+icon: https://www.terraform.io/assets/images/logo-text-8c3ba8a6.svg
+url: https://terraform.io/
+
+tags: []
+
+deployTo:
+  controlPlane: true
+  runtimeCluster: false
+
+dependencies: []
+
+invisible: false

--- a/pkg/addon/testdata/test-view/views/pod-view.cue
+++ b/pkg/addon/testdata/test-view/views/pod-view.cue
@@ -1,0 +1,75 @@
+import (
+	"vela/ql"
+)
+
+parameter: {
+	name:      string
+	namespace: string
+	cluster:   *"" | string
+}
+pod: ql.#Read & {
+	value: {
+		apiVersion: "v1"
+		kind:       "Pod"
+		metadata: {
+			name:      parameter.name
+			namespace: parameter.namespace
+		}
+	}
+	cluster: parameter.cluster
+}
+eventList: ql.#SearchEvents & {
+	value: {
+		apiVersion: "v1"
+		kind:       "Pod"
+		metadata:   pod.value.metadata
+	}
+	cluster: parameter.cluster
+}
+podMetrics: ql.#Read & {
+	cluster: parameter.cluster
+	value: {
+		apiVersion: "metrics.k8s.io/v1beta1"
+		kind:       "PodMetrics"
+		metadata: {
+			name:      parameter.name
+			namespace: parameter.namespace
+		}
+	}
+}
+status: {
+	if pod.err == _|_ {
+		containers: [ for container in pod.value.spec.containers {
+			name:  container.name
+			image: container.image
+			resources: {
+				if container.resources.limits != _|_ {
+					limits: container.resources.limits
+				}
+				if container.resources.requests != _|_ {
+					requests: container.resources.requests
+				}
+				if podMetrics.err == _|_ {
+					usage: {for containerUsage in podMetrics.value.containers {
+						if containerUsage.name == container.name {
+							cpu:    containerUsage.usage.cpu
+							memory: containerUsage.usage.memory
+						}
+					}}
+				}
+			}
+			if pod.value.status.containerStatuses != _|_ {
+				status: {for containerStatus in pod.value.status.containerStatuses if containerStatus.name == container.name {
+					state:        containerStatus.state
+					restartCount: containerStatus.restartCount
+				}}
+			}
+		}]
+		if eventList.err == _|_ {
+			events: eventList.list
+		}
+	}
+	if pod.err != _|_ {
+		error: pod.err
+	}
+}

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -48,6 +48,9 @@ type InstallPackage struct {
 	// Definitions and CUEDefinitions are converted as OAM X-Definitions, they will only in control plane cluster
 	Definitions    []ElementFile `json:"definitions"`
 	CUEDefinitions []ElementFile `json:"CUEDefinitions"`
+	// Views are the instances of velaql, they will only in control plane cluster
+	Views []ElementFile `json:"views"`
+
 	// DefSchemas are UI schemas read by VelaUX, it will only be installed in control plane clusters
 	DefSchemas []ElementFile `json:"defSchemas,omitempty"`
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3905 

separate the deployment of views in addon and deploy them separately instead of nested in application.

add a `views` folder in the outermost directory of addon. The addon directory structure is:

```shell
├── resources/
├── definitions/
├── schemas/
├── views/
│   ├── pod-view.cue
│   └── component-pod-view.cue
├── README.md
├── metadata.yaml
└── template.yaml
```

The view in the `views` folder are organized in a cue file format. Each view is placed in a cue file. An example of a view file is as follows: 
```
import (
	"vela/ql"
)

parameter: {
	name:      string
	namespace: string
	cluster:   *"" | string
}
pod: ql.#Read & {
	value: {
		apiVersion: "v1"
		kind:       "Pod"
		metadata: {
			name:      parameter.name
			namespace: parameter.namespace
		}
	}
	cluster: parameter.cluster
}
eventList: ql.#SearchEvents & {
	value: {
		apiVersion: "v1"
		kind:       "Pod"
		metadata:   pod.value.metadata
	}
	cluster: parameter.cluster
}
podMetrics: ql.#Read & {
	cluster: parameter.cluster
	value: {
		apiVersion: "metrics.k8s.io/v1beta1"
		kind:       "PodMetrics"
		metadata: {
			name:      parameter.name
			namespace: parameter.namespace
		}
	}
}
status: {
	if pod.err == _|_ {
		containers: [ for container in pod.value.spec.containers {
			name:  container.name
			image: container.image
			resources: {
				if container.resources.limits != _|_ {
					limits: container.resources.limits
				}
				if container.resources.requests != _|_ {
					requests: container.resources.requests
				}
				if podMetrics.err == _|_ {
					usage: {for containerUsage in podMetrics.value.containers {
						if containerUsage.name == container.name {
							cpu:    containerUsage.usage.cpu
							memory: containerUsage.usage.memory
						}
					}}
				}
			}
			if pod.value.status.containerStatuses != _|_ {
				status: {for containerStatus in pod.value.status.containerStatuses if containerStatus.name == container.name {
					state:        containerStatus.state
					restartCount: containerStatus.restartCount
				}}
			}
		}]
		if eventList.err == _|_ {
			events: eventList.list
		}
	}
	if pod.err != _|_ {
		error: pod.err
	}
}

```


see the issue for details

Refs #3905

Signed-off-by: HanMengnan <1448189829@qq.com>

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->