### PR TITLE
Fix: controller topology policy use cluster client

### DIFF
--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -47,6 +47,7 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Name:      "cluster-a",
 			Namespace: multicluster.ClusterGatewaySecretNamespace,
 			Labels: map[string]string{
+				clustercommon.LabelKeyClusterEndpointType:   string(clusterv1alpha1.ClusterEndpointTypeConst),
 				clustercommon.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
 				"key": "value",
 			},
@@ -56,6 +57,7 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Name:      "cluster-b",
 			Namespace: multicluster.ClusterGatewaySecretNamespace,
 			Labels: map[string]string{
+				clustercommon.LabelKeyClusterEndpointType:   string(clusterv1alpha1.ClusterEndpointTypeConst),
 				clustercommon.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
 				"key": "value",
 			},
@@ -65,6 +67,7 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Name:      "cluster-c",
 			Namespace: multicluster.ClusterGatewaySecretNamespace,
 			Labels: map[string]string{
+				clustercommon.LabelKeyClusterEndpointType:   string(clusterv1alpha1.ClusterEndpointTypeConst),
 				clustercommon.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
 				"key": "none",
 			},


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Controller use cluster client to support empty label selector selecting local cluster.

Writing
```yaml
  - name: topology
    type: topology
    properties:
      clusterLabelSelector: {}
```
will select all the clusters including the local cluster.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->