### PR TITLE
Feat: store outputs for unsuccessful steps in workflow context

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -2311,6 +2311,94 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
 	})
 
+	It("application with timeout outputs in workflow", func() {
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-timeout-output",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-timeout-output"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-timeout-output",
+				Namespace: "app-with-timeout-output",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name:    "myweb1",
+							Type:    "apply-component",
+							Timeout: "1s",
+							Outputs: common.StepOutputs{
+								{
+									Name:      "output",
+									ValueFrom: "context.name",
+								},
+							},
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name: "myweb2",
+							Inputs: common.StepInputs{
+								{
+									From:         "output",
+									ParameterKey: "",
+								},
+							},
+							If:         `inputs.output == "app-with-timeout-output"`,
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		time.Sleep(time.Second)
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(BeNil())
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowTerminated))
+	})
+
 	It("application with if always in workflow", func() {
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -293,14 +293,11 @@ func (h *AppHandler) applyComponentFunc(appParser *appfile.Parser, appRev *v1bet
 			return nil, nil, false, errors.WithMessage(err, "CollectHealthStatus")
 		}
 
-		if !isHealth {
-			return nil, nil, false, nil
-		}
 		if DisableResourceApplyDoubleCheck {
-			return readyWorkload, readyTraits, true, nil
+			return readyWorkload, readyTraits, isHealth, nil
 		}
 		workload, traits, err := getComponentResources(auth.ContextWithUserInfo(ctx, h.app), manifest, wl.SkipApplyWorkload, h.r.Client)
-		return workload, traits, true, err
+		return workload, traits, isHealth, err
 	}
 }
 

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -418,14 +418,13 @@ func (val *Value) StepByFields(handle func(name string, in *Value) (bool, error)
 		if err != nil {
 			return errors.WithMessagef(err, "step %s", field.Name)
 		}
-		if stop {
-			return nil
-		}
-
 		if !isDef(field.Name) {
 			if err := val.FillObject(field.Value, field.Name); err != nil {
 				return err
 			}
+		}
+		if stop {
+			return nil
 		}
 
 		if end {

--- a/pkg/velaql/view_test.go
+++ b/pkg/velaql/view_test.go
@@ -58,8 +58,11 @@ var _ = Describe("Test VelaQL View", func() {
 		velaQL := fmt.Sprintf("%s{%s}.%s", readView.Name, Map2URLParameter(parameter), "appStatus")
 		query, err := ParseVelaQL(velaQL)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = viewHandler.QueryView(context.Background(), query)
-		Expect(err).Should(HaveOccurred())
+		v, err := viewHandler.QueryView(context.Background(), query)
+		Expect(err).ShouldNot(HaveOccurred())
+		s, err := v.String()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(s).Should(Equal("null\n"))
 
 		By("query an non-existent view")
 		velaQL = fmt.Sprintf("%s{%s}.%s", "view-resource", Map2URLParameter(parameter), "objStatus")

--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -47,10 +47,10 @@ func Output(ctx wfContext.Context, taskValue *value.Value, step v1beta1.Workflow
 	if wfTypes.IsStepFinish(status.Phase, status.Reason) {
 		for _, output := range step.Outputs {
 			v, err := taskValue.LookupByScript(output.ValueFrom)
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "not found") {
 				return err
 			}
-			if v.Error() != nil {
+			if err != nil || v.Error() != nil {
 				v, err = taskValue.MakeValue("null")
 				if err != nil {
 					return err

--- a/pkg/workflow/operation/operation.go
+++ b/pkg/workflow/operation/operation.go
@@ -104,7 +104,7 @@ func (wo wfOperator) Resume(ctx context.Context, app *v1beta1.Application) error
 			return err
 		}
 	}
-	return nil
+	return wo.writeOutputF("Successfully resume workflow: %s\n", app.Name)
 }
 
 // Rollback a running in middle state workflow.
@@ -269,7 +269,7 @@ func (wo wfOperator) Terminate(ctx context.Context, app *v1beta1.Application) er
 		return err
 	}
 
-	return nil
+	return wo.writeOutputF("Successfully terminate workflow: %s\n", app.Name)
 }
 
 func (wo wfOperator) writeOutput(str string) error {


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Previously, if the component was not ready, its output would not be stored in the context. This PR fixes the problem and now we can pass the status of the component even if it's failed like:

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: err-with-always
  namespace: default
spec:
  components:
  - name: invalid
    type: webservice
    properties:
      image: invalid
      ports:
        - port: 8000
  workflow:
    steps:
      - name: comp
        type: apply-component
        timeout: 5s
        outputs:
          - name: status
            valueFrom: output.status.conditions[0].type + output.status.conditions[0].status
        properties:
          component: invalid
      - name: notification
        type: notification
        inputs:
          - from: status
            parameterKey: slack.message.text
        if: always
        properties:
          slack:
            url:
              value: <url>
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->