### PR TITLE
Feat: enhance ServiceAccount trait to support privileges

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/service-account.yaml
+++ b/charts/vela-core/templates/defwithtemplate/service-account.yaml
@@ -14,10 +14,114 @@ spec:
   schematic:
     cue:
       template: |
+        #Privileges: {
+        	// +usage=Specify the verbs to be allowed for the resource
+        	verbs: [...string]
+        	// +usage=Specify the apiGroups of the resource
+        	apiGroups?: [...string]
+        	// +usage=Specify the resources to be allowed
+        	resources?: [...string]
+        	// +usage=Specify the resourceNames to be allowed
+        	resourceNames?: [...string]
+        	// +usage=Specify the resource url to be allowed
+        	nonResourceURLs?: [...string]
+        	// +usage=Specify the scope of the privileges, default to be namespace scope
+        	scope: *"namespace" | "cluster"
+        }
         parameter: {
         	// +usage=Specify the name of ServiceAccount
         	name: string
+        	// +usage=Specify whether to create new ServiceAccount or not
+        	create: *false | bool
+        	// +usage=Specify the privileges of the ServiceAccount, if not empty, RoleBindings(ClusterRoleBindings) will be created
+        	privileges?: [...#Privileges]
         }
         // +patchStrategy=retainKeys
         patch: spec: template: spec: serviceAccountName: parameter.name
+        _clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
+        _namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+        outputs: {
+        	if parameter.create {
+        		"service-account": {
+        			apiVersion: "v1"
+        			kind:       "ServiceAccount"
+        			metadata: name: parameter.name
+        		}
+        	}
+        	if parameter.privileges != _|_ {
+        		if len(_clusterPrivileges) > 0 {
+        			"cluster-role": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "ClusterRole"
+        				metadata: name: "\(context.namespace):\(parameter.name)"
+        				rules: [ for p in _clusterPrivileges {
+        					verbs: p.verbs
+        					if p.apiGroups != _|_ {
+        						apiGroups: p.apiGroups
+        					}
+        					if p.resources != _|_ {
+        						resources: p.resources
+        					}
+        					if p.resourceNames != _|_ {
+        						resources: p.resourceNames
+        					}
+        					if p.nonResourceURLs != _|_ {
+        						nonResourceURLs: p.nonResourceURLs
+        					}
+        				}]
+        			}
+        			"cluster-role-binding": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "ClusterRoleBinding"
+        				metadata: name: "\(context.namespace):\(parameter.name)"
+        				roleRef: {
+        					apiGroup: "rbac.authorization.k8s.io"
+        					kind:     "ClusterRole"
+        					name:     "\(context.namespace):\(parameter.name)"
+        				}
+        				subjects: [{
+        					kind:      "ServiceAccount"
+        					name:      parameter.name
+        					namespace: "\(context.namespace)"
+        				}]
+        			}
+        		}
+        		if len(_namespacePrivileges) > 0 {
+        			role: {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "Role"
+        				metadata: name: parameter.name
+        				rules: [ for p in _namespacePrivileges {
+        					verbs: p.verbs
+        					if p.apiGroups != _|_ {
+        						apiGroups: p.apiGroups
+        					}
+        					if p.resources != _|_ {
+        						resources: p.resources
+        					}
+        					if p.resourceNames != _|_ {
+        						resources: p.resourceNames
+        					}
+        					if p.nonResourceURLs != _|_ {
+        						nonResourceURLs: p.nonResourceURLs
+        					}
+        				}]
+        			}
+        			"role-binding": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "RoleBinding"
+        				metadata: name: parameter.name
+        				roleRef: {
+        					apiGroup: "rbac.authorization.k8s.io"
+        					kind:     "Role"
+        					name:     parameter.name
+        				}
+        				subjects: [{
+        					kind: "ServiceAccount"
+        					name: parameter.name
+        				}]
+        			}
+        		}
+        	}
+        }
 

--- a/charts/vela-minimal/templates/defwithtemplate/service-account.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/service-account.yaml
@@ -14,10 +14,114 @@ spec:
   schematic:
     cue:
       template: |
+        #Privileges: {
+        	// +usage=Specify the verbs to be allowed for the resource
+        	verbs: [...string]
+        	// +usage=Specify the apiGroups of the resource
+        	apiGroups?: [...string]
+        	// +usage=Specify the resources to be allowed
+        	resources?: [...string]
+        	// +usage=Specify the resourceNames to be allowed
+        	resourceNames?: [...string]
+        	// +usage=Specify the resource url to be allowed
+        	nonResourceURLs?: [...string]
+        	// +usage=Specify the scope of the privileges, default to be namespace scope
+        	scope: *"namespace" | "cluster"
+        }
         parameter: {
         	// +usage=Specify the name of ServiceAccount
         	name: string
+        	// +usage=Specify whether to create new ServiceAccount or not
+        	create: *false | bool
+        	// +usage=Specify the privileges of the ServiceAccount, if not empty, RoleBindings(ClusterRoleBindings) will be created
+        	privileges?: [...#Privileges]
         }
         // +patchStrategy=retainKeys
         patch: spec: template: spec: serviceAccountName: parameter.name
+        _clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
+        _namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+        outputs: {
+        	if parameter.create {
+        		"service-account": {
+        			apiVersion: "v1"
+        			kind:       "ServiceAccount"
+        			metadata: name: parameter.name
+        		}
+        	}
+        	if parameter.privileges != _|_ {
+        		if len(_clusterPrivileges) > 0 {
+        			"cluster-role": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "ClusterRole"
+        				metadata: name: "\(context.namespace):\(parameter.name)"
+        				rules: [ for p in _clusterPrivileges {
+        					verbs: p.verbs
+        					if p.apiGroups != _|_ {
+        						apiGroups: p.apiGroups
+        					}
+        					if p.resources != _|_ {
+        						resources: p.resources
+        					}
+        					if p.resourceNames != _|_ {
+        						resources: p.resourceNames
+        					}
+        					if p.nonResourceURLs != _|_ {
+        						nonResourceURLs: p.nonResourceURLs
+        					}
+        				}]
+        			}
+        			"cluster-role-binding": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "ClusterRoleBinding"
+        				metadata: name: "\(context.namespace):\(parameter.name)"
+        				roleRef: {
+        					apiGroup: "rbac.authorization.k8s.io"
+        					kind:     "ClusterRole"
+        					name:     "\(context.namespace):\(parameter.name)"
+        				}
+        				subjects: [{
+        					kind:      "ServiceAccount"
+        					name:      parameter.name
+        					namespace: "\(context.namespace)"
+        				}]
+        			}
+        		}
+        		if len(_namespacePrivileges) > 0 {
+        			role: {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "Role"
+        				metadata: name: parameter.name
+        				rules: [ for p in _namespacePrivileges {
+        					verbs: p.verbs
+        					if p.apiGroups != _|_ {
+        						apiGroups: p.apiGroups
+        					}
+        					if p.resources != _|_ {
+        						resources: p.resources
+        					}
+        					if p.resourceNames != _|_ {
+        						resources: p.resourceNames
+        					}
+        					if p.nonResourceURLs != _|_ {
+        						nonResourceURLs: p.nonResourceURLs
+        					}
+        				}]
+        			}
+        			"role-binding": {
+        				apiVersion: "rbac.authorization.k8s.io/v1"
+        				kind:       "RoleBinding"
+        				metadata: name: parameter.name
+        				roleRef: {
+        					apiGroup: "rbac.authorization.k8s.io"
+        					kind:     "Role"
+        					name:     parameter.name
+        				}
+        				subjects: [{
+        					kind: "ServiceAccount"
+        					name: parameter.name
+        				}]
+        			}
+        		}
+        	}
+        }
 

--- a/vela-templates/definitions/internal/trait/service-account.cue
+++ b/vela-templates/definitions/internal/trait/service-account.cue
@@ -9,10 +9,115 @@
 	}
 }
 template: {
+	#Privileges: {
+		// +usage=Specify the verbs to be allowed for the resource
+		verbs: [...string]
+		// +usage=Specify the apiGroups of the resource
+		apiGroups?: [...string]
+		// +usage=Specify the resources to be allowed
+		resources?: [...string]
+		// +usage=Specify the resourceNames to be allowed
+		resourceNames?: [...string]
+		// +usage=Specify the resource url to be allowed
+		nonResourceURLs?: [...string]
+		// +usage=Specify the scope of the privileges, default to be namespace scope
+		scope: *"namespace" | "cluster"
+	}
 	parameter: {
 		// +usage=Specify the name of ServiceAccount
 		name: string
+		// +usage=Specify whether to create new ServiceAccount or not
+		create: *false | bool
+		// +usage=Specify the privileges of the ServiceAccount, if not empty, RoleBindings(ClusterRoleBindings) will be created
+		privileges?: [...#Privileges]
 	}
 	// +patchStrategy=retainKeys
 	patch: spec: template: spec: serviceAccountName: parameter.name
+
+	_clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
+	_namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+	outputs: {
+		if parameter.create {
+			"service-account": {
+				apiVersion: "v1"
+				kind:       "ServiceAccount"
+				metadata: name: parameter.name
+			}
+		}
+		if parameter.privileges != _|_ {
+			if len(_clusterPrivileges) > 0 {
+				"cluster-role": {
+					apiVersion: "rbac.authorization.k8s.io/v1"
+					kind:       "ClusterRole"
+					metadata: name: "\(context.namespace):\(parameter.name)"
+					rules: [ for p in _clusterPrivileges {
+						verbs: p.verbs
+						if p.apiGroups != _|_ {
+							apiGroups: p.apiGroups
+						}
+						if p.resources != _|_ {
+							resources: p.resources
+						}
+						if p.resourceNames != _|_ {
+							resources: p.resourceNames
+						}
+						if p.nonResourceURLs != _|_ {
+							nonResourceURLs: p.nonResourceURLs
+						}
+					}]
+				}
+				"cluster-role-binding": {
+					apiVersion: "rbac.authorization.k8s.io/v1"
+					kind:       "ClusterRoleBinding"
+					metadata: name: "\(context.namespace):\(parameter.name)"
+					roleRef: {
+						apiGroup: "rbac.authorization.k8s.io"
+						kind:     "ClusterRole"
+						name:     "\(context.namespace):\(parameter.name)"
+					}
+					subjects: [{
+						kind:      "ServiceAccount"
+						name:      parameter.name
+						namespace: "\(context.namespace)"
+					}]
+				}
+			}
+			if len(_namespacePrivileges) > 0 {
+				"role": {
+					apiVersion: "rbac.authorization.k8s.io/v1"
+					kind:       "Role"
+					metadata: name: parameter.name
+					rules: [ for p in _namespacePrivileges {
+						verbs: p.verbs
+						if p.apiGroups != _|_ {
+							apiGroups: p.apiGroups
+						}
+						if p.resources != _|_ {
+							resources: p.resources
+						}
+						if p.resourceNames != _|_ {
+							resources: p.resourceNames
+						}
+						if p.nonResourceURLs != _|_ {
+							nonResourceURLs: p.nonResourceURLs
+						}
+					}]
+				}
+				"role-binding": {
+					apiVersion: "rbac.authorization.k8s.io/v1"
+					kind:       "RoleBinding"
+					metadata: name: parameter.name
+					roleRef: {
+						apiGroup: "rbac.authorization.k8s.io"
+						kind:     "Role"
+						name:     parameter.name
+					}
+					subjects: [{
+						kind: "ServiceAccount"
+						name: parameter.name
+					}]
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Allow writing privileges in the ServiceAccount trait which will create roles and rolebindings automatically.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->