### PR TITLE
Feat: cli def alias support

### DIFF
--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -45,6 +45,8 @@ import (
 const (
 	// DescriptionKey the key for accessing definition description
 	DescriptionKey = "definition.oam.dev/description"
+	// AliasKey the key for accessing definition alias
+	AliasKey = "definition.oam.dev/alias"
 	// UserPrefix defines the prefix of user customized label or annotation
 	UserPrefix = "custom.definition.oam.dev/"
 )
@@ -106,6 +108,7 @@ func (def *Definition) ToCUE() (*cue.Value, string, error) {
 			annotations[strings.TrimPrefix(key, UserPrefix)] = val
 		}
 	}
+	alias := def.GetAnnotations()[AliasKey]
 	desc := def.GetAnnotations()[DescriptionKey]
 	labels := map[string]string{}
 	for key, val := range def.GetLabels() {
@@ -122,6 +125,7 @@ func (def *Definition) ToCUE() (*cue.Value, string, error) {
 	obj := map[string]interface{}{
 		def.GetName(): map[string]interface{}{
 			"type":        def.GetType(),
+			"alias":       alias,
 			"description": desc,
 			"annotations": annotations,
 			"labels":      labels,
@@ -239,6 +243,12 @@ func (def *Definition) FromCUE(val *cue.Value, templateString string) error {
 				if err = def.SetType(_type); err != nil {
 					return err
 				}
+			case "alias":
+				alias, err := _value.String()
+				if err != nil {
+					return err
+				}
+				annotations[AliasKey] = alias
 			case "description":
 				desc, err := _value.String()
 				if err != nil {

--- a/references/cli/common.go
+++ b/references/cli/common.go
@@ -30,6 +30,8 @@ const (
 
 	// FlagDescription command flag to specify the description of the definition
 	FlagDescription = "desc"
+	// FlagAlias command flag to specify the alias of the definition
+	FlagAlias = "alias"
 	// FlagDryRun command flag to disable actual changes and only display intend changes
 	FlagDryRun = "dry-run"
 	// FlagTemplateYAML command flag to specify which existing template YAML file to use

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -183,6 +183,10 @@ func NewDefinitionInitCommand(c common.Args) *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "failed to get `%s`", FlagType)
 			}
+			alias, err := cmd.Flags().GetString(FlagAlias)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get `%s`", FlagAlias)
+			}
 			desc, err := cmd.Flags().GetString(FlagDescription)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get `%s`", FlagDescription)
@@ -256,6 +260,7 @@ func NewDefinitionInitCommand(c common.Args) *cobra.Command {
 				def.SetName(name)
 				def.SetAnnotations(map[string]string{
 					pkgdef.DescriptionKey: desc,
+					pkgdef.AliasKey:       alias,
 				})
 				def.SetLabels(map[string]string{})
 				def.Object["spec"] = pkgdef.GetDefinitionDefaultSpec(def.GetKind())
@@ -282,6 +287,7 @@ func NewDefinitionInitCommand(c common.Args) *cobra.Command {
 	}
 	cmd.Flags().StringP(FlagType, "t", "", "Specify the type of the new definition. Valid types: "+strings.Join(pkgdef.ValidDefinitionTypes(), ", "))
 	cmd.Flags().StringP(FlagDescription, "d", "", "Specify the description of the new definition.")
+	cmd.Flags().StringP(FlagAlias, "a", "", "Specify the alias of the new definition.")
 	cmd.Flags().StringP(FlagTemplateYAML, "f", "", "Specify the template yaml file that definition will use to build the schema. If empty, a default template for the given definition type will be used.")
 	cmd.Flags().StringP(FlagOutput, "o", "", "Specify the output path of the generated definition. If empty, the definition will be printed in the console.")
 	cmd.Flags().BoolP(FlagInteractive, "i", false, "Specify whether use interactive process to help generate definitions.")


### PR DESCRIPTION
Signed-off-by: Zhiyu Wang <zhiyuwang.newbis@gmail.com>

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

User can use alias metadata in cue.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

go run cmd/plugin/main.go def render test.cue
go run cmd/plugin/main.go def get test-trait
```
test: {
	type:  "trait"
	alias: "可以加上中文别名"
}
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

The alias field can also be placed in the annotation, but I think it's better as a native field.

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->