### PR TITLE
Fix: the target conflict when syncing the application

### DIFF
--- a/pkg/apiserver/domain/service/cloudshell.go
+++ b/pkg/apiserver/domain/service/cloudshell.go
@@ -205,6 +205,7 @@ func (c *cloudShellServiceImpl) prepareKubeConfig(ctx context.Context) error {
 			readOnly = checkReadOnly(p.Name, permissions)
 		}
 		if readOnly {
+			// TODO:(@barnettZQG) there needs a method to revoke the privileges
 			if err := c.managePrivilegesForUser(ctx, p.Name, true, userName, false); err != nil {
 				log.Logger.Errorf("failed to privileges the user %s", err.Error())
 			}
@@ -334,7 +335,6 @@ func checkReadOnly(projectName string, permissions []*model.Permission) bool {
 
 // managePrivilegesForUser grant or revoke privileges for a user
 func (c *cloudShellServiceImpl) managePrivilegesForUser(ctx context.Context, projectName string, readOnly bool, userName string, revoke bool) error {
-
 	targets, err := c.TargetService.ListTargets(ctx, 0, 0, projectName)
 	if err != nil {
 		log.Logger.Infof("failed to list the targets by the project name %s :%s", projectName, err.Error())

--- a/pkg/apiserver/event/sync/store.go
+++ b/pkg/apiserver/event/sync/store.go
@@ -82,12 +82,13 @@ func StoreEnv(ctx context.Context, app *model.DataStoreApp, ds datastore.DataSto
 		return err
 	}
 	_, err = envService.CreateEnv(ctx, v1.CreateEnvRequest{
-		Name:        app.Env.Name,
-		Alias:       app.Env.Alias,
-		Description: app.Env.Description,
-		Project:     app.Env.Project,
-		Namespace:   app.Env.Namespace,
-		Targets:     app.Env.Targets,
+		Name:                app.Env.Name,
+		Alias:               app.Env.Alias,
+		Description:         app.Env.Description,
+		Project:             app.Env.Project,
+		Namespace:           app.Env.Namespace,
+		Targets:             app.Env.Targets,
+		AllowTargetConflict: true,
 	})
 	if err != nil && !errors.Is(err, bcode.ErrEnvAlreadyExists) {
 		return err

--- a/pkg/apiserver/event/sync/testdata/test-app4.yaml
+++ b/pkg/apiserver/event/sync/testdata/test-app4.yaml
@@ -1,0 +1,16 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: example-exist-env
+spec:
+  components:
+    - name: example-exist-env
+      type: webservice
+      properties:
+        image: wordpress
+      traits:
+        - type: gateway
+          properties:
+            domain: testsvc.example.com
+            http:
+              "/": 8000

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -794,6 +794,9 @@ type CreateEnvRequest struct {
 	// Targets defines the name of delivery target that belongs to this env
 	// In one project, a delivery target can only belong to one env.
 	Targets []string `json:"targets,omitempty"  optional:"true"`
+
+	// AllowTargetConflict means allow binding the targets that belong to other envs
+	AllowTargetConflict bool `json:"allowTargetConflict,omitempty"  optional:"true"`
 }
 
 // UpdateEnvRequest defines the data of Env for update


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Allow different env to bind the same target when syncing the application.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.