### PR TITLE
Feat: Addon support app template written by cuelang.

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -305,10 +305,13 @@ func GetUIDataFromReader(r AsyncReader, meta *SourceMeta, opt ListOptions) (*UID
 		}
 	}
 
-	if opt.GetParameter && addon.Parameters != "" {
+	if opt.GetParameter && (len(addon.Parameters) != 0 || len(addon.GlobalParameters) != 0) {
 		err := genAddonAPISchema(addon)
 		if err != nil {
 			return nil, fmt.Errorf("fail to generate openAPIschema for addon %s : %w", meta.Name, err)
+		}
+		if len(addon.GlobalParameters) != 0 {
+			addon.Parameters = addon.GlobalParameters
 		}
 	}
 	addon.AvailableVersions = []string{addon.Version}
@@ -328,11 +331,10 @@ func GetInstallPackageFromReader(r AsyncReader, meta *SourceMeta, uiData *UIData
 
 	// Read the installed data from UI metadata object to reduce network payload
 	var addon = &InstallPackage{
-		Meta:             uiData.Meta,
-		Definitions:      uiData.Definitions,
-		CUEDefinitions:   uiData.CUEDefinitions,
-		Parameters:       uiData.Parameters,
-		GlobalParameters: uiData.GlobalParameters,
+		Meta:           uiData.Meta,
+		Definitions:    uiData.Definitions,
+		CUEDefinitions: uiData.CUEDefinitions,
+		Parameters:     uiData.Parameters,
 	}
 
 	for contentType, method := range addonContentsReader {

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Test render addon with specified clusters", func() {
 		}
 		ap, err := RenderApp(ctx, i, k8sClient, args)
 		Expect(err).Should(BeNil())
-		Expect(ap.Spec.Policies).Should(BeEquivalentTo([]v1beta1.AppPolicy{{Name: "specified-addon-clusters",
+		Expect(ap.Spec.Policies).Should(BeEquivalentTo([]v1beta1.AppPolicy{{Name: specifyAddonClustersTopologyPolicy,
 			Type:       v1alpha12.TopologyPolicyType,
 			Properties: &runtime.RawExtension{Raw: []byte(`{"clusters":["add-c1","add-c2","local"]}`)}}}))
 	})

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -47,6 +47,7 @@ import (
 	clustercommon "github.com/oam-dev/cluster-gateway/pkg/common"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -290,10 +291,9 @@ func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 
 	app, err := RenderApp(ctx, &addonDeployToRuntime, nil, map[string]interface{}{})
 	assert.NoError(t, err)
-	steps := app.Spec.Workflow.Steps
-	assert.True(t, len(steps) >= 2)
-	assert.Equal(t, steps[len(steps)-2].Type, "apply-application")
-	assert.Equal(t, steps[len(steps)-1].Type, "deploy2runtime")
+	policies := app.Spec.Policies
+	assert.True(t, len(policies) == 1)
+	assert.Equal(t, policies[0].Type, v1alpha1.TopologyPolicyType)
 }
 
 func TestRenderDefinitions(t *testing.T) {
@@ -757,84 +757,6 @@ status: {
 
 `
 
-func TestRenderApp4Observability(t *testing.T) {
-	k8sClient := fake.NewClientBuilder().Build()
-	testcases := []struct {
-		addon       InstallPackage
-		args        map[string]interface{}
-		application string
-		err         error
-	}{
-		{
-			addon: InstallPackage{
-				Meta: Meta{
-					Name: "observability",
-				},
-			},
-			args:        map[string]interface{}{},
-			application: `{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"addon-observability","namespace":"vela-system","creationTimestamp":null,"labels":{"addons.oam.dev/name":"observability","addons.oam.dev/version":""}},"spec":{"components":[],"policies":[{"name":"domain","type":"env-binding","properties":{"envs":null}}],"workflow":{"steps":[{"name":"deploy-control-plane","type":"apply-application"}]}},"status":{}}`,
-		},
-	}
-	for _, tc := range testcases {
-		t.Run("", func(t *testing.T) {
-			app, err := RenderApp(ctx, &tc.addon, k8sClient, tc.args)
-			assert.Equal(t, tc.err, err)
-			if app != nil {
-				data, err := json.Marshal(app)
-				assert.NoError(t, err)
-				assert.Equal(t, tc.application, string(data))
-			}
-		})
-	}
-}
-
-// TestRenderApp4ObservabilityWithEnvBinding tests the case of RenderApp for Addon Observability with some Kubernetes data
-func TestRenderApp4ObservabilityWithK8sData(t *testing.T) {
-	k8sClient := fake.NewClientBuilder().Build()
-	ctx := context.Background()
-	secret1 := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-secret",
-			Labels: map[string]string{
-				clustercommon.LabelKeyClusterCredentialType: string(v1alpha12.CredentialTypeX509Certificate),
-			},
-		},
-		Data: map[string][]byte{
-			"test-key": []byte("test-value"),
-		},
-	}
-	err := k8sClient.Create(ctx, secret1)
-	assert.NoError(t, err)
-
-	testcases := []struct {
-		addon       InstallPackage
-		args        map[string]interface{}
-		application string
-		err         error
-	}{
-		{
-			addon: InstallPackage{
-				Meta: Meta{
-					Name: "observability",
-				},
-			},
-			args:        map[string]interface{}{},
-			application: `{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"addon-observability","namespace":"vela-system","creationTimestamp":null,"labels":{"addons.oam.dev/name":"observability","addons.oam.dev/version":""}},"spec":{"components":[],"policies":[{"name":"domain","type":"env-binding","properties":{"envs":[{"name":"test-secret","placement":{"clusterSelector":{"name":"test-secret"}}}]}}],"workflow":{"steps":[{"name":"deploy-control-plane","type":"apply-application-in-parallel"},{"name":"test-secret","type":"deploy2env","properties":{"env":"test-secret","parallel":true,"policy":"domain"}}]}},"status":{}}`,
-		},
-	}
-	for _, tc := range testcases {
-		t.Run("", func(t *testing.T) {
-			app, err := RenderApp(ctx, &tc.addon, k8sClient, tc.args)
-			assert.Equal(t, tc.err, err)
-			if app != nil {
-				data, err := json.Marshal(app)
-				assert.NoError(t, err)
-				assert.Equal(t, tc.application, string(data))
-			}
-		})
-	}
-}
-
 func TestGetPatternFromItem(t *testing.T) {
 	ossR, err := NewAsyncReader("http://ep.beijing", "some-bucket", "", "some-sub-path", "", ossType)
 	assert.NoError(t, err)
@@ -1199,10 +1121,14 @@ func TestReadViewFile(t *testing.T) {
 func TestRenderCUETemplate(t *testing.T) {
 	fileDate, err := os.ReadFile("./testdata/example/resources/configmap.cue")
 	assert.NoError(t, err)
-	component, err := renderCUETemplate(ElementFile{Data: string(fileDate), Name: "configmap.cue"}, "{\"example\": \"\"}", map[string]interface{}{
+	addon := &InstallPackage{
+		Meta: Meta{
+			Version: "1.0.1",
+		},
+		Parameters: "{\"example\": \"\"}",
+	}
+	component, err := renderCompAccordingCUETemplate(ElementFile{Data: string(fileDate), Name: "configmap.cue"}, addon, map[string]interface{}{
 		"example": "render",
-	}, Meta{
-		Version: "1.0.1",
 	})
 	assert.NoError(t, err)
 	assert.True(t, component.Type == "raw")

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -517,6 +517,7 @@ var baseAddon = InstallPackage{
 	Meta: Meta{
 		Name:          "test-render-cue-definition-addon",
 		NeedNamespace: []string{"test-ns"},
+		DeployTo:      &DeployTo{RuntimeCluster: true},
 	},
 	CUEDefinitions: []ElementFile{
 		{

--- a/pkg/addon/error.go
+++ b/pkg/addon/error.go
@@ -40,6 +40,9 @@ var (
 
 	// ErrRegistryNotExist means registry not exists
 	ErrRegistryNotExist = NewAddonError("registry does not exist")
+
+	// ErrBothCueAndYamlTmpl means yaml and cue app template are exist in addon
+	ErrBothCueAndYamlTmpl = NewAddonError("yaml and cue app template are exist in addon, should only keep one of them")
 )
 
 // WrapErrRateLimit return ErrRateLimit if is the situation, or return error directly

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KubeVela Authors.
+Copyright 2022 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	cueyaml "cuelang.org/go/encoding/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	addonutil "github.com/oam-dev/kubevela/pkg/utils/addon"
+)
+
+type addonCueTemplateRender struct {
+	addon                *InstallPackage
+	inputParameter       map[string]interface{}
+	useResourceParameter bool
+}
+
+func (a addonCueTemplateRender) toObject(cueTemplate string, object interface{}) error {
+	bt, err := json.Marshal(a.inputParameter)
+	if err != nil {
+		return err
+	}
+	var contextFile = strings.Builder{}
+	var paramFile = cuemodel.ParameterFieldName + ": {}"
+	if string(bt) != "null" {
+		paramFile = fmt.Sprintf("%s: %s", cuemodel.ParameterFieldName, string(bt))
+	}
+	// addon metadata context
+	metadataJSON, err := json.Marshal(a.addon.Meta)
+	if err != nil {
+		return err
+	}
+	contextFile.WriteString(fmt.Sprintf("context: metadata: %s\n", string(metadataJSON)))
+	// parameter definition
+	contextFile.WriteString(paramFile + "\n")
+	// user custom parameter
+	contextFile.WriteString(a.addon.GlobalParameters + "\n")
+
+	if a.useResourceParameter && len(a.addon.Parameters) != 0 {
+		// use parameter defined in resource/ dir override the global parameter.
+		contextFile.WriteString(a.addon.Parameters + "\n")
+	}
+
+	v, err := value.NewValue(contextFile.String(), nil, "")
+	if err != nil {
+		return err
+	}
+	out, err := v.LookupByScript(cueTemplate)
+	if err != nil {
+		return err
+	}
+	outputContent, err := out.LookupValue("output")
+	if err != nil {
+		return err
+	}
+	b, err := cueyaml.Encode(outputContent.CueValue())
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(b, object)
+}
+
+// generateAppFramework generate application from yaml defined by template.yaml or cue file from template.cue
+func generateAppFramework(addon *InstallPackage, parameters map[string]interface{}) (*v1beta1.Application, error) {
+	var app *v1beta1.Application
+	var err error
+	if len(addon.AppCueTemplate.Data) != 0 {
+		app, err = renderAppAccordingToCueTemplate(addon, parameters)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		app = addon.AppTemplate
+		if app == nil {
+			app = &v1beta1.Application{
+				TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "Application"},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common2.ApplicationComponent{},
+				},
+			}
+		}
+		if app.Spec.Components == nil {
+			app.Spec.Components = []common2.ApplicationComponent{}
+		}
+	}
+
+	app.Name = addonutil.Addon2AppName(addon.Name)
+	// force override the namespace defined vela with DefaultVelaNS,this value can be modified by Env
+	app.SetNamespace(types.DefaultKubeVelaNS)
+	if app.Labels == nil {
+		app.Labels = make(map[string]string)
+	}
+	app.Labels[oam.LabelAddonName] = addon.Name
+	app.Labels[oam.LabelAddonVersion] = addon.Version
+	return app, nil
+}
+
+func renderAppAccordingToCueTemplate(addon *InstallPackage, parameters map[string]interface{}) (*v1beta1.Application, error) {
+	app := v1beta1.Application{}
+	r := addonCueTemplateRender{
+		addon:                addon,
+		inputParameter:       parameters,
+		useResourceParameter: false,
+	}
+	if err := r.toObject(addon.AppCueTemplate.Data, &app); err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
+// renderCompAccordingCUETemplate will return a component from cue template
+func renderCompAccordingCUETemplate(cueTemplate ElementFile, addon *InstallPackage, parameters map[string]interface{}) (*common2.ApplicationComponent, error) {
+	comp := common2.ApplicationComponent{}
+
+	r := addonCueTemplateRender{
+		addon:                addon,
+		inputParameter:       parameters,
+		useResourceParameter: true,
+	}
+	if err := r.toObject(cueTemplate.Data, &comp); err != nil {
+		return nil, err
+	}
+	if len(comp.Name) == 0 {
+		fileName := strings.ReplaceAll(cueTemplate.Name, path.Ext(cueTemplate.Name), "")
+		comp.Name = strings.ReplaceAll(fileName, ".", "-")
+	}
+	return &comp, nil
+}
+
+// RenderApp render a K8s application
+func RenderApp(ctx context.Context, addon *InstallPackage, k8sClient client.Client, args map[string]interface{}) (*v1beta1.Application, error) {
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+	app, err := generateAppFramework(addon, args)
+	if err != nil {
+		return nil, err
+	}
+	app.Spec.Components = append(app.Spec.Components, renderNeededNamespaceAsComps(addon)...)
+
+	resources, err := renderResources(addon, args)
+	if err != nil {
+		return nil, err
+	}
+	app.Spec.Components = append(app.Spec.Components, resources...)
+
+	// for legacy addons those hasn't define policy in template.cue but still want to deploy runtime cluster
+	// attach topology policy to application.
+	if checkLegacyAddon(app, addon) {
+		if err := attachPolicyForLegacyAddon(ctx, app, addon, args, k8sClient); err != nil {
+			return nil, err
+		}
+	}
+	return app, nil
+}
+
+// checkLegacyAddon will check this addon want to deploy to runtime-cluster, but application template doesn't specify the
+// topology policy, then will attach the policy to application automatically.
+func checkLegacyAddon(app *v1beta1.Application, addon *InstallPackage) bool {
+	isLegacy := true
+	if addon.Meta.DeployTo != nil && (addon.Meta.DeployTo.RuntimeCluster || addon.Meta.DeployTo.LegacyRuntimeCluster) {
+		for _, policy := range app.Spec.Policies {
+			if policy.Type == v1alpha1.TopologyPolicyType {
+				isLegacy = false
+				break
+			}
+		}
+	}
+	return isLegacy
+}
+
+func attachPolicyForLegacyAddon(ctx context.Context, app *v1beta1.Application, addon *InstallPackage, args map[string]interface{}, k8sClient client.Client) error {
+	deployClusters, err := checkDeployClusters(ctx, k8sClient, args)
+	if err != nil {
+		return err
+	}
+	if isDeployToRuntime(addon) {
+		if len(deployClusters) == 0 {
+			// empty cluster args deploy to all clusters
+			clusterSelector := map[string]interface{}{
+				// empty labelSelector means deploy resources to all clusters
+				ClusterLabelSelector: map[string]string{},
+			}
+			properties, err := json.Marshal(clusterSelector)
+			if err != nil {
+				return err
+			}
+			policy := v1beta1.AppPolicy{
+				Name:       "deploy-addon-to-clusters",
+				Type:       v1alpha1.TopologyPolicyType,
+				Properties: &runtime.RawExtension{Raw: properties},
+			}
+			app.Spec.Policies = append(app.Spec.Policies, policy)
+		} else {
+			var found bool
+			for _, c := range deployClusters {
+				if c == multicluster.ClusterLocalName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				deployClusters = append(deployClusters, multicluster.ClusterLocalName)
+			}
+			// deploy to specified clusters
+			if app.Spec.Policies == nil {
+				app.Spec.Policies = []v1beta1.AppPolicy{}
+			}
+			body, err := json.Marshal(map[string][]string{types.ClustersArg: deployClusters})
+			if err != nil {
+				return err
+			}
+			app.Spec.Policies = append(app.Spec.Policies, v1beta1.AppPolicy{
+				Name:       "specified-addon-clusters",
+				Type:       v1alpha1.TopologyPolicyType,
+				Properties: &runtime.RawExtension{Raw: body},
+			})
+			// addon should not contain workflow, this also update legacy addon with deploy2runtime steps
+			app.Spec.Workflow = nil
+		}
+	}
+	return nil
+}
+
+func isDeployToRuntime(addon *InstallPackage) bool {
+	if addon.DeployTo == nil {
+		return false
+	}
+	return addon.DeployTo.RuntimeCluster || addon.DeployTo.LegacyRuntimeCluster
+}

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -251,9 +251,6 @@ func renderResources(addon *InstallPackage, args map[string]interface{}) ([]comm
 		if err != nil {
 			return nil, NewAddonError(fmt.Sprintf("fail to render cue template %s", err.Error()))
 		}
-		if addon.Name == ObservabilityAddon && strings.HasSuffix(comp.Name, ".cue") {
-			comp.Name = strings.Split(comp.Name, ".cue")[0]
-		}
 		resources = append(resources, *comp)
 	}
 	return resources, nil

--- a/pkg/addon/render_test.go
+++ b/pkg/addon/render_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KubeVela Authors.
+Copyright 2022 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/addon/render_test.go
+++ b/pkg/addon/render_test.go
@@ -18,6 +18,7 @@ package addon
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,12 +92,12 @@ func TestRenderAppTemplate(t *testing.T) {
 	assert.Equal(t, len(app.Spec.Components), 1)
 	str, err := json.Marshal(app.Spec.Components[0].Properties)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"objects":[{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"vela-system"}}]}`, string(str))
+	assert.True(t, strings.Contains(string(str), `{"name":"vela-system"}`))
 
 	assert.Equal(t, len(app.Spec.Policies), 2)
 	str, err = json.Marshal(app.Spec.Policies)
 	assert.NoError(t, err)
-	assert.Equal(t, `[{"name":"namespace","type":"shared-resource","properties":{"rules":[{"selector":{"resourceTypes":["Namespace"]}}]}},{"name":"deploy-topology","type":"topology","properties":{"clusterLabelSelector":{},"namespace":"vela-system"}}]`, string(str))
+	assert.True(t, strings.Contains(string(str), `"clusterLabelSelector":{}`))
 }
 
 func TestAppComponentRender(t *testing.T) {
@@ -223,13 +224,11 @@ func TestGenerateAppFrameworkWithCue(t *testing.T) {
 	assert.Equal(t, len(app.Spec.Components), 1)
 	str, err := json.Marshal(app.Spec.Components[0].Properties)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"objects":[{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"vela-system"}}]}`, string(str))
-
+	assert.True(t, strings.Contains(string(str), `{"name":"vela-system"}`))
 	assert.Equal(t, len(app.Spec.Policies), 2)
 	str, err = json.Marshal(app.Spec.Policies)
 	assert.NoError(t, err)
-	assert.Equal(t, `[{"name":"namespace","type":"shared-resource","properties":{"rules":[{"selector":{"resourceTypes":["Namespace"]}}]}},{"name":"deploy-topology","type":"topology","properties":{"clusterLabelSelector":{},"namespace":"vela-system"}}]`, string(str))
-
+	assert.True(t, strings.Contains(string(str), `"clusterLabelSelector":{}`))
 	assert.Equal(t, len(app.Labels), 2)
 }
 

--- a/pkg/addon/render_test.go
+++ b/pkg/addon/render_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+func TestRenderAppTemplate(t *testing.T) {
+	paraDefined := `parameter: {
+	// +usage=The clusters to install
+	clusters?: [...string]
+	namespace: string
+}`
+	appTemplate := `output: {
+	   apiVersion: "core.oam.dev/v1beta1"
+	   kind: "Application"
+	   metadata: {
+	       name:  "velaux"
+	       namespace: "vela-system"
+	   }
+	   spec: {
+	       components: [{
+	           type: "k8s-objects"
+	           name: "vela-namespace"
+	           properties: objects: [{
+	               apiVersion: "v1"
+	               kind: "Namespace"
+	               metadata: name: parameter.namespace
+	           }]
+	       }]
+	       policies: [{
+	           type: "shared-resource"
+	           name: "namespace"
+	           properties: rules: [{selector: resourceTypes: ["Namespace"]}]
+	       }, {
+	           type: "topology"
+	           name: "deploy-topology"
+	           properties: {
+	               if parameter.clusters != _|_ {
+	                   clusters: parameter.clusters
+	               }
+	               if parameter.clusters == _|_ {
+	                   clusterLabelSelector: {}
+	               }
+	               namespace: parameter.namespace
+	           }
+	       }]
+	   }
+	}`
+	addon := &InstallPackage{
+		Meta: Meta{
+			Name: "velaux",
+			DeployTo: &DeployTo{
+				RuntimeCluster: true,
+			},
+		},
+		Parameters: paraDefined,
+	}
+
+	render := addonCueTemplateRender{
+		addon: addon,
+		inputArgs: map[string]interface{}{
+			"namespace": "vela-system",
+		},
+	}
+	app := v1beta1.Application{}
+	err := render.toObject(appTemplate, &app)
+	assert.NoError(t, err)
+	assert.Equal(t, len(app.Spec.Components), 1)
+	str, err := json.Marshal(app.Spec.Components[0].Properties)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"objects":[{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"vela-system"}}]}`, string(str))
+
+	assert.Equal(t, len(app.Spec.Policies), 2)
+	str, err = json.Marshal(app.Spec.Policies)
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"name":"namespace","type":"shared-resource","properties":{"rules":[{"selector":{"resourceTypes":["Namespace"]}}]}},{"name":"deploy-topology","type":"topology","properties":{"clusterLabelSelector":{},"namespace":"vela-system"}}]`, string(str))
+}
+
+func TestAppComponentRender(t *testing.T) {
+	paraDefined := `parameter: {
+	image: string
+}`
+	compTemplate := `output: {
+       type: "webservice"
+       name: "velaux"
+       properties: {
+          image: parameter.image}
+}`
+	addon := &InstallPackage{
+		Meta: Meta{
+			Name: "velaux",
+			DeployTo: &DeployTo{
+				RuntimeCluster: true,
+			},
+		},
+		Parameters: paraDefined,
+	}
+
+	render := addonCueTemplateRender{
+		addon: addon,
+		inputArgs: map[string]interface{}{
+			"image": "1.4.1",
+		},
+	}
+	comp := common.ApplicationComponent{}
+	err := render.toObject(compTemplate, &comp)
+	assert.NoError(t, err)
+	assert.Equal(t, comp.Name, "velaux")
+	assert.Equal(t, comp.Type, "webservice")
+	str, err := json.Marshal(comp.Properties)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"image":"1.4.1"}`, string(str))
+}
+
+func TestCheckNeedAttachTopologyPolicy(t *testing.T) {
+	addon1 := &InstallPackage{
+		Meta: Meta{
+			DeployTo: nil,
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(nil, addon1), false)
+
+	addon2 := &InstallPackage{
+		Meta: Meta{
+			DeployTo: &DeployTo{RuntimeCluster: false},
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(nil, addon2), false)
+
+	addon3 := &InstallPackage{
+		Meta: Meta{
+			DeployTo: &DeployTo{RuntimeCluster: true},
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(&v1beta1.Application{Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{
+		Type: v1alpha1.TopologyPolicyType,
+	}}}}, addon3), false)
+
+	addon4 := &InstallPackage{
+		Meta: Meta{
+			DeployTo: &DeployTo{RuntimeCluster: true},
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(&v1beta1.Application{Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{
+		Type: v1alpha1.SharedResourcePolicyType,
+	}}}}, addon4), true)
+}

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -319,6 +319,9 @@ func (r *Registry) GetUIData(meta *SourceMeta, opt ListOptions) (*UIData, error)
 	if err != nil {
 		return nil, err
 	}
+	if len(addon.GlobalParameters) != 0 {
+		addon.Parameters = addon.GlobalParameters
+	}
 	return addon, nil
 }
 

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -33,10 +33,11 @@ type UIData struct {
 	// Detail is README.md in an addon
 	Detail string `json:"detail,omitempty"`
 
-	Definitions    []ElementFile `json:"definitions"`
-	CUEDefinitions []ElementFile `json:"CUEDefinitions"`
-	Parameters     string        `json:"parameters"`
-	RegistryName   string        `json:"registryName"`
+	Definitions      []ElementFile `json:"definitions"`
+	CUEDefinitions   []ElementFile `json:"CUEDefinitions"`
+	Parameters       string        `json:"parameters"`
+	GlobalParameters string        `json:"globalParameters"`
+	RegistryName     string        `json:"registryName"`
 
 	AvailableVersions []string `json:"availableVersions"`
 }
@@ -54,12 +55,14 @@ type InstallPackage struct {
 	// DefSchemas are UI schemas read by VelaUX, it will only be installed in control plane clusters
 	DefSchemas []ElementFile `json:"defSchemas,omitempty"`
 
-	Parameters string `json:"parameters"`
+	Parameters       string `json:"parameters"`
+	GlobalParameters string `json:"globalParameters"`
 
 	// CUETemplates and YAMLTemplates are resources needed to be installed in managed clusters
-	CUETemplates  []ElementFile        `json:"CUETemplates"`
-	YAMLTemplates []ElementFile        `json:"YAMLTemplates,omitempty"`
-	AppTemplate   *v1beta1.Application `json:"appTemplate"`
+	CUETemplates   []ElementFile        `json:"CUETemplates"`
+	YAMLTemplates  []ElementFile        `json:"YAMLTemplates,omitempty"`
+	AppTemplate    *v1beta1.Application `json:"appTemplate"`
+	AppCueTemplate ElementFile          `json:"appCueTemplate,omitempty"`
 }
 
 // WholeAddonPackage contains all infos of an addon

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -55,8 +55,7 @@ type InstallPackage struct {
 	// DefSchemas are UI schemas read by VelaUX, it will only be installed in control plane clusters
 	DefSchemas []ElementFile `json:"defSchemas,omitempty"`
 
-	Parameters       string `json:"parameters"`
-	GlobalParameters string `json:"globalParameters"`
+	Parameters string `json:"parameters"`
 
 	// CUETemplates and YAMLTemplates are resources needed to be installed in managed clusters
 	CUETemplates   []ElementFile        `json:"CUETemplates"`

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -151,7 +151,10 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 			if err != nil {
 				return err
 			}
-			addonArgs[types.ClustersArg] = transClusters(addonClusters)
+			clusterArgs := transClusters(addonClusters)
+			if len(clusterArgs) != 0 {
+				addonArgs[types.ClustersArg] = clusterArgs
+			}
 			config, err := c.GetConfig()
 			if err != nil {
 				return err
@@ -265,7 +268,10 @@ non-empty new arg
 			if err != nil {
 				return err
 			}
-			addonInputArgs[types.ClustersArg] = transClusters(addonClusters)
+			clusterArgs := transClusters(addonClusters)
+			if len(clusterArgs) != 0 {
+				addonInputArgs[types.ClustersArg] = clusterArgs
+			}
 			addonOrDir := args[0]
 			var name string
 			if file, err := os.Stat(addonOrDir); err == nil {
@@ -1071,6 +1077,9 @@ func hasAddon(addons []*pkgaddon.UIData, name string) bool {
 }
 
 func transClusters(cstr string) []string {
+	if len(cstr) == 0 {
+		return nil
+	}
 	cstr = strings.TrimPrefix(strings.TrimSuffix(cstr, "}"), "{")
 	var clusterL []string
 	clusterList := strings.Split(cstr, ",")


### PR DESCRIPTION
This pr support writing basic addon application template framework by cue, so addon-developer can define the final app with parameter.Will allow user define a `parameter.cue` file  outside `resource` dir. All parameters defined in this file will affect resources in `resources` dir and `template.cue`.

So  a new addon dir is like this:
```dir
definitions/
resources/
——component1.cue
——component2.yaml
template.cue
parameter.cue
metadata.yaml
```

Besides, this pr also dose such things:

1. Keep compatibility for old addon, new version CLI can still enable old version addon.
2. If an addon defines `deployTo.runtimeCluster=true` want to deploy to runtime clusters but still don't have a topology polocy, we assume it's a legacy addon, will attach a topology policy to this app,  not two workflowSteps(deploy-local, deploy-all-runtime) as before.
3. Delete all hack code for observability addon, because all these codes only for selecting cluster and override policy for different cluster, this will handled by writing a `template.cue`.
4. Refactor some codes, put render related code to a single file.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4283 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->