### PR TITLE
Fix: Jfrog Webhook Handler Cannot Get Right Image

### DIFF
--- a/pkg/apiserver/domain/service/webhook.go
+++ b/pkg/apiserver/domain/service/webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
@@ -425,7 +426,8 @@ func (j *jfrogHandlerImpl) handle(ctx context.Context, webhookTrigger *model.App
 	if err != nil {
 		return nil, err
 	}
-	image := fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, jfrogReq.Data.ImageName, jfrogReq.Data.Tag)
+	pathArray := strings.Split(jfrogReq.Data.Path,"/")
+	image := fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, strings.Join(pathArray[:len(pathArray)-2],"/"), jfrogReq.Data.Tag)
 	if jfrogReq.Data.URL != "" {
 		image = fmt.Sprintf("%s/%s", jfrogReq.Data.URL, image)
 	}
@@ -441,7 +443,7 @@ func (j *jfrogHandlerImpl) handle(ctx context.Context, webhookTrigger *model.App
 		TriggerType:  apisv1.TriggerTypeWebhook,
 		Force:        true,
 		ImageInfo: &model.ImageInfo{
-			Type: model.PayloadTypeHarbor,
+			Type: model.PayloadTypeJFrog,
 			Resource: &model.ImageResource{
 				Digest: jfrogReq.Data.Digest,
 				Tag:    jfrogReq.Data.Tag,

--- a/pkg/apiserver/domain/service/webhook.go
+++ b/pkg/apiserver/domain/service/webhook.go
@@ -426,7 +426,6 @@ func (j *jfrogHandlerImpl) handle(ctx context.Context, webhookTrigger *model.App
 	if err != nil {
 		return nil, err
 	}
-	pathArray := strings.Split(jfrogReq.Data.Path,"/")
         image := fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, jfrogReq.Data.ImageName, jfrogReq.Data.Tag)
         pathArray := strings.Split(jfrogReq.Data.Path, "/")
 	if len(pathArray) > 2 {

--- a/pkg/apiserver/domain/service/webhook.go
+++ b/pkg/apiserver/domain/service/webhook.go
@@ -427,7 +427,11 @@ func (j *jfrogHandlerImpl) handle(ctx context.Context, webhookTrigger *model.App
 		return nil, err
 	}
 	pathArray := strings.Split(jfrogReq.Data.Path,"/")
-	image := fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, strings.Join(pathArray[:len(pathArray)-2],"/"), jfrogReq.Data.Tag)
+        image := fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, jfrogReq.Data.ImageName, jfrogReq.Data.Tag)
+        pathArray := strings.Split(jfrogReq.Data.Path, "/")
+	if len(pathArray) > 2 {
+		image = fmt.Sprintf("%s/%s:%s", jfrogReq.Data.RepoKey, strings.Join(pathArray[:len(pathArray)-2], "/"), jfrogReq.Data.Tag)
+	}
 	if jfrogReq.Data.URL != "" {
 		image = fmt.Sprintf("%s/%s", jfrogReq.Data.URL, image)
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4202
1. Fix the image path from the JFrog webhook when it is triggered.
2. Fix the Info Payload Type From `Harhor` to `JFrog` in JFrog handle function
I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->