### PR TITLE
Feat: implement addon init command

### DIFF
--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -50,7 +50,7 @@ func CreateAddonFromHelmChart(addonName, addonPath, helmRepoURL, chartName, char
 	// Make sure url is valid
 	isValidURL := utils.IsValidURL(helmRepoURL)
 	if !isValidURL {
-		return fmt.Errorf("invalid helm repo url")
+		return fmt.Errorf("invalid helm repo url %s", helmRepoURL)
 	}
 
 	err := preAddonCreation(addonName, addonPath)

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -191,12 +191,9 @@ func createAddonFiles(addonPath, addonName, helmRepoURL, chartName, chartVersion
 	// However, this may change in the future, possibly with `argocd`.
 	metadataFilePath := path.Join(addonPath, MetadataFileName)
 	metadataTemplate := Meta{
-		Name:        addonName,
-		Version:     chartVersion,
-		Description: "Insert the description of your addon here.",
-		// Just use a dummy image with the addon name in it
-		Icon:         fmt.Sprintf("https://dummyimage.com/400x400/aaaaaa/333333&text=%s", addonName), // no need to escape url
-		URL:          "https://kubevela.io",
+		Name:         addonName,
+		Version:      chartVersion,
+		Description:  "An addon for KubeVela.",
 		Tags:         []string{chartVersion},
 		Dependencies: []*Dependency{{Name: "fluxcd"}},
 	}

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -18,11 +18,12 @@ package addon
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"os"
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/fatih/color"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/format"
@@ -63,7 +64,7 @@ func CreateAddonFromHelmChart(addonName, addonPath, helmRepoURL, chartName, char
 		return fmt.Errorf("cannot create addon files: %w", err)
 	}
 
-	postAddonCreation(addonName, addonPath)
+	postAddonCreation(addonPath)
 
 	return nil
 }
@@ -84,7 +85,7 @@ func CreateAddonSample(addonName, addonPath string) error {
 		return err
 	}
 
-	postAddonCreation(addonName, addonPath)
+	postAddonCreation(addonPath)
 
 	return nil
 }
@@ -113,7 +114,7 @@ func preAddonCreation(addonName, addonPath string) error {
 
 // postAddonCreation is after before creating an addon scaffold
 // It prints some instructions to get started.
-func postAddonCreation(addonName, addonPath string) {
+func postAddonCreation(addonPath string) {
 	fmt.Println("Scaffold created in directory " +
 		color.New(color.Bold).Sprint(addonPath) + ". What to do next:\n" +
 		"- Check out our guide on how to build your own addon: " +

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/encoding/gocode/gocodec"
+	"github.com/fatih/color"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils"
+)
+
+// CreateAddonFromHelmChart create an addon scaffold from a Helm Chart
+func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion string) error {
+	if len(addonPath) == 0 || len(helmRepoURL) == 0 || len(chartName) == 0 || len(chartVersion) == 0 {
+		return fmt.Errorf("addon path, helm URL, chart name, and chart verion should not be empty")
+	}
+
+	// Currently, we do not check whether the Helm Chart actually exists, because it is just a scaffold.
+	// The user can still edit it after creation.
+	// Also, if the user is offline, we cannot check whether the Helm Chart exists.
+
+	// Extract addon name from path (using dir name)
+	absPath, err := filepath.Abs(addonPath)
+	if err != nil {
+		return err
+	}
+	addonName := filepath.Base(absPath)
+
+	// Make sure addon name is valid
+	err = CheckAddonName(addonName)
+	if err != nil {
+		return err
+	}
+
+	// Make sure addonPath is pointing to an empty directory, or does not exist at all
+	// so that we can create it later
+	_, err = os.Stat(addonPath)
+	if !os.IsNotExist(err) {
+		emptyDir, err := utils.IsEmptyDir(addonPath)
+		if err != nil {
+			return fmt.Errorf("we can't create directory %s. Make sure the name has not already been taken and you have the proper rights to write to it ", addonPath)
+		}
+
+		if !emptyDir {
+			return fmt.Errorf("directory %s is not empty. To avoid any data loss, manually delete it first", addonPath)
+		}
+
+		// addonPath is en empty dir, delete it
+		err = os.Remove(addonPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Make sure url is valid
+	_, err = url.ParseRequestURI(helmRepoURL)
+	if err != nil {
+		return fmt.Errorf("invalid helm repo url: %w", err)
+	}
+
+	// Create dirs
+	err = createAddonDirs(addonPath)
+	if err != nil {
+		return fmt.Errorf("cannot addon structure: %w", err)
+	}
+
+	// Create files like template.yaml, README.md, and etc.
+	err = createAddonFiles(addonPath, addonName, helmRepoURL, chartName, chartVersion)
+	if err != nil {
+		return fmt.Errorf("cannot create addon files: %w", err)
+	}
+
+	fmt.Println("Scaffold created in directory " +
+		color.New(color.Bold).Sprint(addonPath) + ". What to do next:\n" +
+		"- Review and edit what we have generated in " + color.New(color.Bold).Sprint(addonPath) + "\n" +
+		"- Check out our guide on how to build your own addon: " +
+		color.BlueString("https://kubevela.io/docs/platform-engineers/addon/intro") + "\n" +
+		"- To enable the addon, run: " +
+		color.New(color.FgGreen).Sprint("vela") + color.GreenString(" addon enable ") + color.New(color.Bold, color.FgGreen).Sprint(addonPath))
+
+	return nil
+}
+
+// CheckAddonName checks if an addon name is valid
+func CheckAddonName(addonName string) error {
+	if len(addonName) == 0 {
+		return fmt.Errorf("addon name should not be empty")
+	}
+
+	// Make sure addonName only contains lowercase letters, dashes, and numbers, e.g. some-addon
+	re := regexp.MustCompile(`^[a-z\d]+(-[a-z\d]+)*$`)
+	if !re.MatchString(addonName) {
+		return fmt.Errorf("addon name should only cocntain lowercase letters, dashes, and numbers, e.g. some-addon")
+	}
+
+	return nil
+}
+
+// writeHelmComponentTemplate writes a cue, with a helm component inside, intended as addon resource
+func writeHelmComponentTemplate(tmpl HelmComponentTemplate, filePath string) error {
+	r := cue.Runtime{}
+	v, err := gocodec.New(&r, nil).Decode(tmpl)
+	if err != nil {
+		return err
+	}
+
+	// Use `output` value
+	v = v.Lookup("output")
+	// Format output
+	bs, err := format.Node(v.Syntax())
+	if err != nil {
+		return err
+	}
+
+	// Append "output: " to the beginning of the string, like "output: {}"
+	bs = append([]byte("output: "), bs...)
+	err = os.WriteFile(filePath, bs, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot write %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// createAddonFiles creates the files structure for an addon,
+// including template.yaml, readme.md, metadata.yaml, and <addon-nam>.cue.
+func createAddonFiles(addonPath, addonName, helmRepoURL, chartName, chartVersion string) error {
+
+	// TODO(charlie0129): fill out some basic info in the template for the user (read them from the chart), like chart logo, description, and readme, if the chart exists
+
+	// Write README.md
+	readmeFilePath := path.Join(addonPath, ReadmeFileName)
+	err := os.WriteFile(readmeFilePath,
+		[]byte(fmt.Sprintf("# %s\nInsert the README of your addon here.\n\nAlso check how to build your own addon: https://kubevela.net/docs/platform-engineers/addon/intro", addonName)),
+		0644)
+	if err != nil {
+		return fmt.Errorf("cannot write %s: %w", readmeFilePath, err)
+	}
+
+	// Write template.yaml with an empty Application
+	templateFilePath := path.Join(addonPath, TemplateFileName)
+	applicationTemplate := v1beta1.Application{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "Application",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      addonName,
+			Namespace: types.DefaultKubeVelaNS,
+		},
+	}
+
+	applicationTemplateBytes, err := yaml.Marshal(applicationTemplate)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(templateFilePath,
+		applicationTemplateBytes,
+		0644)
+	if err != nil {
+		return fmt.Errorf("cannot write %s: %w", templateFilePath, err)
+	}
+
+	// Write metadata.yaml with `fluxcd` as a dependency because we are using helm.
+	// However, this may change in the future, possibly with `argocd`.
+	metadataFilePath := path.Join(addonPath, MetadataFileName)
+	metadataTemplate := Meta{
+		Name:        addonName,
+		Version:     chartVersion,
+		Description: "Insert the description of your addon here.",
+		// Just use a dummy image with the addon name in it
+		Icon:         fmt.Sprintf("https://dummyimage.com/400x400/aaaaaa/333333&text=%s", addonName), // no need to escape url
+		URL:          "https://kubevela.io",
+		Tags:         []string{chartVersion},
+		Dependencies: []*Dependency{{Name: "fluxcd"}},
+	}
+
+	metadataTemplateBytes, err := yaml.Marshal(metadataTemplate)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(metadataFilePath,
+		metadataTemplateBytes,
+		0644)
+	if err != nil {
+		return fmt.Errorf("cannot write %s: %w", metadataFilePath, err)
+	}
+
+	// Write addonName.cue, containing the helm chart
+	addonResourcePath := path.Join(addonPath, ResourcesDirName, addonName+".cue")
+	resourceTmpl := HelmComponentTemplate{}
+	resourceTmpl.Output.Type = "helm"
+	resourceTmpl.Output.Properties.RepoType = "helm"
+	resourceTmpl.Output.Properties.URL = helmRepoURL
+	resourceTmpl.Output.Properties.Chart = chartName
+	resourceTmpl.Output.Properties.Version = chartVersion
+	err = writeHelmComponentTemplate(resourceTmpl, addonResourcePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createAddonDirs creates the directories structure for an addon
+func createAddonDirs(addonDir string) error {
+	err := os.MkdirAll(addonDir, 0750)
+	if err != nil {
+		return err
+	}
+	dirs := []string{
+		path.Join(addonDir, ResourcesDirName),
+		path.Join(addonDir, DefinitionsDirName),
+		path.Join(addonDir, DefSchemaName),
+	}
+	for _, dir := range dirs {
+		err = os.MkdirAll(dir, 0750)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// HelmComponentTemplate is a template for a helm component .cue in an addon
+type HelmComponentTemplate struct {
+	Output struct {
+		Type       string `json:"type"`
+		Properties struct {
+			RepoType string `json:"repoType"`
+			URL      string `json:"url"`
+			Chart    string `json:"chart"`
+			Version  string `json:"version"`
+		} `json:"properties"`
+	} `json:"output"`
+}

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -18,7 +18,6 @@ package addon
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,7 +73,7 @@ func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion st
 			return fmt.Errorf("directory %s is not empty. To avoid any data loss, manually delete it first", addonPath)
 		}
 
-		// addonPath is en empty dir, delete it
+		// Now we are sure addonPath is en empty dir, delete it
 		err = os.Remove(addonPath)
 		if err != nil {
 			return err
@@ -82,8 +81,8 @@ func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion st
 	}
 
 	// Make sure url is valid
-	_, err = url.ParseRequestURI(helmRepoURL)
-	if err != nil {
+	isValidURL := utils.IsValidURL(helmRepoURL)
+	if !isValidURL {
 		return fmt.Errorf("invalid helm repo url: %w", err)
 	}
 

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -46,6 +46,8 @@ func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion st
 	// The user can still edit it after creation.
 	// Also, if the user is offline, we cannot check whether the Helm Chart exists.
 
+	// TODO(charlie0129): check if the Helm Chart exists (optional)
+
 	// Extract addon name from path (using dir name)
 	absPath, err := filepath.Abs(addonPath)
 	if err != nil {
@@ -149,7 +151,7 @@ func writeHelmComponentTemplate(tmpl HelmComponentTemplate, filePath string) err
 	return nil
 }
 
-// createAddonFiles creates the files structure for an addon,
+// createAddonFiles creates the file structure for an addon,
 // including template.yaml, readme.md, metadata.yaml, and <addon-nam>.cue.
 func createAddonFiles(addonPath, addonName, helmRepoURL, chartName, chartVersion string) error {
 
@@ -229,9 +231,10 @@ func createAddonFiles(addonPath, addonName, helmRepoURL, chartName, chartVersion
 	return nil
 }
 
-// createAddonDirs creates the directories structure for an addon
+// createAddonDirs creates the directory structure for an addon
 func createAddonDirs(addonDir string) error {
-	err := os.MkdirAll(addonDir, 0750)
+	// nolint:gosec
+	err := os.MkdirAll(addonDir, 0755)
 	if err != nil {
 		return err
 	}
@@ -241,7 +244,8 @@ func createAddonDirs(addonDir string) error {
 		path.Join(addonDir, DefSchemaName),
 	}
 	for _, dir := range dirs {
-		err = os.MkdirAll(dir, 0750)
+		// nolint:gosec
+		err = os.MkdirAll(dir, 0755)
 		if err != nil {
 			return err
 		}

--- a/pkg/addon/create.go
+++ b/pkg/addon/create.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 
 	"cuelang.org/go/cue"
@@ -36,8 +35,8 @@ import (
 )
 
 // CreateAddonFromHelmChart create an addon scaffold from a Helm Chart
-func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion string) error {
-	if len(addonPath) == 0 || len(helmRepoURL) == 0 || len(chartName) == 0 || len(chartVersion) == 0 {
+func CreateAddonFromHelmChart(addonName, path, helmRepoURL, chartName, chartVersion string) error {
+	if len(addonName) == 0 || len(helmRepoURL) == 0 || len(chartName) == 0 || len(chartVersion) == 0 {
 		return fmt.Errorf("addon path, helm URL, chart name, and chart verion should not be empty")
 	}
 
@@ -45,17 +44,16 @@ func CreateAddonFromHelmChart(addonPath, helmRepoURL, chartName, chartVersion st
 	// The user can still edit it after creation.
 	// Also, if the user is offline, we cannot check whether the Helm Chart exists.
 
-	// TODO(charlie0129): check if the Helm Chart exists (optional)
+	// TODO(charlie0129): check whether the Helm Chart exists (if the user wants)
 
-	// Extract addon name from path (using dir name)
-	absPath, err := filepath.Abs(addonPath)
-	if err != nil {
-		return err
+	// Scaffold will be created in ./addonName, unless the user specifies a path
+	addonPath := addonName
+	if len(path) > 0 {
+		addonPath = path
 	}
-	addonName := filepath.Base(absPath)
 
 	// Make sure addon name is valid
-	err = CheckAddonName(addonName)
+	err := CheckAddonName(addonName)
 	if err != nil {
 		return err
 	}

--- a/pkg/addon/create_test.go
+++ b/pkg/addon/create_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestCheckAddonName(t *testing.T) {
+	var err error
+
+	err = CheckAddonName("")
+	assert.ErrorContains(t, err, "should not be empty")
+
+	invalidNames := []string{
+		"-addon",
+		"addon-",
+		"Caps",
+		"=",
+		".",
+	}
+	for _, name := range invalidNames {
+		err = CheckAddonName(name)
+		assert.ErrorContains(t, err, "should only")
+	}
+
+	validNames := []string{
+		"addon-name",
+		"3-addon-name",
+		"addon-name-3",
+		"addon",
+	}
+	for _, name := range validNames {
+		err = CheckAddonName(name)
+		assert.NilError(t, err)
+	}
+}
+
+func TestWriteHelmComponentTemplate(t *testing.T) {
+	resourceTmpl := HelmComponentTemplate{}
+	resourceTmpl.Output.Type = "helm"
+	resourceTmpl.Output.Properties.RepoType = "helm"
+	resourceTmpl.Output.Properties.URL = "https://charts.bitnami.com/bitnami"
+	resourceTmpl.Output.Properties.Chart = "bitnami/nginx"
+	resourceTmpl.Output.Properties.Version = "12.0.4"
+	err := writeHelmComponentTemplate(resourceTmpl, "test.cue")
+	assert.NilError(t, err)
+	defer func() {
+		_ = os.Remove("test.cue")
+	}()
+	data, err := os.ReadFile("test.cue")
+	assert.NilError(t, err)
+	expected := `output: {
+	type: "helm"
+	properties: {
+		url:      "https://charts.bitnami.com/bitnami"
+		repoType: "helm"
+		chart:    "bitnami/nginx"
+		version:  "12.0.4"
+	}
+}`
+	assert.Equal(t, string(data), expected)
+}
+
+func TestCreateAddonFromHelmChart(t *testing.T) {
+	err := CreateAddonFromHelmChart("", "", "bitnami/nginx", "12.0.4")
+	assert.ErrorContains(t, err, "should not be empty")
+
+	checkFiles := func(base string) {
+		fileList := []string{
+			"definitions",
+			path.Join("resources", base+".cue"),
+			"schemas",
+			MetadataFileName,
+			ReadmeFileName,
+			TemplateFileName,
+		}
+		for _, file := range fileList {
+			_, err = os.Stat(path.Join(base, file))
+			assert.NilError(t, err)
+		}
+	}
+
+	// Empty dir already exists
+	_ = os.MkdirAll("test-addon", 0755)
+	err = CreateAddonFromHelmChart("test-addon", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	checkFiles("test-addon")
+	defer func() {
+		_ = os.RemoveAll("test-addon")
+	}()
+
+	// Non-empty dir already exists
+	err = CreateAddonFromHelmChart("test-addon", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	assert.ErrorContains(t, err, "not empty")
+
+	// Name already taken
+	err = os.WriteFile("already-taken", []byte{}, 0644)
+	assert.NilError(t, err)
+	defer func() {
+		_ = os.Remove("already-taken")
+	}()
+	err = CreateAddonFromHelmChart("already-taken", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	assert.ErrorContains(t, err, "can't create")
+
+	// Invalid addon name
+	err = CreateAddonFromHelmChart("/", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	assert.ErrorContains(t, err, "should only")
+
+	// Invalid URL
+	err = CreateAddonFromHelmChart("invalid-url", "invalid-url", "bitnami/nginx", "12.0.4")
+	assert.ErrorContains(t, err, "invalid helm repo url")
+}

--- a/pkg/addon/create_test.go
+++ b/pkg/addon/create_test.go
@@ -81,7 +81,7 @@ func TestWriteHelmComponentTemplate(t *testing.T) {
 }
 
 func TestCreateAddonFromHelmChart(t *testing.T) {
-	err := CreateAddonFromHelmChart("", "", "bitnami/nginx", "12.0.4")
+	err := CreateAddonFromHelmChart("", "", "", "bitnami/nginx", "12.0.4")
 	assert.ErrorContains(t, err, "should not be empty")
 
 	checkFiles := func(base string) {
@@ -101,14 +101,14 @@ func TestCreateAddonFromHelmChart(t *testing.T) {
 
 	// Empty dir already exists
 	_ = os.MkdirAll("test-addon", 0755)
-	err = CreateAddonFromHelmChart("test-addon", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	err = CreateAddonFromHelmChart("test-addon", "./test-addon", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
 	checkFiles("test-addon")
 	defer func() {
 		_ = os.RemoveAll("test-addon")
 	}()
 
 	// Non-empty dir already exists
-	err = CreateAddonFromHelmChart("test-addon", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	err = CreateAddonFromHelmChart("test-addon", "", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
 	assert.ErrorContains(t, err, "not empty")
 
 	// Name already taken
@@ -117,14 +117,14 @@ func TestCreateAddonFromHelmChart(t *testing.T) {
 	defer func() {
 		_ = os.Remove("already-taken")
 	}()
-	err = CreateAddonFromHelmChart("already-taken", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	err = CreateAddonFromHelmChart("already-taken", "", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
 	assert.ErrorContains(t, err, "can't create")
 
 	// Invalid addon name
-	err = CreateAddonFromHelmChart("/", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
+	err = CreateAddonFromHelmChart("/", "", "https://charts.bitnami.com/bitnami", "bitnami/nginx", "12.0.4")
 	assert.ErrorContains(t, err, "should only")
 
 	// Invalid URL
-	err = CreateAddonFromHelmChart("invalid-url", "invalid-url", "bitnami/nginx", "12.0.4")
+	err = CreateAddonFromHelmChart("invalid-url", "", "invalid-url", "bitnami/nginx", "12.0.4")
 	assert.ErrorContains(t, err, "invalid helm repo url")
 }

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestIsEmptyDir(t *testing.T) {
+	// Test with an empty dir
+	err := os.Mkdir("testdir", 0750)
+	assert.NilError(t, err)
+	defer func() {
+		_ = os.RemoveAll("testdir")
+	}()
+	isEmptyDir, err := IsEmptyDir("testdir")
+	assert.Equal(t, isEmptyDir, true)
+	assert.NilError(t, err)
+	// Test with a file
+	err = os.WriteFile(filepath.Join("testdir", "testfile"), []byte("test"), 0644)
+	assert.NilError(t, err)
+	isEmptyDir, err = IsEmptyDir(filepath.Join("testdir", "testfile"))
+	assert.Equal(t, isEmptyDir, false)
+	assert.Equal(t, err != nil, true)
+	// Test with a non-empty dir
+	isEmptyDir, err = IsEmptyDir("testdir")
+	assert.Equal(t, isEmptyDir, false)
+	assert.NilError(t, err)
+}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -76,10 +76,6 @@ var addonClusters string
 
 var verboseStatus bool
 
-var helmRepoURL string
-var chartName string
-var chartVersion string
-
 // NewAddonCommand create `addon` command
 func NewAddonCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
@@ -368,6 +364,10 @@ func NewAddonStatusCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 
 // NewAddonCreateCommand creates an addon scaffold
 func NewAddonCreateCommand() *cobra.Command {
+	var helmRepoURL string
+	var chartName string
+	var chartVersion string
+
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "bootstrap addon structure",

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -370,10 +370,10 @@ func NewAddonCreateCommand() *cobra.Command {
 	var path string
 
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "bootstrap addon structure",
+		Use:   "init",
+		Short: "create an addon scaffold",
 		Long:  "Create an addon scaffold along with the common files based on a Helm Chart for quick starting.",
-		Example: `	vela addon create mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
+		Example: `	vela addon init mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
 will create something like this:
 	mongodb/
 	├── definitions
@@ -385,7 +385,7 @@ will create something like this:
 	└── template.yaml
 
 If you want to store the scaffold in a different directory, you can use the -p/--path flag:
-	vela addon create mongodb -p ./some/repo --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
+	vela addon init mongodb -p ./some/repo --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -367,19 +367,32 @@ func NewAddonCreateCommand() *cobra.Command {
 	var helmRepoURL string
 	var chartName string
 	var chartVersion string
+	var path string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "bootstrap addon structure",
-		Long:  "Create an addon scaffold based on a Helm Chart for quick starting. Created files are located in <addon-name>.",
-		Example: `vela addon create <addon-name> --helm-repo-url=<repo-url> --chart=<chart-name> --version=<chart-version>
-vela addon create mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16`,
+		Long:  "Create an addon scaffold along with the common files based on a Helm Chart for quick starting.",
+		Example: `	vela addon create mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
+will create something like this:
+	mongodb/
+	├── definitions
+	├── metadata.yaml
+	├── readme.md
+	├── resources
+	│   └── mongodb.cue
+	├── schemas
+	└── template.yaml
+
+If you want to store the scaffold in a different directory, you can use the -p/--path flag:
+	vela addon create mongodb -p ./some/repo --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("an addon name is required. You can specify a path. It will be used as the base directory for the addon")
+				return fmt.Errorf("an addon name is required")
 			}
 
-			return pkgaddon.CreateAddonFromHelmChart(args[0], helmRepoURL, chartName, chartVersion)
+			return pkgaddon.CreateAddonFromHelmChart(args[0], path, helmRepoURL, chartName, chartVersion)
 		},
 	}
 
@@ -389,17 +402,19 @@ vela addon create mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1
 		return nil
 	}
 
-	cmd.Flags().StringVar(&chartName, "chart", "", "Name of the chart to base on")
+	cmd.Flags().StringVar(&chartName, "chart", "", "Helm Chart name")
 	err = cmd.MarkFlagRequired("chart")
 	if err != nil {
 		return nil
 	}
 
-	cmd.Flags().StringVar(&chartVersion, "version", "", "Version of the chart to base on")
+	cmd.Flags().StringVar(&chartVersion, "version", "", "version of the Chart")
 	err = cmd.MarkFlagRequired("version")
 	if err != nil {
 		return nil
 	}
+
+	cmd.Flags().StringVarP(&path, "path", "p", "", "path to the addon directory (default is ./<addon-name>)")
 
 	return cmd
 }

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Addon status or info", func() {
 
 	Context("when verbose is enabled", func() {
 		BeforeEach(func() {
-			verboseSatatus = true
+			verboseStatus = true
 		})
 
 		When("addon is not installed locally, also not in registry", func() {

--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -420,9 +421,20 @@ func TestNewAddonCreateCommand(t *testing.T) {
 	cmd := NewAddonCreateCommand()
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
-	assert.ErrorContains(t, err, "not set")
+	assert.ErrorContains(t, err, "required")
 
 	cmd.SetArgs([]string{"--chart", "a", "--helm-repo-url", "https://some.com", "--version", "c"})
 	err = cmd.Execute()
 	assert.ErrorContains(t, err, "required")
+
+	cmd.SetArgs([]string{"test-addon", "--chart", "a", "--helm-repo-url", "https://some.com", "--version", "c"})
+	err = cmd.Execute()
+	assert.NilError(t, err)
+	_ = os.RemoveAll("test-addon")
+
+	cmd.SetArgs([]string{"test-addon"})
+	err = cmd.Execute()
+	assert.NilError(t, err)
+	_ = os.RemoveAll("test-addon")
+
 }

--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -415,3 +415,14 @@ func TestGenerateParameterString(t *testing.T) {
 
 	}
 }
+
+func TestNewAddonCreateCommand(t *testing.T) {
+	cmd := NewAddonCreateCommand()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.ErrorContains(t, err, "not set")
+
+	cmd.SetArgs([]string{"--chart", "a", "--helm-repo-url", "https://some.com", "--version", "c"})
+	err = cmd.Execute()
+	assert.ErrorContains(t, err, "required")
+}


### PR DESCRIPTION
### Description of your changes

As described in https://github.com/kubevela/kubevela/issues/4116#issuecomment-1148450959, this pr adds a `vela addon init` command.

- If the user provides all three Chart-related parameters, an addon scaffold, with a `helm` component inside, will be created.
- If the user does't provide all the necessary parameters to create a `helm` component, a basic addon scaffold is generated instead.

This pr does **not** close that issue, since more features are needed.

<details>
<summary>Command Help Text</summary>

```console
$ vela addon init -h
Create an addon scaffold for quick starting. A Helm Component is generated if you provide Chart-related parameters.

Usage:
  vela addon init [flags]

Examples:
	vela addon init mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
will create something like this:
	mongodb/
	├── definitions
	├── metadata.yaml
	├── readme.md
	├── resources
	│   └── mongodb.cue
	├── schemas
	└── template.yaml

If you want to store the scaffold in a different directory, you can use the -p/--path flag:
	vela addon init mongodb -p ./some/repo --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16

If you don't want the Helm component, just omit the three Chart-related parameters. We will create an empty scaffold for you.
	vela addon init mongodb

Flags:
      --chart string           Helm Chart name
      --helm-repo-url string   URL that points to a Helm repo
  -h, --help                   help for init
  -p, --path string            path to the addon directory (default is ./<addon-name>)
      --version string         version of the Chart

Global Flags:
  -y, --yes   Assume yes for all user prompts
```
</details>

Examples:

**Normal creation**

Only when `./<addon-name>` (or user-specified path with `-p`) does not exist, or is an empty directory, will this command succeed. Otherwise, to prevent overwrites, this command will fail.

![Screenshot from 2022-06-14 18-14-29](https://user-images.githubusercontent.com/55270174/173553962-e4c97272-9453-4d58-9257-5757bc6e5407.png)


```console
$ vela addon create mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16 -p mongo/addon
Scaffold created in directory mongo/addon. What to do next:
- Review and edit what we have generated in mongo/addon
- Check out our guide on how to build your own addon: https://kubevela.io/docs/platform-engineers/addon/intro
- To enable the addon, run: vela addon enable mongo/addon
```

<details>
<summary>File Structure and Contents (Helm Component)</summary>

```console
$ vela addon init mongo-helm --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
Scaffold created in directory mongo-helm. What to do next:
- Check out our guide on how to build your own addon: https://kubevela.io/docs/platform-engineers/addon/intro
- Review and edit what we have generated in mongo-helm
- To enable the addon, run: vela addon enable mongo-helm
```
```console
$ tree mongo-helm
mongo-helm
├── definitions
├── metadata.yaml
├── readme.md
├── resources
│   └── mongo-helm.cue
├── schemas
└── template.yaml

3 directories, 4 files
```
```console
$ cat mongo-helm/resources/mongo-helm.cue
output: {
	type: "helm"
	properties: {
		url:      "https://marketplace.azurecr.io/helm/v1/repo"
		repoType: "helm"
		chart:    "mongodb"
		version:  "12.1.16"
	}
}
```
```console
$ cat mongo-helm/metadata.yaml
dependencies:
- name: fluxcd
description: An addon for KubeVela.
icon: ""
invisible: false
name: mongo-helm
tags:
- 12.1.16
version: 12.1.16
```
```console
$ cat mongo-helm/readme.md
# Example mongo-helm Addon

Also check how to build your own addon: https://kubevela.net/docs/platform-engineers/addon/intro

## Directory Structure

- `template.yaml`: contains the basic app, you can add some component and workflow to meet your requirements. Other files in `resources/` and `definitions/` will be rendered as Components and appended in `spec.components`
- `metadata.yaml`: contains addon metadata information.
- `definitions/`: contains the X-Definition yaml/cue files. These file will be rendered as KubeVela Component in `template.yaml`
- `resources/`:
  - `parameter.cue` to expose parameters. It will be converted to JSON schema and rendered in UI forms.
  - All other files will be rendered as KubeVela Components. It can be one of the two types:
    - YAML file that contains only one resource. This will be rendered as a `raw` component
    - CUE template file that can read user input as `parameter.XXX` as defined `parameter.cue`.
      Basically the CUE template file will be combined with `parameter.cue` to render a resource.
      **You can specify the type and trait in this format**
```
```console
$ cat mongo-helm/template.yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  creationTimestamp: null
  name: mongo-helm
  namespace: vela-system
spec:
  components: null
status: {}
```
</details>

<details>
<summary>File Structure and Contents (Basic)</summary>

```console
$ vela addon init mongo-sample
Scaffold created in directory mongo-sample. What to do next:
- Check out our guide on how to build your own addon: https://kubevela.io/docs/platform-engineers/addon/intro
- Review and edit what we have generated in mongo-sample
- To enable the addon, run: vela addon enable mongo-sample
```
```console
$ tree mongo-sample
mongo-sample
├── definitions
├── metadata.yaml
├── readme.md
├── resources
├── schemas
└── template.yaml

3 directories, 3 files
```
```console
$ cat mongo-sample/metadata.yaml
description: An addon for KubeVela.
icon: ""
invisible: false
name: mongo-sample
version: 1.0.0
```
```console
$ cat mongo-sample/template.yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  creationTimestamp: null
  name: mongo-sample
  namespace: vela-system
spec:
  components: null
status: {}

```
</details>

**Directory already exists in local filesystem**
> If the directory is empty, it will behave the same as above.
```console
$ vela addon init mongodb --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
Error: directory mongodb is not empty. To avoid any data loss, manually delete it first
```

**File with the same name already exists or other reasons**
```console
$ vela addon init main --helm-repo-url=https://marketplace.azurecr.io/helm/v1/repo --chart=mongodb --version=12.1.16
Error: we can't create directory main. Make sure the name has not already been taken and you have the proper rights to write to it
```


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Relevant unit tests have been added. Also manually tested several conditions described above.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->