### PR TITLE
Fix: address vela-core crash due to empty policy properties

### DIFF
--- a/pkg/policy/common_test.go
+++ b/pkg/policy/common_test.go
@@ -107,3 +107,14 @@ func TestParseSharedResourcePolicy(t *testing.T) {
 	r.NoError(err)
 	r.Equal(policySpec, spec)
 }
+
+func TestParsePolicy(t *testing.T) {
+	r := require.New(t)
+	// Test skipping empty policy
+	app := &v1beta1.Application{Spec: v1beta1.ApplicationSpec{
+		Policies: []v1beta1.AppPolicy{{Type: "example", Name: "s", Properties: nil}},
+	}}
+	exists, err := parsePolicy(app, "example", nil)
+	r.False(exists, "empty policy should not be included")
+	r.NoError(err)
+}

--- a/pkg/policy/envbinding/utils.go
+++ b/pkg/policy/envbinding/utils.go
@@ -34,7 +34,7 @@ const (
 // GetEnvBindingPolicy extract env-binding policy with given policy name, if policy name is empty, the first env-binding policy will be used
 func GetEnvBindingPolicy(app *v1beta1.Application, policyName string) (*v1alpha1.EnvBindingSpec, error) {
 	for _, policy := range app.Spec.Policies {
-		if (policy.Name == policyName || policyName == "") && policy.Type == v1alpha1.EnvBindingPolicyType {
+		if (policy.Name == policyName || policyName == "") && policy.Type == v1alpha1.EnvBindingPolicyType && policy.Properties != nil {
 			envBindingSpec := &v1alpha1.EnvBindingSpec{}
 			err := json.Unmarshal(policy.Properties.Raw, envBindingSpec)
 			return envBindingSpec, err

--- a/pkg/policy/override.go
+++ b/pkg/policy/override.go
@@ -19,6 +19,7 @@ package policy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +34,7 @@ import (
 // ParseOverridePolicyRelatedDefinitions get definitions inside override policy
 func ParseOverridePolicyRelatedDefinitions(ctx context.Context, cli client.Client, app *v1beta1.Application, policy v1beta1.AppPolicy) (compDefs []*v1beta1.ComponentDefinition, traitDefs []*v1beta1.TraitDefinition, err error) {
 	if policy.Properties == nil {
-		return compDefs, traitDefs, nil
+		return compDefs, traitDefs, fmt.Errorf("override policy %s must not have empty properties", policy.Name)
 	}
 	spec := &v1alpha1.OverridePolicySpec{}
 	if err = json.Unmarshal(policy.Properties.Raw, spec); err != nil {

--- a/pkg/policy/override.go
+++ b/pkg/policy/override.go
@@ -32,6 +32,9 @@ import (
 
 // ParseOverridePolicyRelatedDefinitions get definitions inside override policy
 func ParseOverridePolicyRelatedDefinitions(ctx context.Context, cli client.Client, app *v1beta1.Application, policy v1beta1.AppPolicy) (compDefs []*v1beta1.ComponentDefinition, traitDefs []*v1beta1.TraitDefinition, err error) {
+	if policy.Properties == nil {
+		return compDefs, traitDefs, nil
+	}
 	spec := &v1alpha1.OverridePolicySpec{}
 	if err = json.Unmarshal(policy.Properties.Raw, spec); err != nil {
 		return nil, nil, errors.Wrapf(err, "invalid override policy spec")

--- a/pkg/policy/override_test.go
+++ b/pkg/policy/override_test.go
@@ -62,6 +62,11 @@ func TestParseOverridePolicyRelatedDefinitions(t *testing.T) {
 			Policy: v1beta1.AppPolicy{Properties: &runtime.RawExtension{Raw: []byte(`{"components":[{"type":"comp","traits":[{"type":"trait-404"}]}]}`)}},
 			Error:  "failed to get trait definition",
 		},
+		"empty-policy": {
+			Policy:        v1beta1.AppPolicy{Properties: nil},
+			ComponentDefs: nil,
+			TraitDefs:     nil,
+		},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/policy/override_test.go
+++ b/pkg/policy/override_test.go
@@ -66,6 +66,7 @@ func TestParseOverridePolicyRelatedDefinitions(t *testing.T) {
 			Policy:        v1beta1.AppPolicy{Properties: nil},
 			ComponentDefs: nil,
 			TraitDefs:     nil,
+			Error:         "have empty properties",
 		},
 	}
 	for name, tt := range testCases {

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -18,6 +18,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 
 	prismclusterv1alpha1 "github.com/kubevela/prism/pkg/apis/cluster/v1alpha1"
 	"github.com/pkg/errors"
@@ -65,7 +66,10 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 	}
 	hasTopologyPolicy := false
 	for _, policy := range policies {
-		if policy.Type == v1alpha1.TopologyPolicyType && policy.Properties != nil {
+		if policy.Type == v1alpha1.TopologyPolicyType {
+			if policy.Properties == nil {
+				return nil, fmt.Errorf("topology should not have empty properties")
+			}
 			hasTopologyPolicy = true
 			topologySpec := &v1alpha1.TopologyPolicySpec{}
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, topologySpec); err != nil {

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -94,7 +94,6 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 				}
 			}
 		}
-
 	}
 	if !hasTopologyPolicy {
 		placements = []v1alpha1.PlacementDecision{{Cluster: multicluster.ClusterLocalName}}

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -68,7 +68,7 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 	for _, policy := range policies {
 		if policy.Type == v1alpha1.TopologyPolicyType {
 			if policy.Properties == nil {
-				return nil, fmt.Errorf("topology should not have empty properties")
+				return nil, fmt.Errorf("topology policy %s must not have empty properties", policy.Name)
 			}
 			hasTopologyPolicy = true
 			topologySpec := &v1alpha1.TopologyPolicySpec{}

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -65,32 +65,36 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 	}
 	hasTopologyPolicy := false
 	for _, policy := range policies {
-		if policy.Type == v1alpha1.TopologyPolicyType {
-			hasTopologyPolicy = true
-			topologySpec := &v1alpha1.TopologyPolicySpec{}
-			if err := utils.StrictUnmarshal(policy.Properties.Raw, topologySpec); err != nil {
-				return nil, errors.Wrapf(err, "failed to parse topology policy %s", policy.Name)
+		if policy.Type != v1alpha1.TopologyPolicyType {
+			continue
+		}
+		if policy.Properties == nil {
+			continue
+		}
+		hasTopologyPolicy = true
+		topologySpec := &v1alpha1.TopologyPolicySpec{}
+		if err := utils.StrictUnmarshal(policy.Properties.Raw, topologySpec); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse topology policy %s", policy.Name)
+		}
+		clusterLabelSelector := GetClusterLabelSelectorInTopology(topologySpec)
+		switch {
+		case topologySpec.Clusters != nil:
+			for _, cluster := range topologySpec.Clusters {
+				if err := addCluster(cluster, topologySpec.Namespace, true); err != nil {
+					return nil, err
+				}
 			}
-			clusterLabelSelector := GetClusterLabelSelectorInTopology(topologySpec)
-			switch {
-			case topologySpec.Clusters != nil:
-				for _, cluster := range topologySpec.Clusters {
-					if err := addCluster(cluster, topologySpec.Namespace, true); err != nil {
-						return nil, err
-					}
-				}
-			case clusterLabelSelector != nil:
-				clusterList, err := prismclusterv1alpha1.NewClusterClient(cli).List(ctx, client.MatchingLabels(clusterLabelSelector))
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to find clusters in topology %s", policy.Name)
-				}
-				if len(clusterList.Items) == 0 {
-					return nil, errors.New("failed to find any cluster matches given labels")
-				}
-				for _, cluster := range clusterList.Items {
-					if err = addCluster(cluster.Name, topologySpec.Namespace, false); err != nil {
-						return nil, err
-					}
+		case clusterLabelSelector != nil:
+			clusterList, err := prismclusterv1alpha1.NewClusterClient(cli).List(ctx, client.MatchingLabels(clusterLabelSelector))
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to find clusters in topology %s", policy.Name)
+			}
+			if len(clusterList.Items) == 0 {
+				return nil, errors.New("failed to find any cluster matches given labels")
+			}
+			for _, cluster := range clusterList.Items {
+				if err = addCluster(cluster.Name, topologySpec.Namespace, false); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -151,7 +151,7 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 		},
 		"empty-topology-policy": {
 			Inputs: []v1beta1.AppPolicy{{Type: "topology", Name: "some-name", Properties: nil}},
-			Error:  "topology should not have empty properties",
+			Error:  "have empty properties",
 		},
 	}
 	for name, tt := range testCases {

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -149,6 +149,10 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Inputs:  []v1beta1.AppPolicy{},
 			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
 		},
+		"empty-topology-policy": {
+			Inputs:  []v1beta1.AppPolicy{{Type: "topology", Name: "some-name", Properties: nil}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
+		},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -150,8 +150,8 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
 		},
 		"empty-topology-policy": {
-			Inputs:  []v1beta1.AppPolicy{{Type: "topology", Name: "some-name", Properties: nil}},
-			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
+			Inputs: []v1beta1.AppPolicy{{Type: "topology", Name: "some-name", Properties: nil}},
+			Error:  "topology should not have empty properties",
 		},
 	}
 	for name, tt := range testCases {

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -465,7 +465,7 @@ func (h *gcHandler) GarbageCollectLegacyResourceTrackers(ctx context.Context) er
 		}
 	}
 	for _, policy := range h.app.Spec.Policies {
-		if policy.Type == v1alpha1.EnvBindingPolicyType {
+		if policy.Type == v1alpha1.EnvBindingPolicyType && policy.Properties != nil {
 			spec := &v1alpha1.EnvBindingSpec{}
 			if err = json.Unmarshal(policy.Properties.Raw, &spec); err == nil {
 				for _, env := range spec.Envs {

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -125,7 +125,10 @@ func loadComponents(ctx context.Context, renderer oamProvider.WorkloadRenderer, 
 func overrideConfiguration(policies []v1beta1.AppPolicy, components []common.ApplicationComponent) ([]common.ApplicationComponent, error) {
 	var err error
 	for _, policy := range policies {
-		if policy.Type == v1alpha1.OverridePolicyType && policy.Properties != nil {
+		if policy.Type == v1alpha1.OverridePolicyType {
+			if policy.Properties == nil {
+				return nil, fmt.Errorf("override policy %s must not have empty properties", policy.Name)
+			}
 			overrideSpec := &v1alpha1.OverridePolicySpec{}
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, overrideSpec); err != nil {
 				return nil, errors.Wrapf(err, "failed to parse override policy %s", policy.Name)

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -125,7 +125,7 @@ func loadComponents(ctx context.Context, renderer oamProvider.WorkloadRenderer, 
 func overrideConfiguration(policies []v1beta1.AppPolicy, components []common.ApplicationComponent) ([]common.ApplicationComponent, error) {
 	var err error
 	for _, policy := range policies {
-		if policy.Type == v1alpha1.OverridePolicyType {
+		if policy.Type == v1alpha1.OverridePolicyType && policy.Properties != nil {
 			overrideSpec := &v1alpha1.OverridePolicySpec{}
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, overrideSpec); err != nil {
 				return nil, errors.Wrapf(err, "failed to parse override policy %s", policy.Name)

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -48,6 +48,13 @@ func TestOverrideConfiguration(t *testing.T) {
 			}},
 			Error: "failed to parse override policy",
 		},
+		"empty-policy": {
+			Policies: []v1beta1.AppPolicy{{
+				Name:       "override-policy",
+				Type:       "override",
+				Properties: nil,
+			}},
+		},
 		"normal": {
 			Policies: []v1beta1.AppPolicy{{
 				Name:       "override-policy",

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -54,6 +54,7 @@ func TestOverrideConfiguration(t *testing.T) {
 				Type:       "override",
 				Properties: nil,
 			}},
+			Error: "empty properties",
 		},
 		"normal": {
 			Policies: []v1beta1.AppPolicy{{


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

The [topology doc](https://kubevela.net/docs/next/end-user/policies/references#specification-topology) shows that every property is not required.

<details>
<summary>Click to see app sample</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app
spec:
  components: []
  policies:
    - name: target-default
      type: topology
      properties:
```
</details>


But if we actually don't provide any properties in topology, after applying the sample app, vela-core will 

- crash immediately due to nil pointer dereference
- will **NOT** recover after restarting, because the reconcilation starts again

So the vela-core will keep restarting over and over, and no Application can be created afterwards.

This pr fixes this problem, and similar ones.

> I encountered this problem when writing addons. Sometime it will output a empty policy due to the usage of conditional rendering policies using parameters (we can avoid this if we upgrade CUE above 0.3).

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. **(no permission to add labels)**

### How has this code been tested

Tests are added to avoid regression

### Special notes for your reviewer
