### PR TITLE
[Backport release-1.4] Fix: address vela-core crash due to empty policy properties (#4473)

### DIFF
--- a/pkg/policy/common_test.go
+++ b/pkg/policy/common_test.go
@@ -81,3 +81,14 @@ func TestParseApplyOncePolicy(t *testing.T) {
 	r.NoError(err)
 	r.Equal(policySpec, spec)
 }
+
+func TestParsePolicy(t *testing.T) {
+	r := require.New(t)
+	// Test skipping empty policy
+	app := &v1beta1.Application{Spec: v1beta1.ApplicationSpec{
+		Policies: []v1beta1.AppPolicy{{Type: "example", Name: "s", Properties: nil}},
+	}}
+	exists, err := parsePolicy(app, "example", nil)
+	r.False(exists, "empty policy should not be included")
+	r.NoError(err)
+}

--- a/pkg/policy/envbinding/utils.go
+++ b/pkg/policy/envbinding/utils.go
@@ -34,7 +34,7 @@ const (
 // GetEnvBindingPolicy extract env-binding policy with given policy name, if policy name is empty, the first env-binding policy will be used
 func GetEnvBindingPolicy(app *v1beta1.Application, policyName string) (*v1alpha1.EnvBindingSpec, error) {
 	for _, policy := range app.Spec.Policies {
-		if (policy.Name == policyName || policyName == "") && policy.Type == v1alpha1.EnvBindingPolicyType {
+		if (policy.Name == policyName || policyName == "") && policy.Type == v1alpha1.EnvBindingPolicyType && policy.Properties != nil {
 			envBindingSpec := &v1alpha1.EnvBindingSpec{}
 			err := json.Unmarshal(policy.Properties.Raw, envBindingSpec)
 			return envBindingSpec, err

--- a/pkg/policy/override.go
+++ b/pkg/policy/override.go
@@ -19,6 +19,7 @@ package policy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +33,9 @@ import (
 
 // ParseOverridePolicyRelatedDefinitions get definitions inside override policy
 func ParseOverridePolicyRelatedDefinitions(ctx context.Context, cli client.Client, app *v1beta1.Application, policy v1beta1.AppPolicy) (compDefs []*v1beta1.ComponentDefinition, traitDefs []*v1beta1.TraitDefinition, err error) {
+	if policy.Properties == nil {
+		return compDefs, traitDefs, fmt.Errorf("override policy %s must not have empty properties", policy.Name)
+	}
 	spec := &v1alpha1.OverridePolicySpec{}
 	if err = json.Unmarshal(policy.Properties.Raw, spec); err != nil {
 		return nil, nil, errors.Wrapf(err, "invalid override policy spec")

--- a/pkg/policy/override_test.go
+++ b/pkg/policy/override_test.go
@@ -62,6 +62,12 @@ func TestParseOverridePolicyRelatedDefinitions(t *testing.T) {
 			Policy: v1beta1.AppPolicy{Properties: &runtime.RawExtension{Raw: []byte(`{"components":[{"type":"comp","traits":[{"type":"trait-404"}]}]}`)}},
 			Error:  "failed to get trait definition",
 		},
+		"empty-policy": {
+			Policy:        v1beta1.AppPolicy{Properties: nil},
+			ComponentDefs: nil,
+			TraitDefs:     nil,
+			Error:         "have empty properties",
+		},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -18,6 +18,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -65,6 +66,9 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 	hasTopologyPolicy := false
 	for _, policy := range policies {
 		if policy.Type == v1alpha1.TopologyPolicyType {
+			if policy.Properties == nil {
+				return nil, fmt.Errorf("topology policy %s must not have empty properties", policy.Name)
+			}
 			hasTopologyPolicy = true
 			topologySpec := &v1alpha1.TopologyPolicySpec{}
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, topologySpec); err != nil {

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -146,6 +146,10 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			Inputs:  []v1beta1.AppPolicy{},
 			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
 		},
+		"empty-topology-policy": {
+			Inputs: []v1beta1.AppPolicy{{Type: "topology", Name: "some-name", Properties: nil}},
+			Error:  "have empty properties",
+		},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -437,7 +437,7 @@ func (h *gcHandler) GarbageCollectLegacyResourceTrackers(ctx context.Context) er
 		}
 	}
 	for _, policy := range h.app.Spec.Policies {
-		if policy.Type == v1alpha1.EnvBindingPolicyType {
+		if policy.Type == v1alpha1.EnvBindingPolicyType && policy.Properties != nil {
 			spec := &v1alpha1.EnvBindingSpec{}
 			if err = json.Unmarshal(policy.Properties.Raw, &spec); err == nil {
 				for _, env := range spec.Envs {

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -126,6 +126,9 @@ func overrideConfiguration(policies []v1beta1.AppPolicy, components []common.App
 	var err error
 	for _, policy := range policies {
 		if policy.Type == v1alpha1.OverridePolicyType {
+			if policy.Properties == nil {
+				return nil, fmt.Errorf("override policy %s must not have empty properties", policy.Name)
+			}
 			overrideSpec := &v1alpha1.OverridePolicySpec{}
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, overrideSpec); err != nil {
 				return nil, errors.Wrapf(err, "failed to parse override policy %s", policy.Name)

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -48,6 +48,14 @@ func TestOverrideConfiguration(t *testing.T) {
 			}},
 			Error: "failed to parse override policy",
 		},
+		"empty-policy": {
+			Policies: []v1beta1.AppPolicy{{
+				Name:       "override-policy",
+				Type:       "override",
+				Properties: nil,
+			}},
+			Error: "empty properties",
+		},
 		"normal": {
 			Policies: []v1beta1.AppPolicy{{
 				Name:       "override-policy",


### PR DESCRIPTION
* Fix: fix topology core crash

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

* Test: add tests

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

* Fix: same problem in other places

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

* Style: remove empty line

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

* Feat: raise error when empty topology is used

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

* Feat: raise error when empty override policy is used

Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->