### PR TITLE
Chore: update cue version to 0.4.3

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -222,8 +222,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -223,7 +223,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/daemon.yaml
+++ b/charts/vela-core/templates/defwithtemplate/daemon.yaml
@@ -428,8 +428,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/daemon.yaml
+++ b/charts/vela-core/templates/defwithtemplate/daemon.yaml
@@ -17,7 +17,7 @@ spec:
 
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -26,7 +26,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -35,7 +35,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -44,7 +44,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -53,7 +53,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				if v.mountPropagation != _|_ {
@@ -69,7 +69,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -78,7 +78,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -93,7 +93,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -108,7 +108,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -117,7 +117,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -275,7 +275,7 @@ spec:
         	}
         }
         exposePorts: [
-        	for v in parameter.ports if v.expose == true {
+        	if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
         		port:       v.port
         		targetPort: v.port
         		if v.name != _|_ {
@@ -429,7 +429,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/deploy2runtime.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy2runtime.yaml
@@ -21,9 +21,9 @@ spec:
         app: op.#Steps & {
         	load: op.#Load @step(1)
         	clusters: [...string]
+        	listClusters: op.#ListClusters @step(2)
         	if parameter.clusters == _|_ {
-        		listClusters: op.#ListClusters @step(2)
-        		clusters:     listClusters.outputs.clusters
+        		clusters: listClusters.outputs.clusters
         	}
         	if parameter.clusters != _|_ {
         		clusters: parameter.clusters

--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -94,11 +94,11 @@ spec:
         }
   status:
     customStatus: |-
-      let igs = context.outputs.ingress.status.loadBalancer.ingress
-      if igs == _|_ {
+      if context.outputs.ingress.status.loadBalancer.ingress == _|_ {
         message: "No loadBalancer found, visiting by using 'vela port-forward " + context.appName + "'\n"
       }
-      if len(igs) > 0 {
+      if context.outputs.ingress.status.loadBalancer.ingress != _|_ {
+      	let igs = context.outputs.ingress.status.loadBalancer.ingress
         if igs[0].ip != _|_ {
         	if igs[0].host != _|_ {
       	    message: "Visiting URL: " + context.outputs.ingress.spec.rules[0].host + ", IP: " + igs[0].ip

--- a/charts/vela-core/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/notification.yaml
@@ -201,10 +201,20 @@ spec:
         	verbatim?: bool
         }
         option: {
-        	text:         textType
-        	value:        string
-        	description?: textType
-        	url?:         string
+        	text: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	value: string
+        	description?: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	url?: string
         }
         // send webhook notification
         ding: op.#Steps & {

--- a/charts/vela-core/templates/defwithtemplate/service-account.yaml
+++ b/charts/vela-core/templates/defwithtemplate/service-account.yaml
@@ -41,8 +41,8 @@ spec:
         }
         // +patchStrategy=retainKeys
         patch: spec: template: spec: serviceAccountName: parameter.name
-        _clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
-        _namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+        _clusterPrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "cluster" {p}]
+        _namespacePrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "namespace" {p}]
         outputs: {
         	if parameter.create {
         		"service-account": {

--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -18,7 +18,7 @@ spec:
     cue:
       template: |
         pvcVolumesList: *[
-        		for v in parameter.pvc {
+        		if parameter.pvc != _|_ for v in parameter.pvc {
         		{
         			name: "pvc-" + v.name
         			persistentVolumeClaim: claimName: v.name
@@ -26,7 +26,7 @@ spec:
         	},
         ] | []
         configMapVolumesList: *[
-        			for v in parameter.configMap if v.mountPath != _|_ {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name: "configmap-" + v.name
         			configMap: {
@@ -40,7 +40,7 @@ spec:
         	},
         ] | []
         secretVolumesList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name: "secret-" + v.name
         			secret: {
@@ -54,7 +54,7 @@ spec:
         	},
         ] | []
         emptyDirVolumesList: *[
-        			for v in parameter.emptyDir {
+        			if parameter.emptyDir != _|_ for v in parameter.emptyDir {
         		{
         			name: "emptydir-" + v.name
         			emptyDir: medium: v.medium
@@ -62,7 +62,7 @@ spec:
         	},
         ] | []
         pvcVolumeMountsList: *[
-        			for v in parameter.pvc {
+        			if parameter.pvc != _|_ for v in parameter.pvc {
         		if v.volumeMode == "Filesystem" {
         			{
         				name:      "pvc-" + v.name
@@ -75,7 +75,7 @@ spec:
         	},
         ] | []
         configMapVolumeMountsList: *[
-        				for v in parameter.configMap if v.mountPath != _|_ {
+        				if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name:      "configmap-" + v.name
         			mountPath: v.mountPath
@@ -86,7 +86,7 @@ spec:
         	},
         ] | []
         configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnv != _|_ {
         		{
         			name: v.mountToEnv.envName
         			valueFrom: configMapKeyRef: {
@@ -97,7 +97,7 @@ spec:
         	},
         ] | []
         configMountToEnvsList: *[
-        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
         			name: k.envName
         			valueFrom: configMapKeyRef: {
@@ -108,7 +108,7 @@ spec:
         	},
         ] | []
         secretVolumeMountsList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name:      "secret-" + v.name
         			mountPath: v.mountPath
@@ -119,7 +119,7 @@ spec:
         	},
         ] | []
         secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
+        			if parameter.secret != _|_ if parameter.secret != _|_ for v in parameter.secret if v.mountToEnv != _|_ {
         		{
         			name: v.mountToEnv.envName
         			valueFrom: secretKeyRef: {
@@ -130,7 +130,7 @@ spec:
         	},
         ] | []
         secretMountToEnvsList: *[
-        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
         			name: k.envName
         			valueFrom: secretKeyRef: {
@@ -141,7 +141,7 @@ spec:
         	},
         ] | []
         emptyDirVolumeMountsList: *[
-        				for v in parameter.emptyDir {
+        				if parameter.emptyDir != _|_ for v in parameter.emptyDir {
         		{
         			name:      "emptydir-" + v.name
         			mountPath: v.mountPath
@@ -152,7 +152,7 @@ spec:
         	},
         ] | []
         volumeDevicesList: *[
-        			for v in parameter.pvc if v.volumeMode == "Block" {
+        			if parameter.pvc != _|_ for v in parameter.pvc if v.volumeMode == "Block" {
         		{
         			name:       "pvc-" + v.name
         			devicePath: v.mountPath
@@ -167,17 +167,17 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				_ignore: true
+        				ignore: true
         			}
         			vi
         		},
-        	] if val._ignore == _|_ {
+        	] if val.ignore == _|_ {
         		val
         	},
         ]
         patch: spec: template: spec: {
         	// +patchKey=name
-        	volumes: deDupVolumesArray
+        	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
         	containers: [{
         		// +patchKey=name
@@ -190,7 +190,7 @@ spec:
 
         }
         outputs: {
-        	for v in parameter.pvc {
+        	if parameter.pvc != _|_ for v in parameter.pvc {
         		if v.mountOnly == false {
         			"pvc-\(v.name)": {
         				apiVersion: "v1"
@@ -229,7 +229,7 @@ spec:
         		}
         	}
 
-        	for v in parameter.configMap {
+        	if parameter.configMap != _|_ for v in parameter.configMap {
         		if v.mountOnly == false {
         			"configmap-\(v.name)": {
         				apiVersion: "v1"
@@ -242,7 +242,7 @@ spec:
         		}
         	}
 
-        	for v in parameter.secret {
+        	if parameter.secret != _|_ for v in parameter.secret {
         		if v.mountOnly == false {
         			"secret-\(v.name)": {
         				apiVersion: "v1"

--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -177,7 +177,7 @@ spec:
         ]
         patch: spec: template: spec: {
         	// +patchKey=name
-        	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
+        	volumes: deDupVolumesArray
 
         	containers: [{
         		// +patchKey=name

--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -167,11 +167,11 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				ignore: true
+        				_ignore: true
         			}
         			vi
         		},
-        	] if val.ignore == _|_ {
+        	] if val._ignore == _|_ {
         		val
         	},
         ]

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -175,8 +175,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -63,7 +63,7 @@ spec:
         					}
 
         					if parameter["volumes"] != _|_ {
-        						volumeMounts: [ for v in parameter.volumes {
+        						volumeMounts: [ if parameter.volumes != _|_ for v in parameter.volumes {
         							{
         								mountPath: v.mountPath
         								name:      v.name
@@ -72,7 +72,7 @@ spec:
         				}]
 
         				if parameter["volumes"] != _|_ {
-        					volumes: [ for v in parameter.volumes {
+        					volumes: [ if parameter.volumes != _|_ for v in parameter.volumes {
         						{
         							name: v.name
         							if v.type == "pvc" {
@@ -103,7 +103,7 @@ spec:
         				}
 
         				if parameter["imagePullSecrets"] != _|_ {
-        					imagePullSecrets: [ for v in parameter.imagePullSecrets {
+        					imagePullSecrets: [ if parameter.imagePullSecrets != _|_ for v in parameter.imagePullSecrets {
         						name: v
         					},
         					]
@@ -176,7 +176,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/volumes.yaml
+++ b/charts/vela-core/templates/defwithtemplate/volumes.yaml
@@ -54,8 +54,8 @@ spec:
         	// +usage=Declare volumes and volumeMounts
         	volumes?: [...{
         		name: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/volumes.yaml
+++ b/charts/vela-core/templates/defwithtemplate/volumes.yaml
@@ -55,7 +55,7 @@ spec:
         	volumes?: [...{
         		name: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/webhook-notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webhook-notification.yaml
@@ -133,10 +133,20 @@ spec:
         	verbatim?: bool
         }
         option: {
-        	text:         textType
-        	value:        string
-        	description?: textType
-        	url?:         string
+        	text: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	value: string
+        	description?: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	url?: string
         }
         secretRef: {
         	name: string

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -453,8 +453,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -17,7 +17,7 @@ spec:
 
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -29,7 +29,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -41,7 +41,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -53,7 +53,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -65,7 +65,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -78,7 +78,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -87,7 +87,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -102,7 +102,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -117,7 +117,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -126,7 +126,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -139,11 +139,11 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				_ignore: true
+        				ignore: true
         			}
         			vi
         		},
-        	] if val._ignore == _|_ {
+        	] if val.ignore == _|_ {
         		val
         	},
         ]
@@ -297,7 +297,7 @@ spec:
         	}
         }
         exposePorts: [
-        	for v in parameter.ports if v.expose == true {
+        	if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
         		port:       v.port
         		targetPort: v.port
         		if v.name != _|_ {
@@ -454,7 +454,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -322,8 +322,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -15,7 +15,7 @@ spec:
       template: |
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -24,7 +24,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -33,7 +33,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -42,7 +42,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -51,7 +51,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -61,7 +61,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -70,7 +70,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -85,7 +85,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -100,7 +100,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -109,7 +109,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -323,7 +323,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
@@ -222,8 +222,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
@@ -223,7 +223,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/daemon.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/daemon.yaml
@@ -428,8 +428,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/daemon.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/daemon.yaml
@@ -17,7 +17,7 @@ spec:
 
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -26,7 +26,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -35,7 +35,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -44,7 +44,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -53,7 +53,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				if v.mountPropagation != _|_ {
@@ -69,7 +69,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -78,7 +78,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -93,7 +93,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -108,7 +108,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -117,7 +117,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -275,7 +275,7 @@ spec:
         	}
         }
         exposePorts: [
-        	for v in parameter.ports if v.expose == true {
+        	if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
         		port:       v.port
         		targetPort: v.port
         		if v.name != _|_ {
@@ -429,7 +429,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/deploy2runtime.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/deploy2runtime.yaml
@@ -21,9 +21,9 @@ spec:
         app: op.#Steps & {
         	load: op.#Load @step(1)
         	clusters: [...string]
+        	listClusters: op.#ListClusters @step(2)
         	if parameter.clusters == _|_ {
-        		listClusters: op.#ListClusters @step(2)
-        		clusters:     listClusters.outputs.clusters
+        		clusters: listClusters.outputs.clusters
         	}
         	if parameter.clusters != _|_ {
         		clusters: parameter.clusters

--- a/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
@@ -94,11 +94,11 @@ spec:
         }
   status:
     customStatus: |-
-      let igs = context.outputs.ingress.status.loadBalancer.ingress
-      if igs == _|_ {
+      if context.outputs.ingress.status.loadBalancer.ingress == _|_ {
         message: "No loadBalancer found, visiting by using 'vela port-forward " + context.appName + "'\n"
       }
-      if len(igs) > 0 {
+      if context.outputs.ingress.status.loadBalancer.ingress != _|_ {
+      	let igs = context.outputs.ingress.status.loadBalancer.ingress
         if igs[0].ip != _|_ {
         	if igs[0].host != _|_ {
       	    message: "Visiting URL: " + context.outputs.ingress.spec.rules[0].host + ", IP: " + igs[0].ip

--- a/charts/vela-minimal/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/notification.yaml
@@ -201,10 +201,20 @@ spec:
         	verbatim?: bool
         }
         option: {
-        	text:         textType
-        	value:        string
-        	description?: textType
-        	url?:         string
+        	text: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	value: string
+        	description?: {
+        		type:      string
+        		text:      string
+        		emoji?:    bool
+        		verbatim?: bool
+        	}
+        	url?: string
         }
         // send webhook notification
         ding: op.#Steps & {

--- a/charts/vela-minimal/templates/defwithtemplate/service-account.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/service-account.yaml
@@ -41,8 +41,8 @@ spec:
         }
         // +patchStrategy=retainKeys
         patch: spec: template: spec: serviceAccountName: parameter.name
-        _clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
-        _namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+        _clusterPrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "cluster" {p}]
+        _namespacePrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "namespace" {p}]
         outputs: {
         	if parameter.create {
         		"service-account": {

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -18,7 +18,7 @@ spec:
     cue:
       template: |
         pvcVolumesList: *[
-        		for v in parameter.pvc {
+        		if parameter.pvc != _|_ for v in parameter.pvc {
         		{
         			name: "pvc-" + v.name
         			persistentVolumeClaim: claimName: v.name
@@ -26,7 +26,7 @@ spec:
         	},
         ] | []
         configMapVolumesList: *[
-        			for v in parameter.configMap if v.mountPath != _|_ {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name: "configmap-" + v.name
         			configMap: {
@@ -40,7 +40,7 @@ spec:
         	},
         ] | []
         secretVolumesList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name: "secret-" + v.name
         			secret: {
@@ -54,7 +54,7 @@ spec:
         	},
         ] | []
         emptyDirVolumesList: *[
-        			for v in parameter.emptyDir {
+        			if parameter.emptyDir != _|_ for v in parameter.emptyDir {
         		{
         			name: "emptydir-" + v.name
         			emptyDir: medium: v.medium
@@ -62,7 +62,7 @@ spec:
         	},
         ] | []
         pvcVolumeMountsList: *[
-        			for v in parameter.pvc {
+        			if parameter.pvc != _|_ for v in parameter.pvc {
         		if v.volumeMode == "Filesystem" {
         			{
         				name:      "pvc-" + v.name
@@ -75,7 +75,7 @@ spec:
         	},
         ] | []
         configMapVolumeMountsList: *[
-        				for v in parameter.configMap if v.mountPath != _|_ {
+        				if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name:      "configmap-" + v.name
         			mountPath: v.mountPath
@@ -86,7 +86,7 @@ spec:
         	},
         ] | []
         configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnv != _|_ {
         		{
         			name: v.mountToEnv.envName
         			valueFrom: configMapKeyRef: {
@@ -97,7 +97,7 @@ spec:
         	},
         ] | []
         configMountToEnvsList: *[
-        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        			if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
         			name: k.envName
         			valueFrom: configMapKeyRef: {
@@ -108,7 +108,7 @@ spec:
         	},
         ] | []
         secretVolumeMountsList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name:      "secret-" + v.name
         			mountPath: v.mountPath
@@ -119,7 +119,7 @@ spec:
         	},
         ] | []
         secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
+        			if parameter.secret != _|_ if parameter.secret != _|_ for v in parameter.secret if v.mountToEnv != _|_ {
         		{
         			name: v.mountToEnv.envName
         			valueFrom: secretKeyRef: {
@@ -130,7 +130,7 @@ spec:
         	},
         ] | []
         secretMountToEnvsList: *[
-        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        			if parameter.secret != _|_ for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
         			name: k.envName
         			valueFrom: secretKeyRef: {
@@ -141,7 +141,7 @@ spec:
         	},
         ] | []
         emptyDirVolumeMountsList: *[
-        				for v in parameter.emptyDir {
+        				if parameter.emptyDir != _|_ for v in parameter.emptyDir {
         		{
         			name:      "emptydir-" + v.name
         			mountPath: v.mountPath
@@ -152,7 +152,7 @@ spec:
         	},
         ] | []
         volumeDevicesList: *[
-        			for v in parameter.pvc if v.volumeMode == "Block" {
+        			if parameter.pvc != _|_ for v in parameter.pvc if v.volumeMode == "Block" {
         		{
         			name:       "pvc-" + v.name
         			devicePath: v.mountPath
@@ -167,17 +167,17 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				_ignore: true
+        				ignore: true
         			}
         			vi
         		},
-        	] if val._ignore == _|_ {
+        	] if val.ignore == _|_ {
         		val
         	},
         ]
         patch: spec: template: spec: {
         	// +patchKey=name
-        	volumes: deDupVolumesArray
+        	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
         	containers: [{
         		// +patchKey=name
@@ -190,7 +190,7 @@ spec:
 
         }
         outputs: {
-        	for v in parameter.pvc {
+        	if parameter.pvc != _|_ for v in parameter.pvc {
         		if v.mountOnly == false {
         			"pvc-\(v.name)": {
         				apiVersion: "v1"
@@ -229,7 +229,7 @@ spec:
         		}
         	}
 
-        	for v in parameter.configMap {
+        	if parameter.configMap != _|_ for v in parameter.configMap {
         		if v.mountOnly == false {
         			"configmap-\(v.name)": {
         				apiVersion: "v1"
@@ -242,7 +242,7 @@ spec:
         		}
         	}
 
-        	for v in parameter.secret {
+        	if parameter.secret != _|_ for v in parameter.secret {
         		if v.mountOnly == false {
         			"secret-\(v.name)": {
         				apiVersion: "v1"

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -177,7 +177,7 @@ spec:
         ]
         patch: spec: template: spec: {
         	// +patchKey=name
-        	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
+        	volumes: deDupVolumesArray
 
         	containers: [{
         		// +patchKey=name

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -167,11 +167,11 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				ignore: true
+        				_ignore: true
         			}
         			vi
         		},
-        	] if val.ignore == _|_ {
+        	] if val._ignore == _|_ {
         		val
         	},
         ]

--- a/charts/vela-minimal/templates/defwithtemplate/task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/task.yaml
@@ -175,8 +175,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/task.yaml
@@ -63,7 +63,7 @@ spec:
         					}
 
         					if parameter["volumes"] != _|_ {
-        						volumeMounts: [ for v in parameter.volumes {
+        						volumeMounts: [ if parameter.volumes != _|_ for v in parameter.volumes {
         							{
         								mountPath: v.mountPath
         								name:      v.name
@@ -72,7 +72,7 @@ spec:
         				}]
 
         				if parameter["volumes"] != _|_ {
-        					volumes: [ for v in parameter.volumes {
+        					volumes: [ if parameter.volumes != _|_ for v in parameter.volumes {
         						{
         							name: v.name
         							if v.type == "pvc" {
@@ -103,7 +103,7 @@ spec:
         				}
 
         				if parameter["imagePullSecrets"] != _|_ {
-        					imagePullSecrets: [ for v in parameter.imagePullSecrets {
+        					imagePullSecrets: [ if parameter.imagePullSecrets != _|_ for v in parameter.imagePullSecrets {
         						name: v
         					},
         					]
@@ -176,7 +176,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -453,8 +453,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -17,7 +17,7 @@ spec:
 
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -29,7 +29,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -41,7 +41,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -53,7 +53,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -65,7 +65,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				if v.subPath != _|_ {
@@ -78,7 +78,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -87,7 +87,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -102,7 +102,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -117,7 +117,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -126,7 +126,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -139,11 +139,11 @@ spec:
         	for val in [
         		for i, vi in volumesList {
         			for j, vj in volumesList if j < i && vi.name == vj.name {
-        				_ignore: true
+        				ignore: true
         			}
         			vi
         		},
-        	] if val._ignore == _|_ {
+        	] if val.ignore == _|_ {
         		val
         	},
         ]
@@ -297,7 +297,7 @@ spec:
         	}
         }
         exposePorts: [
-        	for v in parameter.ports if v.expose == true {
+        	if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
         		port:       v.port
         		targetPort: v.port
         		if v.name != _|_ {
@@ -454,7 +454,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -322,8 +322,8 @@ spec:
         	volumes?: [...{
         		name:      string
         		mountPath: string
-        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+        		type: *"emptyDir" | "pvc" | "configMap" | "secret"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -15,7 +15,7 @@ spec:
       template: |
         mountsArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -24,7 +24,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -33,7 +33,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -42,7 +42,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -51,7 +51,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				mountPath: v.mountPath
         				name:      v.name
@@ -61,7 +61,7 @@ spec:
         }
         volumesArray: {
         	pvc: *[
-        		for v in parameter.volumeMounts.pvc {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         			{
         				name: v.name
         				persistentVolumeClaim: claimName: v.claimName
@@ -70,7 +70,7 @@ spec:
         	] | []
 
         	configMap: *[
-        			for v in parameter.volumeMounts.configMap {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
         			{
         				name: v.name
         				configMap: {
@@ -85,7 +85,7 @@ spec:
         	] | []
 
         	secret: *[
-        		for v in parameter.volumeMounts.secret {
+        		if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
         			{
         				name: v.name
         				secret: {
@@ -100,7 +100,7 @@ spec:
         	] | []
 
         	emptyDir: *[
-        			for v in parameter.volumeMounts.emptyDir {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
         			{
         				name: v.name
         				emptyDir: medium: v.medium
@@ -109,7 +109,7 @@ spec:
         	] | []
 
         	hostPath: *[
-        			for v in parameter.volumeMounts.hostPath {
+        			if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
         			{
         				name: v.name
         				hostPath: path: v.path
@@ -323,7 +323,7 @@ spec:
         		name:      string
         		mountPath: string
         		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		type: *"pvc" | "configMap" | "secret" | "emptyDir"
         		if type == "pvc" {
         			claimName: string
         		}

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -984,10 +984,10 @@ var showCdResult = `# Specification
 +---------+--------------------------------------------------------------------------------------------------+----------+----------+---------+
 |  NAME   |                                           DESCRIPTION                                            |   TYPE   | REQUIRED | DEFAULT |
 +---------+--------------------------------------------------------------------------------------------------+----------+----------+---------+
-| cmd     | Commands to run in the container.                                                                | []string | false    |         |
 | count   | specify number of tasks to run in parallel.                                                      | int      | false    |       1 |
-| restart | Define the job restart policy, the value can only be Never or OnFailure. By default, it's Never. | string   | false    | Never   |
 | image   | Which image would you like to use for your service.                                              | string   | true     |         |
+| restart | Define the job restart policy, the value can only be Never or OnFailure. By default, it's Never. | string   | false    | Never   |
+| cmd     | Commands to run in the container.                                                                | []string | false    |         |
 +---------+--------------------------------------------------------------------------------------------------+----------+----------+---------+
 
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oam-dev/kubevela
 go 1.17
 
 require (
-	cuelang.org/go v0.2.2
+	cuelang.org/go v0.4.4-0.20220729051708-0a46a1624353
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/FogDong/uitable v0.0.5
 	github.com/Masterminds/semver/v3 v3.1.1
@@ -83,7 +83,7 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.7.2
 	istio.io/client-go v1.13.4
@@ -124,7 +124,7 @@ require (
 	sigs.k8s.io/gateway-api v0.4.3
 )
 
-require github.com/rogpeppe/go-internal v1.8.0
+require github.com/rogpeppe/go-internal v1.8.1
 
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect
@@ -175,7 +175,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
-	github.com/emicklei/proto v1.6.15 // indirect
+	github.com/emicklei/proto v1.10.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.1.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
@@ -197,6 +197,7 @@ require (
 	github.com/gobuffalo/flect v0.2.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
@@ -235,7 +236,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -258,6 +259,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
-cuelang.org/go v0.2.2 h1:i/wFo48WDibGHKQTRZ08nB8PqmGpVpQ2sRflZPj73nQ=
-cuelang.org/go v0.2.2/go.mod h1:Dyjk8Y/B3CfFT1jQKJU0g5PpCeMiDe0yMOhk57oXwqo=
+cuelang.org/go v0.4.4-0.20220729051708-0a46a1624353 h1:zKp5hMLvsOulekPnhK2HaXKeXBTTfSzy209Yc01DPD8=
+cuelang.org/go v0.4.4-0.20220729051708-0a46a1624353/go.mod h1:LGl1HbaGIFxblk2o2nM53YSW5KN3jmjh4c5jpHMs7rc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/360EntSecGroup-Skylar/excelize v1.4.1/go.mod h1:vnax29X2usfl7HHkBrX5EvSCJcmH3dT9luvxzu8iGAE=
 github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
@@ -633,8 +633,8 @@ github.com/emicklei/go-restful-openapi/v2 v2.3.0/go.mod h1:bs67E3SEVgSmB3qDuRLqp
 github.com/emicklei/go-restful/v3 v3.0.0-rc2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/emicklei/proto v1.6.15 h1:XbpwxmuOPrdES97FrSfpyy67SSCV/wBIKXqgJzh6hNw=
-github.com/emicklei/proto v1.6.15/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
+github.com/emicklei/proto v1.10.0 h1:pDGyFRVV5RvV+nkBK9iy3q67FBy9Xa7vwrOTE+g5aGw=
+github.com/emicklei/proto v1.10.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
@@ -937,6 +937,7 @@ github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2V
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1505,8 +1506,9 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452 h1:hOY53G+kBFhbYFpRVxHl5eS7laP6B1+Cq+Z9Dry1iMU=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
@@ -1821,6 +1823,8 @@ github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:
 github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1/go.mod h1:S5n0C6tSgdnwWshBUceRx5G1OsjLv/EeZ9t3wIfEtsY=
 github.com/prometheus/prometheus v1.8.2-0.20200609102542-5d7e3e970602/go.mod h1:CwaXafRa0mm72de2GQWtfQxjGytbSKIGivWxQvjpRZs=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b h1:zd/2RNzIRkoGGMjE+YIsZ85CnDIz672JK2F3Zl4vux4=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b/go.mod h1:KjY0wibdYKc4DYkerHSbguaf3JeIPGhNJBp2BNiFH78=
 github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
@@ -1850,11 +1854,11 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.6.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc h1:BD7uZqkN8CpjJtN/tScAKiccBikU4dlqe/gNrkRaPY4=
@@ -2293,7 +2297,6 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20200513190911-00229845015e/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -2728,7 +2731,6 @@ golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200603131246-cc40288be839/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -3077,8 +3079,9 @@ gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -589,6 +589,7 @@ func unmarshalToContent(content []byte) (fileContent *github.RepositoryContent, 
 	return nil, nil, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %w", fileUnmarshalError, directoryUnmarshalError)
 }
 
+// nolint:staticcheck
 func genAddonAPISchema(addonRes *UIData) error {
 	param, err := utils2.PrepareParameterCue(addonRes.Name, addonRes.Parameters)
 	if err != nil {

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -184,7 +184,7 @@ func testReaderFunc(t *testing.T, reader AsyncReader) {
 	// test get ui data
 	rName := "KubeVela"
 	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, rName, UIMetaOptions)
-	assert.True(t, strings.Contains(err.Error(), "#parameter.example: preference mark not allowed at this position"))
+	assert.True(t, strings.Contains(err.Error(), "preference mark not allowed at this position"))
 	assert.Equal(t, 5, len(uiDataList))
 	assert.Equal(t, uiDataList[0].RegistryName, rName)
 

--- a/pkg/addon/init.go
+++ b/pkg/addon/init.go
@@ -238,6 +238,7 @@ func (cmd *InitCmd) createURLComponent() error {
 }
 
 // toCUEResourceString formats object to CUE string used in addons
+// nolint:staticcheck
 func toCUEResourceString(obj interface{}) (string, error) {
 	r := cue.Runtime{}
 	v, err := gocodec.New(&r, nil).Decode(obj)

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -41,6 +41,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	addonutil "github.com/oam-dev/kubevela/pkg/utils/addon"
+	verrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 )
 
 const (
@@ -148,7 +149,7 @@ func (a addonCueTemplateRender) renderApp() (*v1beta1.Application, []*unstructur
 	auxiliaryContent, err := v.LookupValue(renderAuxiliaryOutputsPath)
 	if err != nil {
 		// no outputs defined in app template, return normal data
-		if isErrorCueRenderPathNotFound(err, renderAuxiliaryOutputsPath) {
+		if verrors.IsCuePathNotFound(err) {
 			return &app, res, nil
 		}
 		return nil, nil, errors.Wrap(err, "render app from output field from CUE")

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -133,6 +133,10 @@ func (a addonCueTemplateRender) renderApp() (*v1beta1.Application, []*unstructur
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "load app template with CUE files")
 	}
+	if v.Error() != nil {
+		return nil, nil, errors.Wrap(v.Error(), "load app template with CUE files")
+	}
+
 	outputContent, err := v.LookupValue(renderOutputCuePath)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "render app from output field from CUE")

--- a/pkg/addon/render_test.go
+++ b/pkg/addon/render_test.go
@@ -97,7 +97,7 @@ myref: {
 		},
 	}
 	app, _, err := render.renderApp()
-	assert.Equal(t, err.Error(), `load app template with CUE files: reference "myref" not found`)
+	assert.Equal(t, err.Error(), `load app template with CUE files: output.spec.components: reference "myref" not found`)
 	assert.Nil(t, app)
 
 	addon.CUETemplates = []ElementFile{{Data: "package main\n" + resourceComponent1}}
@@ -114,7 +114,7 @@ myref: {
 	assert.Equal(t, len(app.Spec.Policies), 2)
 	str, err = json.Marshal(app.Spec.Policies)
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(str), `"clusterLabelSelector":{}`))
+	assert.Contains(t, string(str), `"clusterLabelSelector":{}`)
 
 	addon.Parameters = "package newp\n" + paraDefined
 	addon.CUETemplates = []ElementFile{{Data: "package newp\n" + resourceComponent1}}
@@ -133,13 +133,13 @@ myref: {
 	addon.CUETemplates = []ElementFile{{Data: "package hello\n" + resourceComponent1}}
 	addon.AppCueTemplate = ElementFile{Data: "package main\n" + appTemplate}
 	_, _, err = render.renderApp()
-	assert.Equal(t, err.Error(), `load app template with CUE files: reference "myref" not found`)
+	assert.Equal(t, err.Error(), `load app template with CUE files: output.spec.components: reference "myref" not found`)
 
 	addon.CUETemplates = []ElementFile{{Data: "package hello\n" + resourceComponent1}}
 	addon.Parameters = paraDefined
 	addon.AppCueTemplate = ElementFile{Data: appTemplate}
 	_, _, err = render.renderApp()
-	assert.Equal(t, err.Error(), `load app template with CUE files: reference "myref" not found`)
+	assert.Equal(t, err.Error(), `load app template with CUE files: output.spec.components: reference "myref" not found`)
 
 }
 

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -441,10 +441,6 @@ func generateAnnotation(meta *Meta) map[string]string {
 	return res
 }
 
-func isErrorCueRenderPathNotFound(err error, path string) bool {
-	return err.Error() == fmt.Sprintf("failed to lookup value: var(path=%s) not exist", path)
-}
-
 func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*unstructured.Unstructured, appName string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, def := range defs {

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -442,7 +442,7 @@ func generateAnnotation(meta *Meta) map[string]string {
 }
 
 func isErrorCueRenderPathNotFound(err error, path string) bool {
-	return err.Error() == fmt.Sprintf("var(path=%s) not exist", path)
+	return err.Error() == fmt.Sprintf("failed to lookup value: var(path=%s) not exist", path)
 }
 
 func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*unstructured.Unstructured, appName string) (map[string]string, error) {

--- a/pkg/appfile/appfile_test.go
+++ b/pkg/appfile/appfile_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	terraformtypes "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
@@ -1178,33 +1178,32 @@ spec:
 			CapabilityCategory: oamtypes.KubeCategory,
 		},
 		expectData: `
-output: { 
-apiVersion: "apps/v1"
-kind:       "Deployment"
-spec: {
-	selector: {
-		matchLabels: {
-			app: "nginx"
-		}
-	}
-	template: {
-		spec: {
-			containers: [{
-				name:  "nginx"
-				image: "nginx:1.14.0"
-			}]
-			ports: [{
-				containerPort: 80
-			}]
-		}
-		metadata: {
-			labels: {
+output: {
+	apiVersion: "apps/v1"
+	kind:       "Deployment"
+	spec: {
+		selector: {
+			matchLabels: {
 				app: "nginx"
 			}
 		}
+		template: {
+			metadata: {
+				labels: {
+					app: "nginx"
+				}
+			}
+			spec: {
+				containers: [{
+					image: "nginx:1.14.0"
+					name:  "nginx"
+				}]
+				ports: [{
+					containerPort: 80
+				}]
+			}
+		}
 	}
-}
- 
 }`,
 		hasError: false,
 	}, "Kube workload with wrong template": {
@@ -1297,14 +1296,14 @@ output: {
 		errInfo:  "unexpected GroupVersion string: app@//v1",
 	}}
 
-	for _, tc := range testcases {
+	for i, tc := range testcases {
 		template, err := GenerateCUETemplate(tc.workload)
 		assert.Equal(t, err != nil, tc.hasError)
 		if tc.hasError {
 			assert.Equal(t, tc.errInfo, err.Error())
 			continue
 		}
-		assert.Equal(t, tc.expectData, template)
+		assert.Equal(t, tc.expectData, template, i)
 	}
 }
 
@@ -1395,11 +1394,9 @@ func TestBaseGenerateComponent(t *testing.T) {
 		}
 	}
 `
-	var r cue.Runtime
-	inst, err := r.Compile("-", base)
-	assert.NilError(t, err)
+	inst := cuecontext.New().CompileString(base)
 	bs, _ := model.NewBase(inst.Value())
-	err = pContext.SetBase(bs)
+	err := pContext.SetBase(bs)
 	assert.NilError(t, err)
 	tr := &Trait{
 		Name:   traitName,

--- a/pkg/appfile/helm/testdata/values.schema.json
+++ b/pkg/appfile/helm/testdata/values.schema.json
@@ -140,6 +140,16 @@
           "type": "boolean"
         },
         "hosts": {
+          "default":[	
+            {	
+              "host":"chart-example.local",	
+              "paths":[	
+                {	
+                  "path":"/"	
+                }	
+              ]	
+            }	
+         ],
           "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"",
           "items": {
             "properties": {
@@ -148,6 +158,11 @@
                 "type": "string"
               },
               "paths": {
+                "default":[	
+                  {	
+                    "path":"/"	
+                  }	
+                ],
                 "items": {
                   "properties": {
                     "path": {

--- a/pkg/appfile/template_test.go
+++ b/pkg/appfile/template_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -121,17 +121,8 @@ spec:
 		t.Error(err)
 		return
 	}
-	var r cue.Runtime
-	inst, err := r.Compile("-", temp.TemplateStr)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	instDest, err := r.Compile("-", cueTemplate)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	inst := cuecontext.New().CompileString(temp.TemplateStr)
+	instDest := cuecontext.New().CompileString(cueTemplate)
 	s1, _ := inst.Value().String()
 	s2, _ := instDest.Value().String()
 	if s1 != s2 {
@@ -226,17 +217,8 @@ spec:
 		t.Error(err)
 		return
 	}
-	var r cue.Runtime
-	inst, err := r.Compile("-", temp.TemplateStr)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	instDest, err := r.Compile("-", cueTemplate)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	inst := cuecontext.New().CompileString(temp.TemplateStr)
+	instDest := cuecontext.New().CompileString(cueTemplate)
 	s1, _ := inst.Value().String()
 	s2, _ := instDest.Value().String()
 	if s1 != s2 {
@@ -345,17 +327,8 @@ spec:
 		t.Error(err)
 		return
 	}
-	var r cue.Runtime
-	inst, err := r.Compile("-", temp.TemplateStr)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	instDest, err := r.Compile("-", cueTemplate)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	inst := cuecontext.New().CompileString(temp.TemplateStr)
+	instDest := cuecontext.New().CompileString(cueTemplate)
 	s1, _ := inst.Value().String()
 	s2, _ := instDest.Value().String()
 	if s1 != s2 {

--- a/pkg/builtin/http/http.go
+++ b/pkg/builtin/http/http.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/oam-dev/kubevela/pkg/builtin/registry"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 )
 
 func init() {
@@ -55,8 +56,8 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 			Timeout:   time.Second * 3,
 		}
 	)
-	if obj := meta.Obj.Lookup("request"); obj.Exists() {
-		if v := obj.Lookup("body"); v.Exists() {
+	if obj := meta.Obj.LookupPath(value.FieldPath("request")); obj.Exists() {
+		if v := obj.LookupPath(value.FieldPath("body")); v.Exists() {
 			r, err = v.Reader()
 			if err != nil {
 				return nil, err
@@ -84,13 +85,13 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 	req.Header = header
 	req.Trailer = trailer
 
-	if tlsConfig := meta.Obj.Lookup("tls_config"); tlsConfig.Exists() {
+	if tlsConfig := meta.Obj.LookupPath(value.FieldPath("tls_config")); tlsConfig.Exists() {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{
 				NextProtos: []string{"http/1.1"},
 			},
 		}
-		ca := tlsConfig.Lookup("ca")
+		ca := tlsConfig.LookupPath(value.FieldPath("ca"))
 		if caCrt, err := ca.String(); err != nil {
 			return nil, errors.WithMessage(err, "parse ca")
 		} else {
@@ -99,8 +100,8 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 			tr.TLSClientConfig.RootCAs = pool
 		}
 
-		cert := tlsConfig.Lookup("client_crt")
-		key := tlsConfig.Lookup("client_key")
+		cert := tlsConfig.LookupPath(value.FieldPath("client_crt"))
+		key := tlsConfig.LookupPath(value.FieldPath("client_key"))
 		if cert.Exists() && key.Exists() {
 			crtData, err := cert.String()
 			if err != nil {
@@ -136,7 +137,7 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 }
 
 func parseHeaders(obj cue.Value, label string) (http.Header, error) {
-	m := obj.Lookup(label)
+	m := obj.LookupPath(value.FieldPath(label))
 	if !m.Exists() {
 		return nil, nil
 	}

--- a/pkg/builtin/registry/registry_runner.go
+++ b/pkg/builtin/registry/registry_runner.go
@@ -24,6 +24,8 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
+
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 )
 
 // Meta provides context for running a task.
@@ -38,7 +40,7 @@ type Meta struct {
 
 // Lookup fetches the value of context by filed
 func (m *Meta) Lookup(field string) cue.Value {
-	f := m.Obj.Lookup(field)
+	f := m.Obj.LookupPath(value.FieldPath(field))
 	if !f.Exists() {
 		m.Err = fmt.Errorf("invalid lookup argument")
 		return cue.Value{}
@@ -51,7 +53,7 @@ func (m *Meta) Lookup(field string) cue.Value {
 
 // Int64 fetch the value formatted int64 of context by filed
 func (m *Meta) Int64(field string) int64 {
-	f := m.Obj.Lookup(field)
+	f := m.Obj.LookupPath(value.FieldPath(field))
 	value, err := f.Int64()
 	if err != nil {
 		m.Err = fmt.Errorf("invalid int64 argument, %w", err)
@@ -63,7 +65,7 @@ func (m *Meta) Int64(field string) int64 {
 
 // String fetch the value formatted string of context by filed
 func (m *Meta) String(field string) string {
-	f := m.Obj.Lookup(field)
+	f := m.Obj.LookupPath(value.FieldPath(field))
 	value, err := f.String()
 	if err != nil {
 		m.Err = fmt.Errorf("invalid string argument, %w", err)
@@ -74,7 +76,7 @@ func (m *Meta) String(field string) string {
 
 // Bytes fetch the value formatted bytes of context by filed
 func (m *Meta) Bytes(field string) []byte {
-	f := m.Obj.Lookup(field)
+	f := m.Obj.LookupPath(value.FieldPath(field))
 	value, err := f.Bytes()
 	if err != nil {
 		m.Err = fmt.Errorf("invalid bytes argument, %w", err)

--- a/pkg/builtin/registry/registry_runner_test.go
+++ b/pkg/builtin/registry/registry_runner_test.go
@@ -20,28 +20,19 @@ import (
 	"testing"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"github.com/bmizerany/assert"
 )
 
 func TestContext(t *testing.T) {
-	var r cue.Runtime
-
 	lpV := `test: "just a test"`
-	inst, err := r.Compile("lp", lpV)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	ctx := Meta{Obj: inst.Value()}
+	inst := cuecontext.New().CompileString(lpV)
+	ctx := Meta{Obj: inst}
 	val := ctx.Lookup("test")
 	assert.Equal(t, true, val.Exists())
 
 	intV := `iTest: 64`
-	iInst, err := r.Compile("int", intV)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	iInst := cuecontext.New().CompileString(intV)
 	iCtx := Meta{Obj: iInst.Value()}
 	iVal := iCtx.Int64("iTest")
 	assert.Equal(t, int64(64), iVal)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	sysruntime "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -465,14 +469,7 @@ var _ = Describe("Test Application Controller", func() {
 	importWdJson, _ := yaml.YAMLToJSON([]byte(wDImportYaml))
 
 	importTd := &v1alpha2.TraitDefinition{}
-	importGateway := &v1alpha2.TraitDefinition{}
-	importStorage := &v1alpha2.TraitDefinition{}
-
-	importEnv := &v1alpha2.TraitDefinition{}
-
 	importHubCpuScaler := &v1beta1.TraitDefinition{}
-
-	importPodAffinity := &v1beta1.TraitDefinition{}
 
 	webserverwd := &v1alpha2.ComponentDefinition{}
 	webserverwdJson, _ := yaml.YAMLToJSON([]byte(webComponentDefYaml))
@@ -505,30 +502,15 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(json.Unmarshal(importTdJson, importTd)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, importTd.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 
-		gatewayJson, gatewayErr := yaml.YAMLToJSON([]byte(gatewayYaml))
-		Expect(gatewayErr).ShouldNot(HaveOccurred())
-		Expect(json.Unmarshal(gatewayJson, importGateway)).Should(BeNil())
-		Expect(k8sClient.Create(ctx, importGateway.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-
-		storageJson, storageErr := yaml.YAMLToJSON([]byte(storageYaml))
-		Expect(storageErr).ShouldNot(HaveOccurred())
-		Expect(json.Unmarshal(storageJson, importStorage)).Should(BeNil())
-		Expect(k8sClient.Create(ctx, importStorage.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-
-		envJson, envErr := yaml.YAMLToJSON([]byte(envYaml))
-		Expect(envErr).ShouldNot(HaveOccurred())
-		Expect(json.Unmarshal(envJson, importEnv)).Should(BeNil())
-		Expect(k8sClient.Create(ctx, importEnv.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+		traitList := []string{"gateway", "storage", "env", "affinity"}
+		for _, trait := range traitList {
+			installDefinition(ctx, trait)
+		}
 
 		hubCpuScalerJson, hubCpuScalerErr := yaml.YAMLToJSON([]byte(hubCpuScalerYaml))
 		Expect(hubCpuScalerErr).ShouldNot(HaveOccurred())
 		Expect(json.Unmarshal(hubCpuScalerJson, importHubCpuScaler)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, importHubCpuScaler.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-
-		affinityJson, podAffinityErr := yaml.YAMLToJSON([]byte(affinityYaml))
-		Expect(podAffinityErr).ShouldNot(HaveOccurred())
-		Expect(json.Unmarshal(affinityJson, importPodAffinity)).Should(BeNil())
-		Expect(k8sClient.Create(ctx, importPodAffinity.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 
 		Expect(json.Unmarshal(tDDefJson, td)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, td.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
@@ -4713,6 +4695,20 @@ var _ = Describe("Test Application Controller", func() {
 	})
 })
 
+func installDefinition(ctx context.Context, name string) {
+	_, file, _, _ := sysruntime.Caller(0)
+	definitionPath := filepath.Join(filepath.Dir(filepath.Dir(file)), "../../../../charts/vela-core/templates/defwithtemplate")
+
+	b, err := ioutil.ReadFile(filepath.Join(definitionPath, name+".yaml"))
+	Expect(err).ShouldNot(HaveOccurred())
+	s := strings.ReplaceAll(string(b), `{{ include "systemDefinitionNamespace" . }}`, "vela-system")
+	defJson, defErr := yaml.YAMLToJSON([]byte(s))
+	Expect(defErr).ShouldNot(HaveOccurred())
+	u := &unstructured.Unstructured{}
+	Expect(json.Unmarshal(defJson, u)).Should(BeNil())
+	Expect(k8sClient.Create(ctx, u.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+}
+
 const (
 	scopeDefYaml = `apiVersion: core.oam.dev/v1beta1
 kind: ScopeDefinition
@@ -4743,15 +4739,6 @@ spec:
       output: {
           apiVersion: "apps/v1"
           kind:       "Deployment"
-          metadata: {
-              annotations: {
-                  if context["config"] != _|_ {
-                      for _, v in context.config {
-                          "\(v.name)" : v.value
-                      }
-                  }
-              }
-          }
           spec: {
               selector: matchLabels: {
                   "app.oam.dev/component": context.name
@@ -5135,106 +5122,7 @@ spec:
           cmd?: [...string]
       }
 `
-	gatewayYaml = `apiVersion: core.oam.dev/v1beta1
-kind: TraitDefinition
-metadata:
-  annotations:
-    definition.oam.dev/description: Enable public web traffic for the component, the ingress API matches K8s v1.20+.
-  name: gateway
-  namespace: vela-system
-spec:
-  appliesToWorkloads:
-    - '*'
-  podDisruptive: false
-  schematic:
-    cue:
-      template: |
-        // trait template can have multiple outputs in one trait
-        outputs: service: {
-        	apiVersion: "v1"
-        	kind:       "Service"
-        	metadata: name: context.name
-        	spec: {
-        		selector: "app.oam.dev/component": context.name
-        		ports: [
-        			for k, v in parameter.http {
-        				port:       v
-        				targetPort: v
-        			},
-        		]
-        	}
-        }
-        outputs: ingress: {
-        	apiVersion: "networking.k8s.io/v1"
-        	kind:       "Ingress"
-        	metadata: {
-        		name: context.name
-        		annotations: {
-        			if !parameter.classInSpec {
-        				"kubernetes.io/ingress.class": parameter.class
-        			}
-        		}
-        	}
-        	spec: {
-        		if parameter.classInSpec {
-        			ingressClassName: parameter.class
-        		}
-        		if parameter.secretName != _|_ {
-        			tls: [{
-        				hosts: [
-        					parameter.domain,
-        				]
-        				secretName: parameter.secretName
-        			}]
-        		}
-        		rules: [{
-        			host: parameter.domain
-        			http: paths: [
-        				for k, v in parameter.http {
-        					path:     k
-        					pathType: "ImplementationSpecific"
-        					backend: service: {
-        						name: context.name
-        						port: number: v
-        					}
-        				},
-        			]
-        		}]
-        	}
-        }
-        parameter: {
-        	// +usage=Specify the domain you want to expose
-        	domain: string
 
-        	// +usage=Specify the mapping relationship between the http path and the workload port
-        	http: [string]: int
-
-        	// +usage=Specify the class of ingress to use
-        	class: *"nginx" | string
-
-        	// +usage=Set ingress class in '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
-        	classInSpec: *false | bool
-
-        	// +usage=Specify the secret name you want to quote.
-        	secretName?: string
-        }
-  status:
-    customStatus: |-
-      let igs = context.outputs.ingress.status.loadBalancer.ingress
-      if igs == _|_ {
-        message: "No loadBalancer found, visiting by using 'vela port-forward " + context.appName + "'\n"
-      }
-      if len(igs) > 0 {
-        if igs[0].ip != _|_ {
-      	  message: "Visiting URL: " + context.outputs.ingress.spec.rules[0].host + ", IP: " + igs[0].ip
-        }
-        if igs[0].ip == _|_ {
-      	  message: "Visiting URL: " + context.outputs.ingress.spec.rules[0].host
-        }
-      }
-    healthPolicy: 'isHealth: len(context.outputs.service.spec.clusterIP) > 0'
-
-`
 	cdDefWithHealthStatusYaml = `apiVersion: core.oam.dev/v1beta1
 kind: ComponentDefinition
 metadata:
@@ -5760,424 +5648,6 @@ spec:
 
 `
 
-	storageYaml = `apiVersion: core.oam.dev/v1beta1
-kind: TraitDefinition
-metadata:
-  annotations:
-    definition.oam.dev/description: Add storages on K8s pod for your workload which follows the pod spec in path 'spec.template'.
-  name: storage
-  namespace: vela-system
-spec:
-  appliesToWorkloads:
-    - deployments.apps
-  podDisruptive: true
-  schematic:
-    cue:
-      template: |
-        pvcVolumesList: *[
-        		for v in parameter.pvc {
-        		{
-        			name: "pvc-" + v.name
-        			persistentVolumeClaim: claimName: v.name
-        		}
-        	},
-        ] | []
-        configMapVolumesList: *[
-        			for v in parameter.configMap if v.mountPath != _|_ {
-        		{
-        			name: "configmap-" + v.name
-        			configMap: {
-        				defaultMode: v.defaultMode
-        				name:        v.name
-        				if v.items != _|_ {
-        					items: v.items
-        				}
-        			}
-        		}
-        	},
-        ] | []
-        secretVolumesList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
-        		{
-        			name: "secret-" + v.name
-        			secret: {
-        				defaultMode: v.defaultMode
-        				secretName:  v.name
-        				if v.items != _|_ {
-        					items: v.items
-        				}
-        			}
-        		}
-        	},
-        ] | []
-        emptyDirVolumesList: *[
-        			for v in parameter.emptyDir {
-        		{
-        			name: "emptydir-" + v.name
-        			emptyDir: medium: v.medium
-        		}
-        	},
-        ] | []
-        pvcVolumeMountsList: *[
-        			for v in parameter.pvc {
-        		if v.volumeMode == "Filesystem" {
-        			{
-        				name:      "pvc-" + v.name
-        				mountPath: v.mountPath
-        			}
-        		}
-        	},
-        ] | []
-        configMapVolumeMountsList: *[
-        				for v in parameter.configMap if v.mountPath != _|_ {
-        		{
-        			name:      "configmap-" + v.name
-        			mountPath: v.mountPath
-        		}
-        	},
-        ] | []
-        configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
-        		{
-        			name: v.mountToEnv.envName
-        			valueFrom: configMapKeyRef: {
-        				name: v.name
-        				key:  v.mountToEnv.configMapKey
-        			}
-        		}
-        	},
-        ] | []
-        configMapMountToEnvsList: *[
-        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
-        		{
-        			name: k.envName
-        			valueFrom: configMapKeyRef: {
-        				name: v.name
-        				key:  k.configMapKey
-        			}
-        		}
-        	},
-        ] | []
-        secretVolumeMountsList: *[
-        			for v in parameter.secret if v.mountPath != _|_ {
-        		{
-        			name:      "secret-" + v.name
-        			mountPath: v.mountPath
-        		}
-        	},
-        ] | []
-        secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
-        		{
-        			name: v.mountToEnv.envName
-        			valueFrom: secretKeyRef: {
-        				name: v.name
-        				key:  v.mountToEnv.secretKey
-        			}
-        		}
-        	},
-        ] | []
-        secretMountToEnvsList: *[
-        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
-        		{
-        			name: k.envName
-        			valueFrom: secretKeyRef: {
-        				name: v.name
-        				key:  k.secretKey
-        			}
-        		}
-        	},
-        ] | []
-        emptyDirVolumeMountsList: *[
-        				for v in parameter.emptyDir {
-        		{
-        			name:      "emptydir-" + v.name
-        			mountPath: v.mountPath
-        		}
-        	},
-        ] | []
-        volumeDevicesList: *[
-        			for v in parameter.pvc if v.volumeMode == "Block" {
-        		{
-        			name:       "pvc-" + v.name
-        			devicePath: v.mountPath
-        		}
-        	},
-        ] | []
-        patch: spec: template: spec: {
-        	// +patchKey=name
-        	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
-
-        	containers: [{
-        		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList + configMapMountToEnvsList + secretMountToEnvsList
-        		// +patchKey=name
-        		volumeDevices: volumeDevicesList
-        		// +patchKey=name
-        		volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
-        	},...]
-
-        }
-        outputs: {
-        	for v in parameter.pvc {
-        		if v.mountOnly == false {
-        			"pvc-\(v.name)": {
-        				apiVersion: "v1"
-        				kind:       "PersistentVolumeClaim"
-        				metadata: name: v.name
-        				spec: {
-        					accessModes: v.accessModes
-        					volumeMode:  v.volumeMode
-        					if v.volumeName != _|_ {
-        						volumeName: v.volumeName
-        					}
-        					if v.storageClassName != _|_ {
-        						storageClassName: v.storageClassName
-        					}
-
-        					if v.resources.requests.storage == _|_ {
-        						resources: requests: storage: "8Gi"
-        					}
-        					if v.resources.requests.storage != _|_ {
-        						resources: requests: storage: v.resources.requests.storage
-        					}
-        					if v.resources.limits.storage != _|_ {
-        						resources: limits: storage: v.resources.limits.storage
-        					}
-        					if v.dataSourceRef != _|_ {
-        						dataSourceRef: v.dataSourceRef
-        					}
-        					if v.dataSource != _|_ {
-        						dataSource: v.dataSource
-        					}
-        					if v.selector != _|_ {
-        						dataSource: v.selector
-        					}
-        				}
-        			}
-        		}
-        	}
-
-        	for v in parameter.configMap {
-        		if v.mountOnly == false {
-        			"configmap-\(v.name)": {
-        				apiVersion: "v1"
-        				kind:       "ConfigMap"
-        				metadata: name: v.name
-        				if v.data != _|_ {
-        					data: v.data
-        				}
-        			}
-        		}
-        	}
-
-        	for v in parameter.secret {
-        		if v.mountOnly == false {
-        			"secret-\(v.name)": {
-        				apiVersion: "v1"
-        				kind:       "Secret"
-        				metadata: name: v.name
-        				if v.data != _|_ {
-        					data: v.data
-        				}
-        				if v.stringData != _|_ {
-        					stringData: v.stringData
-        				}
-        			}
-        		}
-        	}
-
-        }
-        parameter: {
-        	// +usage=Declare pvc type storage
-        	pvc?: [...{
-        		name:              string
-        		mountOnly:         *false | bool
-        		mountPath:         string
-        		volumeMode:        *"Filesystem" | string
-        		volumeName?:       string
-        		accessModes:       *["ReadWriteOnce"] | [...string]
-        		storageClassName?: string
-        		resources?: {
-        			requests: storage: =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
-        			limits?: storage:  =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
-        		}
-        		dataSourceRef?: {
-        			name:     string
-        			kind:     string
-        			apiGroup: string
-        		}
-        		dataSource?: {
-        			name:     string
-        			kind:     string
-        			apiGroup: string
-        		}
-        		selector?: {
-        			matchLabels?: [string]: string
-        			matchExpressions?: {
-        				key: string
-        				values: [...string]
-        				operator: string
-        			}
-        		}
-        	}]
-
-        	// +usage=Declare config map type storage
-        	configMap?: [...{
-        		name:      string
-        		mountOnly: *false | bool
-        		mountToEnv?: {
-        			envName:      string
-        			configMapKey: string
-        		}
-        		mountToEnvs?: [...{
-        			envName:      string
-        			configMapKey: string
-        		}]
-        		mountPath?:   string
-        		defaultMode: *420 | int
-        		readOnly:    *false | bool
-        		data?: {...}
-        		items?: [...{
-        			key:  string
-        			path: string
-        			mode: *511 | int
-        		}]
-        	}]
-
-        	// +usage=Declare secret type storage
-        	secret?: [...{
-        		name:      string
-        		mountOnly: *false | bool
-        		mountToEnv?: {
-        			envName:   string
-        			secretKey: string
-        		}
-        		mountToEnvs?: [...{
-        			envName:   string
-        			secretKey: string
-        		}]
-        		mountPath?:   string
-        		defaultMode: *420 | int
-        		readOnly:    *false | bool
-        		stringData?: {...}
-        		data?: {...}
-        		items?: [...{
-        			key:  string
-        			path: string
-        			mode: *511 | int
-        		}]
-        	}]
-
-        	// +usage=Declare empty dir type storage
-        	emptyDir?: [...{
-        		name:      string
-        		mountPath: string
-        		medium:    *"" | "Memory"
-        	}]
-        }
-`
-
-	envYaml = `apiVersion: core.oam.dev/v1beta1
-kind: TraitDefinition
-metadata:
-  annotations:
-    definition.oam.dev/description: Add env on K8s pod for your workload which follows the pod spec in path 'spec.template'
-  labels:
-    custom.definition.oam.dev/ui-hidden: "true"
-  name: env
-  namespace: vela-system
-spec:
-  appliesToWorkloads:
-    - '*'
-  schematic:
-    cue:
-      template: |
-        #PatchParams: {
-        	// +usage=Specify the name of the target container, if not set, use the component name
-        	containerName: *"" | string
-        	// +usage=Specify if replacing the whole environment settings for the container
-        	replace: *false | bool
-        	// +usage=Specify the  environment variables to merge, if key already existing, override its value
-        	env: [string]: string
-        	// +usage=Specify which existing environment variables to unset
-        	unset: *[] | [...string]
-        }
-        PatchContainer: {
-        	_params: #PatchParams
-        	name:    _params.containerName
-        	_delKeys: {for k in _params.unset {"\(k)": ""}}
-        	_baseContainers: context.output.spec.template.spec.containers
-        	_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
-        	_baseContainer: *_|_ | {...}
-        	if len(_matchContainers_) == 0 {
-        		err: "container \(name) not found"
-        	}
-        	if len(_matchContainers_) > 0 {
-        		_baseContainer: _matchContainers_[0]
-        		_baseEnv:       _baseContainer.env
-        		if _baseEnv == _|_ {
-        			// +patchStrategy=replace
-        			env: [ for k, v in _params.env if _delKeys[k] == _|_ {
-        				name:  k
-        				value: v
-        			}]
-        		}
-        		if _baseEnv != _|_ {
-        			_baseEnvMap: {for envVar in _baseEnv {"\(envVar.name)": envVar.value}}
-        			// +patchStrategy=replace
-        			env: [ for envVar in _baseEnv if _delKeys[envVar.name] == _|_ && !_params.replace {
-        				name: envVar.name
-        				if _params.env[envVar.name] != _|_ {
-        					value: _params.env[envVar.name]
-        				}
-        				if _params.env[envVar.name] == _|_ {
-        					value: envVar.value
-        				}
-        			}] + [ for k, v in _params.env if _delKeys[k] == _|_ && (_params.replace || _baseEnvMap[k] == _|_) {
-        				name:  k
-        				value: v
-        			}]
-        		}
-        	}
-        }
-        patch: spec: template: spec: {
-        	if parameter.containers == _|_ {
-        		// +patchKey=name
-        		containers: [{
-        			PatchContainer & {_params: {
-        				if parameter.containerName == "" {
-        					containerName: context.name
-        				}
-        				if parameter.containerName != "" {
-        					containerName: parameter.containerName
-        				}
-        				replace: parameter.replace
-        				env:     parameter.env
-        				unset:   parameter.unset
-        			}}
-        		}]
-        	}
-        	if parameter.containers != _|_ {
-        		// +patchKey=name
-        		containers: [ for c in parameter.containers {
-        			if c.containerName == "" {
-        				err: "containerName must be set for containers"
-        			}
-        			if c.containerName != "" {
-        				PatchContainer & {_params: c}
-        			}
-        		}]
-        	}
-        }
-        parameter: *#PatchParams | close({
-        	// +usage=Specify the environment variables for multiple containers
-        	containers: [...#PatchParams]
-        })
-        errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
-
-`
-
 	hubCpuScalerYaml = `apiVersion: core.oam.dev/v1beta1
 kind: TraitDefinition
 metadata:
@@ -6220,190 +5690,6 @@ spec:
         	targetAPIVersion: *"apps/v1" | string
         	// +usage=Specify the kind of scale target
         	targetKind: *"Deployment" | string
-        }
-`
-	affinityYaml = `apiVersion: core.oam.dev/v1beta1
-kind: TraitDefinition
-metadata:
-  annotations:
-    definition.oam.dev/description: affinity specify affinity and tolerationon K8s pod for your workload which follows the pod spec in path 'spec.template'.
-  labels:
-    custom.definition.oam.dev/ui-hidden: "true"
-  name: affinity
-  namespace: vela-system
-spec:
-  appliesToWorkloads:
-    - '*'
-  podDisruptive: true
-  schematic:
-    cue:
-      template: |
-        patch: spec: template: spec: {
-        	if parameter.podAffinity != _|_ {
-        		affinity: podAffinity: {
-        			if parameter.podAffinity.required != _|_ {
-        				requiredDuringSchedulingIgnoredDuringExecution: [
-        					for k in parameter.podAffinity.required {
-        						if k.labelSelector != _|_ {
-        							labelSelector: k.labelSelector
-        						}
-        						if k.namespace != _|_ {
-        							namespace: k.namespace
-        						}
-        						topologyKey: k.topologyKey
-        						if k.namespaceSelector != _|_ {
-        							namespaceSelector: k.namespaceSelector
-        						}
-        					}]
-        			}
-        			if parameter.podAffinity.preferred != _|_ {
-        				preferredDuringSchedulingIgnoredDuringExecution: [
-        					for k in parameter.podAffinity.preferred {
-        						weight:          k.weight
-        						podAffinityTerm: k.podAffinityTerm
-        					}]
-        			}
-        		}
-        	}
-        	if parameter.podAntiAffinity != _|_ {
-        		affinity: podAntiAffinity: {
-        			if parameter.podAntiAffinity.required != _|_ {
-        				requiredDuringSchedulingIgnoredDuringExecution: [
-        					for k in parameter.podAntiAffinity.required {
-        						if k.labelSelector != _|_ {
-        							labelSelector: k.labelSelector
-        						}
-        						if k.namespace != _|_ {
-        							namespace: k.namespace
-        						}
-        						topologyKey: k.topologyKey
-        						if k.namespaceSelector != _|_ {
-        							namespaceSelector: k.namespaceSelector
-        						}
-        					}]
-        			}
-        			if parameter.podAntiAffinity.preferred != _|_ {
-        				preferredDuringSchedulingIgnoredDuringExecution: [
-        					for k in parameter.podAntiAffinity.preferred {
-        						weight:          k.weight
-        						podAffinityTerm: k.podAffinityTerm
-        					}]
-        			}
-        		}
-        	}
-        	if parameter.nodeAffinity != _|_ {
-        		affinity: nodeAffinity: {
-        			if parameter.nodeAffinity.required != _|_ {
-        				requiredDuringSchedulingIgnoredDuringExecution: nodeSelectorTerms: [
-        					for k in parameter.nodeAffinity.required.nodeSelectorTerms {
-        						if k.matchExpressions != _|_ {
-        							matchExpressions: k.matchExpressions
-        						}
-        						if k.matchFields != _|_ {
-        							matchFields: k.matchFields
-        						}
-        					}]
-        			}
-        			if parameter.nodeAffinity.preferred != _|_ {
-        				preferredDuringSchedulingIgnoredDuringExecution: [
-        					for k in parameter.nodeAffinity.preferred {
-        						weight:     k.weight
-        						preference: k.preference
-        					}]
-        			}
-        		}
-        	}
-        	if parameter.tolerations != _|_ {
-        		tolerations: [
-        			for k in parameter.tolerations {
-        				if k.key != _|_ {
-        					key: k.key
-        				}
-        				if k.effect != _|_ {
-        					effect: k.effect
-        				}
-        				if k.value != _|_ {
-        					value: k.value
-        				}
-        				operator: k.operator
-        				if k.tolerationSeconds != _|_ {
-        					tolerationSeconds: k.tolerationSeconds
-        				}
-        			}]
-        	}
-        }
-        #labelSelector: {
-        	matchLabels?: [string]: string
-        	matchExpressions?: [...{
-        		key:      string
-        		operator: *"In" | "NotIn" | "Exists" | "DoesNotExist"
-        		values?: [...string]
-        	}]
-        }
-        #podAffinityTerm: {
-        	labelSelector?: #labelSelector
-        	namespaces?: [...string]
-        	topologyKey:        string
-        	namespaceSelector?: #labelSelector
-        }
-        #nodeSelecor: {
-        	key:      string
-        	operator: *"In" | "NotIn" | "Exists" | "DoesNotExist" | "Gt" | "Lt"
-        	values?: [...string]
-        }
-        #nodeSelectorTerm: {
-        	matchExpressions?: [...#nodeSelecor]
-        	matchFields?: [...#nodeSelecor]
-        }
-        parameter: {
-        	// +usage=Specify the pod affinity scheduling rules
-        	podAffinity?: {
-        		// +usage=Specify the required during scheduling ignored during execution
-        		required?: [...#podAffinityTerm]
-        		// +usage=Specify the preferred during scheduling ignored during execution
-        		preferred?: [...{
-        			// +usage=Specify weight associated with matching the corresponding podAffinityTerm
-        			weight: int & >=1 & <=100
-        			// +usage=Specify a set of pods
-        			podAffinityTerm: #podAffinityTerm
-        		}]
-        	}
-        	// +usage=Specify the pod anti-affinity scheduling rules
-        	podAntiAffinity?: {
-        		// +usage=Specify the required during scheduling ignored during execution
-        		required?: [...#podAffinityTerm]
-        		// +usage=Specify the preferred during scheduling ignored during execution
-        		preferred?: [...{
-        			// +usage=Specify weight associated with matching the corresponding podAffinityTerm
-        			weight: int & >=1 & <=100
-        			// +usage=Specify a set of pods
-        			podAffinityTerm: #podAffinityTerm
-        		}]
-        	}
-        	// +usage=Specify the node affinity scheduling rules for the pod
-        	nodeAffinity?: {
-        		// +usage=Specify the required during scheduling ignored during execution
-        		required?: {
-        			// +usage=Specify a list of node selector
-        			nodeSelectorTerms: [...#nodeSelectorTerm]
-        		}
-        		// +usage=Specify the preferred during scheduling ignored during execution
-        		preferred?: [...{
-        			// +usage=Specify weight associated with matching the corresponding nodeSelector
-        			weight: int & >=1 & <=100
-        			// +usage=Specify a node selector
-        			preference: #nodeSelectorTerm
-        		}]
-        	}
-        	// +usage=Specify tolerant taint
-        	tolerations?: [...{
-        		key?:     string
-        		operator: *"Equal" | "Exists"
-        		value?:   string
-        		effect?:  "NoSchedule" | "PreferNoSchedule" | "NoExecute"
-        		// +usage=Specify the period of time the toleration
-        		tolerationSeconds?: int
-        	}]
         }
 `
 )

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -183,7 +183,7 @@ func convertStepProperties(step *v1beta1.WorkflowStep, app *v1beta1.Application)
 			step.Inputs = append(step.Inputs, c.Inputs...)
 			for index := range step.Inputs {
 				parameterKey := strings.TrimSpace(step.Inputs[index].ParameterKey)
-				if !strings.HasPrefix(parameterKey, "properties") && !strings.HasPrefix(parameterKey, "traits[") {
+				if parameterKey != "" && !strings.HasPrefix(parameterKey, "properties") && !strings.HasPrefix(parameterKey, "traits[") {
 					parameterKey = "properties." + parameterKey
 				}
 				step.Inputs[index].ParameterKey = parameterKey

--- a/pkg/controller/core.oam.dev/v1alpha2/application/testdata/definitions/panic.yaml
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/testdata/definitions/panic.yaml
@@ -1,0 +1,56 @@
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  annotations: {}
+  name: panic
+  namespace: vela-system
+spec:
+  schematic:
+    cue:
+      template: |
+        pvcVolumesList: *[
+                        for v in parameter.pvc if v.mountPath != _|_ {
+                        {
+                                name: "pvc-" + v.name
+                                persistentVolumeClaim: claimName: v.name
+                        }
+                },
+        ] | []
+        configMapVolumesList: *[
+                                for v in parameter.configMap if v.mountPath != _|_ {
+                        {
+                                name: "configmap-" + v.name
+                                configMap: name: v.name
+                        }
+                },
+        ] | []
+        volumesList: pvcVolumesList + configMapVolumesList
+        deDupVolumesArray: [
+                for val in [
+                        for i, vi in volumesList {
+                                for j, vj in volumesList if j < i && vi.name == vj.name {
+                                        ignore: true
+                                }
+                                vi
+                        },
+                ] if val.ignore == _|_ {
+                        val
+                },
+        ]
+        patch: spec: template: spec: {
+                // +patchKey=name
+                volumes: deDupVolumesArray
+        }
+        parameter: {
+                // +usage=Declare pvc type storage
+                pvc?: [...{
+                        name:       string
+                        mountPath?: string
+                }]
+
+                // +usage=Declare config map type storage
+                configMap?: [...{
+                        name:       string
+                        mountPath?: string
+                }]
+        }

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -45,6 +45,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile/helm"
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -713,6 +714,7 @@ func getOpenAPISchema(capability types.Capability, pd *packages.PackageDiscover)
 }
 
 // generateOpenAPISchemaFromCapabilityParameter returns the parameter of a definition in cue.Value format
+// nolint:staticcheck
 func generateOpenAPISchemaFromCapabilityParameter(capability types.Capability, pd *packages.PackageDiscover) ([]byte, error) {
 	template, err := PrepareParameterCue(capability.Name, capability.CueTemplate)
 	if err != nil {
@@ -735,7 +737,7 @@ func generateOpenAPISchemaFromCapabilityParameter(capability types.Capability, p
 		return common.GenOpenAPI(cueInst)
 	}
 	bi := build.NewContext().NewInstance("", nil)
-	err = bi.AddFile("-", template)
+	err = value.AddFile(bi, "-", template)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -75,7 +75,7 @@ annotations: {
 
 parameter: [string]: string
 `,
-			want: want{data: "{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}", err: nil},
+			want: want{data: "{\"type\":\"object\"}", err: nil},
 		},
 		"parameter in cue is a string type,": {
 			reason: "Prepare a normal parameter cue file",
@@ -170,7 +170,7 @@ patch: {
 
 parameter: [string]: string
 `,
-			want: want{data: "{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}", err: nil},
+			want: want{data: "{\"type\":\"object\"}", err: nil},
 		},
 	}
 

--- a/pkg/cue/convert.go
+++ b/pkg/cue/convert.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/build"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 )
 
@@ -34,27 +34,11 @@ var ErrParameterNotExist = errors.New("parameter not exist")
 
 // GetParameters get parameter from cue template
 func GetParameters(templateStr string, pd *packages.PackageDiscover) ([]types.Parameter, error) {
-	var template *cue.Instance
-	var err error
-	if pd != nil {
-		bi := build.NewContext().NewInstance("", nil)
-		err := bi.AddFile("-", templateStr+BaseTemplate)
-		if err != nil {
-			return nil, err
-		}
-
-		template, err = pd.ImportPackagesAndBuildInstance(bi)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		r := cue.Runtime{}
-		template, err = r.Compile("", templateStr+BaseTemplate)
-		if err != nil {
-			return nil, err
-		}
+	template, err := value.NewValue(templateStr+BaseTemplate, pd, "")
+	if err != nil {
+		return nil, err
 	}
-	tempStruct, err := template.Value().Struct()
+	tempStruct, err := template.CueValue().Struct()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cue/convert_test.go
+++ b/pkg/cue/convert_test.go
@@ -42,10 +42,10 @@ func TestGetParameter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []types.Parameter{
 		{Name: "name", Required: true, Default: "", Type: cue.StringKind},
-		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
 		{Name: "image", Short: "i", Required: true, Usage: "Which image would you like to use for your service", Default: "", Type: cue.StringKind},
 		{Name: "port", Short: "p", Required: false, Usage: "Which port do you want customer traffic sent to", Default: int64(8080),
 			Type: cue.IntKind},
+		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
 		{Name: "cpu", Short: "", Required: false, Usage: "", Default: "", Type: cue.StringKind}},
 		params)
 
@@ -54,9 +54,9 @@ func TestGetParameter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []types.Parameter{
 		{Name: "name", Required: true, Default: "", Type: cue.StringKind},
-		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
 		{Name: "image", Short: "i", Required: true, Usage: "Which image would you like to use for your service", Default: "", Type: cue.StringKind},
 		{Name: "port", Short: "p", Usage: "Which port do you want customer traffic sent to", Default: int64(8080), Type: cue.IntKind},
+		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
 		{Name: "enable", Default: false, Type: cue.BoolKind},
 		{Name: "fval", Default: 64.3, Type: cue.FloatKind},
 		{Name: "nval", Default: float64(0), Required: true, Type: cue.NumberKind}}, params)

--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -1079,7 +1079,7 @@ parameter: { errs: [...string] }`,
 		}
 		r.NoError(err, cassinfo)
 		base, assists := ctx.Output()
-		// r.Equal(len(v.expAssObjs), len(assists), cassinfo)
+		r.Equal(len(v.expAssObjs), len(assists), cassinfo)
 		r.NotNil(base)
 		obj, err := base.Unstructured()
 		r.NoError(err)

--- a/pkg/cue/model/instance.go
+++ b/pkg/cue/model/instance.go
@@ -17,9 +17,6 @@ limitations under the License.
 package model
 
 import (
-	"regexp"
-	"strings"
-
 	"cuelang.org/go/cue"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -106,18 +103,4 @@ func NewOther(v cue.Value) (Instance, error) {
 	return &instance{
 		v: v,
 	}, nil
-}
-
-// IndexMatchLine will index and extract the line contains the pattern.
-func IndexMatchLine(ret, target string) (string, bool) {
-	if strings.Contains(ret, target) {
-		if target == "_|_" {
-			r := regexp.MustCompile(`_\|_[\s]//.*`)
-			match := r.FindAllString(ret, -1)
-			if len(match) > 0 {
-				return strings.Join(match, ","), true
-			}
-		}
-	}
-	return "", false
 }

--- a/pkg/cue/model/instance_test.go
+++ b/pkg/cue/model/instance_test.go
@@ -26,45 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestGetCompileError(t *testing.T) {
-	testcases := []struct {
-		src     string
-		wantErr bool
-		errInfo string
-	}{{
-		src: ` env: [{
-	name:  "HELLO"
-	value: "_A_|_B_|_C_"
-}]`,
-		wantErr: false,
-		errInfo: "",
-	}, {
-		src: ` env: [{
-	name:  conflicting
-	value:  _|_ // conflicting values "ENV_LEVEL" and "JAVA_TOOL_OPTIONS"
-}]`,
-		wantErr: true,
-		errInfo: "_|_ // conflicting values \"ENV_LEVEL\" and \"JAVA_TOOL_OPTIONS\"",
-	}, {
-		src: ` env: [{
-	name:  conflicting-1
-	value:  _|_ // conflicting values "ENV_LEVEL" and "JAVA_TOOL_OPTIONS"
-	},{
-	name:  conflicting-2
-	value:  _|_ // conflicting values "HELLO" and "WORLD"
-}]`,
-		wantErr: true,
-		errInfo: "_|_ // conflicting values \"ENV_LEVEL\" and \"JAVA_TOOL_OPTIONS\"," +
-			"_|_ // conflicting values \"HELLO\" and \"WORLD\"",
-	}}
-	for _, tt := range testcases {
-		errInfo, contains := IndexMatchLine(tt.src, "_|_")
-		assert.Equal(t, tt.wantErr, contains)
-		assert.Equal(t, tt.errInfo, errInfo)
-	}
-
-}
-
 func TestInstance(t *testing.T) {
 
 	testCases := []struct {

--- a/pkg/cue/model/instance_test.go
+++ b/pkg/cue/model/instance_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -83,12 +83,7 @@ metadata: name: "test"
 	}
 
 	for _, v := range testCases {
-		var r cue.Runtime
-		inst, err := r.Compile("-", v.src)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+		inst := cuecontext.New().CompileString(v.src)
 		base, err := NewBase(inst.Value())
 		if err != nil {
 			t.Error(err)
@@ -169,9 +164,7 @@ output: {
 }
 `
 
-	var r cue.Runtime
-	inst, err := r.Compile("-", base)
-	assert.NoError(t, err)
+	inst := cuecontext.New().CompileString(base)
 	newbase, err := NewBase(inst.Value())
 	assert.NoError(t, err)
 	data, err := newbase.Unstructured()
@@ -181,26 +174,27 @@ output: {
 }
 
 func TestError(t *testing.T) {
+	ctx := cuecontext.New()
 	ins := &instance{
-		v: ``,
+		v: ctx.CompileString(``),
 	}
 	_, err := ins.Unstructured()
 	assert.Equal(t, err.Error(), "Object 'Kind' is missing in '{}'")
 	ins = &instance{
-		v: `
+		v: ctx.CompileString(`
 apiVersion: "apps/v1"
 kind:       "Deployment"
 metadata: name: parameter.name
-`,
+`),
 	}
 	_, err = ins.Unstructured()
-	assert.Equal(t, err.Error(), fmt.Sprintf(`failed to have the workload/trait unstructured: metadata.name: reference "%s" not found`, ParameterFieldName))
+	assert.Equal(t, err.Error(), fmt.Sprintf("failed to have the workload/trait unstructured: metadata.name: reference \"%s\" not found", ParameterFieldName))
 	ins = &instance{
-		v: `
+		v: ctx.CompileString(`
 apiVersion: "apps/v1"
 kind:       "Deployment"
 metadata: name: "abc"
-`,
+`),
 	}
 	obj, err := ins.Unstructured()
 	assert.Equal(t, err, nil)
@@ -215,7 +209,7 @@ metadata: name: "abc"
 	})
 
 	ins = &instance{
-		v: `
+		v: ctx.CompileString(`
 apiVersion: "source.toolkit.fluxcd.io/v1beta1"
 metadata: {
 	name: "grafana"
@@ -224,7 +218,7 @@ kind: "HelmRepository"
 spec: {
 	url:      string
 	interval: *"5m" | string
-}`,
+}`),
 	}
 	o, err := ins.Unstructured()
 	assert.Nil(t, o)

--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -22,7 +22,7 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
-	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/cuecontext"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 )
@@ -190,7 +190,10 @@ func strategyPatchHandle() interceptor {
 				paths := append(ctx.Pos(), labelStr(field.Label))
 				baseSubNode, err := lookUp(baseNode, paths...)
 				if err != nil {
-					return
+					if errors.Is(err, notFoundErr) {
+						return
+					}
+					baseSubNode = ast.NewList()
 				}
 				baselist, ok := baseSubNode.(*ast.ListLit)
 				if !ok {
@@ -256,69 +259,60 @@ func IsJSONPatch(patcher cue.Value) bool {
 }
 
 // StrategyUnify unify the objects by the strategy
-func StrategyUnify(base, patch string, options ...UnifyOption) (ret string, err error) {
+func StrategyUnify(base, patch cue.Value, options ...UnifyOption) (ret cue.Value, err error) {
 	params := newUnifyParams(options...)
 	var patchOpts []interceptor
 	if params.PatchStrategy == StrategyJSONMergePatch || params.PatchStrategy == StrategyJSONPatch {
-		base, err = OpenBaiscLit(base)
+		_, err := OpenBaiscLit(base)
 		if err != nil {
 			return base, err
 		}
 	} else {
 		patchOpts = []interceptor{strategyPatchHandle()}
 	}
-	baseFile, err := parser.ParseFile("-", base, parser.ParseComments)
-	if err != nil {
-		return "", errors.WithMessage(err, "invalid base cue file")
-	}
-	patchFile, err := parser.ParseFile("-", patch, parser.ParseComments)
-	if err != nil {
-		return "", errors.WithMessage(err, "invalid patch cue file")
-	}
-
-	return strategyUnify(baseFile, patchFile, params, patchOpts...)
+	return strategyUnify(base, patch, params, patchOpts...)
 }
 
-func strategyUnify(baseFile *ast.File, patchFile *ast.File, params *UnifyParams, patchOpts ...interceptor) (string, error) {
+// nolint:staticcheck
+func strategyUnify(base cue.Value, patch cue.Value, params *UnifyParams, patchOpts ...interceptor) (val cue.Value, err error) {
+	if params.PatchStrategy == StrategyJSONMergePatch {
+		return jsonMergePatch(base, patch)
+	} else if params.PatchStrategy == StrategyJSONPatch {
+		return jsonPatch(base, patch.LookupPath(cue.ParsePath("operations")))
+	}
+	openBase, err := openListLit(base)
+	if err != nil {
+		return cue.Value{}, errors.Wrapf(err, "failed to open list it for merge")
+	}
+	patchFile, err := ToFile(patch.Syntax(cue.Docs(true), cue.ResolveReferences(true)))
+	if err != nil {
+		return cue.Value{}, err
+	}
 	for _, option := range patchOpts {
-		if err := option(baseFile, patchFile); err != nil {
-			return "", errors.WithMessage(err, "process patchOption")
+		if err := option(openBase, patchFile); err != nil {
+			return cue.Value{}, errors.WithMessage(err, "process patchOption")
 		}
 	}
 
-	var r cue.Runtime
+	baseInst := cuecontext.New().BuildFile(openBase)
+	patchInst := cuecontext.New().BuildFile(patchFile)
 
-	baseInst, err := r.CompileFile(baseFile)
+	ret := baseInst.Unify(patchInst)
+
+	_, err = toString(ret, removeTmpVar)
 	if err != nil {
-		return "", errors.WithMessage(err, "compile base file")
-	}
-	patchInst, err := r.CompileFile(patchFile)
-	if err != nil {
-		return "", errors.WithMessage(err, "compile patch file")
-	}
-
-	if params.PatchStrategy == StrategyJSONMergePatch {
-		return jsonMergePatch(baseInst.Value(), patchInst.Value())
-	} else if params.PatchStrategy == StrategyJSONPatch {
-		return jsonPatch(baseInst.Value(), patchInst.Lookup("operations"))
-	}
-
-	ret := baseInst.Value().Unify(patchInst.Value())
-
-	rv, err := toString(ret, removeTmpVar)
-	if err != nil {
-		return rv, errors.WithMessage(err, " format result toString")
+		return ret, errors.WithMessage(err, " format result toString")
 	}
 
 	if err := ret.Err(); err != nil {
-		return rv, errors.WithMessage(err, "result check err")
+		return ret, errors.WithMessage(err, "result check err")
 	}
 
 	if err := ret.Validate(cue.All()); err != nil {
-		return rv, errors.WithMessage(err, "result validate")
+		return ret, errors.WithMessage(err, "result validate")
 	}
 
-	return rv, nil
+	return ret, nil
 }
 
 func findCommentTag(commentGroup []*ast.CommentGroup) map[string]string {
@@ -348,47 +342,51 @@ func findCommentTag(commentGroup []*ast.CommentGroup) map[string]string {
 	return kval
 }
 
-func jsonMergePatch(base cue.Value, patch cue.Value) (string, error) {
+func jsonMergePatch(base cue.Value, patch cue.Value) (cue.Value, error) {
+	ctx := cuecontext.New()
 	baseJSON, err := base.MarshalJSON()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal base value")
+		return cue.Value{}, errors.Wrapf(err, "failed to marshal base value")
 	}
 	patchJSON, err := patch.MarshalJSON()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal patch value")
+		return cue.Value{}, errors.Wrapf(err, "failed to marshal patch value")
 	}
 	merged, err := jsonpatch.MergePatch(baseJSON, patchJSON)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to merge base value and patch value by JsonMergePatch")
+		return cue.Value{}, errors.Wrapf(err, "failed to merge base value and patch value by JsonMergePatch")
 	}
-	output, err := OpenBaiscLit(string(merged))
+	val := ctx.CompileBytes(merged)
+	output, err := OpenBaiscLit(val)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse open basic lit for merged result")
+		return cue.Value{}, errors.Wrapf(err, "failed to parse open basic lit for merged result")
 	}
-	return output, nil
+	return ctx.BuildFile(output), nil
 }
 
-func jsonPatch(base cue.Value, patch cue.Value) (string, error) {
+func jsonPatch(base cue.Value, patch cue.Value) (cue.Value, error) {
+	ctx := cuecontext.New()
 	baseJSON, err := base.MarshalJSON()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal base value")
+		return cue.Value{}, errors.Wrapf(err, "failed to marshal base value")
 	}
 	patchJSON, err := patch.MarshalJSON()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal patch value")
+		return cue.Value{}, errors.Wrapf(err, "failed to marshal patch value")
 	}
 	decodedPatch, err := jsonpatch.DecodePatch(patchJSON)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to decode patch")
+		return cue.Value{}, errors.Wrapf(err, "failed to decode patch")
 	}
 
 	merged, err := decodedPatch.Apply(baseJSON)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to apply json patch")
+		return cue.Value{}, errors.Wrapf(err, "failed to apply json patch")
 	}
-	output, err := OpenBaiscLit(string(merged))
+	val := ctx.CompileBytes(merged)
+	output, err := OpenBaiscLit(val)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse open basic lit for merged result")
+		return cue.Value{}, errors.Wrapf(err, "failed to parse open basic lit for merged result")
 	}
-	return output, nil
+	return ctx.BuildFile(output), nil
 }

--- a/pkg/cue/model/sets/operation_test.go
+++ b/pkg/cue/model/sets/operation_test.go
@@ -384,6 +384,26 @@ containers: [{
 	}, ...]
 }, ...]
 `},
+		{
+			base: `containers: [{name: "x1"}]`,
+			patch: `
+containers: [{
+	// +patchKey=name
+	env: [{
+		name: "k"
+		value: "v"
+	}]
+}, ...]`,
+			result: `containers: [{
+	name: "x1"
+	// +patchKey=name
+	env: [{
+		name:  "k"
+		value: "v"
+	}]
+}, ...]
+`,
+		},
 	}
 
 	for i, tcase := range testCase {

--- a/pkg/cue/model/sets/walk_test.go
+++ b/pkg/cue/model/sets/walk_test.go
@@ -86,6 +86,7 @@ func TestWalk(t *testing.T) {
 		    tags_str: strings.Compare(b,"c")
 		}
 	`,
+		`a: [1, 2, 3]`,
 	}
 
 	for _, src := range testCases {

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -747,7 +747,7 @@ func (a *assembler) installTo(expr ast.Expr) error {
 				return err
 			}
 		} else {
-			return errors.New("assembler parse selector.Sel invalid(!=ident)")
+			return errors.New("invalid sel type in selector")
 		}
 		if err := a.installTo(v.X); err != nil {
 			return err

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -26,6 +26,7 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/literal"
 	"cuelang.org/go/cue/parser"
 	"cuelang.org/go/cue/token"
@@ -42,7 +43,7 @@ const DefaultPackageHeader = "package main\n"
 // Value is an object with cue.runtime and vendors
 type Value struct {
 	v          cue.Value
-	r          cue.Runtime
+	r          *cue.Context
 	addImports func(instance *build.Instance) error
 }
 
@@ -57,6 +58,9 @@ func (val *Value) Error() error {
 	v := val.CueValue()
 	if !v.Exists() {
 		return errors.New("empty value")
+	}
+	if err := val.v.Err(); err != nil {
+		return err
 	}
 	var gerr error
 	v.Walk(func(value cue.Value) bool {
@@ -156,16 +160,29 @@ func newValue(builder *build.Instance, pd *packages.PackageDiscover, tagTempl st
 		return nil, err
 	}
 
-	var r cue.Runtime
-	inst, err := r.Build(builder)
-	if err != nil {
-		return nil, err
-	}
+	r := cuecontext.New()
+	inst := r.BuildInstance(builder)
 	val := new(Value)
 	val.r = r
-	val.v = inst.Value()
+	val.v = inst
 	val.addImports = addImports
+	// do not check val.Err() error here, because the value may be filled later
 	return val, nil
+}
+
+// AddFile add file to the instance
+func AddFile(bi *build.Instance, filename string, src interface{}) error {
+	if filename == "" {
+		filename = "-"
+	}
+	file, err := parser.ParseFile(filename, src, parser.ParseComments)
+	if err != nil {
+		return err
+	}
+	if err := bi.AddSyntax(file); err != nil {
+		return err
+	}
+	return nil
 }
 
 // TagFieldOrder add step tag.
@@ -241,51 +258,66 @@ func (vs *visitor) addAttrForExpr(node ast.Node, index *int) {
 // MakeValue generate an value with same runtime
 func (val *Value) MakeValue(s string) (*Value, error) {
 	builder := &build.Instance{}
-	if err := builder.AddFile("-", s); err != nil {
+	file, err := parser.ParseFile("-", s, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	if err := builder.AddSyntax(file); err != nil {
 		return nil, err
 	}
 	if err := val.addImports(builder); err != nil {
 		return nil, err
 	}
-	inst, err := val.r.Build(builder)
-	if err != nil {
-		return nil, err
-	}
+	inst := val.r.BuildInstance(builder)
 	v := new(Value)
 	v.r = val.r
-	v.v = inst.Value()
+	v.v = inst
 	v.addImports = val.addImports
+	if v.Error() != nil {
+		return nil, v.Error()
+	}
 	return v, nil
 }
 
 func (val *Value) makeValueWithFile(files ...*ast.File) (*Value, error) {
 	builder := &build.Instance{}
+	newFile := &ast.File{}
+	imports := map[string]*ast.ImportSpec{}
 	for _, f := range files {
-		if err := builder.AddSyntax(f); err != nil {
-			return nil, err
+		for _, importSpec := range f.Imports {
+			if _, ok := imports[importSpec.Name.String()]; !ok {
+				imports[importSpec.Name.String()] = importSpec
+			}
 		}
+		newFile.Decls = append(newFile.Decls, f.Decls...)
+	}
+
+	for _, imp := range imports {
+		newFile.Imports = append(newFile.Imports, imp)
+	}
+
+	if err := builder.AddSyntax(newFile); err != nil {
+		return nil, err
 	}
 	if err := val.addImports(builder); err != nil {
 		return nil, err
 	}
-	inst, err := val.r.Build(builder)
-	if err != nil {
-		return nil, err
-	}
+	inst := val.r.BuildInstance(builder)
 	v := new(Value)
 	v.r = val.r
-	v.v = inst.Value()
+	v.v = inst
 	v.addImports = val.addImports
 	return v, nil
 }
 
 // FillRaw unify the value with the cue format string x at the given path.
 func (val *Value) FillRaw(x string, paths ...string) error {
-	xInst, err := val.r.Compile("-", x)
+	file, err := parser.ParseFile("-", x, parser.ParseComments)
 	if err != nil {
 		return err
 	}
-	v := val.v.Fill(xInst.Value(), paths...)
+	xInst := val.r.BuildFile(file)
+	v := val.v.FillPath(FieldPath(paths...), xInst)
 	if v.Err() != nil {
 		return v.Err()
 	}
@@ -296,7 +328,12 @@ func (val *Value) FillRaw(x string, paths ...string) error {
 // FillValueByScript unify the value x at the given script path.
 func (val *Value) FillValueByScript(x *Value, path string) error {
 	if !strings.Contains(path, "[") {
-		return val.FillObject(x, strings.Split(path, ".")...)
+		newV := val.v.FillPath(FieldPath(path), x.v)
+		if err := newV.Err(); err != nil {
+			return err
+		}
+		val.v = newV
+		return nil
 	}
 	s, err := x.String()
 	if err != nil {
@@ -343,25 +380,50 @@ func (val *Value) FillObject(x interface{}, paths ...string) error {
 		}
 		insert = v.v
 	}
-	newV := val.v.Fill(insert, paths...)
-	if newV.Err() != nil {
-		return newV.Err()
-	}
+	newV := val.v.FillPath(FieldPath(paths...), insert)
+	// do not check newV.Err() error here, because the value may be filled later
 	val.v = newV
 	return nil
 }
 
 // LookupValue reports the value at a path starting from val
 func (val *Value) LookupValue(paths ...string) (*Value, error) {
-	v := val.v.Lookup(paths...)
+	v := val.v.LookupPath(FieldPath(paths...))
 	if !v.Exists() {
-		return nil, errors.Errorf("var(path=%s) not exist", strings.Join(paths, "."))
+		return nil, errors.Errorf("failed to lookup value: var(path=%s) not exist", strings.Join(paths, "."))
 	}
 	return &Value{
 		v:          v,
 		r:          val.r,
 		addImports: val.addImports,
 	}, nil
+}
+
+func isScript(content string) (bool, error) {
+	content = strings.TrimSpace(content)
+	scriptFile, err := parser.ParseFile("-", content, parser.ParseComments)
+	if err != nil {
+		return false, errors.WithMessage(err, "parse script")
+	}
+	if len(scriptFile.Imports) != 0 {
+		return true, nil
+	}
+	if len(scriptFile.Decls) == 0 || len(scriptFile.Decls) > 1 {
+		return true, nil
+	}
+
+	return !isSelector(scriptFile.Decls[0]), nil
+}
+
+func isSelector(node ast.Node) bool {
+	switch v := node.(type) {
+	case *ast.EmbedDecl:
+		return isSelector(v.Expr)
+	case *ast.SelectorExpr, *ast.IndexExpr, *ast.Ident:
+		return true
+	default:
+		return false
+	}
 }
 
 // LookupByScript reports the value by cue script.
@@ -371,6 +433,14 @@ func (val *Value) LookupByScript(script string) (*Value, error) {
 	scriptFile, err := parser.ParseFile("-", script, parser.ParseComments)
 	if err != nil {
 		return nil, errors.WithMessage(err, "parse script")
+	}
+	isScriptPath, err := isScript(script)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isScriptPath {
+		return val.LookupValue(script)
 	}
 
 	raw, err := val.String()
@@ -392,6 +462,7 @@ func (val *Value) LookupByScript(script string) (*Value, error) {
 
 	return newV.LookupValue(outputKey)
 }
+
 func behindKey(file *ast.File, key string) {
 	var (
 		implDecls []ast.Decl
@@ -456,68 +527,106 @@ func (val *Value) StepByList(handle func(name string, in *Value) (bool, error)) 
 
 // StepByFields process the fields in order
 func (val *Value) StepByFields(handle func(name string, in *Value) (bool, error)) error {
-	for i := 0; ; i++ {
-		field, end, err := val.fieldIndex(i)
-		if err != nil {
-			return err
-		}
+	iter := steps(val)
+	for iter.next() {
+		iter.do(handle)
+	}
+	return iter.err
+}
 
-		if end {
-			return nil
-		}
-		stop, err := handle(field.Name, field.Value)
-		if err != nil {
-			return errors.WithMessagef(err, "step %s", field.Name)
-		}
-		if !isDef(field.Name) {
-			if err := val.FillObject(field.Value, field.Name); err != nil {
-				return err
-			}
-		}
-		if stop {
-			return nil
-		}
+type stepsIterator struct {
+	queue   []*field
+	index   int
+	target  *Value
+	err     error
+	stopped bool
+}
+
+func steps(v *Value) *stepsIterator {
+	return &stepsIterator{
+		target: v,
 	}
 }
 
-func (val *Value) fieldIndex(index int) (*field, bool, error) {
-	fields, err := val.fields()
-	if err != nil {
-		return nil, false, err
+func (iter *stepsIterator) next() bool {
+	if iter.stopped {
+		return false
 	}
-	if index >= len(fields) {
-		return nil, true, nil
+	if iter.err != nil {
+		return false
 	}
-	return fields[index], false, nil
+	if iter.queue != nil {
+		iter.index++
+	}
+	iter.assemble()
+	return iter.index <= len(iter.queue)-1
 }
 
-func (val *Value) fields() ([]*field, error) {
-	st, err := val.v.Struct()
+func (iter *stepsIterator) assemble() {
+	st, err := iter.target.v.Struct()
 	if err != nil {
-		return nil, err
+		iter.err = err
+		return
 	}
-	var fields []*field
+
+	filters := map[string]struct{}{}
+	for _, item := range iter.queue {
+		filters[item.Name] = struct{}{}
+	}
+	var addFields []*field
 	for i := 0; i < st.Len(); i++ {
-		v := st.Field(i)
-		attr := v.Value.Attribute("step")
+		name := st.Field(i).Name
+		attr := st.Field(i).Value.Attribute("step")
 		no, err := attr.Int(0)
 		if err != nil {
 			no = 100
-			if v.Name == "#do" || v.Name == "#provider" {
+			if name == "#do" || name == "#provider" {
 				no = 0
 			}
 		}
-		fields = append(fields, &field{
-			no:   no,
-			Name: v.Name,
-			Value: &Value{
-				r:          val.r,
-				v:          v.Value,
-				addImports: val.addImports,
-			}})
+		if _, ok := filters[name]; !ok {
+			addFields = append(addFields, &field{
+				Name: name,
+				no:   no,
+			})
+		}
 	}
-	sort.Sort(sortFields(fields))
-	return fields, nil
+
+	suffixItems := append(addFields, iter.queue[iter.index:]...)
+	sort.Sort(sortFields(suffixItems))
+	iter.queue = append(iter.queue[:iter.index], suffixItems...)
+}
+
+func (iter *stepsIterator) value() *Value {
+	v := iter.target.v.LookupPath(FieldPath(iter.name()))
+	return &Value{
+		r:          iter.target.r,
+		v:          v,
+		addImports: iter.target.addImports,
+	}
+}
+
+func (iter *stepsIterator) name() string {
+	return iter.queue[iter.index].Name
+}
+
+func (iter *stepsIterator) do(handle func(name string, in *Value) (bool, error)) {
+	if iter.err != nil {
+		return
+	}
+	v := iter.value()
+	stopped, err := handle(iter.name(), v)
+	if err != nil {
+		iter.err = err
+		return
+	}
+	iter.stopped = stopped
+	if !isDef(iter.name()) {
+		if err := iter.target.FillObject(v, iter.name()); err != nil {
+			iter.err = err
+			return
+		}
+	}
 }
 
 type sortFields []*field
@@ -535,13 +644,7 @@ func (sf sortFields) Swap(i, j int) {
 
 // Field return the cue value corresponding to the specified field
 func (val *Value) Field(label string) (cue.Value, error) {
-	var v cue.Value
-	if isDef(label) {
-		v = val.v.LookupDef(label)
-	} else {
-		v = val.v.Lookup(label)
-	}
-
+	v := val.v.LookupPath(cue.ParsePath(label))
 	if !v.Exists() {
 		return v, errors.Errorf("label %s not found", label)
 	}
@@ -592,19 +695,13 @@ func (val *Value) GetBool(paths ...string) (bool, error) {
 
 // OpenCompleteValue make that the complete value can be modified.
 func (val *Value) OpenCompleteValue() error {
-	s, err := val.String()
+	newS, err := sets.OpenBaiscLit(val.CueValue())
 	if err != nil {
 		return err
 	}
-	newS, err := sets.OpenBaiscLit(s)
-	if err != nil {
-		return err
-	}
-	v, err := val.MakeValue(newS)
-	if err != nil {
-		return err
-	}
-	val.v = v.CueValue()
+
+	v := cuecontext.New().BuildFile(newS)
+	val.v = v
 	return nil
 }
 func isDef(s string) bool {
@@ -645,12 +742,17 @@ func (a *assembler) installTo(expr ast.Expr) error {
 			return err
 		}
 	case *ast.SelectorExpr:
-		if err := a.installTo(v.Sel); err != nil {
-			return err
+		if ident, ok := v.Sel.(*ast.Ident); ok {
+			if err := a.installTo(ident); err != nil {
+				return err
+			}
+		} else {
+			return errors.New("assembler parse selector.Sel invalid(!=ident)")
 		}
 		if err := a.installTo(v.X); err != nil {
 			return err
 		}
+
 	case *ast.Ident:
 		a.fill2Path(v.String())
 	case *ast.BasicLit:
@@ -667,4 +769,37 @@ func (a *assembler) installTo(expr ast.Expr) error {
 		return errors.New("invalid path")
 	}
 	return nil
+}
+
+// makePath creates a Path from a sequence of string.
+func makePath(paths ...string) string {
+	mergedPath := ""
+	if len(paths) == 0 {
+		return mergedPath
+	}
+	if paths[0] == "" || (len(paths) == 1 && (strings.Contains(paths[0], ".") || strings.Contains(paths[0], "["))) {
+		return paths[0]
+	}
+	mergedPath = paths[0]
+	if !strings.HasPrefix(paths[0], "_") && !strings.Contains(paths[0], "#") {
+		mergedPath = fmt.Sprintf("\"%s\"", mergedPath)
+	}
+	for _, p := range paths[1:] {
+		mergedPath += fmt.Sprintf("[\"%s\"]", p)
+	}
+	return mergedPath
+}
+
+func isNumber(s string) bool {
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
+
+// FieldPath return the cue path of the given paths
+func FieldPath(paths ...string) cue.Path {
+	s := makePath(paths...)
+	if isNumber(s) {
+		return cue.MakePath(cue.Str(s))
+	}
+	return cue.ParsePath(s)
 }

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -777,15 +777,19 @@ func makePath(paths ...string) string {
 	if len(paths) == 0 {
 		return mergedPath
 	}
-	if paths[0] == "" || (len(paths) == 1 && (strings.Contains(paths[0], ".") || strings.Contains(paths[0], "["))) {
+	mergedPath = paths[0]
+	if mergedPath == "" || (len(paths) == 1 && (strings.Contains(mergedPath, ".") || strings.Contains(mergedPath, "["))) {
 		return paths[0]
 	}
-	mergedPath = paths[0]
-	if !strings.HasPrefix(paths[0], "_") && !strings.Contains(paths[0], "#") {
+	if !strings.HasPrefix(mergedPath, "_") && !strings.HasPrefix(mergedPath, "#") {
 		mergedPath = fmt.Sprintf("\"%s\"", mergedPath)
 	}
 	for _, p := range paths[1:] {
-		mergedPath += fmt.Sprintf("[\"%s\"]", p)
+		if !strings.HasPrefix(p, "#") {
+			mergedPath += fmt.Sprintf("[\"%s\"]", p)
+		} else {
+			mergedPath += fmt.Sprintf(".%s", p)
+		}
 	}
 	return mergedPath
 }

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -18,9 +18,13 @@ package value
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/oam-dev/kubevela/pkg/cue/model/sets"
+
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -99,13 +103,13 @@ step3: {
 	prefix: 101
 	value:  102
 }
-step4: {
-	prefix: 102
-	value:  103
-}
 step5: {
 	prefix: 103
 	value:  104
+}
+step4: {
+	prefix: 102
+	value:  103
 }
 `},
 
@@ -202,6 +206,8 @@ step3: "3"
 }
 
 func TestStepWithTag(t *testing.T) {
+	// comment all the tests with comprehension with if for now,
+	// refer to issue: https://github.com/cue-lang/cue/issues/1826
 	testCases := []struct {
 		base     string
 		expected string
@@ -211,9 +217,6 @@ step1: {}
 step2: {prefix: step1.value}
 step3: {prefix: step2.value}
 step4: {prefix: step3.value}
-if step4.value > 100 {
-        step5: {}
-}
 step5: {
 	value:  *100|int
 }
@@ -239,9 +242,7 @@ step5: {
 `}, {base: `
 step1: {}
 step2: {prefix: step1.value}
-if step2.value > 100 {
-        step2_3: {prefix: step2.value}
-}
+step2_3: {prefix: step2.value}
 step3: {prefix: step2.value}
 step4: {prefix: step3.value}
 `,
@@ -268,9 +269,7 @@ step4: {
 step2: {prefix: step1.value} @step(2)
 step1: {} @step(1)
 step3: {prefix: step2.value} @step(4)
-if step2.value > 100 {
-        step2_3: {prefix: step2.value} @step(3)
-}
+step2_3: {prefix: step2.value} @step(3)
 `,
 			expected: `step2: {
 	prefix: 100
@@ -292,9 +291,7 @@ step2_3: {
 		{base: `
 step2: {prefix: step1.value} 
 step1: {} @step(-1)
-if step2.value > 100 {
-        step2_3: {prefix: step2.value}
-}
+step2_3: {prefix: step2.value}
 step3: {prefix: step2.value}
 `,
 			expected: `step2: {
@@ -314,9 +311,10 @@ step3: {
 } @step(3)
 `}}
 
-	for _, tCase := range testCases {
+	for i, tCase := range testCases {
+		r := require.New(t)
 		val, err := NewValue(tCase.base, nil, "", TagFieldOrder)
-		assert.NilError(t, err)
+		r.NoError(err)
 		number := 99
 		err = val.StepByFields(func(name string, in *Value) (bool, error) {
 			number++
@@ -324,10 +322,10 @@ step3: {
 				"value": number,
 			})
 		})
-		assert.NilError(t, err)
-		str, err := val.String()
-		assert.NilError(t, err)
-		assert.Equal(t, str, tCase.expected)
+		r.NoError(err)
+		str, err := sets.ToString(val.CueValue())
+		r.NoError(err)
+		r.Equal(str, tCase.expected, fmt.Sprintf("testPatch for case(no:%d) %s", i, str))
 	}
 }
 
@@ -371,7 +369,7 @@ func TestStepByList(t *testing.T) {
 	var i int64
 	err = v.StepByList(func(name string, in *Value) (bool, error) {
 		i++
-		num, err := in.CueValue().Lookup("step").Int64()
+		num, err := in.CueValue().LookupPath(FieldPath("step")).Int64()
 		assert.NilError(t, err)
 		assert.Equal(t, num, i)
 		return false, nil
@@ -409,8 +407,8 @@ func TestValue(t *testing.T) {
 provider: xxx
 `
 	val, err := NewValue(caseError, nil, "")
-	assert.Equal(t, err != nil, true)
-	assert.Equal(t, val == nil, true)
+	assert.NilError(t, err)
+	assert.Equal(t, val.Error() != nil, true)
 
 	val, err = NewValue(":", nil, "")
 	assert.Equal(t, err != nil, true)
@@ -448,8 +446,8 @@ close({provider: int})
 	cv, err = val.MakeValue(caseClose)
 	assert.NilError(t, err)
 	err = val.FillObject(cv)
-	assert.Equal(t, err != nil, true)
-	assert.Equal(t, originCue, val.CueValue())
+	assert.NilError(t, err)
+	assert.Equal(t, val.Error() != nil, true)
 
 	_, err = val.LookupValue("abc")
 	assert.Equal(t, err != nil, true)
@@ -485,8 +483,7 @@ do: "apply"
 	assert.NilError(t, err)
 	err = val.FillRaw(`
 provider: "conflict"`)
-	assert.NilError(t, err)
-	assert.Equal(t, val.Error() != nil, true)
+	assert.Equal(t, err != nil, true)
 
 	val, err = NewValue(caseOk, nil, "")
 	assert.NilError(t, err)
@@ -658,7 +655,7 @@ strings.Join(apply.arr,".")+"$"`,
 		{
 			src: `
    op: string 
-   op: 12
+   op: "help"
 `,
 			script: `op(1`,
 			err:    "parse script: expected ')', found 'EOF'",
@@ -669,7 +666,7 @@ strings.Join(apply.arr,".")+"$"`,
    op: "help"
 `,
 			script: `oss`,
-			err:    "zz_output__: reference \"oss\" not found",
+			err:    "failed to lookup value: var(path=oss) not exist",
 		},
 	}
 
@@ -869,7 +866,7 @@ func TestFillByScript(t *testing.T) {
 			raw:  `a: b: [{x: y:[{name: "key"}]}]`,
 			path: "a.b[0].x.y[0].name",
 			v:    `"foo"`,
-			err:  "a.b.0.x.y.0.name: conflicting values \"key\" and \"foo\"",
+			err:  "remake value: a.b.0.x.y.0.name: conflicting values \"foo\" and \"key\"",
 		},
 		{
 			name: "filled value with wrong cue format",

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -206,7 +206,7 @@ step3: "3"
 }
 
 func TestStepWithTag(t *testing.T) {
-	// comment all the tests with comprehension with if for now,
+	// TODO(@FogDong): add if condition test cases back.
 	// refer to issue: https://github.com/cue-lang/cue/issues/1826
 	testCases := []struct {
 		base     string

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -547,6 +547,7 @@ a: [
 			s, err := sets.ToString(result.v)
 			r.Equal(s, `"v"
 `)
+			r.NoError(err)
 		})
 	}
 }

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -427,6 +427,8 @@ do: "apply"
 	assert.Equal(t, err != nil, true)
 	_, err = val.MakeValue(":")
 	assert.Equal(t, err != nil, true)
+	_, err = val.MakeValue("test: _|_")
+	assert.Equal(t, err != nil, true)
 	err = val.FillRaw(caseError)
 	assert.Equal(t, err != nil, true)
 	assert.Equal(t, originCue, val.CueValue())

--- a/pkg/cue/package_suit_test.go
+++ b/pkg/cue/package_suit_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
@@ -99,7 +100,7 @@ var _ = Describe("Package discovery resources for definition from K8s APIServer"
 
 		By("test ingress in kube package")
 		bi := build.NewContext().NewInstance("", nil)
-		err := bi.AddFile("-", `
+		err := value.AddFile(bi, "-", `
 import (
 	kube	"kube/networking.k8s.io/v1beta1"
 )
@@ -132,9 +133,9 @@ parameter: {
 	}
 }`)
 		Expect(err).ToNot(HaveOccurred())
-		inst, err := pd.ImportPackagesAndBuildInstance(bi)
+		inst, err := pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err := model.NewBase(inst.Lookup("output"))
+		base, err := model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err := base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -158,7 +159,7 @@ parameter: {
 		})).Should(BeEquivalentTo(""))
 		By("test Invalid Import path")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	kube	"kube/networking.k8s.io/v1"
 )
@@ -179,15 +180,16 @@ parameter: {
 	name:  "myapp"
 	image: "nginx"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
 		Expect(err).Should(BeNil())
-		_, err = model.NewBase(inst.Lookup("output"))
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
+		Expect(err).Should(BeNil())
+		_, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("_|_ // undefined field \"#Deployment\""))
 
 		By("test Deployment in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	kube	"kube/apps/v1"
 )
@@ -207,9 +209,10 @@ parameter: {
 	name:  "myapp"
 	image: "nginx"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
+		Expect(err).Should(BeNil())
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -229,7 +232,7 @@ parameter: {
 
 		By("test Secret in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	kube "kube/v1"
 )
@@ -243,9 +246,10 @@ output: {
 parameter: {
 	name:  "myapp"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
+		Expect(err).Should(BeNil())
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -257,7 +261,7 @@ parameter: {
 
 		By("test Service in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	kube "kube/v1"
 )
@@ -271,9 +275,10 @@ output: {
 parameter: {
 	name:  "myapp"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
+		Expect(err).Should(BeNil())
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -360,7 +365,7 @@ parameter: {
 		}, time.Second*30, time.Millisecond*300).Should(BeNil())
 
 		bi = build.NewContext().NewInstance("", nil)
-		err = bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	kv1 "kube/example.com/v1"
 )
@@ -371,9 +376,9 @@ output: {
 }
 `)
 		Expect(err).Should(BeNil())
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -392,7 +397,7 @@ output: {
 
 		By("test ingress in kube package")
 		bi := build.NewContext().NewInstance("", nil)
-		err := bi.AddFile("-", `
+		err := value.AddFile(bi, "-", `
 import (
 	network "k8s.io/networking/v1beta1"
 )
@@ -423,9 +428,9 @@ parameter: {
 	}
 }`)
 		Expect(err).ToNot(HaveOccurred())
-		inst, err := pd.ImportPackagesAndBuildInstance(bi)
+		inst, err := pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err := model.NewBase(inst.Lookup("output"))
+		base, err := model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err := base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -449,7 +454,7 @@ parameter: {
 		})).Should(BeEquivalentTo(""))
 		By("test Invalid Import path")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		value.AddFile(bi, "-", `
 import (
 	"k8s.io/networking/v1"
 )
@@ -470,15 +475,15 @@ parameter: {
 	name:  "myapp"
 	image: "nginx"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		_, err = model.NewBase(inst.Lookup("output"))
+		_, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("_|_ // undefined field \"#Deployment\""))
 
 		By("test Deployment in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		value.AddFile(bi, "-", `
 import (
 	apps "k8s.io/apps/v1"
 )
@@ -498,9 +503,9 @@ parameter: {
 	name:  "myapp"
 	image: "nginx"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -520,7 +525,7 @@ parameter: {
 
 		By("test Secret in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		value.AddFile(bi, "-", `
 import (
 	"k8s.io/core/v1"
 )
@@ -534,9 +539,9 @@ output: {
 parameter: {
 	name:  "myapp"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -548,7 +553,7 @@ parameter: {
 
 		By("test Service in kube package")
 		bi = build.NewContext().NewInstance("", nil)
-		bi.AddFile("-", `
+		value.AddFile(bi, "-", `
 import (
 	"k8s.io/core/v1"
 )
@@ -562,9 +567,9 @@ output: {
 parameter: {
 	name:  "myapp"
 }`)
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())
@@ -651,7 +656,7 @@ parameter: {
 		}, time.Second*30, time.Millisecond*300).Should(BeNil())
 
 		bi = build.NewContext().NewInstance("", nil)
-		err = bi.AddFile("-", `
+		err = value.AddFile(bi, "-", `
 import (
 	ev1 "example.com/v1"
 )
@@ -662,9 +667,9 @@ output: {
 }
 `)
 		Expect(err).Should(BeNil())
-		inst, err = pd.ImportPackagesAndBuildInstance(bi)
+		inst, err = pd.ImportPackagesAndBuildValue(bi)
 		Expect(err).Should(BeNil())
-		base, err = model.NewBase(inst.Lookup("output"))
+		base, err = model.NewBase(inst.LookupPath(value.FieldPath("output")))
 		Expect(err).Should(BeNil())
 		data, err = base.Unstructured()
 		Expect(err).Should(BeNil())

--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -201,7 +201,11 @@ func (ctx *templateContext) BaseContextFile() (string, error) {
 	}
 
 	if ctx.base != nil {
-		buff += fmt.Sprintf(model.OutputFieldName+": %s\n", structMarshal(ctx.base.String()))
+		base, err := ctx.base.String()
+		if err != nil {
+			return "", err
+		}
+		buff += fmt.Sprintf(model.OutputFieldName+": %s\n", structMarshal(base))
 	}
 
 	if ctx.components != nil {
@@ -215,7 +219,11 @@ func (ctx *templateContext) BaseContextFile() (string, error) {
 	if len(ctx.auxiliaries) > 0 {
 		var auxLines []string
 		for _, auxiliary := range ctx.auxiliaries {
-			auxLines = append(auxLines, fmt.Sprintf("\"%s\": %s", auxiliary.Name, structMarshal(auxiliary.Ins.String())))
+			aux, err := auxiliary.Ins.String()
+			if err != nil {
+				return "", err
+			}
+			auxLines = append(auxLines, fmt.Sprintf("\"%s\": %s", auxiliary.Name, structMarshal(aux)))
 		}
 		if len(auxLines) > 0 {
 			buff += fmt.Sprintf(model.OutputsFieldName+": {%s}\n", strings.Join(auxLines, "\n"))

--- a/pkg/cue/process/handle_test.go
+++ b/pkg/cue/process/handle_test.go
@@ -17,14 +17,13 @@ limitations under the License.
 package process
 
 import (
-	"fmt"
 	"testing"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/bmizerany/assert"
 
 	"github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 )
 
 func TestContext(t *testing.T) {
@@ -115,55 +114,55 @@ image: "myserver"
 	}
 	ctxInst := cuecontext.New().CompileString(c)
 
-	gName, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextName))).String()
+	gName, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextName)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "mycomp", gName)
 
-	myAppName, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextAppName))).String()
+	myAppName, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextAppName)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myapp", myAppName)
 
-	myAppRevision, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextAppRevision))).String()
+	myAppRevision, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextAppRevision)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myapp-v1", myAppRevision)
 
-	myAppRevisionNum, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextAppRevisionNum))).Int64()
+	myAppRevisionNum, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextAppRevisionNum)).Int64()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, int64(1), myAppRevisionNum)
 
-	myWorkflowName, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextWorkflowName))).String()
+	myWorkflowName, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextWorkflowName)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myworkflow", myWorkflowName)
 
-	myPublishVersion, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextPublishVersion))).String()
+	myPublishVersion, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextPublishVersion)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "mypublishversion", myPublishVersion)
 
-	inputJs, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.OutputFieldName))).MarshalJSON()
+	inputJs, err := ctxInst.LookupPath(value.FieldPath("context", model.OutputFieldName)).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, `{"image":"myserver"}`, string(inputJs))
 
-	outputsJs, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s.%s", model.OutputsFieldName, "service"))).MarshalJSON()
+	outputsJs, err := ctxInst.LookupPath(value.FieldPath("context", model.OutputsFieldName, "service")).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\"}", string(outputsJs))
 
-	outputsJs, err = ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s[\"%s\"]", model.OutputsFieldName, "service-1"))).MarshalJSON()
+	outputsJs, err = ctxInst.LookupPath(value.FieldPath("context", model.OutputsFieldName, "service-1")).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\"}", string(outputsJs))
 
-	ns, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextNamespace))).String()
+	ns, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextNamespace)).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myns", ns)
 
-	params, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ParameterFieldName))).MarshalJSON()
+	params, err := ctxInst.LookupPath(value.FieldPath("context", model.ParameterFieldName)).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"parameter1\":\"string\",\"parameter2\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"parameter3\":[\"item1\",\"item2\"]}", string(params))
 
-	artifacts, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", model.ContextDataArtifacts))).MarshalJSON()
+	artifacts, err := ctxInst.LookupPath(value.FieldPath("context", model.ContextDataArtifacts)).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"bool\":false,\"int\":10,\"map\":{\"key\":\"value\"},\"slice\":[\"str1\",\"str2\",\"str3\"],\"string\":\"mytxt\"}", string(artifacts))
 
-	arbitraryData, err := ctxInst.LookupPath(cue.ParsePath(fmt.Sprintf("context.%s", "arbitraryData"))).MarshalJSON()
+	arbitraryData, err := ctxInst.LookupPath(value.FieldPath("context", "arbitraryData")).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"bool\":false,\"int\":10,\"map\":{\"key\":\"value\"},\"slice\":[\"str1\",\"str2\",\"str3\"],\"string\":\"mytxt\"}", string(arbitraryData))
 }

--- a/pkg/cue/task/process.go
+++ b/pkg/cue/task/process.go
@@ -25,24 +25,21 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/builtin"
 	"github.com/oam-dev/kubevela/pkg/builtin/registry"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 )
 
 // Process processing the http task
-func Process(inst *cue.Instance) (*cue.Instance, error) {
-	taskVal := inst.Lookup("processing", "http")
+func Process(val cue.Value) (cue.Value, error) {
+	taskVal := val.LookupPath(value.FieldPath("processing", "http"))
 	if !taskVal.Exists() {
-		return inst, errors.New("there is no http in processing")
+		return val, errors.New("there is no http in processing")
 	}
 	resp, err := exec(taskVal)
 	if err != nil {
-		return nil, fmt.Errorf("fail to exec http task, %w", err)
+		return val, fmt.Errorf("fail to exec http task, %w", err)
 	}
 
-	appInst, err := inst.Fill(resp, "processing", "output")
-	if err != nil {
-		return nil, fmt.Errorf("fail to fill output from http, %w", err)
-	}
-	return appInst, nil
+	return val.FillPath(value.FieldPath("processing", "output"), resp), nil
 }
 
 func exec(v cue.Value) (map[string]interface{}, error) {

--- a/pkg/definition/definition_test.go
+++ b/pkg/definition/definition_test.go
@@ -84,8 +84,8 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 	if err = def.FromCUEString("template:"+parts[1], nil); err == nil {
 		t.Fatalf("should encounter no metadata found error but not found error")
 	}
-	if err = def.FromCUEString("import \"strconv\"\n"+cueString, nil); err == nil {
-		t.Fatalf("should encounter cue compile error due to useless import but not found error")
+	if err = def.FromCUEString("import \"strconv\"\n"+cueString, nil); err != nil {
+		t.Fatalf("should not encounter cue compile error due to useless import")
 	}
 	if err = def.FromCUEString("abc: {}\n"+cueString, nil); err == nil {
 		t.Fatalf("should encounter duplicated object name error but not found error")

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -101,6 +101,7 @@ func NewStructParameter() StructParameter {
 }
 
 // parseParameters will be called recursively to parse parameters
+// nolint:staticcheck
 func parseParameters(paraValue cue.Value, paramKey string) error {
 	param := NewStructParameter()
 	param.Name = paramKey

--- a/pkg/stdlib/op.cue
+++ b/pkg/stdlib/op.cue
@@ -65,7 +65,7 @@ import (
 #ApplyComponentRemaining: #Steps & {
 	// exceptions specify the resources not to apply.
 	exceptions: [...string]
-	_exceptions: {for c in exceptions {"\(c)": true}}
+	exceptions_: {for c in exceptions {"\(c)": true}}
 	component: string
 
 	load:   oam.#LoadComponets @step(1)
@@ -77,7 +77,7 @@ import (
 			value: rendered.output
 		}
 		for name, c in rendered.outputs {
-			if _exceptions[name] == _|_ {
+			if exceptions_[name] == _|_ {
 				"\(name)": kube.#Apply & {
 					value: c
 				}
@@ -89,12 +89,12 @@ import (
 #ApplyRemaining: #Steps & {
 	// exceptions specify the resources not to apply.
 	exceptions: [...string]
-	_exceptions: {for c in exceptions {"\(c)": true}}
+	exceptions_: {for c in exceptions {"\(c)": true}}
 
 	load:       oam.#LoadComponets @step(1)
 	components: #Steps & {
 		for name, c in load.value {
-			if _exceptions[name] == _|_ {
+			if exceptions_[name] == _|_ {
 				"\(name)": oam.#ApplyComponent & {
 					value: c
 				}

--- a/pkg/stdlib/packages.go
+++ b/pkg/stdlib/packages.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/parser"
 	"k8s.io/klog/v2"
 )
 
@@ -88,7 +89,11 @@ func AddImportsFor(inst *build.Instance, tagTempl string) error {
 			PkgName:    filepath.Base("vela/custom"),
 			ImportPath: "vela/custom",
 		}
-		if err := p.AddFile("-", tagTempl); err != nil {
+		file, err := parser.ParseFile("-", tagTempl, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+		if err := p.AddSyntax(file); err != nil {
 			return err
 		}
 		inst.Imports = append(inst.Imports, p)
@@ -107,7 +112,11 @@ func initBuiltinImports() ([]*build.Instance, error) {
 			PkgName:    filepath.Base(path),
 			ImportPath: path,
 		}
-		if err := p.AddFile("-", content); err != nil {
+		file, err := parser.ParseFile("-", content, parser.ParseComments)
+		if err != nil {
+			return nil, err
+		}
+		if err := p.AddSyntax(file); err != nil {
 			return nil, err
 		}
 		imports = append(imports, p)

--- a/pkg/stdlib/pkgs/multicluster.cue
+++ b/pkg/stdlib/pkgs/multicluster.cue
@@ -78,7 +78,7 @@
 
 	loadPolicies: oam.#LoadPolicies @step(1)
 	policy_:      string
-	if inputs.policy == "" {
+	if inputs.policy == "" && loadPolicies.value != _|_ {
 		envBindingPolicies: [ for k, v in loadPolicies.value if v.type == "env-binding" {k}]
 		policy_: envBindingPolicies[0]
 	}

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -264,7 +264,7 @@ func GetCUEParameterValue(cueStr string, pd *packages.PackageDiscover) (cue.Valu
 func GenOpenAPI(inst *cue.Instance) (b []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic in cue: %v", r)
+			err = fmt.Errorf("invalid cue definition to generate open api: %v", r)
 			return
 		}
 	}()

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -32,7 +32,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
-	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/format"
 	"cuelang.org/go/encoding/openapi"
 	"github.com/AlecAivazis/survey/v2"
@@ -71,6 +70,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
@@ -234,27 +234,11 @@ func HTTPGetKubernetesObjects(ctx context.Context, url string) ([]*unstructured.
 
 // GetCUEParameterValue converts definitions to cue format
 func GetCUEParameterValue(cueStr string, pd *packages.PackageDiscover) (cue.Value, error) {
-	var template *cue.Instance
-	var err error
-	if pd != nil {
-		bi := build.NewContext().NewInstance("", nil)
-		err := bi.AddFile("-", cueStr+velacue.BaseTemplate)
-		if err != nil {
-			return cue.Value{}, err
-		}
-
-		template, err = pd.ImportPackagesAndBuildInstance(bi)
-		if err != nil {
-			return cue.Value{}, err
-		}
-	} else {
-		r := cue.Runtime{}
-		template, err = r.Compile("", cueStr+velacue.BaseTemplate)
-		if err != nil {
-			return cue.Value{}, err
-		}
+	template, err := value.NewValue(cueStr+velacue.BaseTemplate, pd, "")
+	if err != nil {
+		return cue.Value{}, err
 	}
-	tempStruct, err := template.Value().Struct()
+	tempStruct, err := template.CueValue().Struct()
 	if err != nil {
 		return cue.Value{}, err
 	}
@@ -277,7 +261,13 @@ func GetCUEParameterValue(cueStr string, pd *packages.PackageDiscover) (cue.Valu
 }
 
 // GenOpenAPI generates OpenAPI json schema from cue.Instance
-func GenOpenAPI(inst *cue.Instance) ([]byte, error) {
+func GenOpenAPI(inst *cue.Instance) (b []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in cue: %v", r)
+			return
+		}
+	}()
 	if inst.Err != nil {
 		return nil, inst.Err
 	}
@@ -285,8 +275,8 @@ func GenOpenAPI(inst *cue.Instance) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defaultConfig := &openapi.Config{}
-	b, err := openapi.Gen(paramOnlyIns, defaultConfig)
+	defaultConfig := &openapi.Config{ExpandReferences: true}
+	b, err = openapi.Gen(paramOnlyIns, defaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +286,9 @@ func GenOpenAPI(inst *cue.Instance) ([]byte, error) {
 }
 
 // extractParameterDefinitionNodeFromInstance extracts the `#parameter` ast.Node from root instance, if failed fall back to `parameter` by LookUpDef
+// nolint:staticcheck
 func extractParameterDefinitionNodeFromInstance(inst *cue.Instance) ast.Node {
-	opts := []cue.Option{cue.All(), cue.DisallowCycles(true), cue.ResolveReferences(true), cue.Docs(true)}
+	opts := []cue.Option{cue.Docs(true), cue.InlineImports(true)}
 	node := inst.Value().Syntax(opts...)
 	if fileNode, ok := node.(*ast.File); ok {
 		for _, decl := range fileNode.Decls {
@@ -313,13 +304,14 @@ func extractParameterDefinitionNodeFromInstance(inst *cue.Instance) ast.Node {
 }
 
 // RefineParameterInstance refines cue instance to merely include `parameter` identifier
+// nolint:staticcheck
 func RefineParameterInstance(inst *cue.Instance) (*cue.Instance, error) {
 	r := cue.Runtime{}
-	paramVal := inst.LookupDef(model.ParameterFieldName)
+	paramVal := inst.Lookup(model.ParameterFieldName)
 	var paramOnlyStr string
 	switch k := paramVal.IncompleteKind(); k {
 	case cue.StructKind, cue.ListKind:
-		paramSyntax, _ := format.Node(extractParameterDefinitionNodeFromInstance(inst))
+		paramSyntax, _ := format.Node(paramVal.Value().Syntax(cue.Docs(true), cue.ResolveReferences(true)))
 		paramOnlyStr = fmt.Sprintf("#%s: %s\n", model.ParameterFieldName, string(paramSyntax))
 	case cue.IntKind, cue.StringKind, cue.FloatKind, cue.BoolKind:
 		paramOnlyStr = fmt.Sprintf("#%s: %v", model.ParameterFieldName, paramVal)

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -305,6 +305,7 @@ name
 	}
 }
 
+// nolint:staticcheck
 func TestGenOpenAPI(t *testing.T) {
 	type want struct {
 		targetSchemaFile string
@@ -445,6 +446,7 @@ variable "mapVar" {
 	assert.True(t, intVarExisted)
 }
 
+// nolint:staticcheck
 func TestRefineParameterInstance(t *testing.T) {
 	// test #parameter exists: mock issues in #1939 & #2062
 	s := `parameter: #parameter

--- a/pkg/utils/common/testdata/workload1.cue
+++ b/pkg/utils/common/testdata/workload1.cue
@@ -1,4 +1,4 @@
-#parameter: {
+parameter: {
 	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string

--- a/pkg/utils/common/testdata/workload1.json
+++ b/pkg/utils/common/testdata/workload1.json
@@ -13,16 +13,16 @@
                "image"
             ],
             "properties": {
+               "image": {
+                  "description": "+usage=Which image would you like to use for your service\n+short=i",
+                  "type": "string"
+               },
                "cmd": {
                   "description": "+usage=Commands to run in the container",
                   "type": "array",
                   "items": {
                      "type": "string"
                   }
-               },
-               "image": {
-                  "description": "+usage=Which image would you like to use for your service\n+short=i",
-                  "type": "string"
                },
                "cpu": {
                   "type": "string"

--- a/pkg/utils/errors/reason.go
+++ b/pkg/utils/errors/reason.go
@@ -38,5 +38,5 @@ func IsLabelConflict(err error) bool {
 
 // IsCuePathNotFound checks if the error is cue path not found error
 func IsCuePathNotFound(err error) bool {
-	return strings.Contains(err.Error(), "failed to lookup value")
+	return strings.Contains(err.Error(), "failed to lookup value") && strings.Contains(err.Error(), "not exist")
 }

--- a/pkg/utils/errors/reason.go
+++ b/pkg/utils/errors/reason.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package errors
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	// LabelConflict defines the conflict label error string
@@ -32,4 +34,9 @@ func IsLabelConflict(err error) bool {
 		return true
 	}
 	return false
+}
+
+// IsCuePathNotFound checks if the error is cue path not found error
+func IsCuePathNotFound(err error) bool {
+	return strings.Contains(err.Error(), "failed to lookup value")
 }

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Test Query Provider", func() {
 			Expect(err).Should(BeNil())
 			err = prd.ListResourcesInApp(nil, newV, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("var(path=app) not exist"))
+			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=app) not exist"))
 		})
 	})
 
@@ -392,14 +392,14 @@ var _ = Describe("Test Query Provider", func() {
 			Expect(err).Should(BeNil())
 			err = prd.SearchEvents(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("var(path=value) not exist"))
+			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=value) not exist"))
 
 			optWithoutCluster := `value: {}`
 			v, err = value.NewValue(optWithoutCluster, nil, "")
 			Expect(err).Should(BeNil())
 			err = prd.SearchEvents(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("var(path=cluster) not exist"))
+			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=cluster) not exist"))
 
 			optWithWrongValue := `value: {}
 cluster: "test"`
@@ -424,13 +424,13 @@ cluster: "test"`
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("var(path=cluster) not exist"))
+			Expect(err.Error()).Should(ContainSubstring("failed to lookup value: var(path=cluster) not exist"))
 
 			v, err = value.NewValue(`cluster: "local"`, nil, "")
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("var(path=namespace) not exist"))
+			Expect(err.Error()).Should(ContainSubstring("failed to lookup value: var(path=namespace) not exist"))
 
 			v, err = value.NewValue(`cluster: "local"
 namespace: "default"`, nil, "")

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
+	verrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	querytypes "github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
 )
@@ -252,7 +253,7 @@ var _ = Describe("Test Query Provider", func() {
 			Expect(err).Should(BeNil())
 			err = prd.ListResourcesInApp(nil, newV, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=app) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 		})
 	})
 
@@ -392,14 +393,14 @@ var _ = Describe("Test Query Provider", func() {
 			Expect(err).Should(BeNil())
 			err = prd.SearchEvents(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=value) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			optWithoutCluster := `value: {}`
 			v, err = value.NewValue(optWithoutCluster, nil, "")
 			Expect(err).Should(BeNil())
 			err = prd.SearchEvents(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(Equal("failed to lookup value: var(path=cluster) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			optWithWrongValue := `value: {}
 cluster: "test"`
@@ -424,20 +425,20 @@ cluster: "test"`
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("failed to lookup value: var(path=cluster) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			v, err = value.NewValue(`cluster: "local"`, nil, "")
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("failed to lookup value: var(path=namespace) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			v, err = value.NewValue(`cluster: "local"
 namespace: "default"`, nil, "")
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("var(path=pod) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			v, err = value.NewValue(`cluster: "local"
 namespace: "default"
@@ -445,7 +446,7 @@ pod: "hello-world"`, nil, "")
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("var(path=options) not exist"))
+			Expect(verrors.IsCuePathNotFound(err)).Should(BeTrue())
 
 			v, err = value.NewValue(`cluster: "local"
 namespace: "default"

--- a/pkg/workflow/context/context.go
+++ b/pkg/workflow/context/context.go
@@ -273,10 +273,6 @@ type ComponentManifest struct {
 
 // Patch the ComponentManifest with value
 func (comp *ComponentManifest) Patch(patchValue *value.Value) error {
-	// pInst, err := model.NewOther(patchValue.CueValue())
-	// if err != nil {
-	// 	return err
-	// }
 	return comp.Workload.Unify(patchValue.CueValue())
 }
 

--- a/pkg/workflow/context/context_test.go
+++ b/pkg/workflow/context/context_test.go
@@ -44,7 +44,9 @@ func TestComponent(t *testing.T) {
 	_, ok := components["server"]
 	r.Equal(ok, true)
 
-	r.Equal(cmf.Workload.String(), `apiVersion: "v1"
+	s, err := cmf.Workload.String()
+	r.NoError(err)
+	r.Equal(s, `apiVersion: "v1"
 kind:       "Pod"
 metadata: {
 	labels: {
@@ -53,32 +55,34 @@ metadata: {
 }
 spec: {
 	containers: [{
-		name: "main"
 		env: [{
 			name:  "APP"
 			value: "nginx"
-		}, ...]
+		}]
 		image:           "nginx:1.14.2"
 		imagePullPolicy: "IfNotPresent"
+		name:            "main"
 		ports: [{
 			containerPort: 8080
 			protocol:      "TCP"
-		}, ...]
-	}, ...]
+		}]
+	}]
 }
 `)
 	r.Equal(len(cmf.Auxiliaries), 1)
-	r.Equal(cmf.Auxiliaries[0].String(), `apiVersion: "v1"
+	s, err = cmf.Auxiliaries[0].String()
+	r.NoError(err)
+	r.Equal(s, `apiVersion: "v1"
 kind:       "Service"
 metadata: {
 	name: "my-service"
 }
 spec: {
 	ports: [{
-		protocol:   "TCP"
 		port:       80
+		protocol:   "TCP"
 		targetPort: 8080
-	}, ...]
+	}]
 	selector: {
 		app: "nginx"
 	}
@@ -96,7 +100,9 @@ env:[{name: "ClusterIP",value: "1.1.1.1"}]}]
 
 	cmf, err = wfCtx.GetComponent("server")
 	r.NoError(err)
-	r.Equal(cmf.Workload.String(), `apiVersion: "v1"
+	s, err = cmf.Workload.String()
+	r.NoError(err)
+	r.Equal(s, `apiVersion: "v1"
 kind:       "Pod"
 metadata: {
 	labels: {
@@ -105,7 +111,6 @@ metadata: {
 }
 spec: {
 	containers: [{
-		name: "main"
 		// +patchKey=name
 		env: [{
 			name:  "APP"
@@ -116,11 +121,12 @@ spec: {
 		}, ...]
 		image:           "nginx:1.14.2"
 		imagePullPolicy: "IfNotPresent"
+		name:            "main"
 		ports: [{
 			containerPort: 8080
 			protocol:      "TCP"
 		}, ...]
-	}, ...]
+	}]
 }
 `)
 
@@ -201,7 +207,7 @@ result: 101
 	conflictV, err := value.NewValue(`score: 101`, nil, "")
 	r.NoError(err)
 	err = wfCtx.SetVar(conflictV, "football")
-	r.Equal(err.Error(), "football.result: conflicting values 100 and 101")
+	r.Equal(err.Error(), "football.score: conflicting values 101 and 100")
 }
 
 func TestRefObj(t *testing.T) {

--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -38,8 +38,10 @@ func Input(ctx wfContext.Context, paramValue *value.Value, step v1beta1.Workflow
 		if err != nil {
 			return errors.WithMessagef(err, "get input from [%s]", input.From)
 		}
-		if err := paramValue.FillValueByScript(inputValue, input.ParameterKey); err != nil {
-			return err
+		if input.ParameterKey != "" {
+			if err := paramValue.FillValueByScript(inputValue, input.ParameterKey); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/workflow/providers/email/send_test.go
+++ b/pkg/workflow/providers/email/send_test.go
@@ -58,11 +58,11 @@ stepID: "success"
 		},
 		"no-step-id": {
 			from:        ``,
-			expectedErr: errors.New("var(path=stepID) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=stepID) not exist"),
 		},
 		"no-sender": {
 			from:        `stepID:"no-sender"`,
-			expectedErr: errors.New("var(path=from) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=from) not exist"),
 		},
 		"no-receiver": {
 			from: `
@@ -75,7 +75,7 @@ port: 465
 }
 stepID: "no-receiver"
 `,
-			expectedErr: errors.New("var(path=to) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=to) not exist"),
 		},
 		"no-content": {
 			from: `
@@ -89,7 +89,7 @@ port: 465
 to: ["user1@gmail.com", "user2@gmail.com"]
 stepID: "no-content"
 `,
-			expectedErr: errors.New("var(path=content) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=content) not exist"),
 		},
 		"send-fail": {
 			from: `

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -69,10 +69,6 @@ func (h *provider) Apply(ctx wfContext.Context, v *value.Value, act types.Action
 			return err
 		}
 
-		// patcher, err := model.NewOther(pv)
-		// if err != nil {
-		// 	return err
-		// }
 		if err := base.Unify(pv); err != nil {
 			return err
 		}

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -69,11 +69,11 @@ func (h *provider) Apply(ctx wfContext.Context, v *value.Value, act types.Action
 			return err
 		}
 
-		patcher, err := model.NewOther(pv)
-		if err != nil {
-			return err
-		}
-		if err := base.Unify(patcher); err != nil {
+		// patcher, err := model.NewOther(pv)
+		// if err != nil {
+		// 	return err
+		// }
+		if err := base.Unify(pv); err != nil {
 			return err
 		}
 		workload, err = base.Unstructured()

--- a/pkg/workflow/providers/kube/handle_test.go
+++ b/pkg/workflow/providers/kube/handle_test.go
@@ -117,13 +117,15 @@ var _ = Describe("Test Workflow Provider Kube", func() {
 		component, err := ctx.GetComponent("server")
 		Expect(err).ToNot(HaveOccurred())
 
+		s, err := component.Workload.String()
+		Expect(err).ToNot(HaveOccurred())
 		v, err := value.NewValue(fmt.Sprintf(`
 value:{
 	%s
 	metadata: name: "app"
 }
 cluster: ""
-`, component.Workload.String()), nil, "")
+`, s), nil, "")
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Apply(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -136,13 +138,15 @@ cluster: ""
 			}, workload)
 		}, time.Second*2, time.Millisecond*300).Should(BeNil())
 
+		s, err = component.Workload.String()
+		Expect(err).ToNot(HaveOccurred())
 		v, err = value.NewValue(fmt.Sprintf(`
 value: {
 %s
 metadata: name: "app"
 }
 cluster: ""
-`, component.Workload.String()), nil, "")
+`, s), nil, "")
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Read(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -179,10 +183,12 @@ cluster: ""
 
 		component, err := ctx.GetComponent("server")
 		Expect(err).ToNot(HaveOccurred())
+		s, err := component.Workload.String()
+		Expect(err).ToNot(HaveOccurred())
 		v, err := value.NewValue(fmt.Sprintf(`
 value: {%s}
 cluster: ""
-patch: metadata: name: "test-app-1"`, component.Workload.String()), nil, "")
+patch: metadata: name: "test-app-1"`, s), nil, "")
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Apply(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/workflow/providers/oam/apply_test.go
+++ b/pkg/workflow/providers/oam/apply_test.go
@@ -42,7 +42,7 @@ func TestParser(t *testing.T) {
 	v, err := value.NewValue("", nil, "")
 	r.NoError(err)
 	err = p.ApplyComponent(nil, v, act)
-	r.Equal(err.Error(), "var(path=value) not exist")
+	r.Equal(err.Error(), "failed to lookup value: var(path=value) not exist")
 	v.FillObject(map[string]interface{}{}, "value")
 	err = p.ApplyComponent(nil, v, act)
 	r.NoError(err)
@@ -53,10 +53,10 @@ func TestParser(t *testing.T) {
 	r.Equal(outStr, `apiVersion: "v1"
 kind:       "Pod"
 metadata: {
-	name: "rss-site"
 	labels: {
 		app: "web"
 	}
+	name: "rss-site"
 }
 `)
 
@@ -68,10 +68,10 @@ metadata: {
 	apiVersion: "v1"
 	kind:       "Service"
 	metadata: {
-		name: "service"
 		labels: {
 			"trait.oam.dev/resource": "service"
 		}
+		name: "service"
 	}
 }
 `)

--- a/pkg/workflow/providers/time/date_test.go
+++ b/pkg/workflow/providers/time/date_test.go
@@ -53,12 +53,12 @@ layout: "Mon, 02 Jan 2006 15:04:05 MST"`,
 		"test convert date without time layout": {
 			from:        `date: "2021-11-07T01:47:51Z"`,
 			expected:    0,
-			expectedErr: errors.New("var(path=layout) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=layout) not exist"),
 		},
 		"test convert without date": {
 			from:        ``,
 			expected:    0,
-			expectedErr: errors.New("var(path=date) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=date) not exist"),
 		},
 		"test convert date with wrong time layout": {
 			from: `date: "2021-11-07T01:47:51Z"
@@ -119,12 +119,12 @@ layout: "Mon, 02 Jan 2006 15:04:05 MST"
 		"test convert date without time layout": {
 			from:        `timestamp: 1551452400`,
 			expected:    "",
-			expectedErr: errors.New("var(path=layout) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=layout) not exist"),
 		},
 		"test convert without timestamp": {
 			from:        ``,
 			expected:    "",
-			expectedErr: errors.New("var(path=timestamp) not exist"),
+			expectedErr: errors.New("failed to lookup value: var(path=timestamp) not exist"),
 		},
 	}
 

--- a/pkg/workflow/providers/util/util.go
+++ b/pkg/workflow/providers/util/util.go
@@ -47,11 +47,7 @@ func (p *provider) PatchK8sObject(ctx wfContext.Context, v *value.Value, act typ
 	if err != nil {
 		return err
 	}
-	patcher, err := model.NewOther(pv.CueValue())
-	if err != nil {
-		return err
-	}
-	if err = base.Unify(patcher); err != nil {
+	if err = base.Unify(pv.CueValue()); err != nil {
 		return v.FillObject(err, "err")
 	}
 

--- a/pkg/workflow/providers/util/util_test.go
+++ b/pkg/workflow/providers/util/util_test.go
@@ -169,7 +169,7 @@ func TestConvertString(t *testing.T) {
 		},
 		"fail": {
 			from:        `bt: 123`,
-			expectedErr: errors.New("bt: cannot use value 123 (type int) as string|bytes"),
+			expectedErr: errors.New("bt: cannot use value 123 (type int) as (string|bytes)"),
 		},
 	}
 

--- a/pkg/workflow/providers/workspace/workspace.go
+++ b/pkg/workflow/providers/workspace/workspace.go
@@ -58,13 +58,21 @@ func (h *provider) Load(ctx wfContext.Context, v *value.Value, act types.Action)
 }
 
 func fillComponent(v *value.Value, component *wfContext.ComponentManifest, paths ...string) error {
-	if err := v.FillRaw(component.Workload.String(), append(paths, "workload")...); err != nil {
+	workload, err := component.Workload.String()
+	if err != nil {
+		return err
+	}
+	if err := v.FillRaw(workload, append(paths, "workload")...); err != nil {
 		return err
 	}
 	if len(component.Auxiliaries) > 0 {
 		var auxiliaries []string
 		for _, aux := range component.Auxiliaries {
-			auxiliaries = append(auxiliaries, "{"+aux.String()+"}")
+			auxiliary, err := aux.String()
+			if err != nil {
+				return err
+			}
+			auxiliaries = append(auxiliaries, "{"+auxiliary+"}")
 		}
 		if err := v.FillRaw(fmt.Sprintf("[%s]", strings.Join(auxiliaries, ",")), append(paths, "auxiliaries")...); err != nil {
 			return err
@@ -138,7 +146,7 @@ func (h *provider) Wait(ctx wfContext.Context, v *value.Value, act types.Action)
 
 	cv := v.CueValue()
 	if cv.Exists() {
-		ret := cv.Lookup("continue")
+		ret := cv.LookupPath(value.FieldPath("continue"))
 		if ret.Exists() {
 			isContinue, err := ret.Bool()
 			if err == nil && isContinue {

--- a/pkg/workflow/providers/workspace/workspace_test.go
+++ b/pkg/workflow/providers/workspace/workspace_test.go
@@ -85,7 +85,8 @@ component: "server"
 	assert.NilError(t, err)
 	component, err := wfCtx.GetComponent("server")
 	assert.NilError(t, err)
-	s := component.Workload.String()
+	s, err := component.Workload.String()
+	assert.NilError(t, err)
 	assert.Equal(t, s, `apiVersion: "v1"
 kind:       "Pod"
 metadata: {
@@ -95,7 +96,6 @@ metadata: {
 }
 spec: {
 	containers: [{
-		name: "main"
 		// +patchKey=name
 		env: [{
 			name:  "APP"
@@ -106,11 +106,12 @@ spec: {
 		}, ...]
 		image:           "nginx:1.14.2"
 		imagePullPolicy: "IfNotPresent"
+		name:            "main"
 		ports: [{
 			containerPort: 8080
 			protocol:      "TCP"
 		}, ...]
-	}, ...]
+	}]
 }
 `)
 
@@ -320,18 +321,18 @@ metadata:
 	}
 	spec: {
 		containers: [{
-			name: "main"
 			env: [{
 				name:  "APP"
 				value: "nginx"
-			}, ...]
+			}]
 			image:           "nginx:1.14.2"
 			imagePullPolicy: "IfNotPresent"
+			name:            "main"
 			ports: [{
 				containerPort: 8080
 				protocol:      "TCP"
-			}, ...]
-		}, ...]
+			}]
+		}]
 	}
 }
 auxiliaries: [{
@@ -342,10 +343,10 @@ auxiliaries: [{
 	}
 	spec: {
 		ports: [{
-			protocol:   "TCP"
 			port:       80
+			protocol:   "TCP"
 			targetPort: 8080
-		}, ...]
+		}]
 		selector: {
 			app: "nginx"
 		}

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -146,7 +146,9 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 
 			defer func() {
 				if r := recover(); r != nil {
-					rErr = fmt.Errorf("panic in cue: %v", r)
+					exec.err(ctx, false, fmt.Errorf("invalid cue task for evaluation: %v", r), wfTypes.StatusReasonRendering)
+					stepStatus = exec.status()
+					operations = exec.operation()
 					return
 				}
 				if taskv == nil {

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -645,6 +645,14 @@ func TestValidateIfValue(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "error if",
+			step: v1beta1.WorkflowStep{
+				If: `test == true`,
+			},
+			expectedErr: "invalid if value",
+			expected:    false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/references/cli/debug_test.go
+++ b/references/cli/debug_test.go
@@ -94,7 +94,6 @@ func TestDebugApplicationWithWorkflow(t *testing.T) {
 				},
 			},
 			step:        "test-wf1",
-			focus:       "test",
 			expectedErr: "failed to parse debug configmap",
 		},
 		"success": {

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -114,6 +114,7 @@ func getPrompt(cmd *cobra.Command, reader *bufio.Reader, description string, pro
 	}
 }
 
+// nolint:staticcheck
 func buildTemplateFromYAML(templateYAML string, def *pkgdef.Definition) error {
 	templateYAMLBytes, err := utils.ReadRemoteOrLocalPath(templateYAML, false)
 	if err != nil {

--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -163,7 +163,7 @@ func NewInstallCommand(c common.Args, order string, ioStreams util.IOStreams) *c
 			}
 			// Step4: apply new CRDs
 			if err := upgradeCRDs(cmd.Context(), kubeClient, chart); err != nil {
-				return errors.New(fmt.Sprintf("upgrade CRD failure %s", err.Error()))
+				return fmt.Errorf("upgrade CRD failure %w", err)
 			}
 			// Step5: Install or upgrade helm release
 			release, err := installArgs.helmHelper.UpgradeChart(chart, kubeVelaReleaseName, installArgs.Namespace, values,

--- a/references/docgen/cluster_test.go
+++ b/references/docgen/cluster_test.go
@@ -57,10 +57,6 @@ var _ = Describe("DefinitionFiles", func() {
 		Category:    types.CUECategory,
 		Parameters: []types.Parameter{
 			{
-				Type: cue.ListKind,
-				Name: "env",
-			},
-			{
 				Name:     "image",
 				Type:     cue.StringKind,
 				Default:  "",
@@ -74,6 +70,10 @@ var _ = Describe("DefinitionFiles", func() {
 				Short:   "p",
 				Default: int64(8080),
 				Usage:   "Which port do you want customer traffic sent to",
+			},
+			{
+				Type: cue.ListKind,
+				Name: "env",
 			},
 		},
 		CrdInfo: &types.CRDInfo{
@@ -89,22 +89,25 @@ var _ = Describe("DefinitionFiles", func() {
 		Type:        types.TypeComponentDefinition,
 		Description: "description not defined",
 		Category:    types.CUECategory,
-		Parameters: []types.Parameter{{
-			Name: "env", Type: cue.ListKind,
-		}, {
-			Name:     "image",
-			Type:     cue.StringKind,
-			Default:  "",
-			Short:    "i",
-			Required: true,
-			Usage:    "Which image would you like to use for your service",
-		}, {
-			Name:    "port",
-			Type:    cue.IntKind,
-			Short:   "p",
-			Default: int64(6379),
-			Usage:   "Which port do you want customer traffic sent to",
-		}},
+		Parameters: []types.Parameter{
+			{
+				Name:     "image",
+				Type:     cue.StringKind,
+				Default:  "",
+				Short:    "i",
+				Required: true,
+				Usage:    "Which image would you like to use for your service",
+			}, {
+				Name:    "port",
+				Type:    cue.IntKind,
+				Short:   "p",
+				Default: int64(6379),
+				Usage:   "Which port do you want customer traffic sent to",
+			},
+			{
+				Name: "env", Type: cue.ListKind,
+			},
+		},
 		CrdName: "deployments.apps",
 		CrdInfo: &types.CRDInfo{
 			APIVersion: "apps/v1",

--- a/references/docgen/parser_test.go
+++ b/references/docgen/parser_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -592,5 +591,5 @@ parameter: {
 	err = w.Close()
 	assert.NoError(t, err)
 	out, _ := ioutil.ReadAll(r)
-	assert.True(t, strings.Contains(string(out), "map[string]:#KeySecret"))
+	assert.Contains(t, string(out), "map[string]:#KeySecret")
 }

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,8 +1,9 @@
 # This is config file for staticcheck.
 # If you need to add ignored checks, pls also add explaination in comments. 
 
-checks = ["all", "-ST1000", "-ST1003", "-ST1016"]
+checks = ["all", "-ST1000", "-ST1003", "-ST1016", "-SA1019"]
 
 # ST1000 - Incorrect or missing package comment (non-default)
 # ST1003 – Poorly chosen identifier (non-default)
 # ST1016 – Use consistent method receiver names (non-default)
+# SA1019 – Using a deprecated function, variable, constant or field (non-default), ignore it for now for cue upgrades (TODO: remove it after CUE compatible)

--- a/vela-templates/definitions/deprecated/volumes.cue
+++ b/vela-templates/definitions/deprecated/volumes.cue
@@ -54,8 +54,8 @@ template: {
 		// +usage=Declare volumes and volumeMounts
 		volumes?: [...{
 			name: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/deprecated/volumes.cue
+++ b/vela-templates/definitions/deprecated/volumes.cue
@@ -55,7 +55,7 @@ template: {
 		volumes?: [...{
 			name: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/deprecated/webhook-notification.cue
+++ b/vela-templates/definitions/deprecated/webhook-notification.cue
@@ -133,10 +133,20 @@ template: {
 	}
 
 	option: {
-		text:         textType
-		value:        string
-		description?: textType
-		url?:         string
+		text: {
+			type:      string
+			text:      string
+			emoji?:    bool
+			verbatim?: bool
+		}
+		value: string
+		description?: {
+			type:      string
+			text:      string
+			emoji?:    bool
+			verbatim?: bool
+		}
+		url?: string
 	}
 
 	secretRef: {

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -225,7 +225,7 @@ template: {
 			name:      string
 			mountPath: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -224,8 +224,8 @@ template: {
 		volumes?: [...{
 			name:      string
 			mountPath: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/daemon.cue
+++ b/vela-templates/definitions/internal/component/daemon.cue
@@ -498,8 +498,8 @@ template: {
 		volumes?: [...{
 			name:      string
 			mountPath: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/daemon.cue
+++ b/vela-templates/definitions/internal/component/daemon.cue
@@ -78,7 +78,7 @@ daemon: {
 template: {
 	mountsArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -87,7 +87,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -96,7 +96,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -105,7 +105,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -114,7 +114,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					mountPath: v.mountPath
 					if v.mountPropagation != _|_ {
@@ -131,7 +131,7 @@ template: {
 
 	volumesArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					name: v.name
 					persistentVolumeClaim: claimName: v.claimName
@@ -140,7 +140,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					name: v.name
 					configMap: {
@@ -155,7 +155,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					name: v.name
 					secret: {
@@ -170,7 +170,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					name: v.name
 					emptyDir: medium: v.medium
@@ -179,7 +179,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					name: v.name
 					hostPath: {
@@ -343,7 +343,7 @@ template: {
 	}
 
 	exposePorts: [
-		for v in parameter.ports if v.expose == true {
+		if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
 			port:       v.port
 			targetPort: v.port
 			if v.name != _|_ {
@@ -499,7 +499,7 @@ template: {
 			name:      string
 			mountPath: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -93,7 +93,7 @@ template: {
 						}
 
 						if parameter["volumes"] != _|_ {
-							volumeMounts: [ for v in parameter.volumes {
+							volumeMounts: [ if parameter.volumes != _|_ for v in parameter.volumes {
 								{
 									mountPath: v.mountPath
 									name:      v.name
@@ -102,7 +102,7 @@ template: {
 					}]
 
 					if parameter["volumes"] != _|_ {
-						volumes: [ for v in parameter.volumes {
+						volumes: [ if parameter.volumes != _|_ for v in parameter.volumes {
 							{
 								name: v.name
 								if v.type == "pvc" {
@@ -133,7 +133,7 @@ template: {
 					}
 
 					if parameter["imagePullSecrets"] != _|_ {
-						imagePullSecrets: [ for v in parameter.imagePullSecrets {
+						imagePullSecrets: [ if parameter.imagePullSecrets != _|_ for v in parameter.imagePullSecrets {
 							name: v
 						},
 						]
@@ -207,7 +207,7 @@ template: {
 			name:      string
 			mountPath: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -206,8 +206,8 @@ template: {
 		volumes?: [...{
 			name:      string
 			mountPath: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -54,7 +54,7 @@ webservice: {
 template: {
 	mountsArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -66,7 +66,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -78,7 +78,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -90,7 +90,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -102,7 +102,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -116,7 +116,7 @@ template: {
 
 	volumesArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					name: v.name
 					persistentVolumeClaim: claimName: v.claimName
@@ -125,7 +125,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					name: v.name
 					configMap: {
@@ -140,7 +140,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					name: v.name
 					secret: {
@@ -155,7 +155,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					name: v.name
 					emptyDir: medium: v.medium
@@ -164,7 +164,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					name: v.name
 					hostPath: {
@@ -180,11 +180,11 @@ template: {
 		for val in [
 			for i, vi in volumesList {
 				for j, vj in volumesList if j < i && vi.name == vj.name {
-					_ignore: true
+					ignore: true
 				}
 				vi
 			},
-		] if val._ignore == _|_ {
+		] if val.ignore == _|_ {
 			val
 		},
 	]
@@ -342,7 +342,7 @@ template: {
 	}
 
 	exposePorts: [
-		for v in parameter.ports if v.expose == true {
+		if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
 			port:       v.port
 			targetPort: v.port
 			if v.name != _|_ {
@@ -501,7 +501,7 @@ template: {
 			name:      string
 			mountPath: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -500,8 +500,8 @@ template: {
 		volumes?: [...{
 			name:      string
 			mountPath: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -52,7 +52,7 @@ worker: {
 template: {
 	mountsArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -61,7 +61,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -70,7 +70,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -79,7 +79,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -88,7 +88,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					mountPath: v.mountPath
 					name:      v.name
@@ -99,7 +99,7 @@ template: {
 
 	volumesArray: {
 		pvc: *[
-			for v in parameter.volumeMounts.pvc {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
 				{
 					name: v.name
 					persistentVolumeClaim: claimName: v.claimName
@@ -108,7 +108,7 @@ template: {
 		] | []
 
 		configMap: *[
-				for v in parameter.volumeMounts.configMap {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap {
 				{
 					name: v.name
 					configMap: {
@@ -123,7 +123,7 @@ template: {
 		] | []
 
 		secret: *[
-			for v in parameter.volumeMounts.secret {
+			if parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret {
 				{
 					name: v.name
 					secret: {
@@ -138,7 +138,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-				for v in parameter.volumeMounts.emptyDir {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir {
 				{
 					name: v.name
 					emptyDir: medium: v.medium
@@ -147,7 +147,7 @@ template: {
 		] | []
 
 		hostPath: *[
-				for v in parameter.volumeMounts.hostPath {
+				if parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath {
 				{
 					name: v.name
 					hostPath: {
@@ -367,7 +367,7 @@ template: {
 			name:      string
 			mountPath: string
 			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: "pvc" | "configMap" | "secret" | "emptyDir"
+			type: *"pvc" | "configMap" | "secret" | "emptyDir"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -366,8 +366,8 @@ template: {
 		volumes?: [...{
 			name:      string
 			mountPath: string
-			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
-			type: *"pvc" | "configMap" | "secret" | "emptyDir"
+			// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir", default to emptyDir
+			type: *"emptyDir" | "pvc" | "configMap" | "secret"
 			if type == "pvc" {
 				claimName: string
 			}

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -9,11 +9,11 @@ gateway: {
 
 		status: {
 			customStatus: #"""
-				let igs = context.outputs.ingress.status.loadBalancer.ingress
-				if igs == _|_ {
+				if context.outputs.ingress.status.loadBalancer.ingress == _|_ {
 				  message: "No loadBalancer found, visiting by using 'vela port-forward " + context.appName + "'\n"
 				}
-				if len(igs) > 0 {
+				if context.outputs.ingress.status.loadBalancer.ingress != _|_ {
+					let igs = context.outputs.ingress.status.loadBalancer.ingress
 				  if igs[0].ip != _|_ {
 				  	if igs[0].host != _|_ {
 					    message: "Visiting URL: " + context.outputs.ingress.spec.rules[0].host + ", IP: " + igs[0].ip

--- a/vela-templates/definitions/internal/trait/service-account.cue
+++ b/vela-templates/definitions/internal/trait/service-account.cue
@@ -34,8 +34,8 @@ template: {
 	// +patchStrategy=retainKeys
 	patch: spec: template: spec: serviceAccountName: parameter.name
 
-	_clusterPrivileges: [ for p in parameter.privileges if p.scope == "cluster" {p}]
-	_namespacePrivileges: [ for p in parameter.privileges if p.scope == "namespace" {p}]
+	_clusterPrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "cluster" {p}]
+	_namespacePrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "namespace" {p}]
 	outputs: {
 		if parameter.create {
 			"service-account": {

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -10,7 +10,7 @@ storage: {
 }
 template: {
 	pvcVolumesList: *[
-			for v in parameter.pvc {
+			if parameter.pvc != _|_ for v in parameter.pvc {
 			{
 				name: "pvc-" + v.name
 				persistentVolumeClaim: claimName: v.name
@@ -19,7 +19,7 @@ template: {
 	] | []
 
 	configMapVolumesList: *[
-				for v in parameter.configMap if v.mountPath != _|_ {
+				if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
 			{
 				name: "configmap-" + v.name
 				configMap: {
@@ -34,7 +34,7 @@ template: {
 	] | []
 
 	secretVolumesList: *[
-				for v in parameter.secret if v.mountPath != _|_ {
+				if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
 			{
 				name: "secret-" + v.name
 				secret: {
@@ -49,7 +49,7 @@ template: {
 	] | []
 
 	emptyDirVolumesList: *[
-				for v in parameter.emptyDir {
+				if parameter.emptyDir != _|_ for v in parameter.emptyDir {
 			{
 				name: "emptydir-" + v.name
 				emptyDir: {
@@ -60,7 +60,7 @@ template: {
 	] | []
 
 	pvcVolumeMountsList: *[
-				for v in parameter.pvc {
+				if parameter.pvc != _|_ for v in parameter.pvc {
 			if v.volumeMode == "Filesystem" {
 				{
 					name:      "pvc-" + v.name
@@ -74,7 +74,7 @@ template: {
 	] | []
 
 	configMapVolumeMountsList: *[
-					for v in parameter.configMap if v.mountPath != _|_ {
+					if parameter.configMap != _|_ for v in parameter.configMap if v.mountPath != _|_ {
 			{
 				name:      "configmap-" + v.name
 				mountPath: v.mountPath
@@ -86,7 +86,7 @@ template: {
 	] | []
 
 	configMapEnvMountsList: *[
-				for v in parameter.configMap if v.mountToEnv != _|_ {
+				if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnv != _|_ {
 			{
 				name: v.mountToEnv.envName
 				valueFrom: configMapKeyRef: {
@@ -98,7 +98,7 @@ template: {
 	] | []
 
 	configMountToEnvsList: *[
-				for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+				if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
 			{
 				name: k.envName
 				valueFrom: configMapKeyRef: {
@@ -110,7 +110,7 @@ template: {
 	] | []
 
 	secretVolumeMountsList: *[
-				for v in parameter.secret if v.mountPath != _|_ {
+				if parameter.secret != _|_ for v in parameter.secret if v.mountPath != _|_ {
 			{
 				name:      "secret-" + v.name
 				mountPath: v.mountPath
@@ -122,7 +122,7 @@ template: {
 	] | []
 
 	secretEnvMountsList: *[
-				for v in parameter.secret if v.mountToEnv != _|_ {
+				if parameter.secret != _|_ if parameter.secret != _|_ for v in parameter.secret if v.mountToEnv != _|_ {
 			{
 				name: v.mountToEnv.envName
 				valueFrom: secretKeyRef: {
@@ -134,7 +134,7 @@ template: {
 	] | []
 
 	secretMountToEnvsList: *[
-				for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+				if parameter.secret != _|_ for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
 			{
 				name: k.envName
 				valueFrom: secretKeyRef: {
@@ -146,7 +146,7 @@ template: {
 	] | []
 
 	emptyDirVolumeMountsList: *[
-					for v in parameter.emptyDir {
+					if parameter.emptyDir != _|_ for v in parameter.emptyDir {
 			{
 				name:      "emptydir-" + v.name
 				mountPath: v.mountPath
@@ -158,7 +158,7 @@ template: {
 	] | []
 
 	volumeDevicesList: *[
-				for v in parameter.pvc if v.volumeMode == "Block" {
+				if parameter.pvc != _|_ for v in parameter.pvc if v.volumeMode == "Block" {
 			{
 				name:       "pvc-" + v.name
 				devicePath: v.mountPath
@@ -174,18 +174,18 @@ template: {
 		for val in [
 			for i, vi in volumesList {
 				for j, vj in volumesList if j < i && vi.name == vj.name {
-					_ignore: true
+					ignore: true
 				}
 				vi
 			},
-		] if val._ignore == _|_ {
+		] if val.ignore == _|_ {
 			val
 		},
 	]
 
 	patch: spec: template: spec: {
 		// +patchKey=name
-		volumes: deDupVolumesArray
+		volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
 		containers: [{
 			// +patchKey=name
@@ -199,7 +199,7 @@ template: {
 	}
 
 	outputs: {
-		for v in parameter.pvc {
+		if parameter.pvc != _|_ for v in parameter.pvc {
 			if v.mountOnly == false {
 				"pvc-\(v.name)": {
 					apiVersion: "v1"
@@ -240,7 +240,7 @@ template: {
 			}
 		}
 
-		for v in parameter.configMap {
+		if parameter.configMap != _|_ for v in parameter.configMap {
 			if v.mountOnly == false {
 				"configmap-\(v.name)": {
 					apiVersion: "v1"
@@ -253,7 +253,7 @@ template: {
 			}
 		}
 
-		for v in parameter.secret {
+		if parameter.secret != _|_ for v in parameter.secret {
 			if v.mountOnly == false {
 				"secret-\(v.name)": {
 					apiVersion: "v1"

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -174,11 +174,11 @@ template: {
 		for val in [
 			for i, vi in volumesList {
 				for j, vj in volumesList if j < i && vi.name == vj.name {
-					ignore: true
+					_ignore: true
 				}
 				vi
 			},
-		] if val.ignore == _|_ {
+		] if val._ignore == _|_ {
 			val
 		},
 	]

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -185,7 +185,7 @@ template: {
 
 	patch: spec: template: spec: {
 		// +patchKey=name
-		volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
+		volumes: deDupVolumesArray
 
 		containers: [{
 			// +patchKey=name

--- a/vela-templates/definitions/internal/workflowstep/deploy2runtime.cue
+++ b/vela-templates/definitions/internal/workflowstep/deploy2runtime.cue
@@ -15,9 +15,9 @@ template: {
 	app: op.#Steps & {
 		load: op.#Load @step(1)
 		clusters: [...string]
+		listClusters: op.#ListClusters @step(2)
 		if parameter.clusters == _|_ {
-			listClusters: op.#ListClusters @step(2)
-			clusters:     listClusters.outputs.clusters
+			clusters: listClusters.outputs.clusters
 		}
 		if parameter.clusters != _|_ {
 			clusters: parameter.clusters

--- a/vela-templates/definitions/internal/workflowstep/notification.cue
+++ b/vela-templates/definitions/internal/workflowstep/notification.cue
@@ -201,10 +201,20 @@ template: {
 	}
 
 	option: {
-		text:         textType
-		value:        string
-		description?: textType
-		url?:         string
+		text: {
+			type:      string
+			text:      string
+			emoji?:    bool
+			verbatim?: bool
+		}
+		value: string
+		description?: {
+			type:      string
+			text:      string
+			emoji?:    bool
+			verbatim?: bool
+		}
+		url?: string
 	}
 
 	// send webhook notification


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR update cue version from v0.2.2 to v0.4.4(master).

This PR:
1. Fixes multiple definitions that reference optional fields in the for loops of optional fields, see issue: cue-lang/cue#1815 and cue-lang/cue#1828
2. Comments some tests with attributes in if comprehension(To be fixed), see issue: cue-lang/cue#1826
3. Modifies the definition of `webhook-notification` and `notification` because of the panic raised in cue, see issue:  cue-lang/cue#1829
4. `[string]:string` will be resolved as `{}` in openapi, see issue: cue-lang/cue#1813
5. Loses close struct, see issue: cue-lang/cue#1609
6. Ignore SA1019 static check for now, see issue: cue-lang/cue#1806

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->