### PR TITLE
Fix: ref-objects parameter with invalid field definition

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
@@ -14,12 +14,12 @@ spec:
     cue:
       template: |
         #K8sObject: {
-        	apiVersion: string
-        	kind:       string
-        	metadata: {
-        		name: string
-        		...
-        	}
+        	resource?:  string
+        	group?:     string
+        	name?:      string
+        	namespace?: string
+        	cluster?:   string
+        	labelSelector?: [string]: string
         	...
         }
         output: {

--- a/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
@@ -14,12 +14,12 @@ spec:
     cue:
       template: |
         #K8sObject: {
-        	apiVersion: string
-        	kind:       string
-        	metadata: {
-        		name: string
-        		...
-        	}
+        	resource?:  string
+        	group?:     string
+        	name?:      string
+        	namespace?: string
+        	cluster?:   string
+        	labelSelector?: [string]: string
         	...
         }
         output: {

--- a/vela-templates/definitions/internal/component/ref-objects.cue
+++ b/vela-templates/definitions/internal/component/ref-objects.cue
@@ -55,12 +55,12 @@
 }
 template: {
 	#K8sObject: {
-		apiVersion: string
-		kind:       string
-		metadata: {
-			name: string
-			...
-		}
+		resource?: string
+		group?: string
+		name?: string
+		namespace?: string
+		cluster?: string
+		labelSelector?: [string]: string
 		...
 	}
 

--- a/vela-templates/definitions/internal/component/ref-objects.cue
+++ b/vela-templates/definitions/internal/component/ref-objects.cue
@@ -55,11 +55,11 @@
 }
 template: {
 	#K8sObject: {
-		resource?: string
-		group?: string
-		name?: string
+		resource?:  string
+		group?:     string
+		name?:      string
 		namespace?: string
-		cluster?: string
+		cluster?:   string
 		labelSelector?: [string]: string
 		...
 	}


### PR DESCRIPTION
invalid field of parameter cause validating webhook or application apply failed when use ref-objects component. so update the parameter definition to the correct version, according to [ObjectReferrer](https://github.com/jiangshantao-dbg/kubevela/blob/92fa67cd6961a28fd388298a9bb8b5162b301271/apis/core.oam.dev/v1alpha1/component_types.go#L33)


### Description of your changes
use the correct version of the `ref_objects.ObjectReferrer` to define the optional fields of the cue parameter type `#K8sObject`

Fixes  #4318

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->