### PR TITLE
Feat: show warnings about internal addon rendering logic

### DIFF
--- a/pkg/addon/init.go
+++ b/pkg/addon/init.go
@@ -180,9 +180,7 @@ func (cmd *InitCmd) createRequiredFiles() {
 		Description:  "An addon for KubeVela.",
 		Tags:         []string{"my-tag"},
 		Dependencies: []*Dependency{},
-		DeployTo: &DeployTo{
-			RuntimeCluster: false,
-		},
+		DeployTo:     nil,
 	}
 }
 
@@ -507,10 +505,6 @@ parameter: {
 output: {
 	apiVersion: "core.oam.dev/v1beta1"
 	kind:       "Application"
-	metadata: {
-		name:      "my-addon-name"
-		namespace: "vela-system"
-	}
 	spec: {
 		components: []
 		policies: []

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -193,7 +193,7 @@ func generateAppFramework(addon *InstallPackage, parameters map[string]interface
 	if app.Name != "" && app.Name != addonutil.Addon2AppName(addon.Name) {
 		klog.Warningf("Application name %s will be overwritten with %s. Consider removing metadata.name in template.", app.Name, addonutil.Addon2AppName(addon.Name))
 	}
-	app.Name = addonutil.Addon2AppName(addon.Name)
+	app.SetName(addonutil.Addon2AppName(addon.Name))
 
 	if app.Namespace != "" && app.Namespace != types.DefaultKubeVelaNS {
 		klog.Warningf("Namespace %s will be overwritten with %s. Consider removing metadata.namespace in template.", app.Namespace, types.DefaultKubeVelaNS)

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -198,7 +198,7 @@ func generateAppFramework(addon *InstallPackage, parameters map[string]interface
 	if app.Namespace != "" && app.Namespace != types.DefaultKubeVelaNS {
 		klog.Warningf("Namespace %s will be overwritten with %s. Consider removing metadata.namespace in template.", app.Namespace, types.DefaultKubeVelaNS)
 	}
-	// force override the namespace defined vela with DefaultVelaNS. this value can be modified by Env
+	// force override the namespace defined vela with DefaultVelaNS. This value can be modified by env
 	app.SetNamespace(types.DefaultKubeVelaNS)
 
 	if app.Labels == nil {

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -191,12 +191,12 @@ func generateAppFramework(addon *InstallPackage, parameters map[string]interface
 	}
 
 	if app.Name != "" && app.Name != addonutil.Addon2AppName(addon.Name) {
-		klog.Warningf("Application name %s will be overwritten with %s. Consider removing app name in template.", app.Name, addonutil.Addon2AppName(addon.Name))
+		klog.Warningf("Application name %s will be overwritten with %s. Consider removing metadata.name in template.", app.Name, addonutil.Addon2AppName(addon.Name))
 	}
 	app.Name = addonutil.Addon2AppName(addon.Name)
 
 	if app.Namespace != "" && app.Namespace != types.DefaultKubeVelaNS {
-		klog.Warningf("Namespace %s will be overwritten with %s. Consider removing namespace in template.", app.Namespace, types.DefaultKubeVelaNS)
+		klog.Warningf("Namespace %s will be overwritten with %s. Consider removing metadata.namespace in template.", app.Namespace, types.DefaultKubeVelaNS)
 	}
 	// force override the namespace defined vela with DefaultVelaNS. this value can be modified by Env
 	app.SetNamespace(types.DefaultKubeVelaNS)


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

The addon internal rendering logic (black-box) may confuse some users, e.g.:
- app `name` in `template.yaml/cue` is not working
- app `namespace` in `template.yaml/cue` is not working
- `deployTo` in metadata/yaml is not working when they have `topology` enabled

**This pr shows some warnings to let the user know what's going on and what to do**

```
W0726 21:19:31.278144 3891326 render.go:194] Application name some-name will be overwritten with addon-sample-addon-cue. Consider removing metadata.name in template.
W0726 21:19:31.278162 3891326 render.go:199] Namespace some-ns will be overwritten with vela-system. Consider removing metadata.namespace in template.
W0726 21:19:31.278477 3891326 render.go:357] deployTo in metadata will NOT have any effect. It conflicts with topology policy named test-topology. Consider removing deployTo field in addon metadata.
```

Note: warnings will **only** show when there is some overwriting or conflicts going on. If the user have set the same value as the rendering process is going to set, nothing will be shown.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->