### PR TITLE
Feat: add the revisionHistoryLimit parameter for the webservice

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -152,6 +152,9 @@ spec:
         	kind:       "Deployment"
         	spec: {
         		selector: matchLabels: "app.oam.dev/component": context.name
+        		if parameter.revisionHistoryLimit != _|_ {
+        			revisionHistoryLimit: parameter.revisionHistoryLimit
+        		}
 
         		template: {
         			metadata: {
@@ -492,6 +495,9 @@ spec:
         		ip: string
         		hostnames: [...string]
         	}]
+
+        	// +usage=Specify the total limit of the ReplicaSet, the default is 10
+        	revisionHistoryLimit?: int
         }
         #HealthProbe: {
 

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -152,6 +152,9 @@ spec:
         	kind:       "Deployment"
         	spec: {
         		selector: matchLabels: "app.oam.dev/component": context.name
+        		if parameter.revisionHistoryLimit != _|_ {
+        			revisionHistoryLimit: parameter.revisionHistoryLimit
+        		}
 
         		template: {
         			metadata: {
@@ -492,6 +495,9 @@ spec:
         		ip: string
         		hostnames: [...string]
         	}]
+
+        	// +usage=Specify the total limit of the ReplicaSet, the default is 10
+        	revisionHistoryLimit?: int
         }
         #HealthProbe: {
 

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -196,6 +196,9 @@ template: {
 			selector: matchLabels: {
 				"app.oam.dev/component": context.name
 			}
+			if parameter.revisionHistoryLimit != _|_ {
+				revisionHistoryLimit: parameter.revisionHistoryLimit
+			}
 
 			template: {
 				metadata: {
@@ -539,6 +542,9 @@ template: {
 			ip: string
 			hostnames: [...string]
 		}]
+
+		// +usage=Specify the total limit of the ReplicaSet, the default is 10
+		revisionHistoryLimit?: int
 	}
 
 	#HealthProbe: {


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

![image](https://user-images.githubusercontent.com/18493394/182150744-6c82c00d-fe22-40dd-94cc-eef65a73faed.png)

This default history ReplicaSets are too much.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->