### PR TITLE
Fix: provider can't be added since 1.4 as context abused && Feat: add cache for remote terraform module in vela show 

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -308,12 +308,12 @@ func setStatus(status *common.ApplicationComponentStatus, observedGeneration, ge
 		}
 		return true
 	}
+	status.Message = message
 	if !isLatest() || state != terraformtypes.Available {
 		status.Healthy = false
 		return false
 	}
 	status.Healthy = true
-	status.Message = message
 	return true
 }
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -199,7 +199,7 @@ func convertStepProperties(step *v1beta1.WorkflowStep, app *v1beta1.Application)
 }
 
 func checkDependsOnValidComponent(dependsOnComponentNames, allComponentNames []string) (string, bool) {
-	// does not depends on other components
+	// does not depend on other components
 	if dependsOnComponentNames == nil {
 		return "", true
 	}

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -30,7 +30,7 @@ import (
 	"cuelang.org/go/cue/build"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,25 +215,25 @@ func GetOpenAPISchemaFromTerraformComponentDefinition(configuration string) ([]b
 
 // GetTerraformConfigurationFromRemote gets Terraform Configuration(HCL)
 func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (string, error) {
-	tmpPath := filepath.Join("./tmp/terraform", name)
-	// Check if the directory exists. If yes, remove it.
-	if _, err := os.Stat(tmpPath); err == nil {
-		err := os.RemoveAll(tmpPath)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to remove the directory")
-		}
-	}
-	_, err := git.PlainClone(tmpPath, false, &git.CloneOptions{
-		URL:      remoteURL,
-		Progress: nil,
-	})
+	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
+	cachePath := filepath.Join(userHome, ".vela", "terraform", name)
+	// Check if the directory exists. If yes, remove it.
+	entities, err := os.ReadDir(cachePath)
+	if err != nil || len(entities) == 0 {
+		if _, err = git.PlainClone(cachePath, false, &git.CloneOptions{
+			URL:      remoteURL,
+			Progress: os.Stdout,
+		}); err != nil {
+			return "", err
+		}
+	}
 
-	tfPath := filepath.Join(tmpPath, remotePath, "variables.tf")
+	tfPath := filepath.Join(cachePath, remotePath, "variables.tf")
 	if _, err := os.Stat(tfPath); err != nil {
-		tfPath = filepath.Join(tmpPath, remotePath, "main.tf")
+		tfPath = filepath.Join(cachePath, remotePath, "main.tf")
 		if _, err := os.Stat(tfPath); err != nil {
 			return "", errors.Wrap(err, "failed to find main.tf or variables.tf in Terraform configurations of the remote repository")
 		}
@@ -242,10 +242,6 @@ func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (st
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read Terraform configuration")
 	}
-	if err := os.RemoveAll(tmpPath); err != nil {
-		return "", err
-	}
-
 	return string(conf), nil
 }
 

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -223,6 +223,7 @@ func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (st
 	// Check if the directory exists. If yes, remove it.
 	entities, err := os.ReadDir(cachePath)
 	if err != nil || len(entities) == 0 {
+		fmt.Printf("loading terraform module %s into %s from %s\n", name, cachePath, remoteURL)
 		if _, err = git.PlainClone(cachePath, false, &git.CloneOptions{
 			URL:      remoteURL,
 			Progress: os.Stdout,

--- a/pkg/utils/config/application.go
+++ b/pkg/utils/config/application.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	errAuthenticateProvider   = "failed to authenticate Terraform cloud provider %s for %s"
 	errProviderExists         = "terraform provider %s for %s already exists"
 	errDeleteProvider         = "failed to delete Terraform Provider %s err: %w"
 	errCouldNotDeleteProvider = "the Terraform Provider %s could not be disabled because it was created by enabling a Terraform provider or was manually created"
@@ -54,7 +53,7 @@ func CreateApplication(ctx context.Context, k8sClient client.Client, name, compo
 	if strings.HasPrefix(componentType, types.TerraformComponentPrefix) {
 		existed, err := IsTerraformProviderExisted(ctx, k8sClient, name)
 		if err != nil {
-			return errors.Wrapf(err, errAuthenticateProvider, name, componentType)
+			return errors.Wrapf(err, errCheckProviderExistence, name)
 		}
 		if existed {
 			return fmt.Errorf(errProviderExists, name, componentType)

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -166,9 +166,8 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 				return nil, err
 			}
 			for _, p := range parameters {
-				if p.Name == providerNameParam {
-					p.Default = providerType + "-default"
-				}
+				// TODO(wonderflow): make the provider default name to be unique but keep the compatiblility as some Application didn't specify the name,
+				// now it's “default” for every one, the name will conflict if we have more than one cloud provider.
 				cmd.Flags().String(p.Name, fmt.Sprint(p.Default), p.Usage)
 			}
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -166,9 +166,13 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 				return nil, err
 			}
 			for _, p := range parameters {
+				if p.Name == providerNameParam {
+					p.Default = providerType + "-default"
+				}
 				cmd.Flags().String(p.Name, fmt.Sprint(p.Default), p.Usage)
 			}
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				newContext := context.Background()
 				name, err := cmd.Flags().GetString(providerNameParam)
 				if err != nil || name == "" {
 					return fmt.Errorf("must specify a name for the Terraform Cloud Provider %s", providerType)
@@ -188,8 +192,7 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 				if err != nil {
 					return fmt.Errorf(errAuthenticateProvider, providerType, err)
 				}
-
-				if err := config.CreateApplication(ctx, k8sClient, name, providerType, string(data), config.UIParam{}); err != nil {
+				if err := config.CreateApplication(newContext, k8sClient, name, providerType, string(data), config.UIParam{}); err != nil {
 					return fmt.Errorf(errAuthenticateProvider, providerType, err)
 				}
 				ioStreams.Infof("Successfully authenticate provider %s for %s\n", name, providerType)

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -430,7 +430,8 @@ variable "acl" {
 		"configuration is in git remote": {
 			args: args{
 				cap: types.Capability{
-					TerraformConfiguration: "https://github.com/zzxwill/terraform-alibaba-eip.git",
+					Name:                   "ecs",
+					TerraformConfiguration: "https://github.com/wonderflow/terraform-alicloud-ecs-instance.git",
 					ConfigurationType:      "remote",
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

* Fixes the error:

```
vela provider add terraform-alibaba --ALICLOUD_ACCESS_KEY xxx --ALICLOUD_SECRET_KEY xxx --ALICLOUD_REGION cn-hangzhou
Error: failed to authenticate Terraform cloud provider terraform-alibaba err: failed to authenticate Terraform cloud provider default for terraform-alibaba: context canceled
```

* Feat: add cache for remote terraform module in vela show

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->