### PR TITLE
Fix: support to test authentication with dex

### DIFF
--- a/pkg/apiserver/domain/model/system_info.go
+++ b/pkg/apiserver/domain/model/system_info.go
@@ -57,6 +57,8 @@ type DexConfig struct {
 	Issuer           string                   `json:"issuer"`
 	Web              DexWeb                   `json:"web"`
 	Storage          DexStorage               `json:"storage"`
+	Telemetry        Telemetry                `json:"telemetry"`
+	Frontend         WebConfig                `json:"frontend"`
 	StaticClients    []DexStaticClient        `json:"staticClients"`
 	Connectors       []map[string]interface{} `json:"connectors,omitempty"`
 	EnablePasswordDB bool                     `json:"enablePasswordDB"`
@@ -95,6 +97,26 @@ type DexStorageConfig struct {
 
 // DexWeb dex web
 type DexWeb struct {
+	HTTP           string   `json:"http"`
+	HTTPS          string   `json:"https"`
+	TLSCert        string   `json:"tlsCert"`
+	TLSKey         string   `json:"tlsKey"`
+	AllowedOrigins []string `json:"allowedOrigins"`
+}
+
+// WebConfig holds the server's frontend templates and asset configuration.
+type WebConfig struct {
+	LogoURL string
+
+	// Defaults to "dex"
+	Issuer string
+
+	// Defaults to "light"
+	Theme string
+}
+
+// Telemetry is the config format for telemetry including the HTTP server config.
+type Telemetry struct {
 	HTTP string `json:"http"`
 }
 

--- a/pkg/apiserver/domain/service/authentication.go
+++ b/pkg/apiserver/domain/service/authentication.go
@@ -156,13 +156,13 @@ func (a *authenticationServiceImpl) Login(ctx context.Context, loginReq apisv1.L
 	}
 	loginType := sysInfo.LoginType
 
-	switch loginType {
-	case model.LoginTypeDex:
+	switch {
+	case loginType == model.LoginTypeDex || (loginReq.Code != "" && loginReq.Username == ""):
 		handler, err = a.newDexHandler(ctx, loginReq)
 		if err != nil {
 			return nil, err
 		}
-	case model.LoginTypeLocal:
+	case loginType == model.LoginTypeLocal:
 		handler, err = a.newLocalHandler(loginReq)
 		if err != nil {
 			return nil, err
@@ -287,6 +287,11 @@ func generateDexConfig(ctx context.Context, kubeClient client.Client, update *mo
 	}
 	if len(update.StaticPasswords) > 0 {
 		dexConfig.StaticPasswords = update.StaticPasswords
+	}
+	// This is the title that the dex login page.
+	// It will be: Log in to KubeVela
+	if dexConfig.Frontend.Issuer == "" {
+		dexConfig.Frontend.Issuer = "KubeVela"
 	}
 	config, err := model.NewJSONStructByStruct(dexConfig)
 	if err != nil {

--- a/pkg/apiserver/domain/service/authentication.go
+++ b/pkg/apiserver/domain/service/authentication.go
@@ -328,7 +328,7 @@ func initDexConfig(ctx context.Context, kubeClient client.Client, velaAddress st
 		StaticClients: []model.DexStaticClient{
 			{
 				ID:           "velaux",
-				Name:         "Vela UX",
+				Name:         "VelaUX",
 				Secret:       "velaux-secret",
 				RedirectURIs: []string{fmt.Sprintf("%s/callback", velaAddress)},
 			},
@@ -408,9 +408,13 @@ func getDexConfig(ctx context.Context, kubeClient client.Client) (*model.DexConf
 		Namespace: velatypes.DefaultKubeVelaNS,
 	}, dexConfigSecret); err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, bcode.ErrDexConfigNotFound
+			dexConfigSecret, err = initDexConfig(ctx, kubeClient, "http://velaux.com")
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 	if dexConfigSecret.Data == nil {
 		return nil, bcode.ErrInvalidDexConfig

--- a/pkg/apiserver/domain/service/user.go
+++ b/pkg/apiserver/domain/service/user.go
@@ -192,18 +192,17 @@ func (u *userServiceImpl) UpdateUser(ctx context.Context, user *model.User, req 
 	if err != nil {
 		return nil, err
 	}
-	if sysInfo.LoginType == model.LoginTypeDex {
-		return nil, bcode.ErrUserCannotModified
-	}
 	if req.Alias != "" {
 		user.Alias = req.Alias
 	}
-	if req.Password != "" {
-		hash, err := GeneratePasswordHash(req.Password)
-		if err != nil {
-			return nil, err
+	if sysInfo.LoginType != model.LoginTypeDex {
+		if req.Password != "" {
+			hash, err := GeneratePasswordHash(req.Password)
+			if err != nil {
+				return nil, err
+			}
+			user.Password = hash
 		}
-		user.Password = hash
 	}
 	if req.Email != "" {
 		if user.Email != "" {
@@ -211,6 +210,7 @@ func (u *userServiceImpl) UpdateUser(ctx context.Context, user *model.User, req 
 		}
 		user.Email = req.Email
 	}
+
 	// TODO: validate the roles, they must be platform roles
 	if req.Roles != nil {
 		user.UserRoles = *req.Roles

--- a/pkg/apiserver/domain/service/velaql.go
+++ b/pkg/apiserver/domain/service/velaql.go
@@ -82,8 +82,13 @@ func (v *velaQLServiceImpl) QueryView(ctx context.Context, velaQL string) (*apis
 		return nil, bcode.ErrParseQuery2Json
 	}
 	if strings.Contains(velaQL, "collect-logs") {
-		enc, _ := base64.StdEncoding.DecodeString(resp["logs"].(string))
-		resp["logs"] = string(enc)
+		logs, ok := resp["logs"].(string)
+		if ok {
+			enc, _ := base64.StdEncoding.DecodeString(logs)
+			resp["logs"] = string(enc)
+		} else {
+			resp["logs"] = ""
+		}
 	}
 	return &resp, err
 }


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

This PR support login with the code but does not need to set the login mode to dex. In this way, the user can test the use of dex to complete the authentication before switching the login mode.

In addition, added more dex configuration parameters.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->