### PR TITLE
Fix: only compare with the default environment

### DIFF
--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -804,7 +804,7 @@ func (c *applicationServiceImpl) renderOAMApplication(ctx context.Context, appMo
 			return nil, err
 		}
 	}
-	if workflow != nil {
+	if workflow != nil && envName == "" {
 		envName = workflow.EnvName
 	}
 


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

It should compare with the specified environment.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->