### PR TITLE
Fix: cue patch remove temp var

### DIFF
--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -302,7 +302,7 @@ func strategyUnify(baseFile *ast.File, patchFile *ast.File, params *UnifyParams,
 
 	ret := baseInst.Value().Unify(patchInst.Value())
 
-	rv, err := toString(ret)
+	rv, err := toString(ret, removeTmpVar)
 	if err != nil {
 		return rv, errors.WithMessage(err, " format result toString")
 	}

--- a/pkg/cue/model/sets/walk_test.go
+++ b/pkg/cue/model/sets/walk_test.go
@@ -23,6 +23,7 @@ import (
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/parser"
 	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWalk(t *testing.T) {
@@ -127,4 +128,34 @@ func TestWalk(t *testing.T) {
 		}).walk(f)
 	}
 
+}
+
+func TestRemoveTmpVar(t *testing.T) {
+	src := `spec: {
+    _tmp: "x"
+	list: [{
+		_tmp: "x"
+		retain: "y"
+	}, {
+		_tmp: "x"
+		retain: "z"
+	}]
+	retain: "y"
+}
+`
+	r := require.New(t)
+	var runtime cue.Runtime
+	inst, err := runtime.Compile("-", src)
+	r.NoError(err)
+	s, err := toString(inst.Value(), removeTmpVar)
+	r.NoError(err)
+	r.Equal(`spec: {
+	list: [{
+		retain: "y"
+	}, {
+		retain: "z"
+	}]
+	retain: "y"
+}
+`, s)
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

While dealing with multiple trait patch in one component, the temp variable used in previous trait patch will remain in the following patch, which will lead to two problems:
1. Recursive explosion. For example, one trait patch use a map [1] to record all containers, then the second trait also use a map [2] to record all containers, but since the map [1] is included in the container the first trait patch to, the map[2] will include map [1] and this will cause lots of useless render.
2. The temporary variable will cause name conflict across different traits.

Fixes #4203

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->