### PR TITLE
Feat: reuse informer for app metrics

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/auth"
 	ctrlClient "github.com/oam-dev/kubevela/pkg/client"
@@ -324,10 +325,11 @@ func main() {
 	klog.InfoS("Use storage driver", "storageDriver", os.Getenv(system.StorageDriverEnv))
 
 	klog.Info("Start the vela application monitor")
-	if err := watcher.StartApplicationMetricsWatcher(restConfig); err != nil {
-		klog.ErrorS(err, "Unable to start application metrics watcher")
-		os.Exit(1)
+	informer, err := mgr.GetCache().GetInformer(context.Background(), &v1beta1.Application{})
+	if err != nil {
+		klog.ErrorS(err, "Unable to get informer for application")
 	}
+	watcher.StartApplicationMetricsWatcher(informer)
 
 	klog.Info("Start the vela controller manager")
 

--- a/pkg/monitor/watcher/application.go
+++ b/pkg/monitor/watcher/application.go
@@ -23,11 +23,8 @@ import (
 	"sync"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
@@ -39,42 +36,8 @@ type applicationMetricsWatcher struct {
 	stepPhaseCounter map[string]int
 	phaseDirty       map[string]struct{}
 	stepPhaseDirty   map[string]struct{}
-	informer         cache.SharedIndexInformer
+	informer         ctrlcache.Informer
 	stopCh           chan struct{}
-}
-
-func newApplicationMetricsWatcher(cfg *rest.Config) (*applicationMetricsWatcher, error) {
-	dc, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-	f := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dc, 0, metav1.NamespaceAll, nil)
-	informer := f.ForResource(v1beta1.SchemeGroupVersion.WithResource("applications")).Informer()
-	watcher := &applicationMetricsWatcher{
-		phaseCounter:     map[string]int{},
-		stepPhaseCounter: map[string]int{},
-		phaseDirty:       map[string]struct{}{},
-		stepPhaseDirty:   map[string]struct{}{},
-		informer:         informer,
-		stopCh:           make(chan struct{}, 1),
-	}
-	watcher.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			app := watcher.getApp(obj)
-			watcher.inc(app, 1)
-		},
-		UpdateFunc: func(oldObj, obj interface{}) {
-			oldApp := watcher.getApp(oldObj)
-			app := watcher.getApp(obj)
-			watcher.inc(oldApp, -1)
-			watcher.inc(app, 1)
-		},
-		DeleteFunc: func(obj interface{}) {
-			app := watcher.getApp(obj)
-			watcher.inc(app, -1)
-		},
-	})
-	return watcher, nil
 }
 
 func (watcher *applicationMetricsWatcher) getApp(obj interface{}) *v1beta1.Application {
@@ -132,15 +95,33 @@ func (watcher *applicationMetricsWatcher) run() {
 			}
 		}
 	}()
-	go watcher.informer.Run(watcher.stopCh)
 }
 
 // StartApplicationMetricsWatcher start metrics watcher for reporting application stats
-func StartApplicationMetricsWatcher(cfg *rest.Config) error {
-	watcher, err := newApplicationMetricsWatcher(cfg)
-	if err != nil {
-		return err
+func StartApplicationMetricsWatcher(informer ctrlcache.Informer) {
+	watcher := &applicationMetricsWatcher{
+		phaseCounter:     map[string]int{},
+		stepPhaseCounter: map[string]int{},
+		phaseDirty:       map[string]struct{}{},
+		stepPhaseDirty:   map[string]struct{}{},
+		informer:         informer,
+		stopCh:           make(chan struct{}, 1),
 	}
+	watcher.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			app := watcher.getApp(obj)
+			watcher.inc(app, 1)
+		},
+		UpdateFunc: func(oldObj, obj interface{}) {
+			oldApp := watcher.getApp(oldObj)
+			app := watcher.getApp(obj)
+			watcher.inc(oldApp, -1)
+			watcher.inc(app, 1)
+		},
+		DeleteFunc: func(obj interface{}) {
+			app := watcher.getApp(obj)
+			watcher.inc(app, -1)
+		},
+	})
 	watcher.run()
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Reuse application informer for recording application metrics to reduce memory use.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->