### PR TITLE
Fix: vela status print wrong STATUS

### DIFF
--- a/pkg/resourcetracker/tree.go
+++ b/pkg/resourcetracker/tree.go
@@ -85,10 +85,7 @@ func (options *ResourceTreePrintOptions) loadResourceRows(currentRT *v1beta1.Res
 			if mr.Deleted {
 				continue
 			}
-			rows = append(rows, &resourceRow{
-				mr:     mr.DeepCopy(),
-				status: resourceRowStatusUpdated,
-			})
+			rows = append(rows, buildResourceRow(mr, resourceRowStatusUpdated))
 		}
 	}
 	for _, rt := range historyRT {
@@ -100,10 +97,7 @@ func (options *ResourceTreePrintOptions) loadResourceRows(currentRT *v1beta1.Res
 				}
 			}
 			if matchedRow == nil {
-				rows = append(rows, &resourceRow{
-					mr:     mr.DeepCopy(),
-					status: resourceRowStatusOutdated,
-				})
+				rows = append(rows, buildResourceRow(mr, resourceRowStatusOutdated))
 			}
 		}
 	}
@@ -409,4 +403,15 @@ func RetrieveKubeCtlGetMessageGenerator(cfg *rest.Config) (ResourceDetailRetriev
 		}
 		return nil
 	}, nil
+}
+
+func buildResourceRow(mr v1beta1.ManagedResource, resourceStatus string) *resourceRow {
+	rr := &resourceRow{
+		mr:     mr.DeepCopy(),
+		status: resourceStatus,
+	}
+	if rr.mr.Cluster == "" {
+		rr.mr.Cluster = multicluster.ClusterLocalName
+	}
+	return rr
 }

--- a/pkg/resourcetracker/tree_test.go
+++ b/pkg/resourcetracker/tree_test.go
@@ -22,6 +22,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 )
 
 func TestResourceTreePrintOption_getWidthForDetails(t *testing.T) {
@@ -45,4 +49,40 @@ func TestResourceTreePrintOptions_wrapDetails(t *testing.T) {
 			"value  test-append: test-append-val",
 		},
 		options._wrapDetails(detail, 40))
+}
+
+func TestBuildResourceRow(t *testing.T) {
+	r := require.New(t)
+
+	cases := map[string]struct {
+		Cluster                   string
+		ResourceRowStatus         string
+		ExpectedCluster           string
+		ExpectedResourceRowStatus string
+	}{
+		"localCluster": {
+			Cluster:                   "",
+			ResourceRowStatus:         resourceRowStatusUpdated,
+			ExpectedCluster:           multicluster.ClusterLocalName,
+			ExpectedResourceRowStatus: resourceRowStatusUpdated,
+		},
+		"remoteCluster": {
+			Cluster:                   "remoteCluster",
+			ResourceRowStatus:         resourceRowStatusUpdated,
+			ExpectedCluster:           "remoteCluster",
+			ExpectedResourceRowStatus: resourceRowStatusUpdated,
+		},
+	}
+
+	for name, c := range cases {
+		mr := v1beta1.ManagedResource{
+			ClusterObjectReference: common.ClusterObjectReference{
+				Cluster: c.Cluster,
+			},
+		}
+		rr := buildResourceRow(mr, c.ResourceRowStatus)
+		r.Equal(c.ExpectedCluster, rr.mr.Cluster, name)
+		r.Equal(c.ExpectedResourceRowStatus, rr.status, name)
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4238 

Before:
```
➜  chart vela -n vela-system status addon-terraform -t
CLUSTER       NAMESPACE       RESOURCE                            STATUS       
local     ─┬─ vela-system ─┬─ HelmRelease/terraform-controller    updated      
           │               └─ HelmRepository/terraform-controller updated      
           └─ -           ─── -                                   not-deployed 
```


After:
```
➜  bin git:(master) ✗ ./vela -n vela-system status addon-terraform -t
CLUSTER       NAMESPACE       RESOURCE                            STATUS    
local     ─── vela-system ─┬─ HelmRelease/terraform-controller    updated   
                           └─ HelmRepository/terraform-controller updated   
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->