### PR TITLE
[Backport release-1.5] Fix: missing return when token is null

### DIFF
--- a/pkg/apiserver/interfaces/api/authentication.go
+++ b/pkg/apiserver/interfaces/api/authentication.go
@@ -104,6 +104,7 @@ func authCheckFilter(req *restful.Request, res *restful.Response, chain *restful
 		}
 		if tokenValue == "" {
 			bcode.ReturnError(req, res, bcode.ErrNotAuthorized)
+			return
 		}
 	}
 


### PR DESCRIPTION
Backport of https://github.com/kubevela/kubevela/pull/4512 to release-1.5.