### PR TITLE
Fix: escape resource name for label selector

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -54,6 +54,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
+	pkgutils "github.com/oam-dev/kubevela/pkg/utils"
 )
 
 type contextKey string
@@ -625,7 +626,7 @@ func (h *AppHandler) handleComponentRevisionNameUnspecified(ctx context.Context,
 
 	crList := &appsv1.ControllerRevisionList{}
 	listOpts := []client.ListOption{client.MatchingLabels{
-		oam.LabelControllerRevisionComponent: comp.Name,
+		oam.LabelControllerRevisionComponent: pkgutils.EscapeResourceNameToLabelValue(comp.Name),
 	}, client.InNamespace(h.getComponentRevisionNamespace(ctx))}
 	if err := h.r.List(auth.ContextWithUserInfo(ctx, h.app), crList, listOpts...); err != nil {
 		return err
@@ -732,10 +733,10 @@ func (h *AppHandler) createControllerRevision(ctx context.Context, cm *types.Com
 			Name:      cm.RevisionName,
 			Namespace: h.getComponentRevisionNamespace(ctx),
 			Labels: map[string]string{
-				oam.LabelAppComponent:                cm.Name,
+				oam.LabelAppComponent:                pkgutils.EscapeResourceNameToLabelValue(cm.Name),
 				oam.LabelAppCluster:                  multicluster.ClusterNameInContext(ctx),
 				oam.LabelAppEnv:                      envbinding.EnvNameInContext(ctx),
-				oam.LabelControllerRevisionComponent: cm.Name,
+				oam.LabelControllerRevisionComponent: pkgutils.EscapeResourceNameToLabelValue(cm.Name),
 				oam.LabelComponentRevisionHash:       cm.RevisionHash,
 			},
 		},
@@ -962,7 +963,7 @@ func cleanUpWorkflowComponentRevision(ctx context.Context, h *AppHandler) error 
 	for _, curComp := range h.app.Status.AppliedResources {
 		crList := &appsv1.ControllerRevisionList{}
 		listOpts := []client.ListOption{client.MatchingLabels{
-			oam.LabelControllerRevisionComponent: curComp.Name,
+			oam.LabelControllerRevisionComponent: pkgutils.EscapeResourceNameToLabelValue(curComp.Name),
 		}, client.InNamespace(h.getComponentRevisionNamespace(ctx))}
 		_ctx := multicluster.ContextWithClusterName(ctx, curComp.Cluster)
 		if err := h.r.List(_ctx, crList, listOpts...); err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component.go
@@ -38,6 +38,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	pkgutil "github.com/oam-dev/kubevela/pkg/utils"
 )
 
 // ControllerRevisionComponentLabel indicate which component the revision belong to
@@ -189,7 +190,7 @@ func (c *ComponentHandler) createControllerRevision(mt metav1.Object, obj client
 				},
 			},
 			Labels: map[string]string{
-				ControllerRevisionComponentLabel: comp.Name,
+				ControllerRevisionComponentLabel: pkgutil.EscapeResourceNameToLabelValue(comp.Name),
 			},
 		},
 		Revision: nextRevision,
@@ -250,7 +251,7 @@ func sortedControllerRevision(appConfigs []v1alpha2.ApplicationConfiguration, re
 func (c *ComponentHandler) cleanupControllerRevision(curComp *v1alpha2.Component) error {
 	labels := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			ControllerRevisionComponentLabel: curComp.Name,
+			ControllerRevisionComponentLabel: pkgutil.EscapeResourceNameToLabelValue(curComp.Name),
 		},
 	}
 	selector, err := metav1.LabelSelectorAsSelector(labels)

--- a/pkg/resourcekeeper/containsresources.go
+++ b/pkg/resourcekeeper/containsresources.go
@@ -20,6 +20,7 @@ import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 // ContainsResources check if resources all exist
 func (h *resourceKeeper) ContainsResources(resources []*unstructured.Unstructured) bool {
+	h.ClearNamespaceForClusterScopedResources(resources)
 	for _, rsc := range resources {
 		if rsc == nil {
 			continue

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -182,4 +183,9 @@ func CreateOrUpdate(ctx context.Context, cli client.Client, obj client.Object) (
 		obj.SetManagedFields(managedFields)
 		return nil
 	})
+}
+
+// EscapeResourceNameToLabelValue parse characters in resource name to label valid name
+func EscapeResourceNameToLabelValue(resourceName string) string {
+	return strings.ReplaceAll(resourceName, ":", "_")
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Kubernetes resources support names containing character ':', but label does not allow it. This PR escapes the name when filling it into the value of label.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->