### PR TITLE
Fix: clear namespace for cluster scoped resource for dispatching

### DIFF
--- a/pkg/resourcekeeper/delete.go
+++ b/pkg/resourcekeeper/delete.go
@@ -49,6 +49,7 @@ func newDeleteConfig(options ...DeleteOption) *deleteConfig {
 
 // Delete delete resources
 func (h *resourceKeeper) Delete(ctx context.Context, manifests []*unstructured.Unstructured, options ...DeleteOption) (err error) {
+	h.ClearNamespaceForClusterScopedResources(manifests)
 	if err = h.AdmissionCheck(ctx, manifests); err != nil {
 		return err
 	}

--- a/pkg/resourcekeeper/dispatch.go
+++ b/pkg/resourcekeeper/dispatch.go
@@ -59,6 +59,7 @@ func (h *resourceKeeper) Dispatch(ctx context.Context, manifests []*unstructured
 	if h.applyOncePolicy != nil && h.applyOncePolicy.Enable && h.applyOncePolicy.Rules == nil {
 		options = append(options, MetaOnlyOption{})
 	}
+	h.ClearNamespaceForClusterScopedResources(manifests)
 	// 0. check admission
 	if err = h.AdmissionCheck(ctx, manifests); err != nil {
 		return err

--- a/pkg/resourcekeeper/utils.go
+++ b/pkg/resourcekeeper/utils.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcekeeper
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ClearNamespaceForClusterScopedResources clear namespace for cluster scoped resources
+func (h *resourceKeeper) ClearNamespaceForClusterScopedResources(manifests []*unstructured.Unstructured) {
+	for _, manifest := range manifests {
+		mappings, err := h.Client.RESTMapper().RESTMappings(manifest.GroupVersionKind().GroupKind(), manifest.GroupVersionKind().Version)
+		if err != nil {
+			continue
+		}
+		if len(mappings) > 0 && mappings[0].Scope.Name() == meta.RESTScopeNameRoot {
+			manifest.SetNamespace("")
+		}
+	}
+}

--- a/pkg/resourcekeeper/utils_test.go
+++ b/pkg/resourcekeeper/utils_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcekeeper
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/utils/apply"
+)
+
+var _ = Describe("Test ResourceKeeper utilities", func() {
+
+	It("Test ClearNamespaceForClusterScopedResources", func() {
+		cli := testClient
+		h := &resourceKeeper{
+			Client:     cli,
+			app:        &v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}},
+			applicator: apply.NewAPIApplicator(cli),
+			cache:      newResourceCache(cli),
+		}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "vela"}}
+		nsObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ns)
+		Expect(err).Should(Succeed())
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "vela"}}
+		cmObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+		Expect(err).Should(Succeed())
+		uns := []*unstructured.Unstructured{{Object: nsObj}, {Object: cmObj}}
+		uns[0].SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+		uns[1].SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		h.ClearNamespaceForClusterScopedResources(uns)
+		Expect(uns[0].GetNamespace()).Should(Equal(""))
+		Expect(uns[1].GetNamespace()).Should(Equal("vela"))
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

ResourceTracker will record resources with metadata. The namespace for cluster scoped resource is incorrectly recorded. Although it does not affect the normal function, it will makes the resource view a bit weird.

Before:
![image](https://user-images.githubusercontent.com/14019297/173989819-7a511de8-412e-4c11-ba24-917cb8fd1151.png)

After:
![image](https://user-images.githubusercontent.com/14019297/173989853-f1551ade-0978-4c39-959b-5c7e3f226951.png)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->