### PR TITLE
Fix: check definition of addon whether is conflict 

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1071,12 +1071,12 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	}
 
 	if !h.overrideDefs {
-		existDefs, err := checkConflictDefs(h.ctx, h.cli, defs, *app)
+		existDefs, err := checkConflictDefs(h.ctx, h.cli, defs, app.Name)
 		if err != nil {
 			return err
 		}
 		if len(existDefs) != 0 {
-			return fmt.Errorf(`definitions: %s in this addon already exist, if you want override them, Please use add "--override-defs" to re-enable or re-upgrade`, existDefs)
+			return produceDefConflictError(existDefs)
 		}
 	}
 

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1071,12 +1071,12 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	}
 
 	if !h.overrideDefs {
-		conflict, err := checkDefAlreadyExist(h.ctx, h.cli, defs)
+		existDefs, err := checkConflictDefs(h.ctx, h.cli, defs, *app)
 		if err != nil {
 			return err
 		}
-		if conflict {
-			return fmt.Errorf(`definitions in this addon already exist, if you want override them, Please use "vela addon enable <addon-name> --override-defs" to enable`)
+		if len(existDefs) != 0 {
+			return fmt.Errorf(`definitions: %s in this addon already exist, if you want override them, Please use add "--override-defs" to re-enable or re-upgrade`, existDefs)
 		}
 	}
 

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -418,17 +418,17 @@ var _ = Describe("test override defs of addon", func() {
 		u := unstructured.Unstructured{Object: compUnstructured}
 		u.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 		u.SetKind(v1beta1.ComponentDefinitionKind)
-		c, err := checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
+		c, err := checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app.GetName())
 		Expect(err).Should(BeNil())
 		Expect(len(c)).Should(BeEquivalentTo(1))
 
 		u.SetName("rollout")
-		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app.GetName())
 		Expect(err).Should(BeNil())
 		Expect(len(c)).Should(BeEquivalentTo(0))
 
 		u.SetKind("NotExistKind")
-		_, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
+		_, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app.GetName())
 		Expect(err).ShouldNot(BeNil())
 
 		compUnstructured2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&comp2)
@@ -436,7 +436,7 @@ var _ = Describe("test override defs of addon", func() {
 		u2 := &unstructured.Unstructured{Object: compUnstructured2}
 		u2.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 		u2.SetKind(v1beta1.ComponentDefinitionKind)
-		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u2}, app)
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u2}, app.GetName())
 		Expect(err).Should(BeNil())
 		Expect(len(c)).Should(BeEquivalentTo(1))
 
@@ -445,7 +445,7 @@ var _ = Describe("test override defs of addon", func() {
 		u3 := &unstructured.Unstructured{Object: compUnstructured3}
 		u3.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 		u3.SetKind(v1beta1.ComponentDefinitionKind)
-		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u3}, app)
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u3}, app.GetName())
 		Expect(err).Should(BeNil())
 		Expect(len(c)).Should(BeEquivalentTo(0))
 	})

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -400,27 +400,54 @@ var _ = Describe("test enable addon which applies the views independently", func
 var _ = Describe("test override defs of addon", func() {
 	It("test compDef exist", func() {
 		ctx := context.Background()
-		comp := v1beta1.ComponentDefinition{}
+		comp := v1beta1.ComponentDefinition{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: v1beta1.ComponentDefinitionKind}}
 		Expect(yaml.Unmarshal([]byte(helmCompDefYaml), &comp)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, &comp)).Should(BeNil())
 
-		u := unstructured.Unstructured{}
+		comp2 := v1beta1.ComponentDefinition{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: v1beta1.ComponentDefinitionKind}}
+		Expect(yaml.Unmarshal([]byte(kustomizeCompDefYaml), &comp2)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &comp2)).Should(BeNil())
+		app := v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Name: "addon-fluxcd"}}
+
+		comp3 := v1beta1.ComponentDefinition{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: v1beta1.ComponentDefinitionKind}}
+		Expect(yaml.Unmarshal([]byte(kustomizeCompDefYaml1), &comp3)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &comp3)).Should(BeNil())
+
+		compUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&comp)
+		Expect(err).Should(BeNil())
+		u := unstructured.Unstructured{Object: compUnstructured}
 		u.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 		u.SetKind(v1beta1.ComponentDefinitionKind)
-		u.SetNamespace("vela-system")
-		u.SetName("helm")
-		c, err := checkDefAlreadyExist(ctx, k8sClient, []*unstructured.Unstructured{&u})
+		c, err := checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
 		Expect(err).Should(BeNil())
-		Expect(c).Should(BeEquivalentTo(true))
+		Expect(len(c)).Should(BeEquivalentTo(1))
 
 		u.SetName("rollout")
-		c, err = checkDefAlreadyExist(ctx, k8sClient, []*unstructured.Unstructured{&u})
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
 		Expect(err).Should(BeNil())
-		Expect(c).Should(BeEquivalentTo(false))
+		Expect(len(c)).Should(BeEquivalentTo(0))
 
 		u.SetKind("NotExistKind")
-		c, err = checkDefAlreadyExist(ctx, k8sClient, []*unstructured.Unstructured{&u})
+		_, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app)
 		Expect(err).ShouldNot(BeNil())
+
+		compUnstructured2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&comp2)
+		Expect(err).Should(BeNil())
+		u2 := &unstructured.Unstructured{Object: compUnstructured2}
+		u2.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
+		u2.SetKind(v1beta1.ComponentDefinitionKind)
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u2}, app)
+		Expect(err).Should(BeNil())
+		Expect(len(c)).Should(BeEquivalentTo(1))
+
+		compUnstructured3, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&comp3)
+		Expect(err).Should(BeNil())
+		u3 := &unstructured.Unstructured{Object: compUnstructured3}
+		u3.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
+		u3.SetKind(v1beta1.ComponentDefinitionKind)
+		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{u3}, app)
+		Expect(err).Should(BeNil())
+		Expect(len(c)).Should(BeEquivalentTo(0))
 	})
 })
 
@@ -526,6 +553,40 @@ kind: ComponentDefinition
 metadata:
   name: helm
   namespace: vela-system
+  ownerReferences:
+  - apiVersion: core.oam.dev/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Application
+    name: addon-fluxcd-helm
+    uid: 73c47933-002e-4182-a673-6da6a9dcf080
+spec:
+  schematic:
+    cue:
+`
+	kustomizeCompDefYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: kustomize
+  namespace: vela-system
+spec:
+  schematic:
+    cue:
+`
+	kustomizeCompDefYaml1 = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: kustomize-another
+  namespace: vela-system
+  ownerReferences:
+  - apiVersion: core.oam.dev/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Application
+    name: addon-fluxcd
+    uid: 73c47933-002e-4182-a673-6da6a9dcf080
 spec:
   schematic:
     cue:

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -1320,7 +1320,7 @@ func TestMergeAddonInstallArgs(t *testing.T) {
 func TestGenerateConflictError(t *testing.T) {
 	confictAddon := map[string]string{
 		"helm":      "definition: helm already exist and not belong to any addon \n",
-		"kustomize": "definition: %s in this addon already exist in fluxcd \n",
+		"kustomize": "definition: kustomize in this addon already exist in fluxcd \n",
 	}
 	err := produceDefConflictError(confictAddon)
 	assert.Error(t, err)

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -945,6 +945,11 @@ func TestCheckSemVer(t *testing.T) {
 			require: ">=v1.2.4-beta.3",
 			res:     false,
 		},
+		{
+			actual:  "1.5.0-beta.2",
+			require: ">=1.5.0",
+			res:     false,
+		},
 	}
 	for _, testCase := range testCases {
 		result, err := checkSemVer(testCase.actual, testCase.require)

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -950,6 +950,11 @@ func TestCheckSemVer(t *testing.T) {
 			require: ">=1.5.0",
 			res:     false,
 		},
+		{
+			actual:  "1.5.0-alpha.2",
+			require: ">=1.5.0",
+			res:     false,
+		},
 	}
 	for _, testCase := range testCases {
 		result, err := checkSemVer(testCase.actual, testCase.require)
@@ -1310,4 +1315,16 @@ func TestMergeAddonInstallArgs(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGenerateConflictError(t *testing.T) {
+	confictAddon := map[string]string{
+		"helm":      "definition: helm already exist and not belong to any addon \n",
+		"kustomize": "definition: %s in this addon already exist in fluxcd \n",
+	}
+	err := produceDefConflictError(confictAddon)
+	assert.Error(t, err)
+	strings.Contains(err.Error(), "in this addon already exist in fluxcd")
+
+	assert.NoError(t, produceDefConflictError(map[string]string{}))
 }

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -471,6 +471,6 @@ func produceDefConflictError(conflictDefs map[string]string) error {
 	for _, s := range conflictDefs {
 		errorInfo += s
 	}
-	errorInfo += "if you want override them, Please use arguments '--override' to enable \n"
+	errorInfo += "if you want override them, please use argument '--override-definitions' to enable \n"
 	return errors.New(errorInfo)
 }

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -27,6 +27,7 @@ import (
 	errors "github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	rest "k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,12 +44,17 @@ const (
 	compDefAnnotation         = "addon.oam.dev/componentDefinitions"
 	traitDefAnnotation        = "addon.oam.dev/traitDefinitions"
 	workflowStepDefAnnotation = "addon.oam.dev/workflowStepDefinitions"
+	policyDefAnnotation       = "addon.oam.dev/policyDefinitions"
 	defKeytemplate            = "addon-%s-%s"
+	compMapKey                = "comp"
+	traitMapKey               = "trait"
+	wfStepMapKey              = "wfStep"
+	policyMapKey              = "policy"
 )
 
 // parse addon's created x-defs in addon-app's annotation, this will be used to check whether app still using it while disabling.
 func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Application) error {
-	var comps, traits, workflowSteps []string
+	var comps, traits, workflowSteps, policies []string
 	for _, def := range defs {
 		switch def.GetObjectKind().GroupVersionKind().Kind {
 		case v1beta1.ComponentDefinitionKind:
@@ -57,6 +63,8 @@ func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Appl
 			traits = append(traits, def.GetName())
 		case v1beta1.WorkflowStepDefinitionKind:
 			workflowSteps = append(workflowSteps, def.GetName())
+		case v1beta1.PolicyDefinitionKind:
+			policies = append(policies, def.GetName())
 		default:
 			return fmt.Errorf("cannot handle definition types %s, name %s", def.GetObjectKind().GroupVersionKind().Kind, def.GetName())
 		}
@@ -69,6 +77,9 @@ func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Appl
 	}
 	if len(workflowSteps) != 0 {
 		app.SetAnnotations(util.MergeMapOverrideWithDst(app.GetAnnotations(), map[string]string{workflowStepDefAnnotation: strings.Join(workflowSteps, ",")}))
+	}
+	if len(policies) != 0 {
+		app.SetAnnotations(util.MergeMapOverrideWithDst(app.GetAnnotations(), map[string]string{policyDefAnnotation: strings.Join(policies, ",")}))
 	}
 	return nil
 }
@@ -87,7 +98,7 @@ func checkAddonHasBeenUsed(ctx context.Context, k8sClient client.Client, name st
 	createdDefs := make(map[string]bool)
 	for key, defNames := range addonApp.GetAnnotations() {
 		switch key {
-		case compDefAnnotation, traitDefAnnotation, workflowStepDefAnnotation:
+		case compDefAnnotation, traitDefAnnotation, workflowStepDefAnnotation, policyDefAnnotation:
 			merge2DefMap(key, defNames, createdDefs)
 		}
 	}
@@ -102,25 +113,34 @@ func checkAddonHasBeenUsed(ctx context.Context, k8sClient client.Client, name st
 CHECKNEXT:
 	for _, app := range apps.Items {
 		for _, component := range app.Spec.Components {
-			if createdDefs[fmt.Sprintf(defKeytemplate, "comp", component.Type)] {
+			if createdDefs[fmt.Sprintf(defKeytemplate, compMapKey, component.Type)] {
 				res = append(res, app)
 				// this app has used this addon, there is no need check other components
 				continue CHECKNEXT
 			}
 			for _, trait := range component.Traits {
-				if createdDefs[fmt.Sprintf(defKeytemplate, "trait", trait.Type)] {
+				if createdDefs[fmt.Sprintf(defKeytemplate, traitMapKey, trait.Type)] {
 					res = append(res, app)
 					continue CHECKNEXT
 				}
 			}
 		}
-		if app.Spec.Workflow == nil || len(app.Spec.Workflow.Steps) == 0 {
-			return res, nil
+
+		if app.Spec.Workflow != nil && len(app.Spec.Workflow.Steps) != 0 {
+			for _, s := range app.Spec.Workflow.Steps {
+				if createdDefs[fmt.Sprintf(defKeytemplate, wfStepMapKey, s.Type)] {
+					res = append(res, app)
+					continue CHECKNEXT
+				}
+			}
 		}
-		for _, s := range app.Spec.Workflow.Steps {
-			if createdDefs[fmt.Sprintf(defKeytemplate, "wfStep", s.Type)] {
-				res = append(res, app)
-				continue CHECKNEXT
+
+		if app.Spec.Policies != nil && len(app.Spec.Policies) != 0 {
+			for _, p := range app.Spec.Policies {
+				if createdDefs[fmt.Sprintf(defKeytemplate, policyMapKey, p.Type)] {
+					res = append(res, app)
+					continue CHECKNEXT
+				}
 			}
 		}
 	}
@@ -134,11 +154,13 @@ func merge2DefMap(defType string, defNames string, defMap map[string]bool) {
 	for _, defName := range list {
 		switch defType {
 		case compDefAnnotation:
-			defMap[fmt.Sprintf(template, "comp", defName)] = true
+			defMap[fmt.Sprintf(template, compMapKey, defName)] = true
 		case traitDefAnnotation:
-			defMap[fmt.Sprintf(template, "trait", defName)] = true
+			defMap[fmt.Sprintf(template, traitMapKey, defName)] = true
 		case workflowStepDefAnnotation:
-			defMap[fmt.Sprintf(template, "wfStep", defName)] = true
+			defMap[fmt.Sprintf(template, wfStepMapKey, defName)] = true
+		case policyDefAnnotation:
+			defMap[fmt.Sprintf(template, policyMapKey, defName)] = true
 		}
 	}
 }
@@ -210,6 +232,8 @@ func findLegacyAddonDefs(ctx context.Context, k8sClient client.Client, addonName
 			defs[fmt.Sprintf(defKeytemplate, "trait", defObject.GetName())] = true
 		case v1beta1.WorkflowStepDefinitionKind:
 			defs[fmt.Sprintf(defKeytemplate, "wfStep", defObject.GetName())] = true
+		case v1beta1.PolicyDefinitionKind:
+
 		}
 	}
 	return nil
@@ -240,6 +264,10 @@ type InstallOption func(installer *Installer)
 // SkipValidateVersion means skip validating system version
 func SkipValidateVersion(installer *Installer) {
 	installer.skipVersionValidate = true
+}
+
+func OverrideDefinitions(installer *Installer) {
+	installer.overrideDefs = true
 }
 
 // IsAddonDir validates an addon directory.
@@ -408,4 +436,17 @@ func generateAnnotation(meta *Meta) map[string]string {
 
 func isErrorCueRenderPathNotFound(err error, path string) bool {
 	return err.Error() == fmt.Sprintf("var(path=%s) not exist", path)
+}
+
+func checkDefAlreadyExist(ctx context.Context, k8sClient client.Client, defs []*unstructured.Unstructured) (bool, error) {
+	for _, def := range defs {
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(def), def)
+		if err == nil {
+			return true, nil
+		}
+		if !errors2.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return false, nil
 }

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -108,9 +108,13 @@ var _ = Describe("Test definition check", func() {
 		Expect(yaml.Unmarshal([]byte(testApp3Yaml), &app3)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, &app3)).Should(BeNil())
 
+		app4 := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(testApp4Yaml), &app4)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &app4)).Should(BeNil())
+
 		usedApps, err := checkAddonHasBeenUsed(ctx, k8sClient, "my-addon", addonApp, cfg)
 		Expect(err).Should(BeNil())
-		Expect(len(usedApps)).Should(BeEquivalentTo(3))
+		Expect(len(usedApps)).Should(BeEquivalentTo(4))
 	})
 
 	It("check fetch lagacy addon definitions", func() {
@@ -319,6 +323,7 @@ metadata:
     addon.oam.dev/componentDefinitions: "my-comp"
     addon.oam.dev/traitDefinitions: "my-trait"
     addon.oam.dev/workflowStepDefinitions: "my-wfstep"
+    addon.oam.dev/policyDefinitions: "my-policy"
   name: addon-myaddon
   namespace: vela-system
 spec:
@@ -367,6 +372,22 @@ spec:
     - type: my-wfstep
       name: deploy
 `
+	testApp4Yaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-4
+  namespace: test-ns
+spec:
+  components:
+    - name: podinfo
+      type: webservice
+
+  policies:
+    - type: my-policy
+      name: topology
+`
+
 	registryCmYaml = `
 apiVersion: v1
 data:

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -205,7 +205,7 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 	cmd.Flags().StringVarP(&addonVersion, "version", "v", "", "specify the addon version to enable")
 	cmd.Flags().StringVarP(&addonClusters, types.ClustersArg, "c", "", "specify the runtime-clusters to enable")
 	cmd.Flags().BoolVarP(&skipValidate, "skip-version-validating", "s", false, "skip validating system version requirement")
-	cmd.Flags().BoolVarP(&overrideDefs, "override-defs", "o", false, "override already exist definitions within addon")
+	cmd.Flags().BoolVarP(&overrideDefs, "override-definitions", "", false, "override existing definitions if conflict with those contained in this addon")
 	return cmd
 }
 
@@ -326,7 +326,7 @@ non-empty new arg
 	}
 	cmd.Flags().StringVarP(&addonVersion, "version", "v", "", "specify the addon version to upgrade")
 	cmd.Flags().BoolVarP(&skipValidate, "skip-version-validating", "s", false, "skip validating system version requirement")
-	cmd.Flags().BoolVarP(&overrideDefs, "override-defs", "o", false, "override already exist definitions within addon")
+	cmd.Flags().BoolVarP(&overrideDefs, "override-definitions", "", false, "override existing definitions if conflict with those contained in this addon")
 	return cmd
 }
 

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -77,6 +77,8 @@ var verboseStatus bool
 
 var skipValidate bool
 
+var overrideDefs bool
+
 // NewAddonCommand create `addon` command
 func NewAddonCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
@@ -203,6 +205,7 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 	cmd.Flags().StringVarP(&addonVersion, "version", "v", "", "specify the addon version to enable")
 	cmd.Flags().StringVarP(&addonClusters, types.ClustersArg, "c", "", "specify the runtime-clusters to enable")
 	cmd.Flags().BoolVarP(&skipValidate, "skip-version-validating", "s", false, "skip validating system version requirement")
+	cmd.Flags().BoolVarP(&overrideDefs, "override-defs", "o", false, "override already exist definitions within addon")
 	return cmd
 }
 
@@ -323,6 +326,7 @@ non-empty new arg
 	}
 	cmd.Flags().StringVarP(&addonVersion, "version", "v", "", "specify the addon version to upgrade")
 	cmd.Flags().BoolVarP(&skipValidate, "skip-version-validating", "s", false, "skip validating system version requirement")
+	cmd.Flags().BoolVarP(&overrideDefs, "override-defs", "o", false, "override already exist definitions within addon")
 	return cmd
 }
 
@@ -535,6 +539,9 @@ func enableAddon(ctx context.Context, k8sClient client.Client, dc *discovery.Dis
 		if skipValidate {
 			opts = append(opts, pkgaddon.SkipValidateVersion)
 		}
+		if overrideDefs {
+			opts = append(opts, pkgaddon.OverrideDefinitions)
+		}
 		err = pkgaddon.EnableAddon(ctx, name, version, k8sClient, dc, apply.NewAPIApplicator(k8sClient), config, registry, args, nil, opts...)
 		if errors.Is(err, pkgaddon.ErrNotExist) {
 			continue
@@ -569,6 +576,9 @@ func enableAddonByLocal(ctx context.Context, name string, dir string, k8sClient 
 	var opts []pkgaddon.InstallOption
 	if skipValidate {
 		opts = append(opts, pkgaddon.SkipValidateVersion)
+	}
+	if overrideDefs {
+		opts = append(opts, pkgaddon.OverrideDefinitions)
 	}
 	if err := pkgaddon.EnableAddonByLocalDir(ctx, name, dir, k8sClient, dc, apply.NewAPIApplicator(k8sClient), config, args, opts...); err != nil {
 		return err


### PR DESCRIPTION
1. fix bug check an  addon whether been used when disable.
2. add check definitions of an addon whether exist.
3. fix check addon system requirement special case bug: `actual: v1.5.0-beta.1` require:  `>=1.5.0` res: `ture`

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->