### PR TITLE
Feat: add pending phase in workflow step

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -420,6 +420,8 @@ const (
 	WorkflowStepPhaseStopped WorkflowStepPhase = "stopped"
 	// WorkflowStepPhaseRunning will make the controller continue the workflow.
 	WorkflowStepPhaseRunning WorkflowStepPhase = "running"
+	// WorkflowStepPhasePending will make the controller wait for the step to run.
+	WorkflowStepPhasePending WorkflowStepPhase = "pending"
 )
 
 // DefinitionType describes the type of DefinitionRevision.

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -2659,8 +2659,8 @@ var _ = Describe("Test Application Controller", func() {
 
 		checkApp := &v1beta1.Application{}
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
-		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhasePending))
-		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
+		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhasePending))
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
 	})
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -2399,6 +2399,271 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationWorkflowTerminated))
 	})
 
+	It("application with skip outputs in workflow", func() {
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-skip-output",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-skip-output"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-skip-output",
+				Namespace: "app-with-skip-output",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name: "myweb1",
+							Type: "apply-component",
+							If:   "false",
+							Outputs: common.StepOutputs{
+								{
+									Name:      "output",
+									ValueFrom: "context.name",
+								},
+							},
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name: "myweb2",
+							Inputs: common.StepInputs{
+								{
+									From:         "output",
+									ParameterKey: "",
+								},
+							},
+							If:         `inputs.output == "app-with-timeout-output"`,
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(util.NotFoundMatcher{})
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseSkipped))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseSkipped))
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunning))
+	})
+
+	It("application with invalid inputs in workflow", func() {
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-invalid-input",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-invalid-input"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-invalid-input",
+				Namespace: "app-with-invalid-input",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name: "myweb1",
+							Type: "apply-component",
+							Outputs: common.StepOutputs{
+								{
+									Name:      "output",
+									ValueFrom: "context.name",
+								},
+							},
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name: "myweb2",
+							Inputs: common.StepInputs{
+								{
+									From:         "invalid",
+									ParameterKey: "",
+								},
+							},
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+		expDeployment.Status.Replicas = 1
+		expDeployment.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, expDeployment)).Should(BeNil())
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseSucceeded))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhasePending))
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
+	})
+
+	It("application with invalid inputs in workflow in dag mode", func() {
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-invalid-input-dag",
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		healthComponentDef := &v1beta1.ComponentDefinition{}
+		hCDefJson, _ := yaml.YAMLToJSON([]byte(cdDefWithHealthStatusYaml))
+		Expect(json.Unmarshal(hCDefJson, healthComponentDef)).Should(BeNil())
+		healthComponentDef.Name = "worker-with-health"
+		healthComponentDef.Namespace = "app-with-invalid-input-dag"
+		Expect(k8sClient.Create(ctx, healthComponentDef)).Should(BeNil())
+		app := &v1beta1.Application{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Application",
+				APIVersion: "core.oam.dev/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-with-invalid-input-dag",
+				Namespace: "app-with-invalid-input-dag",
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name:       "myweb1",
+						Type:       "worker-with-health",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","lives": "i am lives","enemies": "empty"}`)},
+					},
+					{
+						Name:       "myweb2",
+						Type:       "worker",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox"}`)},
+					},
+				},
+				Workflow: &v1beta1.Workflow{
+					Mode: &v1beta1.WorkflowExecuteMode{
+						Steps: common.WorkflowModeDAG,
+					},
+					Steps: []v1beta1.WorkflowStep{
+						{
+							Name: "myweb1",
+							Type: "apply-component",
+							Outputs: common.StepOutputs{
+								{
+									Name:      "output",
+									ValueFrom: "context.name",
+								},
+							},
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb1"}`)},
+						},
+						{
+							Name: "myweb2",
+							Inputs: common.StepInputs{
+								{
+									From:         "invalid",
+									ParameterKey: "",
+								},
+							},
+							Type:       "apply-component",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"component":"myweb2"}`)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), app)).Should(BeNil())
+		appKey := types.NamespacedName{Namespace: ns.Name, Name: app.Name}
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+		testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		expDeployment := &v1.Deployment{}
+		web1Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb1"}
+		Expect(k8sClient.Get(ctx, web1Key, expDeployment)).Should(BeNil())
+		web2Key := types.NamespacedName{Namespace: ns.Name, Name: "myweb2"}
+		Expect(k8sClient.Get(ctx, web2Key, expDeployment)).Should(util.NotFoundMatcher{})
+
+		checkApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+		Expect(checkApp.Status.Workflow.Steps[0].Phase).Should(BeEquivalentTo(common.WorkflowStepPhasePending))
+		Expect(checkApp.Status.Workflow.Steps[1].Phase).Should(BeEquivalentTo(common.WorkflowStepPhaseRunning))
+		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
+	})
+
 	It("application with if always in workflow", func() {
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Test Workflow", func() {
 		Expect(checkCM.Data["lives"]).Should(BeEquivalentTo("hello,i am lives"))
 	})
 
-	FIt("test application with depends on and workflow", func() {
+	It("test application with depends on and workflow", func() {
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "app-with-dependson-workflow",

--- a/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/workflow_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Test Workflow", func() {
 		Expect(checkCM.Data["lives"]).Should(BeEquivalentTo("hello,i am lives"))
 	})
 
-	It("test application with depends on and workflow", func() {
+	FIt("test application with depends on and workflow", func() {
 		ns := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "app-with-dependson-workflow",

--- a/pkg/monitor/watcher/application.go
+++ b/pkg/monitor/watcher/application.go
@@ -77,7 +77,7 @@ func (watcher *applicationMetricsWatcher) report() {
 		metrics.ApplicationPhaseCounter.WithLabelValues(phase).Set(float64(watcher.phaseCounter[phase]))
 	}
 	for stepPhase := range watcher.stepPhaseDirty {
-		metrics.WorkflowStepPhaseGauge.WithLabelValues(strings.Split(stepPhase, "/")...).Set(float64(watcher.stepPhaseCounter[stepPhase]))
+		metrics.WorkflowStepPhaseGauge.WithLabelValues(strings.Split(stepPhase, "/")[:2]...).Set(float64(watcher.stepPhaseCounter[stepPhase]))
 	}
 	watcher.phaseDirty = map[string]struct{}{}
 	watcher.stepPhaseDirty = map[string]struct{}{}

--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -78,7 +78,8 @@ func SetAdditionalNameInStatus(stepStatus map[string]common.StepStatus, name str
 		return
 	}
 	o := struct {
-		Name string `json:"name"`
+		Name      string `json:"name"`
+		Component string `json:"component"`
 	}{}
 	js, err := properties.MarshalJSON()
 	if err != nil {
@@ -87,7 +88,17 @@ func SetAdditionalNameInStatus(stepStatus map[string]common.StepStatus, name str
 	if err := json.Unmarshal(js, &o); err != nil {
 		return
 	}
-	if _, ok := stepStatus[o.Name]; !ok {
-		stepStatus[o.Name] = status
+	additionalName := ""
+	switch {
+	case o.Name != "":
+		additionalName = o.Name
+	case o.Component != "":
+		additionalName = o.Component
+	default:
+		return
+	}
+	if _, ok := stepStatus[additionalName]; !ok {
+		stepStatus[additionalName] = status
+		return
 	}
 }

--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -72,6 +72,7 @@ func Output(ctx wfContext.Context, taskValue *value.Value, step v1beta1.Workflow
 	return nil
 }
 
+// SetAdditionalNameInStatus sets additional name from properties to status map
 func SetAdditionalNameInStatus(stepStatus map[string]common.StepStatus, name string, properties *runtime.RawExtension, status common.StepStatus) {
 	if stepStatus == nil || properties == nil {
 		return
@@ -89,5 +90,4 @@ func SetAdditionalNameInStatus(stepStatus map[string]common.StepStatus, name str
 	if _, ok := stepStatus[o.Name]; !ok {
 		stepStatus[o.Name] = status
 	}
-	return
 }

--- a/pkg/workflow/hooks/data_passing_test.go
+++ b/pkg/workflow/hooks/data_passing_test.go
@@ -66,6 +66,7 @@ func TestOutput(t *testing.T) {
 output: score: 99 
 `, nil, "")
 	r.NoError(err)
+	stepStatus := make(map[string]common.StepStatus)
 	err = Output(wfCtx, taskValue, v1beta1.WorkflowStep{
 		Properties: &runtime.RawExtension{
 			Raw: []byte("{\"name\":\"mystep\"}"),
@@ -76,7 +77,7 @@ output: score: 99
 		}},
 	}, common.StepStatus{
 		Phase: common.WorkflowStepPhaseSucceeded,
-	})
+	}, stepStatus)
 	r.NoError(err)
 	result, err := wfCtx.GetVar("myscore")
 	r.NoError(err)
@@ -84,6 +85,7 @@ output: score: 99
 	r.NoError(err)
 	r.Equal(s, `99
 `)
+	r.Equal(stepStatus["mystep"].Phase, common.WorkflowStepPhaseSucceeded)
 }
 
 func mockContext(t *testing.T) wfContext.Context {

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -145,20 +145,18 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 			var paramFile string
 
 			defer func() {
-				if len(wfStep.Outputs) > 0 {
-					if taskv == nil {
-						taskv, err = convertTemplate(ctx, t.pd, strings.Join([]string{templ, paramFile}, "\n"), exec.wfStatus.ID, options.PCtx)
-						if err != nil {
-							return
-						}
+				if taskv == nil {
+					taskv, err = convertTemplate(ctx, t.pd, strings.Join([]string{templ, paramFile}, "\n"), exec.wfStatus.ID, options.PCtx)
+					if err != nil {
+						return
 					}
-					for _, hook := range options.PostStopHooks {
-						if err := hook(ctx, taskv, wfStep, exec.status()); err != nil {
-							exec.wfStatus.Message = err.Error()
-							stepStatus = exec.status()
-							operations = exec.operation()
-							return
-						}
+				}
+				for _, hook := range options.PostStopHooks {
+					if err := hook(ctx, taskv, wfStep, exec.status(), options.StepStatus); err != nil {
+						exec.wfStatus.Message = err.Error()
+						stepStatus = exec.status()
+						operations = exec.operation()
+						return
 					}
 				}
 			}()

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -63,7 +63,7 @@ func (t *TaskLoader) GetTaskGenerator(ctx context.Context, name string) (wfTypes
 type taskRunner struct {
 	name         string
 	run          func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error)
-	checkPending func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
+	checkPending func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus)
 }
 
 // Name return step name.
@@ -77,7 +77,7 @@ func (tr *taskRunner) Run(ctx wfContext.Context, options *wfTypes.TaskRunOptions
 }
 
 // Pending check task should be executed or not.
-func (tr *taskRunner) Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool {
+func (tr *taskRunner) Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus) {
 	return tr.checkPending(ctx, stepStatus)
 }
 
@@ -120,10 +120,10 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 
 		tRunner := new(taskRunner)
 		tRunner.name = wfStep.Name
-		tRunner.checkPending = func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool {
-			return CheckPending(ctx, wfStep, stepStatus)
+		tRunner.checkPending = func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus) {
+			return CheckPending(ctx, wfStep, exec.wfStatus.ID, stepStatus)
 		}
-		tRunner.run = func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error) {
+		tRunner.run = func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (stepStatus common.StepStatus, operations *wfTypes.Operation, rErr error) {
 			if options.GetTracer == nil {
 				options.GetTracer = func(id string, step v1beta1.WorkflowStep) monitorContext.Context {
 					return monitorContext.NewTraceContext(context.Background(), "")
@@ -139,9 +139,29 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 				t.runOptionsProcess(options)
 			}
 
+			exec.wfStatus.Message = ""
 			var taskv *value.Value
 			var err error
 			var paramFile string
+
+			defer func() {
+				if len(wfStep.Outputs) > 0 {
+					if taskv == nil {
+						taskv, err = convertTemplate(ctx, t.pd, strings.Join([]string{templ, paramFile}, "\n"), exec.wfStatus.ID, options.PCtx)
+						if err != nil {
+							return
+						}
+					}
+					for _, hook := range options.PostStopHooks {
+						if err := hook(ctx, taskv, wfStep, exec.status()); err != nil {
+							exec.wfStatus.Message = err.Error()
+							stepStatus = exec.status()
+							operations = exec.operation()
+							return
+						}
+					}
+				}
+			}()
 
 			for _, hook := range options.PreCheckHooks {
 				result, err := hook(wfStep, &wfTypes.PreCheckOptions{
@@ -211,12 +231,6 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 				tracer.Error(err, "do steps")
 				exec.err(ctx, true, err, wfTypes.StatusReasonExecute)
 				return exec.status(), exec.operation(), nil
-			}
-			for _, hook := range options.PostStopHooks {
-				if err := hook(ctx, taskv, wfStep, exec.status()); err != nil {
-					exec.err(ctx, false, err, wfTypes.StatusReasonOutput)
-					return exec.status(), exec.operation(), nil
-				}
 			}
 
 			return exec.status(), exec.operation(), nil
@@ -552,20 +566,28 @@ func NewTaskLoader(lt LoadTaskTemplate, pkgDiscover *packages.PackageDiscover, h
 }
 
 // CheckPending checks whether to pending task run
-func CheckPending(ctx wfContext.Context, step v1beta1.WorkflowStep, stepStatus map[string]common.StepStatus) bool {
+func CheckPending(ctx wfContext.Context, step v1beta1.WorkflowStep, id string, stepStatus map[string]common.StepStatus) (bool, common.StepStatus) {
+	pStatus := common.StepStatus{
+		Phase: common.WorkflowStepPhasePending,
+		Type:  step.Type,
+		ID:    id,
+		Name:  step.Name,
+	}
 	for _, depend := range step.DependsOn {
+		pStatus.Message = fmt.Sprintf("Pending on DependsOn: %s", depend)
 		if status, ok := stepStatus[depend]; ok {
 			if !wfTypes.IsStepFinish(status.Phase, status.Reason) {
-				return true
+				return true, pStatus
 			}
 		} else {
-			return true
+			return true, pStatus
 		}
 	}
 	for _, input := range step.Inputs {
+		pStatus.Message = fmt.Sprintf("Pending on Input: %s", input.From)
 		if _, err := ctx.GetVar(strings.Split(input.From, ".")...); err != nil {
-			return true
+			return true, pStatus
 		}
 	}
-	return false
+	return false, common.StepStatus{}
 }

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -504,7 +504,8 @@ func TestSkip(t *testing.T) {
 	r.NoError(err)
 	runner, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	status, operations, err := runner.Run(nil, &types.TaskRunOptions{
+	wfCtx := newWorkflowContextForTest(t)
+	status, operations, err := runner.Run(wfCtx, &types.TaskRunOptions{
 		PreCheckHooks: []types.TaskPreCheckHook{
 			func(step v1beta1.WorkflowStep, options *types.PreCheckOptions) (*types.PreCheckResult, error) {
 				return &types.PreCheckResult{Skip: true}, nil

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -246,9 +246,9 @@ close({
 		case "input":
 			r.Equal(err.Error(), "do preStartHook: get input from [podIP]: var(path=podIP) not exist")
 		case "output-var-conflict":
-			r.Equal(status.Reason, types.StatusReasonOutput)
+			r.Contains(status.Message, "conflict")
 			r.Equal(operation.Waiting, false)
-			r.Equal(status.Phase, common.WorkflowStepPhaseFailed)
+			r.Equal(status.Phase, common.WorkflowStepPhaseSucceeded)
 		case "failed-after-retries":
 			wfContext.CleanupMemoryStore("app-v1", "default")
 			newCtx := newWorkflowContextForTest(t)
@@ -433,14 +433,16 @@ func TestPendingInputCheck(t *testing.T) {
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx, nil), true)
+	p, _ := run.Pending(wfCtx, nil)
+	r.Equal(p, true)
 	score, err := value.NewValue(`
 100
 `, nil, "")
 	r.NoError(err)
 	err = wfCtx.SetVar(score, "score")
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx, nil), false)
+	p, _ = run.Pending(wfCtx, nil)
+	r.Equal(p, false)
 }
 
 func TestPendingDependsOnCheck(t *testing.T) {
@@ -468,13 +470,15 @@ func TestPendingDependsOnCheck(t *testing.T) {
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})
 	r.NoError(err)
-	r.Equal(run.Pending(wfCtx, nil), true)
+	p, _ := run.Pending(wfCtx, nil)
+	r.Equal(p, true)
 	ss := map[string]common.StepStatus{
 		"depend": {
 			Phase: common.WorkflowStepPhaseSucceeded,
 		},
 	}
-	r.Equal(run.Pending(wfCtx, ss), false)
+	p, _ = run.Pending(wfCtx, ss)
+	r.Equal(p, false)
 }
 
 func TestSkip(t *testing.T) {

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -387,7 +387,7 @@ func handleOutput(ctx wfContext.Context, stepStatus *common.StepStatus, operatio
 		}
 
 		for _, hook := range postStopHooks {
-			if err := hook(ctx, contextValue, step, status); err != nil {
+			if err := hook(ctx, contextValue, step, status, nil); err != nil {
 				status.Phase = common.WorkflowStepPhaseFailed
 				if status.Reason == "" {
 					status.Reason = types.StatusReasonOutput

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -91,13 +91,15 @@ func TestSuspendStep(t *testing.T) {
 	r.Equal(runner.Name(), "test")
 
 	// test pending
-	r.Equal(runner.Pending(nil, nil), true)
+	p, _ := runner.Pending(nil, nil)
+	r.Equal(p, true)
 	ss := map[string]common.StepStatus{
 		"depend": {
 			Phase: common.WorkflowStepPhaseSucceeded,
 		},
 	}
-	r.Equal(runner.Pending(nil, ss), false)
+	p, _ = runner.Pending(nil, ss)
+	r.Equal(p, false)
 
 	// test skip
 	status, operations, err := runner.Run(nil, &types.TaskRunOptions{
@@ -181,13 +183,15 @@ func TestStepGroupStep(t *testing.T) {
 	r.Equal(runner.Name(), "test")
 
 	// test pending
-	r.Equal(runner.Pending(nil, nil), true)
+	p, _ := runner.Pending(nil, nil)
+	r.Equal(p, true)
 	ss := map[string]common.StepStatus{
 		"depend": {
 			Phase: common.WorkflowStepPhaseSucceeded,
 		},
 	}
-	r.Equal(runner.Pending(nil, ss), false)
+	p, _ = runner.Pending(nil, ss)
+	r.Equal(p, false)
 
 	// test skip
 	status, operations, err := runner.Run(nil, &types.TaskRunOptions{

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -34,7 +34,7 @@ import (
 // TaskRunner is a task runner.
 type TaskRunner interface {
 	Name() string
-	Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
+	Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus)
 	Run(ctx wfContext.Context, options *TaskRunOptions) (common.StepStatus, *Operation, error)
 }
 

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -85,7 +85,7 @@ type TaskPreCheckHook func(step v1beta1.WorkflowStep, options *PreCheckOptions) 
 type TaskPreStartHook func(ctx wfContext.Context, paramValue *value.Value, step v1beta1.WorkflowStep) error
 
 // TaskPostStopHook  run after task execution.
-type TaskPostStopHook func(ctx wfContext.Context, taskValue *value.Value, step v1beta1.WorkflowStep, status common.StepStatus) error
+type TaskPostStopHook func(ctx wfContext.Context, taskValue *value.Value, step v1beta1.WorkflowStep, status common.StepStatus, stepStatus map[string]common.StepStatus) error
 
 // Operation is workflow operation object.
 type Operation struct {

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -538,7 +538,7 @@ func (e *engine) runAsDAG(taskRunners []wfTypes.TaskRunner, pendingRunners bool)
 		if !finish {
 			done = false
 			if pending, status := tRunner.Pending(wfCtx, e.stepStatus); pending {
-				if !pendingRunners {
+				if pendingRunners {
 					wfCtx.IncreaseCountValueInMemory(wfTypes.ContextPrefixBackoffTimes, status.ID)
 					e.updateStepStatus(status)
 				}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -2030,19 +2030,26 @@ var _ = Describe("Test Workflow", func() {
 			AppRevision: app.Status.Workflow.AppRevision,
 			Mode:        common.WorkflowModeDAG,
 			Message:     string(common.WorkflowStateExecuting),
-			Steps: []common.WorkflowStepStatus{{
-				StepStatus: common.StepStatus{
-					Name:  "s1",
-					Type:  "success",
-					Phase: common.WorkflowStepPhaseSucceeded,
-				},
-			}, {
-				StepStatus: common.StepStatus{
-					Name:  "s3",
-					Type:  "success",
-					Phase: common.WorkflowStepPhaseSucceeded,
-				},
-			}},
+			Steps: []common.WorkflowStepStatus{
+				{
+					StepStatus: common.StepStatus{
+						Name:  "s2",
+						Type:  "pending",
+						Phase: common.WorkflowStepPhasePending,
+					},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s1",
+						Type:  "success",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s3",
+						Type:  "success",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				}},
 		})).Should(BeEquivalentTo(""))
 
 		state, err = wf.ExecuteSteps(ctx, revision, runners)
@@ -2059,25 +2066,26 @@ var _ = Describe("Test Workflow", func() {
 			AppRevision: app.Status.Workflow.AppRevision,
 			Mode:        common.WorkflowModeDAG,
 			Message:     string(common.WorkflowStateSucceeded),
-			Steps: []common.WorkflowStepStatus{{
-				StepStatus: common.StepStatus{
-					Name:  "s1",
-					Type:  "success",
-					Phase: common.WorkflowStepPhaseSucceeded,
-				},
-			}, {
-				StepStatus: common.StepStatus{
-					Name:  "s3",
-					Type:  "success",
-					Phase: common.WorkflowStepPhaseSucceeded,
-				},
-			}, {
-				StepStatus: common.StepStatus{
-					Name:  "s2",
-					Type:  "pending",
-					Phase: common.WorkflowStepPhaseSucceeded,
-				},
-			}},
+			Steps: []common.WorkflowStepStatus{
+				{
+					StepStatus: common.StepStatus{
+						Name:  "s2",
+						Type:  "pending",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s1",
+						Type:  "success",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s3",
+						Type:  "success",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				}},
 		})).Should(BeEquivalentTo(""))
 	})
 
@@ -2246,14 +2254,18 @@ func makeRunner(step oamcore.WorkflowStep, subTaskRunners []wfTypes.TaskRunner) 
 	return &testTaskRunner{
 		step: step,
 		run:  run,
-		checkPending: func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool {
+		checkPending: func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus) {
 			if step.Type != "pending" {
-				return false
+				return false, common.StepStatus{}
 			}
 			if pending == true {
-				return true
+				return true, common.StepStatus{
+					Phase: common.WorkflowStepPhasePending,
+					Name:  step.Name,
+					Type:  step.Type,
+				}
 			}
-			return false
+			return false, common.StepStatus{}
 		},
 	}
 }
@@ -2277,7 +2289,7 @@ metadata:
 type testTaskRunner struct {
 	step         oamcore.WorkflowStep
 	run          func(ctx wfContext.Context, options *wfTypes.TaskRunOptions) (common.StepStatus, *wfTypes.Operation, error)
-	checkPending func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool
+	checkPending func(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus)
 }
 
 // Name return step name.
@@ -2317,7 +2329,7 @@ func (tr *testTaskRunner) Run(ctx wfContext.Context, options *wfTypes.TaskRunOpt
 }
 
 // Pending check task should be executed or not.
-func (tr *testTaskRunner) Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) bool {
+func (tr *testTaskRunner) Pending(ctx wfContext.Context, stepStatus map[string]common.StepStatus) (bool, common.StepStatus) {
 	return tr.checkPending(ctx, stepStatus)
 }
 

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -2033,12 +2033,6 @@ var _ = Describe("Test Workflow", func() {
 			Steps: []common.WorkflowStepStatus{
 				{
 					StepStatus: common.StepStatus{
-						Name:  "s2",
-						Type:  "pending",
-						Phase: common.WorkflowStepPhasePending,
-					},
-				}, {
-					StepStatus: common.StepStatus{
 						Name:  "s1",
 						Type:  "success",
 						Phase: common.WorkflowStepPhaseSucceeded,
@@ -2049,7 +2043,14 @@ var _ = Describe("Test Workflow", func() {
 						Type:  "success",
 						Phase: common.WorkflowStepPhaseSucceeded,
 					},
-				}},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s2",
+						Type:  "pending",
+						Phase: common.WorkflowStepPhasePending,
+					},
+				},
+			},
 		})).Should(BeEquivalentTo(""))
 
 		state, err = wf.ExecuteSteps(ctx, revision, runners)
@@ -2069,12 +2070,6 @@ var _ = Describe("Test Workflow", func() {
 			Steps: []common.WorkflowStepStatus{
 				{
 					StepStatus: common.StepStatus{
-						Name:  "s2",
-						Type:  "pending",
-						Phase: common.WorkflowStepPhaseSucceeded,
-					},
-				}, {
-					StepStatus: common.StepStatus{
 						Name:  "s1",
 						Type:  "success",
 						Phase: common.WorkflowStepPhaseSucceeded,
@@ -2085,7 +2080,14 @@ var _ = Describe("Test Workflow", func() {
 						Type:  "success",
 						Phase: common.WorkflowStepPhaseSucceeded,
 					},
-				}},
+				}, {
+					StepStatus: common.StepStatus{
+						Name:  "s2",
+						Type:  "pending",
+						Phase: common.WorkflowStepPhaseSucceeded,
+					},
+				},
+			},
 		})).Should(BeEquivalentTo(""))
 	})
 


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR adds pending phase for workflow step, for example, if the step is executed but waiting for its inputs or depends on other steps, now its phase is `pending` and message is `Pending on Inputs/DependsOn: xxx`.

Previously, if the step is executed but waiting for its inputs, the step will have no status, and the backoff time will not work.


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->