### PR TITLE
Feat: get raw Application yaml, json or jsonpath

### DIFF
--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -155,7 +155,7 @@ func NewAppStatusCommand(c common.Args, order string, ioStreams cmdutil.IOStream
 	cmd.Flags().BoolP("tree", "t", false, "display the application resources into tree structure")
 	cmd.Flags().BoolP("detail", "d", false, "display the realtime details of application resources, must be used with --tree")
 	cmd.Flags().StringP("detail-format", "", "inline", "the format for displaying details, must be used with --detail. Can be one of inline, wide, list, table, raw.")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format. One of: (json, yaml, jsonpath)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "raw Application output format. One of: (json, yaml, jsonpath)")
 	addNamespaceAndEnvArg(cmd)
 	return cmd
 }

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -17,9 +17,7 @@ limitations under the License.
 package cli
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -32,11 +30,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	pkgtypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/jsonpath"
-	"k8s.io/kubectl/pkg/cmd/get"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	commontypes "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
@@ -115,8 +110,8 @@ func NewAppStatusCommand(c common.Args, order string, ioStreams cmdutil.IOStream
   # Get raw Application yaml (without managedFields)
   vela status first-vela-app -o yaml
 
-  # Get raw Application status
-  vela status first-vela-app -o jsonpath='{.status}' | jq`,
+  # Get raw Application status using jsonpath
+  vela status first-vela-app -o jsonpath='{.status}'`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// check args
 			argsLength := len(args)
@@ -483,59 +478,4 @@ func printRawApplication(ctx context.Context, c common.Args, format string, out 
 
 	_, err = out.Write([]byte(str))
 	return err
-}
-
-// formatApplicationString formats an Application to string in yaml/json/jsonpath for printing (without managedFields).
-//
-// format = "yaml" / "json" / "jsonpath={.field}"
-func formatApplicationString(format string, app *v1beta1.Application) (string, error) {
-	var ret string
-
-	// No, we don't want managedFields, get rid of it.
-	app.ManagedFields = nil
-
-	switch format {
-	case "yaml":
-		b, err := yaml.Marshal(app)
-		if err != nil {
-			return "", err
-		}
-		ret = string(b)
-	case "json":
-		b, err := json.MarshalIndent(app, "", "  ")
-		if err != nil {
-			return "", err
-		}
-		ret = string(b)
-	default:
-		// format is not any of json/yaml/jsonpath, not supported
-		if !strings.HasPrefix(format, "jsonpath") {
-			return "", fmt.Errorf("output %s is not supported", format)
-		}
-
-		// format = jsonpath
-		s := strings.Split(format, "=")
-		if len(s) < 2 {
-			return "", fmt.Errorf("jsonpath template format specified but no template given")
-		}
-		path, err := get.RelaxedJSONPathExpression(s[1])
-		if err != nil {
-			return "", err
-		}
-
-		jp := jsonpath.New("").AllowMissingKeys(true)
-		err = jp.Parse(path)
-		if err != nil {
-			return "", err
-		}
-
-		buf := &bytes.Buffer{}
-		err = jp.Execute(buf, app)
-		if err != nil {
-			return "", err
-		}
-		ret = buf.String()
-	}
-
-	return ret, nil
 }

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -478,10 +478,13 @@ func printRawApplication(ctx context.Context, c common.Args, format string, out 
 	// But we need that information.
 	app.SetGroupVersionKind(v1beta1.ApplicationKindVersionKind)
 
-	return printApplicationUsingFormat(out, format, app)
+	return printApplicationInFormat(out, format, app)
 }
 
-func printApplicationUsingFormat(out io.Writer, format string, app *v1beta1.Application) error {
+func printApplicationInFormat(out io.Writer, format string, app *v1beta1.Application) error {
+	// We don't want managedFields, get rid of it.
+	app.ManagedFields = nil
+
 	switch format {
 	case "yaml":
 		b, err := yaml.Marshal(app)

--- a/references/cli/utils.go
+++ b/references/cli/utils.go
@@ -37,9 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 )

--- a/references/cli/utils_test.go
+++ b/references/cli/utils_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+func TestFormatApplicationString(t *testing.T) {
+	var (
+		str string
+		err error
+	)
+
+	app := &v1beta1.Application{}
+	app.SetGroupVersionKind(v1beta1.ApplicationKindVersionKind)
+	// This should not be preset in the formatted string
+	app.ManagedFields = []v1.ManagedFieldsEntry{
+		{
+			Manager:     "",
+			Operation:   "",
+			APIVersion:  "",
+			Time:        nil,
+			FieldsType:  "",
+			FieldsV1:    nil,
+			Subresource: "",
+		},
+	}
+	app.SetName("app-name")
+
+	_, err = formatApplicationString("", app)
+	assert.ErrorContains(t, err, "no format", "no format provided, should error out")
+
+	_, err = formatApplicationString("invalid", app)
+	assert.ErrorContains(t, err, "not supported", "invalid format provided, should error out")
+
+	str, err = formatApplicationString("yaml", app)
+	assert.NilError(t, err)
+	assert.Equal(t, true, strings.Contains(str, `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  creationTimestamp: null
+  name: app-name
+spec:
+  components: null
+status: {}
+`), "formatted yaml is not correct")
+
+	str, err = formatApplicationString("json", app)
+	assert.NilError(t, err)
+	assert.Equal(t, true, strings.Contains(str, `{
+  "kind": "Application",
+  "apiVersion": "core.oam.dev/v1beta1",
+  "metadata": {
+    "name": "app-name",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "components": null
+  },
+  "status": {}
+}`), "formatted json is not correct")
+
+	_, err = formatApplicationString("jsonpath", app)
+	assert.ErrorContains(t, err, "jsonpath template", "no jsonpath template provided, should not pass")
+
+	str, err = formatApplicationString("jsonpath={.apiVersion}", app)
+	assert.NilError(t, err)
+	assert.Equal(t, str, "core.oam.dev/v1beta1")
+}


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

Added support for getting raw Application yaml in Vela CLI, via `-o` `--output` parameter.

Looking at some examples will give you a better understanding:

---

#### Get whole Application in `yaml`

`vela status first-vela-app -o yaml`

<details>
<summary>Click to see command output</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  annotations:
    app.oam.dev/last-applied-configuration: '{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"first-vela-app","namespace":"default","creationTimestamp":null,"labels":{"oam.dev/render-hash":"ea855623cc3ffbb9"}},"spec":{"components":[{"name":"express-server","type":"webservice","properties":{"image":"oamdev/hello-world","ports":[{"expose":true,"port":8000}]},"traits":[{"type":"scaler","properties":{"replicas":1}}]}],"policies":[{"name":"target-default","type":"topology","properties":{"clusters":["local"],"namespace":"default"}}]},"status":{}}'
    app.oam.dev/last-applied-time: "2022-07-20T16:57:46+08:00"
    oam.dev/kubevela-version: v1.4.0
  creationTimestamp: "2022-07-20T08:57:46Z"
  finalizers:
  - app.oam.dev/resource-tracker-finalizer
  generation: 1
  labels:
    oam.dev/render-hash: ea855623cc3ffbb9
  name: first-vela-app
  namespace: default
  resourceVersion: "4535251"
  uid: 63032d71-85c2-4571-8d81-56b7370bb113
spec:
  components:
  - name: express-server
    properties:
      image: oamdev/hello-world
      ports:
      - expose: true
        port: 8000
    traits:
    - properties:
        replicas: 1
      type: scaler
    type: webservice
  policies:
  - name: target-default
    properties:
      clusters:
      - local
      namespace: default
    type: topology
status:
  appliedResources:
  - apiVersion: apps/v1
    cluster: local
    creator: workflow
    kind: Deployment
    name: express-server
    namespace: default
  - apiVersion: v1
    cluster: local
    creator: workflow
    kind: Service
    name: express-server
    namespace: default
  conditions:
  - lastTransitionTime: "2022-07-20T08:57:46Z"
    reason: Available
    status: "True"
    type: Parsed
  - lastTransitionTime: "2022-07-20T08:57:46Z"
    reason: Available
    status: "True"
    type: Revision
  - lastTransitionTime: "2022-07-20T08:57:46Z"
    reason: Available
    status: "True"
    type: Policy
  - lastTransitionTime: "2022-07-20T08:57:46Z"
    reason: Available
    status: "True"
    type: Render
  - lastTransitionTime: "2022-07-20T08:57:55Z"
    reason: Available
    status: "True"
    type: Workflow
  - lastTransitionTime: "2022-07-20T08:57:55Z"
    reason: ReconcileSuccess
    status: "True"
    type: Ready
  latestRevision:
    name: first-vela-app-v1
    revision: 1
    revisionHash: 8ad93499a2dc2fa9
  observedGeneration: 1
  services:
  - cluster: local
    healthy: true
    message: Ready:1/1
    name: express-server
    namespace: default
    traits:
    - healthy: true
      type: scaler
    workloadDefinition:
      apiVersion: apps/v1
      kind: Deployment
  status: running
  workflow:
    appRevision: first-vela-app-v1:630c401488fe8a9
    contextBackend:
      name: workflow-first-vela-app-context
      uid: a321f89e-2c9c-40ea-81ab-27d6e8a5d273
    finished: true
    message: Succeeded
    mode: DAG
    startTime: "2022-07-20T08:57:46Z"
    steps:
    - firstExecuteTime: "2022-07-20T08:57:46Z"
      id: ega2uspq28
      lastExecuteTime: "2022-07-20T08:57:55Z"
      name: deploy-target-default
      phase: succeeded
      type: deploy
    suspend: false
    terminated: false
```
</details>

---

#### Get whole Application in `json`

`vela status first-vela-app -o json`

<details>
<summary>Click to see command output</summary>

```json
{
  "kind": "Application",
  "apiVersion": "core.oam.dev/v1beta1",
  "metadata": {
    "name": "first-vela-app",
    "namespace": "default",
    "uid": "63032d71-85c2-4571-8d81-56b7370bb113",
    "resourceVersion": "4535251",
    "generation": 1,
    "creationTimestamp": "2022-07-20T08:57:46Z",
    "labels": {
      "oam.dev/render-hash": "ea855623cc3ffbb9"
    },
    "annotations": {
      "app.oam.dev/last-applied-configuration": "{\"kind\":\"Application\",\"apiVersion\":\"core.oam.dev/v1beta1\",\"metadata\":{\"name\":\"first-vela-app\",\"namespace\":\"default\",\"creationTimestamp\":null,\"labels\":{\"oam.dev/render-hash\":\"ea855623cc3ffbb9\"}},\"spec\":{\"components\":[{\"name\":\"express-server\",\"type\":\"webservice\",\"properties\":{\"image\":\"oamdev/hello-world\",\"ports\":[{\"expose\":true,\"port\":8000}]},\"traits\":[{\"type\":\"scaler\",\"properties\":{\"replicas\":1}}]}],\"policies\":[{\"name\":\"target-default\",\"type\":\"topology\",\"properties\":{\"clusters\":[\"local\"],\"namespace\":\"default\"}}]},\"status\":{}}",
      "app.oam.dev/last-applied-time": "2022-07-20T16:57:46+08:00",
      "oam.dev/kubevela-version": "v1.4.0"
    },
    "finalizers": [
      "app.oam.dev/resource-tracker-finalizer"
    ]
  },
  "spec": {
    "components": [
      {
        "name": "express-server",
        "type": "webservice",
        "properties": {
          "image": "oamdev/hello-world",
          "ports": [
            {
              "expose": true,
              "port": 8000
            }
          ]
        },
        "traits": [
          {
            "type": "scaler",
            "properties": {
              "replicas": 1
            }
          }
        ]
      }
    ],
    "policies": [
      {
        "name": "target-default",
        "type": "topology",
        "properties": {
          "clusters": [
            "local"
          ],
          "namespace": "default"
        }
      }
    ]
  },
  "status": {
    "conditions": [
      {
        "type": "Parsed",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:46Z",
        "reason": "Available"
      },
      {
        "type": "Revision",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:46Z",
        "reason": "Available"
      },
      {
        "type": "Policy",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:46Z",
        "reason": "Available"
      },
      {
        "type": "Render",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:46Z",
        "reason": "Available"
      },
      {
        "type": "Workflow",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:55Z",
        "reason": "Available"
      },
      {
        "type": "Ready",
        "status": "True",
        "lastTransitionTime": "2022-07-20T08:57:55Z",
        "reason": "ReconcileSuccess"
      }
    ],
    "observedGeneration": 1,
    "status": "running",
    "services": [
      {
        "name": "express-server",
        "namespace": "default",
        "cluster": "local",
        "workloadDefinition": {
          "apiVersion": "apps/v1",
          "kind": "Deployment"
        },
        "healthy": true,
        "message": "Ready:1/1",
        "traits": [
          {
            "type": "scaler",
            "healthy": true
          }
        ]
      }
    ],
    "workflow": {
      "appRevision": "first-vela-app-v1:630c401488fe8a9",
      "mode": "DAG",
      "message": "Succeeded",
      "suspend": false,
      "terminated": false,
      "finished": true,
      "contextBackend": {
        "name": "workflow-first-vela-app-context",
        "uid": "a321f89e-2c9c-40ea-81ab-27d6e8a5d273"
      },
      "steps": [
        {
          "id": "ega2uspq28",
          "name": "deploy-target-default",
          "type": "deploy",
          "phase": "succeeded",
          "firstExecuteTime": "2022-07-20T08:57:46Z",
          "lastExecuteTime": "2022-07-20T08:57:55Z"
        }
      ],
      "startTime": "2022-07-20T08:57:46Z"
    },
    "latestRevision": {
      "name": "first-vela-app-v1",
      "revision": 1,
      "revisionHash": "8ad93499a2dc2fa9"
    },
    "appliedResources": [
      {
        "cluster": "local",
        "creator": "workflow",
        "kind": "Deployment",
        "namespace": "default",
        "name": "express-server",
        "apiVersion": "apps/v1"
      },
      {
        "cluster": "local",
        "creator": "workflow",
        "kind": "Service",
        "namespace": "default",
        "name": "express-server",
        "apiVersion": "v1"
      }
    ]
  }
}
```
</details>

---

#### Quickly check Application `status` using `jsonpath`

`vela status first-vela-app -o jsonpath='{.status}' | jq`

<details>
<summary>Click to see command output</summary>

```json
{
  "conditions": [
    {
      "type": "Parsed",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:46Z",
      "reason": "Available"
    },
    {
      "type": "Revision",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:46Z",
      "reason": "Available"
    },
    {
      "type": "Policy",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:46Z",
      "reason": "Available"
    },
    {
      "type": "Render",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:46Z",
      "reason": "Available"
    },
    {
      "type": "Workflow",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:55Z",
      "reason": "Available"
    },
    {
      "type": "Ready",
      "status": "True",
      "lastTransitionTime": "2022-07-20T08:57:55Z",
      "reason": "ReconcileSuccess"
    }
  ],
  "observedGeneration": 1,
  "status": "running",
  "services": [
    {
      "name": "express-server",
      "namespace": "default",
      "cluster": "local",
      "workloadDefinition": {
        "apiVersion": "apps/v1",
        "kind": "Deployment"
      },
      "healthy": true,
      "message": "Ready:1/1",
      "traits": [
        {
          "type": "scaler",
          "healthy": true
        }
      ]
    }
  ],
  "workflow": {
    "appRevision": "first-vela-app-v1:630c401488fe8a9",
    "mode": "DAG",
    "message": "Succeeded",
    "suspend": false,
    "terminated": false,
    "finished": true,
    "contextBackend": {
      "name": "workflow-first-vela-app-context",
      "uid": "a321f89e-2c9c-40ea-81ab-27d6e8a5d273"
    },
    "steps": [
      {
        "id": "ega2uspq28",
        "name": "deploy-target-default",
        "type": "deploy",
        "phase": "succeeded",
        "firstExecuteTime": "2022-07-20T08:57:46Z",
        "lastExecuteTime": "2022-07-20T08:57:55Z"
      }
    ],
    "startTime": "2022-07-20T08:57:46Z"
  },
  "latestRevision": {
    "name": "first-vela-app-v1",
    "revision": 1,
    "revisionHash": "8ad93499a2dc2fa9"
  },
  "appliedResources": [
    {
      "cluster": "local",
      "creator": "workflow",
      "kind": "Deployment",
      "namespace": "default",
      "name": "express-server",
      "apiVersion": "apps/v1"
    },
    {
      "cluster": "local",
      "creator": "workflow",
      "kind": "Service",
      "namespace": "default",
      "name": "express-server",
      "apiVersion": "v1"
    }
  ]
}
```
</details>

---

Only the above three formats are supported in `-o` `--output` option.

Fixes #4235

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually tested with possible user inputs. Unit tests for the util function are added.

### Special notes for your reviewer

There is a `--detail-format` flag mentioned in the original issue. I didn't use it because it serves a different purpose.
