### PR TITLE
Feat: use deploy step as default in replace of apply-componet

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -446,9 +446,8 @@ func (p *Parser) loadWorkflowToAppfile(ctx context.Context, af *Appfile) error {
 	}
 	af.WorkflowSteps, err = step.NewChainWorkflowStepGenerator(
 		&step.RefWorkflowStepGenerator{Client: af.WorkflowClient(p.client), Context: ctx},
-		&step.DeployWorkflowStepGenerator{},
 		&step.Deploy2EnvWorkflowStepGenerator{},
-		&step.ApplyComponentWorkflowStepGenerator{},
+		&step.DeployWorkflowStepGenerator{},
 		&step.DeployPreApproveWorkflowStepGenerator{},
 	).Generate(af.app, af.WorkflowSteps)
 	return err

--- a/pkg/workflow/step/generator.go
+++ b/pkg/workflow/step/generator.go
@@ -80,26 +80,6 @@ func (g *RefWorkflowStepGenerator) Generate(app *v1beta1.Application, existingSt
 	return ConvertSteps(wf.Steps), nil
 }
 
-// ApplyComponentWorkflowStepGenerator generate apply-component workflow steps for all components in the application
-type ApplyComponentWorkflowStepGenerator struct{}
-
-// Generate generate workflow steps
-func (g *ApplyComponentWorkflowStepGenerator) Generate(app *v1beta1.Application, existingSteps []v1beta1.WorkflowStep) (steps []v1beta1.WorkflowStep, err error) {
-	if len(existingSteps) > 0 {
-		return existingSteps, nil
-	}
-	for _, comp := range app.Spec.Components {
-		steps = append(steps, v1beta1.WorkflowStep{
-			Name: comp.Name,
-			Type: wftypes.WorkflowStepTypeApplyComponent,
-			Properties: util.Object2RawExtension(map[string]string{
-				"component": comp.Name,
-			}),
-		})
-	}
-	return
-}
-
 // Deploy2EnvWorkflowStepGenerator generate deploy2env workflow steps for all envs in the application
 type Deploy2EnvWorkflowStepGenerator struct{}
 
@@ -157,20 +137,11 @@ func (g *DeployWorkflowStepGenerator) Generate(app *v1beta1.Application, existin
 		})
 	}
 	if len(topologies) == 0 {
-		containsRefObjects := false
-		for _, comp := range app.Spec.Components {
-			if comp.Type == v1alpha1.RefObjectsComponentType {
-				containsRefObjects = true
-				break
-			}
-		}
-		if containsRefObjects {
-			steps = append(steps, v1beta1.WorkflowStep{
-				Name:       "deploy",
-				Type:       "deploy",
-				Properties: util.Object2RawExtension(map[string]interface{}{"policies": append([]string{}, overrides...)}),
-			})
-		}
+		steps = append(steps, v1beta1.WorkflowStep{
+			Name:       "deploy",
+			Type:       "deploy",
+			Properties: util.Object2RawExtension(map[string]interface{}{"policies": append([]string{}, overrides...)}),
+		})
 	}
 	return steps, nil
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Remove apply component step generator and let deploy step handle all.

Effect:
1. When user explicitly use `apply-component`, nothing changes.
2. When user explicitly specify workflow, nothing changes.
3. When user explicitly specify topology policy, nothing changes.
4. When user does not specify topology policy, previously, override policy will not work due to the use of apply-component. Now it can work with the use of deploy workflow step.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->