### PR TITLE
Fix: CloudShell read-only authorization is not automatically revoked

### DIFF
--- a/pkg/apiserver/domain/service/cloudshell.go
+++ b/pkg/apiserver/domain/service/cloudshell.go
@@ -175,12 +175,11 @@ func (c *cloudShellServiceImpl) Destroy(ctx context.Context) error {
 	if err := c.KubeClient.Get(ctx, types.NamespacedName{Namespace: kubevelatypes.DefaultKubeVelaNS, Name: makeUserCloudShellName(userName)}, &cloudShell); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
-		} else {
-			if meta.IsNoMatchError(err) {
-				return bcode.ErrCloudShellAddonNotEnabled
-			}
-			return err
 		}
+		if meta.IsNoMatchError(err) {
+			return bcode.ErrCloudShellAddonNotEnabled
+		}
+		return err
 	}
 	return c.KubeClient.Delete(ctx, &cloudShell)
 }

--- a/pkg/apiserver/domain/service/cloudshell.go
+++ b/pkg/apiserver/domain/service/cloudshell.go
@@ -75,6 +75,7 @@ const (
 type CloudShellService interface {
 	Prepare(ctx context.Context) (*apisv1.CloudShellPrepareResponse, error)
 	GetCloudShellEndpoint(ctx context.Context) (string, error)
+	Destroy(ctx context.Context) error
 }
 
 // GenerateKubeConfig generate the kubeconfig for the cloudshell
@@ -157,6 +158,33 @@ func (c *cloudShellServiceImpl) Prepare(ctx context.Context) (*apisv1.CloudShell
 	return res, nil
 }
 
+// Destroy destroy the cloud shell environment
+func (c *cloudShellServiceImpl) Destroy(ctx context.Context) error {
+	var userName string
+	if user := ctx.Value(&apisv1.CtxKeyUser); user != nil {
+		if u, ok := user.(string); ok {
+			userName = u
+		}
+	}
+	if userName == "" {
+		return bcode.ErrUnauthorized
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*20)
+	defer cancel()
+	var cloudShell v1alpha1.CloudShell
+	if err := c.KubeClient.Get(ctx, types.NamespacedName{Namespace: kubevelatypes.DefaultKubeVelaNS, Name: makeUserCloudShellName(userName)}, &cloudShell); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		} else {
+			if meta.IsNoMatchError(err) {
+				return bcode.ErrCloudShellAddonNotEnabled
+			}
+			return err
+		}
+	}
+	return c.KubeClient.Delete(ctx, &cloudShell)
+}
+
 func (c *cloudShellServiceImpl) GetCloudShellEndpoint(ctx context.Context) (string, error) {
 	var userName string
 	if user := ctx.Value(&apisv1.CtxKeyUser); user != nil {
@@ -182,7 +210,7 @@ func (c *cloudShellServiceImpl) GetCloudShellEndpoint(ctx context.Context) (stri
 	return cloudShell.Status.AccessURL, nil
 }
 
-// prepareKubeConfig prepare the user's kubeconfig
+// prepareKubeConfig prepare the user's kube config
 func (c *cloudShellServiceImpl) prepareKubeConfig(ctx context.Context) error {
 	var userName string
 	if user := ctx.Value(&apisv1.CtxKeyUser); user != nil {
@@ -212,9 +240,12 @@ func (c *cloudShellServiceImpl) prepareKubeConfig(ctx context.Context) error {
 			readOnly = checkReadOnly(p.Name, permissions)
 		}
 		if readOnly {
-			// TODO:(@barnettZQG) there needs a method to revoke the privileges
-			if err := c.managePrivilegesForUser(ctx, p.Name, true, userName, false); err != nil {
+			groupName, err := c.managePrivilegesForProjectRead(ctx, p.Name, true)
+			if err != nil {
 				log.Logger.Errorf("failed to privileges the user %s", err.Error())
+			}
+			if groupName != "" {
+				groups = append(groups, groupName)
 			}
 		} else {
 			groups = append(groups, utils.KubeVelaProjectGroupPrefix+p.Name)
@@ -345,8 +376,8 @@ func checkReadOnly(projectName string, permissions []*model.Permission) bool {
 	return !ra.Match(permissions)
 }
 
-// managePrivilegesForUser grant or revoke privileges for a user
-func (c *cloudShellServiceImpl) managePrivilegesForUser(ctx context.Context, projectName string, readOnly bool, userName string, revoke bool) error {
+// managePrivilegesForProjectRead grant the read privileges for a project
+func (c *cloudShellServiceImpl) managePrivilegesForProjectRead(ctx context.Context, projectName string, readOnly bool) (string, error) {
 	targets, err := c.TargetService.ListTargets(ctx, 0, 0, projectName)
 	if err != nil {
 		log.Logger.Infof("failed to list the targets by the project name %s :%s", projectName, err.Error())
@@ -362,16 +393,12 @@ func (c *cloudShellServiceImpl) managePrivilegesForUser(ctx context.Context, pro
 	for _, e := range envs.Envs {
 		authPDs = append(authPDs, &auth.ApplicationPrivilege{Cluster: kubevelatypes.ClusterLocalName, Namespace: e.Namespace, ReadOnly: readOnly})
 	}
-
-	identity := &auth.Identity{User: userName}
+	groupName := utils.KubeVelaProjectReadGroupPrefix + projectName
+	identity := &auth.Identity{Groups: []string{groupName}}
 	writer := &bytes.Buffer{}
-	f, msg := auth.GrantPrivileges, "GrantPrivileges"
-	if revoke {
-		f, msg = auth.RevokePrivileges, "RevokePrivileges"
+	if err := auth.GrantPrivileges(ctx, c.KubeClient, authPDs, identity, writer, auth.WithReplace); err != nil {
+		return "", err
 	}
-	if err := f(ctx, c.KubeClient, authPDs, identity, writer); err != nil {
-		return err
-	}
-	log.Logger.Debugf("%s: %s", msg, writer.String())
-	return nil
+	log.Logger.Debugf("GrantPrivileges: %s", writer.String())
+	return groupName, nil
 }

--- a/pkg/apiserver/domain/service/rbac.go
+++ b/pkg/apiserver/domain/service/rbac.go
@@ -484,7 +484,7 @@ func (p *rbacServiceImpl) GetUserPermissions(ctx context.Context, user *model.Us
 	perms = append(perms, &model.Permission{
 		Name:      "cloudshell",
 		Resources: []string{"cloudshell"},
-		Actions:   []string{"create"},
+		Actions:   []string{"*"},
 		Effect:    "Allow",
 	})
 	return perms, nil

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -33,7 +33,7 @@ import (
 const KubeVelaProjectGroupPrefix = "kubevela:project:"
 
 // KubeVelaProjectReadGroupPrefix the prefix kubevela project group that only has the read permissions
-const KubeVelaProjectReadGroupPrefix = "kubevela:project-read:"
+const KubeVelaProjectReadGroupPrefix = "kubevela:project-ro:"
 
 // KubeVelaAdminGroupPrefix the prefix kubevela admin
 const KubeVelaAdminGroupPrefix = "kubevela:admin:"

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -32,6 +32,9 @@ import (
 // KubeVelaProjectGroupPrefix the prefix kubevela project
 const KubeVelaProjectGroupPrefix = "kubevela:project:"
 
+// KubeVelaProjectReadGroupPrefix the prefix kubevela project group that only has the read permissions
+const KubeVelaProjectReadGroupPrefix = "kubevela:project-read:"
+
 // KubeVelaAdminGroupPrefix the prefix kubevela admin
 const KubeVelaAdminGroupPrefix = "kubevela:admin:"
 


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

The role is only bound to the group, the user is bound to the group and gets permissions. the relationship between the user and the group save to the cert in the Kube config, which will be updated before the cloud shell environment is created.

Fixes #4489

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

/cc @wonderflow 