### PR TITLE
Feat: add featuregates to disallow url in ref-objects

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -38,6 +39,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/component"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
+	"github.com/oam-dev/kubevela/pkg/features"
 	monitorContext "github.com/oam-dev/kubevela/pkg/monitor/context"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -349,6 +351,9 @@ func (p *Parser) parseReferredObjects(ctx context.Context, af *Appfile) error {
 				return err
 			}
 			af.ReferredObjects = component.AppendUnstructuredObjects(af.ReferredObjects, objs...)
+		}
+		if utilfeature.DefaultMutableFeatureGate.Enabled(features.DisableReferObjectsFromURL) && len(spec.URLs) > 0 {
+			return fmt.Errorf("referring objects from url is disabled")
 		}
 		for _, url := range spec.URLs {
 			objs, err := utilscommon.HTTPGetKubernetesObjects(ctx, url)

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -40,6 +40,8 @@ const (
 	// LegacyResourceOwnerValidation if enabled, the resource dispatch will allow existing resource not to have owner
 	// application and the current application will take over it
 	LegacyResourceOwnerValidation featuregate.Feature = "LegacyResourceOwnerValidation"
+	// DisableReferObjectsFromURL if set, the url ref objects will be disallowed
+	DisableReferObjectsFromURL featuregate.Feature = "DisableReferObjectsFromURL"
 
 	// Edge Features
 
@@ -55,6 +57,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	EnableSuspendOnFailure:        {Default: false, PreRelease: featuregate.Alpha},
 	LegacyComponentRevision:       {Default: false, PreRelease: featuregate.Alpha},
 	LegacyResourceOwnerValidation: {Default: false, PreRelease: featuregate.Alpha},
+	DisableReferObjectsFromURL:    {Default: false, PreRelease: featuregate.Alpha},
 	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 }
 


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

For security issues, allowing url in ref-objects could lead to potential risks. This PR allows administrator to decide whether to enable this feature. (By default, this is enabled.) 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->