### PR TITLE
Feat: make addon init use the latest CUE addon template

### DIFF
--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -23,18 +23,15 @@ import (
 	"strings"
 	"testing"
 
-	"helm.sh/helm/v3/pkg/chartutil"
-
-	"github.com/stretchr/testify/assert"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chartutil"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	velatypes "github.com/oam-dev/kubevela/apis/types"
@@ -213,7 +210,7 @@ func TestIsAddonDir(t *testing.T) {
 	assert.Equal(t, isAddonDir, false)
 	assert.Contains(t, err.Error(), "addon version is empty")
 
-	// No template.yaml
+	// No metadata.yaml
 	meta = &Meta{
 		Name:    "name",
 		Version: "1.0.0",
@@ -232,6 +229,13 @@ func TestIsAddonDir(t *testing.T) {
 	isAddonDir, err = IsAddonDir(filepath.Join("testdata", "testaddon"))
 	assert.Equal(t, isAddonDir, false)
 	assert.Contains(t, err.Error(), "missing")
+
+	// Empty template.cue
+	err = os.WriteFile(filepath.Join("testdata", "testaddon", AppTemplateCueFileName), []byte{}, 0644)
+	assert.NoError(t, err)
+	isAddonDir, err = IsAddonDir(filepath.Join("testdata", "testaddon"))
+	assert.Equal(t, isAddonDir, false)
+	assert.Contains(t, err.Error(), "var(")
 
 	// Pass all checks
 	cmd := InitCmd{


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

We now support using CUE in addon template #4401 (template.cue instead of template.yaml)

This PR makes `vela addon init` use this latest feature (generating template.cue).

Generating template.yaml is no longer supported.

Directory structure:
```
sample-addon-cue/
├── definitions
│   └── mytrait.cue
├── metadata.yaml
├── parameter.cue
├── README.md
├── resources
│   └── myresource.cue
├── schemas
│   └── myschema.yaml
├── template.cue
└── views
    └── my-view.cue
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->