### PR TITLE
Fix: kube apply ignore userinfo for rt

### DIFF
--- a/pkg/auth/userinfo.go
+++ b/pkg/auth/userinfo.go
@@ -47,6 +47,11 @@ func ContextWithUserInfo(ctx context.Context, app *v1beta1.Application) context.
 	return request.WithUser(ctx, GetUserInfoInAnnotation(&app.ObjectMeta))
 }
 
+// ContextClearUserInfo clear user info in context
+func ContextClearUserInfo(ctx context.Context) context.Context {
+	return request.WithUser(ctx, nil)
+}
+
 // SetUserInfoInAnnotation set username and group from userInfo into annotations
 // it will clear the existing service account annotation in avoid of permission leak
 func SetUserInfoInAnnotation(obj *metav1.ObjectMeta, userInfo authv1.UserInfo) {

--- a/pkg/resourcekeeper/dispatch.go
+++ b/pkg/resourcekeeper/dispatch.go
@@ -105,6 +105,7 @@ func (h *resourceKeeper) record(ctx context.Context, manifests []*unstructured.U
 	}
 
 	cfg := newDispatchConfig(options...)
+	ctx = auth.ContextClearUserInfo(ctx)
 	if len(rootManifests) != 0 {
 		rt, err := h.getRootRT(ctx)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The UserInfo is injected to the context for kube.#Apply. But kube.#Apply will call ResourceKeeper.Dispatch and therefore the write of ResourceTracker will misuse the userinfo-carried context and cause some trouble.

Fixes #4296

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->