### PR TITLE
Fix: support stdin and url for vela ql

### DIFF
--- a/pkg/velaql/parse.go
+++ b/pkg/velaql/parse.go
@@ -17,8 +17,6 @@
 package velaql
 
 import (
-	"io/ioutil"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/references/common"
 )
 
 // QueryView contains query data
@@ -99,7 +98,7 @@ func ParseVelaQL(ql string) (QueryView, error) {
 
 // ParseVelaQLFromPath will parse a velaQL file path to QueryView
 func ParseVelaQLFromPath(velaQLViewPath string) (*QueryView, error) {
-	body, err := ioutil.ReadFile(filepath.Clean(velaQLViewPath))
+	body, err := common.ReadRemoteOrLocalPath(velaQLViewPath)
 	if err != nil {
 		return nil, errors.Errorf("read view file from %s: %v", velaQLViewPath, err)
 	}

--- a/references/cli/velaql.go
+++ b/references/cli/velaql.go
@@ -50,12 +50,12 @@ func NewQlCommand(c common.Args, order string, ioStreams util.IOStreams) *cobra.
 		Short: "Show result of executing velaQL.",
 		Long: `Show result of executing velaQL, use it like:
 		vela ql --query "<inner-view-name>{<param1>=<value1>,<param2>=<value2>}
-		vela ql --file=./ql.cue
+		vela ql --file ./ql.cue
 `,
 		Example: `Users can query with a query statement:
 		vela ql --query "<inner-view-name>{<param1>=<value1>,<param2>=<value2>}"
 They can also query by a ql file:
-		vela ql --file=./ql.cue
+		vela ql --file ./ql.cue
 
 Example content of ql.cue:
 ---
@@ -99,7 +99,7 @@ export: "status"
 			types.TagCommandType:  types.TypeApp,
 		},
 	}
-	cmd.Flags().StringVarP(&cueFile, "file", "f", "", "The CUE file path for VelaQL.")
+	cmd.Flags().StringVarP(&cueFile, "file", "f", "", "The CUE file path for VelaQL, it could be a remote url.")
 	cmd.Flags().StringVarP(&querySts, "query", "q", "", "The query statement for VelaQL.")
 	cmd.SetOut(ioStreams.Out)
 	return cmd


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

It supports this kind of usage:

```
cat <<EOF | vela ql -f -
import (
        "vela/ql"
)
configmap: ql.#Read & {
        value: {
                kind:       "Secret"
                apiVersion: "v1"
                metadata: {
                        name:      "outputs-ecs"
                        namespace: "default"
                }
        }
}
status: configmap.value.data["this_public_ip"]
EOF
```

And read from URL.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->