### PR TITLE
Fix: env from secret or configmap in task and cron-task componentdefinition

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -196,14 +196,14 @@ spec:
         		// +usage=Specifies a source the value of this var should come from
         		valueFrom?: {
         			// +usage=Selects a key of a secret in the pod's namespace
-        			secretKeyRef: {
+        			secretKeyRef?: {
         				// +usage=The name of the secret in the pod's namespace to select from
         				name: string
         				// +usage=The key of the secret to select from. Must be a valid secret key
         				key: string
         			}
         			// +usage=Selects a key of a config map in the pod's namespace
-        			configMapKeyRef: {
+        			configMapKeyRef?: {
         				// +usage=The name of the config map in the pod's namespace to select from
         				name: string
         				// +usage=The key of the config map to select from. Must be a valid secret key

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -149,14 +149,14 @@ spec:
         		// +usage=Specifies a source the value of this var should come from
         		valueFrom?: {
         			// +usage=Selects a key of a secret in the pod's namespace
-        			secretKeyRef: {
+        			secretKeyRef?: {
         				// +usage=The name of the secret in the pod's namespace to select from
         				name: string
         				// +usage=The key of the secret to select from. Must be a valid secret key
         				key: string
         			}
         			// +usage=Selects a key of a config map in the pod's namespace
-        			configMapKeyRef: {
+        			configMapKeyRef?: {
         				// +usage=The name of the config map in the pod's namespace to select from
         				name: string
         				// +usage=The key of the config map to select from. Must be a valid secret key

--- a/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
@@ -196,14 +196,14 @@ spec:
         		// +usage=Specifies a source the value of this var should come from
         		valueFrom?: {
         			// +usage=Selects a key of a secret in the pod's namespace
-        			secretKeyRef: {
+        			secretKeyRef?: {
         				// +usage=The name of the secret in the pod's namespace to select from
         				name: string
         				// +usage=The key of the secret to select from. Must be a valid secret key
         				key: string
         			}
         			// +usage=Selects a key of a config map in the pod's namespace
-        			configMapKeyRef: {
+        			configMapKeyRef?: {
         				// +usage=The name of the config map in the pod's namespace to select from
         				name: string
         				// +usage=The key of the config map to select from. Must be a valid secret key

--- a/charts/vela-minimal/templates/defwithtemplate/task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/task.yaml
@@ -149,14 +149,14 @@ spec:
         		// +usage=Specifies a source the value of this var should come from
         		valueFrom?: {
         			// +usage=Selects a key of a secret in the pod's namespace
-        			secretKeyRef: {
+        			secretKeyRef?: {
         				// +usage=The name of the secret in the pod's namespace to select from
         				name: string
         				// +usage=The key of the secret to select from. Must be a valid secret key
         				key: string
         			}
         			// +usage=Selects a key of a config map in the pod's namespace
-        			configMapKeyRef: {
+        			configMapKeyRef?: {
         				// +usage=The name of the config map in the pod's namespace to select from
         				name: string
         				// +usage=The key of the config map to select from. Must be a valid secret key

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -198,14 +198,14 @@ template: {
 			// +usage=Specifies a source the value of this var should come from
 			valueFrom?: {
 				// +usage=Selects a key of a secret in the pod's namespace
-				secretKeyRef: {
+				secretKeyRef?: {
 					// +usage=The name of the secret in the pod's namespace to select from
 					name: string
 					// +usage=The key of the secret to select from. Must be a valid secret key
 					key: string
 				}
 				// +usage=Selects a key of a config map in the pod's namespace
-				configMapKeyRef: {
+				configMapKeyRef?: {
 					// +usage=The name of the config map in the pod's namespace to select from
 					name: string
 					// +usage=The key of the config map to select from. Must be a valid secret key

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -180,14 +180,14 @@ template: {
 			// +usage=Specifies a source the value of this var should come from
 			valueFrom?: {
 				// +usage=Selects a key of a secret in the pod's namespace
-				secretKeyRef: {
+				secretKeyRef?: {
 					// +usage=The name of the secret in the pod's namespace to select from
 					name: string
 					// +usage=The key of the secret to select from. Must be a valid secret key
 					key: string
 				}
 				// +usage=Selects a key of a config map in the pod's namespace
-				configMapKeyRef: {
+				configMapKeyRef?: {
 					// +usage=The name of the config map in the pod's namespace to select from
 					name: string
 					// +usage=The key of the config map to select from. Must be a valid secret key


### PR DESCRIPTION
### Description of your changes

Update the param `env` in task and cron-task ComponentDefinitions. Previous version was:

```
              // +usage=Define arguments by using environment variables
        	env?: [...{
        		// +usage=Environment variable name
        		name: string
        		// +usage=The value of the environment variable
        		value?: string
        		// +usage=Specifies a source the value of this var should come from
        		valueFrom?: {
        			// +usage=Selects a key of a secret in the pod's namespace
        			secretKeyRef: {
        				// +usage=The name of the secret in the pod's namespace to select from
        				name: string
        				// +usage=The key of the secret to select from. Must be a valid secret key
        				key: string
        			}
        			// +usage=Selects a key of a config map in the pod's namespace
        			configMapKeyRef: {
        				// +usage=The name of the config map in the pod's namespace to select from
        				name: string
        				// +usage=The key of the config map to select from. Must be a valid secret key
        				key: string
        			}
        		}
        	}]
```

were `secretKeyRef` and `configMapKeyRef` were both mandatory and it did not work:

```
step apply: run step(provider=oam,do=component-apply): GenerateComponentManifest: evaluate base template component=mytask app=app-worker: failed to have the workload/trait unstructured: cue: marshal error: spec.template.spec.containers.0.env.0.valueFrom.secretKeyRef.name: cannot convert incomplete value "string" to JSON
````

These params should be optional.

Fixes #

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [X] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- add the new componentdefinition and deploy an application using it:

```
  apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: app
spec:
  components:
    - name: comp
      type: task
      properties:
        image: <image>
        count: 2
        cmd: [...]
        env:
          - name: VAR1
            valueFrom:
              secretKeyRef:  
                name: <mysecret>
                key: <data>
```


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->