### PR TITLE
Feat: optimize the dry run feature

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -690,8 +690,8 @@
 				"tags": [
 					"application"
 				],
-				"summary": "compare application with env latest revision",
-				"operationId": "compareAppWithLatestRevision",
+				"summary": "compare application",
+				"operationId": "compareApp",
 				"parameters": [
 					{
 						"name": "body",
@@ -2792,6 +2792,40 @@
 						"schema": {
 							"$ref": "#/definitions/bcode.Bcode"
 						}
+					}
+				}
+			}
+		},
+		"/api/v1/cloudshell": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"cloudshell"
+				],
+				"summary": "prepare the user's cloud shell environment",
+				"operationId": "prepareCloudShell",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.SimpleResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
 					}
 				}
 			}
@@ -5957,6 +5991,74 @@
 					}
 				}
 			}
+		},
+		"/view/cloudshell": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"cloudshell"
+				],
+				"summary": "prepare the user's cloud shell environment",
+				"operationId": "proxy",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.SimpleResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/view/cloudshell/{subpath}": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"cloudshell"
+				],
+				"summary": "prepare the user's cloud shell environment",
+				"operationId": "proxy",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.SimpleResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
 		}
 	},
 	"definitions": {
@@ -7794,12 +7896,15 @@
 			"type": "object"
 		},
 		"v1.AppCompareReq": {
-			"required": [
-				"env"
-			],
 			"properties": {
-				"env": {
-					"type": "string"
+				"compareLatestWithRunning": {
+					"$ref": "#/definitions/v1.CompareLatestWithRunningOption"
+				},
+				"compareRevisionWithLatest": {
+					"$ref": "#/definitions/v1.CompareRevisionWithLatestOption"
+				},
+				"compareRevisionWithRunning": {
+					"$ref": "#/definitions/v1.CompareRevisionWithRunningOption"
 				}
 			}
 		},
@@ -7807,35 +7912,32 @@
 			"required": [
 				"isDiff",
 				"diffReport",
-				"newAppYAML",
-				"oldAppYAML"
+				"baseAppYAML",
+				"targetAppYAML"
 			],
 			"properties": {
+				"baseAppYAML": {
+					"type": "string"
+				},
 				"diffReport": {
 					"type": "string"
 				},
 				"isDiff": {
 					"type": "boolean"
 				},
-				"newAppYAML": {
-					"type": "string"
-				},
-				"oldAppYAML": {
+				"targetAppYAML": {
 					"type": "string"
 				}
 			}
 		},
 		"v1.AppDryRunReq": {
 			"required": [
-				"appName",
 				"dryRunType",
 				"env",
+				"workflow",
 				"version"
 			],
 			"properties": {
-				"appName": {
-					"type": "string"
-				},
 				"dryRunType": {
 					"type": "string"
 				},
@@ -7844,14 +7946,24 @@
 				},
 				"version": {
 					"type": "string"
+				},
+				"workflow": {
+					"type": "string"
 				}
 			}
 		},
 		"v1.AppDryRunResponse": {
 			"required": [
-				"yaml"
+				"yaml",
+				"success"
 			],
 			"properties": {
+				"message": {
+					"type": "string"
+				},
+				"success": {
+					"type": "boolean"
+				},
 				"yaml": {
 					"type": "string"
 				}
@@ -7943,11 +8055,11 @@
 		"v1.ApplicationDeployResponse": {
 			"required": [
 				"version",
-				"note",
-				"triggerType",
-				"createTime",
 				"status",
-				"envName"
+				"envName",
+				"createTime",
+				"note",
+				"triggerType"
 			],
 			"properties": {
 				"codeInfo": {
@@ -8263,6 +8375,20 @@
 				}
 			}
 		},
+		"v1.CloudShellPrepareResponse": {
+			"required": [
+				"status",
+				"message"
+			],
+			"properties": {
+				"message": {
+					"type": "string"
+				},
+				"status": {
+					"type": "string"
+				}
+			}
+		},
 		"v1.ClusterBase": {
 			"required": [
 				"name",
@@ -8377,6 +8503,30 @@
 					"type": "string"
 				},
 				"namespace": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.CompareLatestWithRunningOption": {
+			"required": [
+				"env"
+			],
+			"properties": {
+				"env": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.CompareRevisionWithLatestOption": {
+			"properties": {
+				"revision": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.CompareRevisionWithRunningOption": {
+			"properties": {
+				"revision": {
 					"type": "string"
 				}
 			}
@@ -9044,6 +9194,9 @@
 				"alias": {
 					"type": "string"
 				},
+				"allowTargetConflict": {
+					"type": "boolean"
+				},
 				"description": {
 					"type": "string"
 				},
@@ -9249,7 +9402,8 @@
 				"description",
 				"icon",
 				"status",
-				"labels"
+				"labels",
+				"ownerAddon"
 			],
 			"properties": {
 				"alias": {
@@ -9271,6 +9425,9 @@
 					}
 				},
 				"name": {
+					"type": "string"
+				},
+				"ownerAddon": {
 					"type": "string"
 				},
 				"policy": {
@@ -9329,11 +9486,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"description",
-				"invisible",
-				"version",
 				"icon",
 				"name",
+				"version",
+				"invisible",
+				"description",
 				"schema",
 				"uiSchema",
 				"definitions",
@@ -9413,13 +9570,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"icon",
+				"name",
 				"alias",
-				"project",
 				"description",
+				"icon",
+				"project",
 				"createTime",
 				"updateTime",
-				"name",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -9476,20 +9633,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
-				"reason",
-				"dashboardURL",
-				"labels",
-				"apiServerURL",
-				"kubeConfig",
-				"kubeConfigSecret",
 				"name",
+				"status",
+				"dashboardURL",
+				"createTime",
+				"kubeConfig",
+				"labels",
+				"provider",
+				"apiServerURL",
+				"description",
 				"alias",
 				"icon",
-				"status",
-				"description",
-				"provider",
+				"reason",
+				"kubeConfigSecret",
+				"updateTime",
 				"resourceInfo"
 			],
 			"properties": {
@@ -9547,14 +9704,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"type",
-				"createTime",
-				"name",
-				"updateTime",
-				"alias",
-				"creator",
-				"main",
 				"appPrimaryKey",
+				"creator",
+				"alias",
+				"name",
+				"main",
+				"createTime",
+				"updateTime",
+				"type",
 				"definition"
 			],
 			"properties": {
@@ -9642,12 +9799,13 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
+				"ownerAddon",
 				"name",
-				"status",
-				"labels",
-				"alias",
 				"description",
+				"status",
+				"alias",
 				"icon",
+				"labels",
 				"schema",
 				"uiSchema"
 			],
@@ -9671,6 +9829,9 @@
 					}
 				},
 				"name": {
+					"type": "string"
+				},
+				"ownerAddon": {
 					"type": "string"
 				},
 				"policy": {
@@ -9701,14 +9862,14 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"updateTime",
-				"envName",
-				"name",
 				"type",
 				"description",
 				"creator",
 				"properties",
-				"createTime"
+				"createTime",
+				"updateTime",
+				"envName",
+				"name"
 			],
 			"properties": {
 				"createTime": {
@@ -9741,17 +9902,17 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"version",
-				"envName",
-				"createTime",
-				"appPrimaryKey",
-				"reason",
-				"deployUser",
 				"workflowName",
-				"updateTime",
-				"triggerType",
+				"envName",
 				"status",
-				"note"
+				"deployUser",
+				"triggerType",
+				"updateTime",
+				"appPrimaryKey",
+				"version",
+				"createTime",
+				"note",
+				"reason"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -9805,10 +9966,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"project",
-				"createTime",
 				"updateTime",
-				"name"
+				"name",
+				"createTime",
+				"project"
 			],
 			"properties": {
 				"alias": {
@@ -9848,11 +10009,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
+				"disabled",
 				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
-				"disabled",
 				"projects",
 				"roles"
 			],
@@ -9893,12 +10054,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"namespace",
-				"workflowName",
-				"workflowAlias",
 				"applicationRevision",
 				"status",
 				"name",
+				"namespace",
+				"workflowName",
+				"workflowAlias",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -9950,14 +10111,14 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
-				"name",
-				"description",
-				"envName",
 				"alias",
 				"enable",
-				"default"
+				"envName",
+				"updateTime",
+				"name",
+				"default",
+				"createTime",
+				"description"
 			],
 			"properties": {
 				"alias": {
@@ -10662,11 +10823,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"email",
-				"disabled",
 				"createTime",
 				"lastLoginTime",
 				"name",
+				"email",
+				"disabled",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -679,6 +679,7 @@ spec:
         - containerPort: 80
 
 ---
+## From the trait test-ingress 
 apiVersion: v1
 kind: Service
 metadata:
@@ -701,6 +702,7 @@ spec:
     app.oam.dev/component: express-server
 
 ---
+## From the trait test-ingress 
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -1522,7 +1522,7 @@ func (c *applicationServiceImpl) DryRunAppOrRevision(ctx context.Context, appMod
 		if err != nil {
 			return nil, err
 		}
-	case "Revision":
+	case "REVISION":
 		app, _, err = c.getAppModelFromRevision(ctx, appModel.Name, dryRunReq.Version)
 		if err != nil {
 			return nil, err

--- a/pkg/apiserver/domain/service/application_test.go
+++ b/pkg/apiserver/domain/service/application_test.go
@@ -652,7 +652,7 @@ var _ = Describe("Test application service function", func() {
 	It("Test DryRun with env revision function", func() {
 		appModel, err := appService.GetApplication(context.TODO(), testApp)
 		Expect(err).Should(BeNil())
-		resetResponse, err := appService.DryRunAppOrRevision(context.TODO(), appModel, v1.AppDryRunReq{DryRunType: "Revision", Env: "app-dev"})
+		resetResponse, err := appService.DryRunAppOrRevision(context.TODO(), appModel, v1.AppDryRunReq{DryRunType: "REVISION", Env: "app-dev"})
 		Expect(err).Should(BeNil())
 		Expect(strings.Contains(resetResponse.YAML, "# Application(test-app)")).Should(BeTrue())
 		Expect(strings.Contains(resetResponse.YAML, "# Application(test-app) -- Component(component-name)")).Should(BeTrue())
@@ -661,7 +661,7 @@ var _ = Describe("Test application service function", func() {
 	It("Test DryRun with last revision function", func() {
 		appModel, err := appService.GetApplication(context.TODO(), testApp)
 		Expect(err).Should(BeNil())
-		resetResponse, err := appService.DryRunAppOrRevision(context.TODO(), appModel, v1.AppDryRunReq{DryRunType: "Revision"})
+		resetResponse, err := appService.DryRunAppOrRevision(context.TODO(), appModel, v1.AppDryRunReq{DryRunType: "REVISION"})
 		Expect(err).Should(BeNil())
 		Expect(strings.Contains(resetResponse.YAML, "# Application(test-app)")).Should(BeTrue())
 		Expect(strings.Contains(resetResponse.YAML, "# Application(test-app) -- Component(component-name)")).Should(BeTrue())

--- a/pkg/apiserver/interfaces/api/application.go
+++ b/pkg/apiserver/interfaces/api/application.go
@@ -1234,10 +1234,6 @@ func (c *applicationAPIInterface) dryRunAppOrRevision(req *restful.Request, res 
 		bcode.ReturnError(req, res, err)
 		return
 	}
-	if dryRunReq.AppName == "" {
-		dryRunReq.AppName = app.Name
-	}
-
 	base, err := c.ApplicationService.DryRunAppOrRevision(req.Request.Context(), app, dryRunReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -399,7 +399,7 @@ type CompareLatestWithRunningOption struct {
 
 // AppDryRunReq application dry-run req
 type AppDryRunReq struct {
-	DryRunType string `json:"dryRunType" validate:"oneof=APP Revision"`
+	DryRunType string `json:"dryRunType" validate:"oneof=APP REVISION"`
 	Env        string `json:"env"`
 	Workflow   string `json:"workflow"`
 	Version    string `json:"version"`

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -399,8 +399,7 @@ type CompareLatestWithRunningOption struct {
 
 // AppDryRunReq application dry-run req
 type AppDryRunReq struct {
-	AppName    string `json:"appName"`
-	DryRunType string `json:"dryRunType"`
+	DryRunType string `json:"dryRunType" validate:"oneof=APP Revision"`
 	Env        string `json:"env"`
 	Workflow   string `json:"workflow"`
 	Version    string `json:"version"`
@@ -408,7 +407,9 @@ type AppDryRunReq struct {
 
 // AppDryRunResponse application dry-run result
 type AppDryRunResponse struct {
-	YAML string `json:"yaml"`
+	YAML    string `json:"yaml"`
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
 }
 
 // ApplicationStatusResponse application status response body

--- a/pkg/apiserver/utils/bcode/001_application.go
+++ b/pkg/apiserver/utils/bcode/001_application.go
@@ -94,5 +94,8 @@ var ErrApplicationTriggerNotExist = NewBcode(404, 10024, "application trigger is
 // ErrApplicationComponentNotAllowDelete means the component is main in one application, and it must be deleted before delete app.
 var ErrApplicationComponentNotAllowDelete = NewBcode(400, 10025, "main component in application can not be deleted")
 
-// ErrApplicationPolicyIsBeingUsed means this policy is been used, cannot  deleted.
-var ErrApplicationPolicyIsBeingUsed = NewBcode(400, 10026, "the policy  is being used by workflow, cannot be deleted")
+// ErrApplicationPolicyIsBeingUsed means this policy is been used, cannot deleted.
+var ErrApplicationPolicyIsBeingUsed = NewBcode(400, 10026, "the policy is being used by workflow, cannot be deleted")
+
+// ErrApplicationDryRunFailed means the application configuration does not dry run successfully
+var ErrApplicationDryRunFailed = NewBcode(400, 10026, "The application dry run failed")

--- a/pkg/apiserver/utils/bcode/001_application.go
+++ b/pkg/apiserver/utils/bcode/001_application.go
@@ -98,4 +98,4 @@ var ErrApplicationComponentNotAllowDelete = NewBcode(400, 10025, "main component
 var ErrApplicationPolicyIsBeingUsed = NewBcode(400, 10026, "the policy is being used by workflow, cannot be deleted")
 
 // ErrApplicationDryRunFailed means the application configuration does not dry run successfully
-var ErrApplicationDryRunFailed = NewBcode(400, 10026, "The application dry run failed")
+var ErrApplicationDryRunFailed = NewBcode(400, 10027, "The application dry run failed")

--- a/pkg/appfile/dryrun/diff.go
+++ b/pkg/appfile/dryrun/diff.go
@@ -41,7 +41,7 @@ import (
 // NewLiveDiffOption creates a live-diff option
 func NewLiveDiffOption(c client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover, as []oam.Object) *LiveDiffOption {
 	parser := appfile.NewApplicationParser(c, dm, pd)
-	return &LiveDiffOption{DryRun: NewDryRunOption(c, cfg, dm, pd, as), Parser: parser}
+	return &LiveDiffOption{DryRun: NewDryRunOption(c, cfg, dm, pd, as, false), Parser: parser}
 }
 
 // ManifestKind enums the kind of OAM objects

--- a/pkg/appfile/dryrun/diff_test.go
+++ b/pkg/appfile/dryrun/diff_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Test Live-Diff", func() {
 
 	It("Test renderless diff", func() {
 		liveDiffOpt := LiveDiffOption{
-			DryRun: NewDryRunOption(k8sClient, cfg, dm, pd, nil),
+			DryRun: NewDryRunOption(k8sClient, cfg, dm, pd, nil, false),
 			Parser: appfile.NewApplicationParser(k8sClient, dm, pd),
 		}
 		applyFile := func(filename string, ns string) {

--- a/pkg/appfile/dryrun/dryrun.go
+++ b/pkg/appfile/dryrun/dryrun.go
@@ -38,10 +38,12 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/appfile"
+	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils/apply"
 )
 
 // DryRun executes dry-run on an application
@@ -50,8 +52,8 @@ type DryRun interface {
 }
 
 // NewDryRunOption creates a dry-run option
-func NewDryRunOption(c client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover, as []oam.Object) *Option {
-	return &Option{c, dm, pd, cfg, as}
+func NewDryRunOption(c client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover, as []oam.Object, dryRunInServer bool) *Option {
+	return &Option{c, dm, pd, cfg, as, dryRunInServer}
 }
 
 // Option contains options to execute dry-run
@@ -65,6 +67,9 @@ type Option struct {
 	// DryRun will use capabilities in Auxiliaries as higher priority than
 	// getting one from cluster.
 	Auxiliaries []oam.Object
+
+	// dryRunInServer If set to true, means will dry run via the apiserver.
+	dryRunInServer bool
 }
 
 // validateObjectFromFile will read file into Unstructured object
@@ -122,7 +127,8 @@ func (d *Option) ValidateApp(ctx context.Context, filename string) error {
 
 // ExecuteDryRun simulates applying an application into cluster and returns rendered
 // resources but not persist them into cluster.
-func (d *Option) ExecuteDryRun(ctx context.Context, app *v1beta1.Application) ([]*types.ComponentManifest, []*unstructured.Unstructured, error) {
+func (d *Option) ExecuteDryRun(ctx context.Context, application *v1beta1.Application) ([]*types.ComponentManifest, []*unstructured.Unstructured, error) {
+	app := application.DeepCopy()
 	parser := appfile.NewDryRunApplicationParser(d.Client, d.DiscoveryMapper, d.PackageDiscover, d.Auxiliaries)
 	if app.Namespace != "" {
 		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
@@ -138,11 +144,17 @@ func (d *Option) ExecuteDryRun(ctx context.Context, app *v1beta1.Application) ([
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "cannot generate manifests from components and traits")
 	}
-	objs, err := appFile.GeneratePolicyManifests(ctx)
+	policyManifests, err := appFile.GeneratePolicyManifests(ctx)
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "cannot generate manifests from policies")
 	}
-	return comps, objs, nil
+	if d.dryRunInServer {
+		applyUtil := apply.NewAPIApplicator(d.Client)
+		if err := applyUtil.Apply(ctx, app, apply.DryRunAll()); err != nil {
+			return nil, nil, err
+		}
+	}
+	return comps, policyManifests, nil
 }
 
 // PrintDryRun will print the result of dry-run
@@ -162,6 +174,13 @@ func (d *Option) PrintDryRun(buff *bytes.Buffer, appName string, comps []*types.
 		buff.Write(result)
 		buff.WriteString("\n---\n")
 		for _, t := range c.Traits {
+			traitType := t.GetLabels()[oam.TraitTypeLabel]
+			switch {
+			case traitType == definition.AuxiliaryWorkload:
+				buff.WriteString("## From the auxiliary workload \n")
+			case traitType != "":
+				buff.WriteString(fmt.Sprintf("## From the trait %s \n", traitType))
+			}
 			result, err := yaml.Marshal(t)
 			if err != nil {
 				return errors.New("marshal result for Component " + c.Name + " trait " + t.GetName() + " object in yaml format")

--- a/pkg/appfile/dryrun/dryrun.go
+++ b/pkg/appfile/dryrun/dryrun.go
@@ -52,8 +52,8 @@ type DryRun interface {
 }
 
 // NewDryRunOption creates a dry-run option
-func NewDryRunOption(c client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover, as []oam.Object, dryRunInServer bool) *Option {
-	return &Option{c, dm, pd, cfg, as, dryRunInServer}
+func NewDryRunOption(c client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover, as []oam.Object, serverSideDryRun bool) *Option {
+	return &Option{c, dm, pd, cfg, as, serverSideDryRun}
 }
 
 // Option contains options to execute dry-run
@@ -68,8 +68,8 @@ type Option struct {
 	// getting one from cluster.
 	Auxiliaries []oam.Object
 
-	// dryRunInServer If set to true, means will dry run via the apiserver.
-	dryRunInServer bool
+	// serverSideDryRun If set to true, means will dry run via the apiserver.
+	serverSideDryRun bool
 }
 
 // validateObjectFromFile will read file into Unstructured object
@@ -148,7 +148,7 @@ func (d *Option) ExecuteDryRun(ctx context.Context, application *v1beta1.Applica
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "cannot generate manifests from policies")
 	}
-	if d.dryRunInServer {
+	if d.serverSideDryRun {
 		applyUtil := apply.NewAPIApplicator(d.Client)
 		if err := applyUtil.Apply(ctx, app, apply.DryRunAll()); err != nil {
 			return nil, nil, err

--- a/pkg/appfile/dryrun/suit_test.go
+++ b/pkg/appfile/dryrun/suit_test.go
@@ -107,7 +107,7 @@ var _ = BeforeSuite(func(done Done) {
 	tdMyScaler, err := oamutil.Object2Unstructured(myscalerDef)
 	Expect(err).Should(BeNil())
 
-	dryrunOpt = NewDryRunOption(k8sClient, cfg, dm, pd, []oam.Object{cdMyWorker, tdMyIngress, tdMyScaler})
+	dryrunOpt = NewDryRunOption(k8sClient, cfg, dm, pd, []oam.Object{cdMyWorker, tdMyIngress, tdMyScaler}, false)
 	diffOpt = &LiveDiffOption{DryRun: dryrunOpt, Parser: appfile.NewApplicationParser(k8sClient, dm, pd)}
 
 	close(done)

--- a/references/cli/debug.go
+++ b/references/cli/debug.go
@@ -132,7 +132,7 @@ func (d *debugOpts) debugApplication(ctx context.Context, c common.Args, app *v1
 		if err != nil {
 			return err
 		}
-		dryRunOpt := dryrun.NewDryRunOption(cli, config, dm, pd, []oam.Object{})
+		dryRunOpt := dryrun.NewDryRunOption(cli, config, dm, pd, []oam.Object{}, false)
 		comps, _, err := dryRunOpt.ExecuteDryRun(ctx, app)
 		if err != nil {
 			ioStreams.Info(color.RedString("%s%s", emojiFail, err.Error()))

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -133,7 +133,7 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 		return buff, err
 	}
 
-	dryRunOpt := dryrun.NewDryRunOption(newClient, config, dm, pd, objs)
+	dryRunOpt := dryrun.NewDryRunOption(newClient, config, dm, pd, objs, false)
 	ctx := oamutil.SetNamespaceInCtx(context.Background(), namespace)
 
 	// Perform validation only if not in offline mode

--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Test dry run with policy", func() {
 		dm, err := discoverymapper.New(cfg)
 		Expect(err).Should(BeNil())
 
-		dryRunOpt := dryrun.NewDryRunOption(k8sClient, cfg, dm, pd, nil)
+		dryRunOpt := dryrun.NewDryRunOption(k8sClient, cfg, dm, pd, nil, false)
 
 		comps, plcs, err := dryRunOpt.ExecuteDryRun(context.TODO(), &app)
 		Expect(err).Should(BeNil())


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

1. Support to dry run the application on the server-side.
2. Optimize the dry run API.
3. Optimize the dry run report.

Refer to: kubevela/velaux#577

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.