### PR TITLE
[Backport-1.4]: fix backoff time after default backoff times (backport of #4413)

### DIFF
--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -403,14 +403,14 @@ func (w *workflow) setMetadataToContext(wfCtx wfContext.Context) error {
 	return wfCtx.SetVar(metadata, wfTypes.ContextKeyMetadata)
 }
 
-func (e *engine) getBackoffTimes(stepID string) (success bool, backoffTimes int) {
+func (e *engine) getBackoffTimes(stepID string) int {
 	if v, ok := e.wfCtx.GetValueInMemory(wfTypes.ContextPrefixBackoffTimes, stepID); ok {
 		times, ok := v.(int)
 		if ok {
-			return true, times
+			return times
 		}
 	}
-	return false, 0
+	return -1
 }
 
 func (e *engine) getBackoffWaitTime() int {
@@ -418,17 +418,19 @@ func (e *engine) getBackoffWaitTime() int {
 	minTimes := 15
 	found := false
 	for _, step := range e.status.Steps {
-		success, backoffTimes := e.getBackoffTimes(step.ID)
-		if success && backoffTimes < minTimes {
-			minTimes = backoffTimes
+		if backoffTimes := e.getBackoffTimes(step.ID); backoffTimes > 0 {
 			found = true
+			if backoffTimes < minTimes {
+				minTimes = backoffTimes
+			}
 		}
 		if step.SubStepsStatus != nil {
 			for _, subStep := range step.SubStepsStatus {
-				success, backoffTimes := e.getBackoffTimes(subStep.ID)
-				if success && backoffTimes < minTimes {
-					minTimes = backoffTimes
+				if backoffTimes := e.getBackoffTimes(subStep.ID); backoffTimes > 0 {
 					found = true
+					if backoffTimes < minTimes {
+						minTimes = backoffTimes
+					}
 				}
 			}
 		}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -912,10 +912,12 @@ var _ = Describe("Test Workflow", func() {
 			Expect(interval).Should(BeEquivalentTo(int(0.05 * math.Pow(2, float64(i+5)))))
 		}
 
-		_, err = wf.ExecuteSteps(ctx, revision, runners)
-		Expect(err).ToNot(HaveOccurred())
-		interval = e.getBackoffWaitTime()
-		Expect(interval).Should(BeEquivalentTo(MaxWorkflowWaitBackoffTime))
+		for i := 0; i < 10; i++ {
+			_, err = wf.ExecuteSteps(ctx, revision, runners)
+			Expect(err).ToNot(HaveOccurred())
+			interval = e.getBackoffWaitTime()
+			Expect(interval).Should(BeEquivalentTo(MaxWorkflowWaitBackoffTime))
+		}
 
 		By("Test get backoff time after clean")
 		wfContext.CleanupMemoryStore(app.Name, app.Namespace)


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Refer to #4413

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->