### PR TITLE
Feat: support to manage the CLI-created apps in VelaUX

### DIFF
--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -190,7 +190,7 @@ var ApplicationInitIntercativeCliContext = func(context string, appName string, 
 var ApplicationDeleteWithWaitOptions = func(context string, appName string) bool {
 	return ginkgo.Context(context, func() {
 		ginkgo.It("should print successful deletion information", func() {
-			cli := fmt.Sprintf("vela delete %s --wait", appName)
+			cli := fmt.Sprintf("vela delete %s --wait -y", appName)
 			output, err := e2e.ExecAndTerminate(cli)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(output).To(gomega.ContainSubstring("deleted"))
@@ -218,7 +218,7 @@ var ApplicationDeleteWithForceOptions = func(context string, appName string) boo
 				return k8sClient.Update(ctx, app)
 			}, time.Second*3, time.Millisecond*300).Should(gomega.BeNil())
 
-			cli := fmt.Sprintf("vela delete %s --force", appName)
+			cli := fmt.Sprintf("vela delete %s --force -y", appName)
 			output, err := e2e.LongTimeExec(cli, 3*time.Minute)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(output).To(gomega.ContainSubstring("timed out"))
@@ -230,7 +230,7 @@ var ApplicationDeleteWithForceOptions = func(context string, appName string) boo
 				g.Expect(k8sClient.Update(ctx, app)).Should(gomega.Succeed())
 			}, time.Second*5, time.Millisecond*300).Should(gomega.Succeed())
 
-			cli = fmt.Sprintf("vela delete %s --force", appName)
+			cli = fmt.Sprintf("vela delete %s --force -y", appName)
 			output, err = e2e.ExecAndTerminate(cli)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(output).To(gomega.ContainSubstring("deleted"))

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -133,7 +133,7 @@ var (
 	WorkloadDeleteContext = func(context string, applicationName string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("should print successful deletion information", func() {
-				cli := fmt.Sprintf("vela delete %s", applicationName)
+				cli := fmt.Sprintf("vela delete %s -y", applicationName)
 				output, err := Exec(cli)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(output).To(gomega.ContainSubstring("deleted from namespace"))

--- a/pkg/apiserver/domain/model/application.go
+++ b/pkg/apiserver/domain/model/application.go
@@ -101,6 +101,14 @@ func (a *Application) IsSynced() bool {
 	return false
 }
 
+func (a *Application) IsReadOnly() bool {
+	if a.Labels == nil {
+		return false
+	}
+	sot := a.Labels[LabelSourceOfTruth]
+	return sot == FromInner
+}
+
 // ClusterSelector cluster selector
 type ClusterSelector struct {
 	Name string `json:"name"`

--- a/pkg/apiserver/domain/model/application.go
+++ b/pkg/apiserver/domain/model/application.go
@@ -101,6 +101,8 @@ func (a *Application) IsSynced() bool {
 	return false
 }
 
+// IsReadOnly is readonly app
+// Only the source is inner, the app is readonly
 func (a *Application) IsReadOnly() bool {
 	if a.Labels == nil {
 		return false

--- a/pkg/apiserver/domain/model/whole.go
+++ b/pkg/apiserver/domain/model/whole.go
@@ -50,7 +50,9 @@ const (
 	FromCR = "from-k8s-resource"
 	// FromUX means the data source of truth is from velaux data store
 	FromUX = "from-velaux"
-	// FromInner means the data source of truth is from KubeVela inner usage, such as addon or configuration that don't want to be synced
+	// FromInner means the data source of truth is from KubeVela inner usage
+	// the configuration that don't want to be synced
+	// the addon application should be synced, but set to readonly mode
 	FromInner = "from-inner-system"
 )
 

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -347,9 +347,11 @@ func (w *workflowServiceImpl) SyncWorkflowRecord(ctx context.Context) error {
 		envbinding, err := w.EnvBindingService.GetEnvBinding(ctx, &model.Application{Name: record.AppPrimaryKey}, workflow.EnvName)
 		if err != nil {
 			klog.ErrorS(err, "failed to get envbinding", "app name", record.AppPrimaryKey, "workflow name", record.WorkflowName, "record name", record.Name)
-			continue
 		}
-		appName := envbinding.AppDeployName
+		var appName string
+		if envbinding != nil {
+			appName = envbinding.AppDeployName
+		}
 		if appName == "" {
 			appName = record.AppPrimaryKey
 		}

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -73,10 +73,11 @@ func NewWorkflowService() WorkflowService {
 }
 
 type workflowServiceImpl struct {
-	Store      datastore.DataStore `inject:"datastore"`
-	KubeClient client.Client       `inject:"kubeClient"`
-	Apply      apply.Applicator    `inject:"apply"`
-	EnvService EnvService          `inject:""`
+	Store             datastore.DataStore `inject:"datastore"`
+	KubeClient        client.Client       `inject:"kubeClient"`
+	Apply             apply.Applicator    `inject:"apply"`
+	EnvService        EnvService          `inject:""`
+	EnvBindingService EnvBindingService   `inject:""`
 }
 
 // DeleteWorkflow delete application workflow
@@ -343,7 +344,15 @@ func (w *workflowServiceImpl) SyncWorkflowRecord(ctx context.Context) error {
 			klog.ErrorS(err, "failed to get workflow", "app name", record.AppPrimaryKey, "workflow name", record.WorkflowName, "record name", record.Name)
 			continue
 		}
-		appName := record.AppPrimaryKey
+		envbinding, err := w.EnvBindingService.GetEnvBinding(ctx, &model.Application{Name: record.AppPrimaryKey}, workflow.EnvName)
+		if err != nil {
+			klog.ErrorS(err, "failed to get envbinding", "app name", record.AppPrimaryKey, "workflow name", record.WorkflowName, "record name", record.Name)
+			continue
+		}
+		appName := envbinding.AppDeployName
+		if appName == "" {
+			appName = record.AppPrimaryKey
+		}
 		if err := w.KubeClient.Get(ctx, types.NamespacedName{
 			Name:      appName,
 			Namespace: record.Namespace,

--- a/pkg/apiserver/domain/service/workflow_test.go
+++ b/pkg/apiserver/domain/service/workflow_test.go
@@ -60,20 +60,24 @@ var _ = Describe("Test workflow service functions", func() {
 		rbacService := &rbacServiceImpl{Store: ds}
 		projectService = &projectServiceImpl{Store: ds, RbacService: rbacService}
 		envService = &envServiceImpl{Store: ds, KubeClient: k8sClient, ProjectService: projectService}
+		envBinding := &envBindingServiceImpl{
+			Store:           ds,
+			WorkflowService: workflowService,
+			EnvService:      envService,
+		}
 		workflowService = &workflowServiceImpl{
-			Store:      ds,
-			KubeClient: k8sClient,
-			Apply:      apply.NewAPIApplicator(k8sClient),
-			EnvService: envService}
+			Store:             ds,
+			KubeClient:        k8sClient,
+			Apply:             apply.NewAPIApplicator(k8sClient),
+			EnvService:        envService,
+			EnvBindingService: envBinding,
+		}
 		appService = &applicationServiceImpl{Store: ds, KubeClient: k8sClient,
-			Apply:          apply.NewAPIApplicator(k8sClient),
-			ProjectService: projectService,
-			EnvService:     envService,
-			EnvBindingService: &envBindingServiceImpl{
-				Store:           ds,
-				WorkflowService: workflowService,
-				EnvService:      envService,
-			}}
+			Apply:             apply.NewAPIApplicator(k8sClient),
+			ProjectService:    projectService,
+			EnvService:        envService,
+			EnvBindingService: envBinding,
+		}
 	})
 	It("Test CreateWorkflow function", func() {
 		_, err := projectService.CreateProject(context.TODO(), apisv1.CreateProjectRequest{Name: testProject})

--- a/pkg/apiserver/event/event.go
+++ b/pkg/apiserver/event/event.go
@@ -19,6 +19,8 @@ package event
 import (
 	"context"
 
+	"k8s.io/client-go/util/workqueue"
+
 	"github.com/oam-dev/kubevela/pkg/apiserver/config"
 	"github.com/oam-dev/kubevela/pkg/apiserver/event/collect"
 	"github.com/oam-dev/kubevela/pkg/apiserver/event/sync"
@@ -36,7 +38,9 @@ func InitEvent(cfg config.Config) []interface{} {
 	workflow := &sync.WorkflowRecordSync{
 		Duration: cfg.LeaderConfig.Duration,
 	}
-	application := &sync.ApplicationSync{}
+	application := &sync.ApplicationSync{
+		Queue: workqueue.New(),
+	}
 	collect := &collect.InfoCalculateCronJob{}
 	workers = append(workers, workflow, application, collect)
 	return []interface{}{workflow, application, collect}

--- a/pkg/apiserver/event/sync/cache_test.go
+++ b/pkg/apiserver/event/sync/cache_test.go
@@ -82,6 +82,11 @@ var _ = Describe("Test Cache", func() {
 		app3.Name = "app3"
 		app3.Namespace = "app3-ns"
 		app3.Generation = 3
+		app3.Labels = map[string]string{
+			model.LabelSyncGeneration: "1",
+			model.LabelSyncNamespace:  "app3-ns",
+			model.LabelSourceOfTruth:  model.FromUX,
+		}
 
 		Expect(cr2ux.shouldSync(ctx, app3, false)).Should(BeEquivalentTo(false))
 

--- a/pkg/apiserver/event/sync/convert.go
+++ b/pkg/apiserver/event/sync/convert.go
@@ -18,6 +18,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/event/sync/convert"
+	"github.com/oam-dev/kubevela/pkg/apiserver/utils"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/workflow/step"
 )
@@ -36,9 +38,12 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 	appName := c.getAppMetaName(ctx, targetApp.Name, targetApp.Namespace)
 
 	project := model.DefaultInitName
+	sourceOfTruth := model.FromCR
 	if _, ok := targetApp.Labels[oam.LabelAddonName]; ok && strings.HasPrefix(targetApp.Name, "addon-") {
 		project = model.DefaultAddonProject
+		sourceOfTruth = model.FromInner
 	}
+
 	appMeta := &model.Application{
 		Name:        appName,
 		Description: model.AutoGenDesc,
@@ -47,7 +52,7 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 		Labels: map[string]string{
 			model.LabelSyncNamespace:  targetApp.Namespace,
 			model.LabelSyncGeneration: strconv.FormatInt(targetApp.Generation, 10),
-			model.LabelSourceOfTruth:  model.FromCR,
+			model.LabelSourceOfTruth:  sourceOfTruth,
 		},
 	}
 	appMeta.CreateTime = targetApp.CreationTimestamp.Time
@@ -55,21 +60,50 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 	// 1. convert app meta and env
 	dsApp := &model.DataStoreApp{
 		AppMeta: appMeta,
-		Env: &model.Env{
+	}
+
+	// 1. convert the target
+
+	existTarget := &model.Target{Project: project}
+	existTargets, err := c.ds.List(ctx, existTarget, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fail to list the targets, %w", err)
+	}
+	var envTargetNames []string
+	dsApp.Targets, envTargetNames = convert.FromCRTargets(ctx, c.cli, targetApp, existTargets, project)
+
+	// 2. convert the environment
+	existEnv := &model.Env{Namespace: targetApp.Namespace, Project: project}
+	existEnvs, err := c.ds.List(ctx, existEnv, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fail to list the env, %w", err)
+	}
+	if len(existEnvs) > 0 {
+		env := existEnvs[0].(*model.Env)
+		for _, name := range envTargetNames {
+			if !utils.StringsContain(env.Targets, name) {
+				env.Targets = append(env.Targets, name)
+			}
+		}
+		dsApp.Env = env
+	}
+	if dsApp.Env == nil {
+		dsApp.Env = &model.Env{
 			Name:        model.AutoGenEnvNamePrefix + targetApp.Namespace,
 			Namespace:   targetApp.Namespace,
 			Description: model.AutoGenDesc,
 			Project:     project,
 			Alias:       model.AutoGenEnvNamePrefix + targetApp.Namespace,
-		},
-		Eb: &model.EnvBinding{
-			AppPrimaryKey: appMeta.PrimaryKey(),
-			Name:          model.AutoGenEnvNamePrefix + targetApp.Namespace,
-			AppDeployName: appMeta.GetAppNameForSynced(),
-		},
+			Targets:     envTargetNames,
+		}
+	}
+	dsApp.Eb = &model.EnvBinding{
+		AppPrimaryKey: appMeta.PrimaryKey(),
+		Name:          dsApp.Env.Name,
+		AppDeployName: appMeta.GetAppNameForSynced(),
 	}
 
-	// 2. convert component and trait
+	// 3. convert component and trait
 	for _, cmp := range targetApp.Spec.Components {
 		compModel, err := convert.FromCRComponent(appMeta.PrimaryKey(), cmp)
 		if err != nil {
@@ -78,14 +112,15 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 		dsApp.Comps = append(dsApp.Comps, &compModel)
 	}
 
-	// 3. convert workflow
+	// 4. convert workflow
 	wf, steps, err := convert.FromCRWorkflow(ctx, cli, appMeta.PrimaryKey(), targetApp)
 	if err != nil {
 		return nil, err
 	}
+	wf.EnvName = dsApp.Env.Name
 	dsApp.Workflow = &wf
 
-	// 4. convert policy, some policies are references in workflow step, we need to sync all the outside policy to make that work
+	// 5. convert policy, some policies are references in workflow step, we need to sync all the outside policy to make that work
 	var innerPlc = make(map[string]struct{})
 	for _, plc := range targetApp.Spec.Policies {
 		innerPlc[plc.Name] = struct{}{}
@@ -102,16 +137,8 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 		if err != nil {
 			return nil, err
 		}
+		plcModel.EnvName = dsApp.Env.Name
 		dsApp.Policies = append(dsApp.Policies, &plcModel)
 	}
-
-	// TODO(wonderflow): we don't sync targets as it can't be judged well in velaux env
-	// if we want to sync, we can extract targets from status, like below:
-	/*
-		dsApp.Targets = ConvertFromCRTargets(targetApp)
-		for _, t := range dsApp.Targets {
-			dsApp.Env.Targets = append(dsApp.Env.Targets, t.Name)
-		}
-	*/
 	return dsApp, nil
 }

--- a/pkg/apiserver/event/sync/testdata/test-app1.yaml
+++ b/pkg/apiserver/event/sync/testdata/test-app1.yaml
@@ -22,13 +22,13 @@ spec:
     - name: topology-beijing-demo
       type: topology
       properties:
-        clusterLabelSelector:
-          region: beijing
-        namespace: demo
+        clusters: ["local"]
+        namespace: beijing-demo
     - name: topology-local
       type: topology
       properties:
-        targets: ["local/demo", "local/ackone-demo"]
+        clusters: ["local"]
+        namespace: demo
   workflow:
     steps:
       - type: deploy

--- a/pkg/apiserver/interfaces/api/assembler/v1/do2dto.go
+++ b/pkg/apiserver/interfaces/api/assembler/v1/do2dto.go
@@ -68,10 +68,9 @@ func ConvertAppModelToBase(app *model.Application, projects []*apisv1.ProjectBas
 		Icon:        app.Icon,
 		Labels:      app.Labels,
 		Project:     &apisv1.ProjectBase{Name: app.Project},
+		ReadOnly:    app.IsReadOnly(),
 	}
-	if app.IsSynced() {
-		appBase.ReadOnly = true
-	}
+
 	for _, project := range projects {
 		if project.Name == app.Project {
 			appBase.Project = project

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -507,7 +507,7 @@ func isResourceInTargetCluster(opt FilterOption, resource common.ClusterObjectRe
 	if opt.Cluster == "" && opt.ClusterNamespace == "" {
 		return true
 	}
-	if opt.Cluster == resource.Cluster && opt.ClusterNamespace == resource.ObjectReference.Namespace {
+	if (opt.Cluster == resource.Cluster || (opt.Cluster == "local" && resource.Cluster == "")) && opt.ClusterNamespace == resource.ObjectReference.Namespace {
 		return true
 	}
 	return false

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -204,6 +204,9 @@ func (h *provider) GetApplicationResourceTree(ctx wfContext.Context, v *value.Va
 		}
 		resource.ResourceTree = &root
 	}
+	if appResList == nil {
+		appResList = []*querytypes.AppliedResource{}
+	}
 	return fillQueryResult(v, appResList, "list")
 }
 

--- a/pkg/velaql/view.go
+++ b/pkg/velaql/view.go
@@ -111,7 +111,7 @@ func (handler *ViewHandler) QueryView(ctx context.Context, qv QueryView) (*value
 		return nil, errors.Errorf("run query view: %v", err)
 	}
 	if string(status.Phase) != ViewTaskPhaseSucceeded {
-		return nil, errors.Errorf("failed to query the view: %s", status.Message)
+		return nil, errors.Errorf("failed to query the view %s %s", status.Message, status.Reason)
 	}
 	return viewCtx.GetVar(qv.Export)
 }

--- a/references/cli/delete.go
+++ b/references/cli/delete.go
@@ -76,15 +76,21 @@ func NewDeleteCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams)
 			return err
 		}
 		o.ForceDelete = force
-
+		userInput := NewUserInput()
 		if svcname == "" {
-			ioStreams.Infof(fmt.Sprintf("Deleting Application \"%s\"\n", o.AppName))
+			userConfirmation := userInput.AskBool(fmt.Sprintf("Do you want to delete the application %s from namespace %s", o.AppName, o.Namespace), &UserInputOptions{assumeYes})
+			if !userConfirmation {
+				return fmt.Errorf("stopping Deleting")
+			}
 			if err = o.DeleteApp(ioStreams); err != nil {
 				return err
 			}
 			ioStreams.Info(green.Sprintf("app \"%s\" deleted from namespace \"%s\"", o.AppName, o.Namespace))
 		} else {
-			ioStreams.Infof(fmt.Sprintf("Deleting Service %s from Application \"%s\"\n", svcname, o.AppName))
+			userConfirmation := userInput.AskBool(fmt.Sprintf("Do you want to delete the component %s from application %s in namespace %s", svcname, o.AppName, o.Namespace), &UserInputOptions{assumeYes})
+			if !userConfirmation {
+				return fmt.Errorf("stopping Deleting")
+			}
 			o.CompName = svcname
 			if err = o.DeleteComponent(ioStreams); err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

This PR support automatically hosts CLI-created apps. 

1. Create the application by CLI

```bash
vela up -f https://kubevela.net/example/applications/first-app.yaml
```
2. Open the application page in VelaUX

![image](https://user-images.githubusercontent.com/18493394/174042435-5dd11c8c-82e6-4b2e-9762-bca1e85d44ff.png)

![image](https://user-images.githubusercontent.com/18493394/174042515-f0132ffa-0e69-4727-9dee-9cbe85ca0c68.png)

The workflow status is workflowSuspending, and we could click the Deploy button and select the default env, then

![image](https://user-images.githubusercontent.com/18493394/174042788-9d76b148-2bd7-48a7-8ce8-5ff4e0b70373.png)

Here, the application has been hosted and you can operate the workflow review action through the UI.

If the application has been hosted, change the application CR can not be synced to VelaUX. next, we should support viewing the Diff the application configuration with application CR in the cluster.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### Special notes for your reviewer

/cc @wonderflow 