### PR TITLE
Fix: json-patch & json-merge-patch open result

### DIFF
--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -358,7 +358,11 @@ func jsonMergePatch(base cue.Value, patch cue.Value) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to merge base value and patch value by JsonMergePatch")
 	}
-	return string(merged), nil
+	output, err := OpenBaiscLit(string(merged))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse open basic lit for merged result")
+	}
+	return output, nil
 }
 
 func jsonPatch(base cue.Value, patch cue.Value) (string, error) {
@@ -379,5 +383,9 @@ func jsonPatch(base cue.Value, patch cue.Value) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to apply json patch")
 	}
-	return string(merged), nil
+	output, err := OpenBaiscLit(string(merged))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse open basic lit for merged result")
+	}
+	return output, nil
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

JsonPatch and JsonMergePatch will close the patched result which will cause following cue trait patch failed. So before this PR, traits like `annotations` that uses the JsonPatch or JsonMergePatch must be placed after other patch trait.

Partially fixes #4221.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->