### PR TITLE
Feat: add status check for expose trait

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/expose.yaml
+++ b/charts/vela-core/templates/defwithtemplate/expose.yaml
@@ -14,14 +14,20 @@ spec:
   schematic:
     cue:
       template: |
+        import (
+        	"strconv"
+        )
+
         outputs: service: {
         	apiVersion: "v1"
         	kind:       "Service"
-        	metadata: name: context.name
+        	metadata: name:        context.name
+        	metadata: annotations: parameter.annotations
         	spec: {
         		selector: "app.oam.dev/component": context.name
         		ports: [
         			for p in parameter.port {
+        				name:       "port-" + strconv.FormatInt(p, 10)
         				port:       p
         				targetPort: p
         			},
@@ -32,7 +38,33 @@ spec:
         parameter: {
         	// +usage=Specify the exposion ports
         	port: [...int]
+        	// +usage=Specify the annotaions of the exposed service
+        	annotations: [string]: string
         	// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
         	type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
         }
+  status:
+    customStatus: |-
+      message: *"" | string
+      service: context.outputs.service
+      if service.spec.type == "ClusterIP" {
+      	message: "ClusterIP: \(service.spec.clusterIP)"
+      }
+      if service.spec.type == "LoadBalancer" {
+      	status: service.status
+      	isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+      	if !isHealth {
+      		message: "ExternalIP: Pending"
+      	}
+      	if isHealth {
+      		message: "ExternalIP: \(status.loadBalancer.ingress[0].ip)"
+      	}
+      }
+    healthPolicy: |-
+      isHealth: *true | bool
+      service: context.outputs.service
+      if service.spec.type == "LoadBalancer" {
+      	status: service.status
+      	isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+      }
 

--- a/charts/vela-minimal/templates/defwithtemplate/expose.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/expose.yaml
@@ -14,14 +14,20 @@ spec:
   schematic:
     cue:
       template: |
+        import (
+        	"strconv"
+        )
+
         outputs: service: {
         	apiVersion: "v1"
         	kind:       "Service"
-        	metadata: name: context.name
+        	metadata: name:        context.name
+        	metadata: annotations: parameter.annotations
         	spec: {
         		selector: "app.oam.dev/component": context.name
         		ports: [
         			for p in parameter.port {
+        				name:       "port-" + strconv.FormatInt(p, 10)
         				port:       p
         				targetPort: p
         			},
@@ -32,7 +38,33 @@ spec:
         parameter: {
         	// +usage=Specify the exposion ports
         	port: [...int]
+        	// +usage=Specify the annotaions of the exposed service
+        	annotations: [string]: string
         	// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
         	type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
         }
+  status:
+    customStatus: |-
+      message: *"" | string
+      service: context.outputs.service
+      if service.spec.type == "ClusterIP" {
+      	message: "ClusterIP: \(service.spec.clusterIP)"
+      }
+      if service.spec.type == "LoadBalancer" {
+      	status: service.status
+      	isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+      	if !isHealth {
+      		message: "ExternalIP: Pending"
+      	}
+      	if isHealth {
+      		message: "ExternalIP: \(status.loadBalancer.ingress[0].ip)"
+      	}
+      }
+    healthPolicy: |-
+      isHealth: *true | bool
+      service: context.outputs.service
+      if service.spec.type == "LoadBalancer" {
+      	status: service.status
+      	isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+      }
 

--- a/vela-templates/definitions/internal/trait/expose.cue
+++ b/vela-templates/definitions/internal/trait/expose.cue
@@ -1,3 +1,7 @@
+import (
+	"strconv"
+)
+
 expose: {
 	type: "trait"
 	annotations: {}
@@ -7,17 +11,46 @@ expose: {
 	description: "Expose port to enable web traffic for your component."
 	attributes: {
 		podDisruptive: false
+		status: {
+			customStatus: #"""
+				message: *"" | string
+				service: context.outputs.service
+				if service.spec.type == "ClusterIP" {
+					message: "ClusterIP: \(service.spec.clusterIP)"
+				}
+				if service.spec.type == "LoadBalancer" {
+					status: service.status
+					isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+					if !isHealth {
+						message: "ExternalIP: Pending"
+					}
+					if isHealth {
+						message: "ExternalIP: \(status.loadBalancer.ingress[0].ip)"
+					}
+				}
+				"""#
+			healthPolicy: #"""
+				isHealth: *true | bool
+				service: context.outputs.service
+				if service.spec.type == "LoadBalancer" {
+					status: service.status
+					isHealth: status != _|_ && status.loadBalancer != _|_ && status.loadBalancer.ingress != _|_ && len(status.loadBalancer.ingress) > 0
+				}
+				"""#
+		}
 	}
 }
 template: {
 	outputs: service: {
 		apiVersion: "v1"
 		kind:       "Service"
-		metadata: name: context.name
+		metadata: name:        context.name
+		metadata: annotations: parameter.annotations
 		spec: {
 			selector: "app.oam.dev/component": context.name
 			ports: [
 				for p in parameter.port {
+					name:       "port-" + strconv.FormatInt(p, 10)
 					port:       p
 					targetPort: p
 				},
@@ -28,6 +61,8 @@ template: {
 	parameter: {
 		// +usage=Specify the exposion ports
 		port: [...int]
+		// +usage=Specify the annotaions of the exposed service
+		annotations: [string]: string
 		// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
 		type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
 	}


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add status check for expose trait.

If the expose service is LoadBalancer, the health check will wait the ingress ip to be available.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->