### PR TITLE
Fix: add handle of ".yml" type in readviewfile function

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -422,9 +422,10 @@ func readViewFile(a *InstallPackage, reader AsyncReader, readPath string) error 
 	switch filepath.Ext(filename) {
 	case ".cue":
 		a.CUEViews = append(a.CUEViews, ElementFile{Data: b, Name: filepath.Base(readPath)})
-	case ".yaml":
+	case ".yaml", ".yml":
 		a.YAMLViews = append(a.YAMLViews, ElementFile{Data: b, Name: filepath.Base(readPath)})
 	default:
+		// skip other file formats
 	}
 	return nil
 }


### PR DESCRIPTION
handle of files of type ".yml" miss in the original function.
so I add handle of ".yml" type in readviewfile function

Signed-off-by: HanMengnan <1448189829@qq.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4171

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->