### PR TITLE
Fix: context.namespace use the namespace from override policy

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -258,7 +258,7 @@ func (af *Appfile) GenerateComponentManifests() ([]*types.ComponentManifest, err
 	compManifests := make([]*types.ComponentManifest, len(af.Workloads))
 	af.Artifacts = make([]*types.ComponentManifest, len(af.Workloads))
 	for i, wl := range af.Workloads {
-		cm, err := af.GenerateComponentManifest(wl)
+		cm, err := af.GenerateComponentManifest(wl, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -273,13 +273,16 @@ func (af *Appfile) GenerateComponentManifests() ([]*types.ComponentManifest, err
 }
 
 // GenerateComponentManifest generate only one ComponentManifest
-func (af *Appfile) GenerateComponentManifest(wl *Workload) (*types.ComponentManifest, error) {
+func (af *Appfile) GenerateComponentManifest(wl *Workload, mutate func(*process.ContextData)) (*types.ComponentManifest, error) {
 	if af.Namespace == "" {
 		af.Namespace = corev1.NamespaceDefault
 	}
 	ctxData := GenerateContextDataFromAppFile(af, wl.Name)
+	if mutate != nil {
+		mutate(&ctxData)
+	}
 	// generate context here to avoid nil pointer panic
-	wl.Ctx = NewBasicContext(GenerateContextDataFromAppFile(af, wl.Name), wl.Params)
+	wl.Ctx = NewBasicContext(ctxData, wl.Params)
 	switch wl.CapabilityCategory {
 	case types.HelmCategory:
 		return generateComponentFromHelmModule(wl, ctxData)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -69,8 +69,8 @@ const (
 	ManifestKeyTraits = "Traits"
 	// ManifestKeyScopes is the key in Component Manifest for containing scope cr reference.
 	ManifestKeyScopes = "Scopes"
-	// ComponentRevisionNamespaceContextKey is the key in context that defines the override namespace of component revision
-	ComponentRevisionNamespaceContextKey = contextKey("component-revision-namespace")
+	// ComponentNamespaceContextKey is the key in context that defines the override namespace of component
+	ComponentNamespaceContextKey = contextKey("component-namespace")
 	// ComponentContextKey is the key in context that records the component
 	ComponentContextKey = contextKey("component")
 )
@@ -107,12 +107,17 @@ var (
 	DisableAllApplicationRevision = false
 )
 
-func contextWithComponentRevisionNamespace(ctx context.Context, ns string) context.Context {
-	return context.WithValue(ctx, ComponentRevisionNamespaceContextKey, ns)
+func contextWithComponentNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, ComponentNamespaceContextKey, ns)
+}
+
+func componentNamespaceFromContext(ctx context.Context) string {
+	ns, _ := ctx.Value(ComponentNamespaceContextKey).(string)
+	return ns
 }
 
 func (h *AppHandler) getComponentRevisionNamespace(ctx context.Context) string {
-	if ns, ok := ctx.Value(ComponentRevisionNamespaceContextKey).(string); ok && ns != "" {
+	if ns, ok := ctx.Value(ComponentNamespaceContextKey).(string); ok && ns != "" {
 		return ns
 	}
 	return h.app.Namespace


### PR DESCRIPTION


Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

context.namespace use override namespace when rendering component and trait

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->