### PR TITLE
Feat: add the daemonset resource rule for building the tree

### DIFF
--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -150,7 +150,7 @@ func (c *AppCollector) ListApplicationResources(app *v1beta1.Application, queryT
 			Name:       resource.Name,
 			UID:        resource.UID,
 		}
-		root.LeafNodes, err = iteratorChildResources(ctx, resource.Cluster, c.k8sClient, root, 1, filter)
+		root.LeafNodes, err = iterateListSubResources(ctx, resource.Cluster, c.k8sClient, root, 1, filter)
 		if err != nil {
 			// if the resource has been deleted, continue access next appliedResource don't break the whole request
 			if kerrors.IsNotFound(err) {

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -26,7 +26,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -250,7 +249,7 @@ func (w *WorkloadUnstructured) GetSelector() (labels.Selector, error) {
 		return labels.Everything(), nil
 	}
 	if v, ok := value.(map[string]interface{}); ok {
-		var selector metav1.LabelSelector
+		var selector v1.LabelSelector
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(v, &selector); err != nil {
 			return nil, err
 		}

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -74,7 +74,7 @@ func init() {
 	globalRule = append(globalRule,
 		ChildrenResourcesRule{
 			GroupResourceType: GroupResourceType{Group: "apps", Kind: "Deployment"},
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "apps/v1", Kind: "ReplicaSet"},
 					listOptions:  defaultWorkloadLabelListOption,
@@ -82,7 +82,7 @@ func init() {
 			}),
 		},
 		ChildrenResourcesRule{
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "v1", Kind: "Pod"},
 					listOptions:  defaultWorkloadLabelListOption,
@@ -91,7 +91,7 @@ func init() {
 			GroupResourceType: GroupResourceType{Group: "apps", Kind: "ReplicaSet"},
 		},
 		ChildrenResourcesRule{
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "v1", Kind: "Pod"},
 					listOptions:  defaultWorkloadLabelListOption,
@@ -100,7 +100,7 @@ func init() {
 			GroupResourceType: GroupResourceType{Group: "apps", Kind: "StatefulSet"},
 		},
 		ChildrenResourcesRule{
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "v1", Kind: "Pod"},
 					listOptions:  defaultWorkloadLabelListOption,
@@ -110,7 +110,7 @@ func init() {
 		},
 		ChildrenResourcesRule{
 			GroupResourceType: GroupResourceType{Group: "", Kind: "Service"},
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "discovery.k8s.io/v1beta1", Kind: "EndpointSlice"},
 				},
@@ -122,7 +122,7 @@ func init() {
 		},
 		ChildrenResourcesRule{
 			GroupResourceType: GroupResourceType{Group: "helm.toolkit.fluxcd.io", Kind: "HelmRelease"},
-			CareResources: buildCareResources([]*CareResource{
+			SubResources: buildSubResources([]*SubResourceSelector{
 				{
 					ResourceType: ResourceType{APIVersion: "apps/v1", Kind: "Deployment"},
 				},
@@ -180,12 +180,12 @@ type ResourceType struct {
 
 // customRule define the customize rule created by user
 type customRule struct {
-	ParentResourceType   *GroupResourceType   `json:"parentResourceType,omitempty"`
-	ChildrenResourceType []CustomCareResource `json:"childrenResourceType,omitempty"`
+	ParentResourceType   *GroupResourceType `json:"parentResourceType,omitempty"`
+	ChildrenResourceType []CustomSelector   `json:"childrenResourceType,omitempty"`
 }
 
-// CustomCareResource the custom care resource in configmap. support set the label policy
-type CustomCareResource struct {
+// CustomSelector the custom resource selector configuration in configmap. support set the default label selector policy
+type CustomSelector struct {
 	ResourceType `json:",inline"`
 	// defaultLabelSelector means read the label selector condition from the spec.selector.
 	DefaultLabelSelector bool `json:"defaultLabelSelector"`
@@ -196,23 +196,33 @@ type ChildrenResourcesRule struct {
 	// GroupResourceType the root resource type
 	GroupResourceType GroupResourceType
 	// every subResourceType can have a specified genListOptionFunc.
-	CareResources *CareResources
+	SubResources *SubResources
 	// if specified genListOptionFunc is nil will use use default genListOptionFunc to generate listOption.
 	DefaultGenListOptionFunc genListOptionFunc
 	// DisableFilterByOwnerReference means don't use parent resource's UID filter the result.
 	DisableFilterByOwnerReference bool
 }
 
-func buildCareResources(crs []*CareResource) *CareResources {
-	var cr CareResources = crs
+func buildSubResources(crs []*SubResourceSelector) *SubResources {
+	var cr SubResources = crs
 	return &cr
 }
 
-// CareResources the care resource definitions
-type CareResources []*CareResource
+func buildSubResourceSelector(cus CustomSelector) *SubResourceSelector {
+	cr := SubResourceSelector{
+		ResourceType: cus.ResourceType,
+	}
+	if cus.DefaultLabelSelector {
+		cr.listOptions = defaultWorkloadLabelListOption
+	}
+	return &cr
+}
 
-// Get get the care resource by the resource type
-func (c *CareResources) Get(rt ResourceType) *CareResource {
+// SubResources the sub resource definitions
+type SubResources []*SubResourceSelector
+
+// Get get the sub resource by the resource type
+func (c *SubResources) Get(rt ResourceType) *SubResourceSelector {
 	for _, r := range *c {
 		if r.ResourceType == rt {
 			return r
@@ -221,13 +231,13 @@ func (c *CareResources) Get(rt ResourceType) *CareResource {
 	return nil
 }
 
-// Put add a care resource to the list
-func (c *CareResources) Put(cr *CareResource) {
+// Put add a sub resource to the list
+func (c *SubResources) Put(cr *SubResourceSelector) {
 	*c = append(*c, cr)
 }
 
-// CareResource resource type and list options
-type CareResource struct {
+// SubResourceSelector the sub resource selector configuration
+type SubResourceSelector struct {
 	ResourceType
 	listOptions genListOptionFunc
 }
@@ -787,7 +797,7 @@ func listItemByRule(clusterCTX context.Context, k8sClient client.Client, resourc
 	return itemList.Items, nil
 }
 
-func iteratorChildResources(ctx context.Context, cluster string, k8sClient client.Client, parentResource types.ResourceTreeNode, depth int, filter func(node types.ResourceTreeNode) bool) ([]*types.ResourceTreeNode, error) {
+func iterateListSubResources(ctx context.Context, cluster string, k8sClient client.Client, parentResource types.ResourceTreeNode, depth int, filter func(node types.ResourceTreeNode) bool) ([]*types.ResourceTreeNode, error) {
 	if depth > maxDepth {
 		log.Logger.Warnf("listing application resource tree has reached the max-depth %d parentObject is %v", depth, parentResource)
 		return nil, nil
@@ -801,9 +811,9 @@ func iteratorChildResources(ctx context.Context, cluster string, k8sClient clien
 
 	if rule, ok := globalRule.GetRule(GroupResourceType{Group: group, Kind: kind}); ok {
 		var resList []*types.ResourceTreeNode
-		for i := range *rule.CareResources {
-			resource := (*rule.CareResources)[i].ResourceType
-			specifiedFunc := (*rule.CareResources)[i].listOptions
+		for i := range *rule.SubResources {
+			resource := (*rule.SubResources)[i].ResourceType
+			specifiedFunc := (*rule.SubResources)[i].listOptions
 
 			clusterCTX := multicluster.ContextWithClusterName(ctx, cluster)
 			items, err := listItemByRule(clusterCTX, k8sClient, resource, *parentObject, specifiedFunc, rule.DefaultGenListOptionFunc, rule.DisableFilterByOwnerReference)
@@ -825,7 +835,7 @@ func iteratorChildResources(ctx context.Context, cluster string, k8sClient clien
 					Object:     items[i],
 				}
 				if _, ok := globalRule.GetRule(GroupResourceType{Group: item.GetObjectKind().GroupVersionKind().Group, Kind: item.GetObjectKind().GroupVersionKind().Kind}); ok {
-					childrenRes, err := iteratorChildResources(ctx, cluster, k8sClient, rtn, depth+1, filter)
+					childrenRes, err := iterateListSubResources(ctx, cluster, k8sClient, rtn, depth+1, filter)
 					if err != nil {
 						return nil, err
 					}
@@ -887,31 +897,21 @@ func mergeCustomRules(ctx context.Context, k8sClient client.Client) error {
 
 			if cResource, ok := globalRule.GetRule(*rule.ParentResourceType); ok {
 				for i, resourceType := range rule.ChildrenResourceType {
-					if cResource.CareResources.Get(resourceType.ResourceType) == nil {
-						cResource.CareResources.Put(buildCareResource(rule.ChildrenResourceType[i]))
+					if cResource.SubResources.Get(resourceType.ResourceType) == nil {
+						cResource.SubResources.Put(buildSubResourceSelector(rule.ChildrenResourceType[i]))
 					}
 				}
 			} else {
-				var caredResources []*CareResource
+				var subResources []*SubResourceSelector
 				for i := range rule.ChildrenResourceType {
-					caredResources = append(caredResources, buildCareResource(rule.ChildrenResourceType[i]))
+					subResources = append(subResources, buildSubResourceSelector(rule.ChildrenResourceType[i]))
 				}
 				globalRule = append(globalRule, ChildrenResourcesRule{
 					GroupResourceType:        *rule.ParentResourceType,
 					DefaultGenListOptionFunc: nil,
-					CareResources:            buildCareResources(caredResources)})
+					SubResources:             buildSubResources(subResources)})
 			}
 		}
 	}
 	return nil
-}
-
-func buildCareResource(cus CustomCareResource) *CareResource {
-	cr := CareResource{
-		ResourceType: cus.ResourceType,
-	}
-	if cus.DefaultLabelSelector {
-		cr.listOptions = defaultWorkloadLabelListOption
-	}
-	return &cr
 }

--- a/pkg/velaql/providers/query/tree_test.go
+++ b/pkg/velaql/providers/query/tree_test.go
@@ -1519,9 +1519,9 @@ childrenResourceType:
 		Expect(dsChildrenResources.DefaultGenListOptionFunc).Should(BeNil())
 		Expect(len(*dsChildrenResources.CareResources)).Should(BeEquivalentTo(2))
 
+		// with the error version
 		crPod2 := dsChildrenResources.CareResources.Get(ResourceType{APIVersion: "v1", Kind: "ControllerRevision"})
-		Expect(crPod2).ShouldNot(BeNil())
-		Expect(crPod2.listOptions).Should(BeNil())
+		Expect(crPod2).Should(BeNil())
 
 		crPod3 := dsChildrenResources.CareResources.Get(ResourceType{APIVersion: "v1", Kind: "Pod"})
 		Expect(crPod3).ShouldNot(BeNil())

--- a/pkg/velaql/providers/query/tree_test.go
+++ b/pkg/velaql/providers/query/tree_test.go
@@ -1288,7 +1288,7 @@ var _ = Describe("unit-test to e2e test", func() {
 	})
 
 	It("iterate resource", func() {
-		tn, err := iteratorChildResources(ctx, "", k8sClient, types.ResourceTreeNode{
+		tn, err := iterateListSubResources(ctx, "", k8sClient, types.ResourceTreeNode{
 			Cluster:    "",
 			Namespace:  "test-namespace",
 			Name:       "deploy1",
@@ -1508,34 +1508,34 @@ childrenResourceType:
 		childrenResources, ok := globalRule.GetRule(GroupResourceType{Group: "apps.kruise.io", Kind: "CloneSet"})
 		Expect(ok).Should(BeTrue())
 		Expect(childrenResources.DefaultGenListOptionFunc).Should(BeNil())
-		Expect(len(*childrenResources.CareResources)).Should(BeEquivalentTo(2))
+		Expect(len(*childrenResources.SubResources)).Should(BeEquivalentTo(2))
 
-		crPod := childrenResources.CareResources.Get(ResourceType{APIVersion: "v1", Kind: "Pod"})
+		crPod := childrenResources.SubResources.Get(ResourceType{APIVersion: "v1", Kind: "Pod"})
 		Expect(crPod).ShouldNot(BeNil())
 		Expect(crPod.listOptions).ShouldNot(BeNil())
 
 		dsChildrenResources, ok := globalRule.GetRule(GroupResourceType{Group: "apps", Kind: "DaemonSet"})
 		Expect(ok).Should(BeTrue())
 		Expect(dsChildrenResources.DefaultGenListOptionFunc).Should(BeNil())
-		Expect(len(*dsChildrenResources.CareResources)).Should(BeEquivalentTo(2))
+		Expect(len(*dsChildrenResources.SubResources)).Should(BeEquivalentTo(2))
 
 		// with the error version
-		crPod2 := dsChildrenResources.CareResources.Get(ResourceType{APIVersion: "v1", Kind: "ControllerRevision"})
+		crPod2 := dsChildrenResources.SubResources.Get(ResourceType{APIVersion: "v1", Kind: "ControllerRevision"})
 		Expect(crPod2).Should(BeNil())
 
-		crPod3 := dsChildrenResources.CareResources.Get(ResourceType{APIVersion: "v1", Kind: "Pod"})
+		crPod3 := dsChildrenResources.SubResources.Get(ResourceType{APIVersion: "v1", Kind: "Pod"})
 		Expect(crPod3).ShouldNot(BeNil())
 		Expect(crPod3.listOptions).ShouldNot(BeNil())
 
-		cr := dsChildrenResources.CareResources.Get(ResourceType{APIVersion: "apps/v1", Kind: "ControllerRevision"})
+		cr := dsChildrenResources.SubResources.Get(ResourceType{APIVersion: "apps/v1", Kind: "ControllerRevision"})
 		Expect(cr).ShouldNot(BeNil())
 		Expect(cr.listOptions).Should(BeNil())
 
 		stsChildrenResources, ok := globalRule.GetRule(GroupResourceType{Group: "apps", Kind: "StatefulSet"})
 		Expect(ok).Should(BeTrue())
 		Expect(stsChildrenResources.DefaultGenListOptionFunc).Should(BeNil())
-		Expect(len(*stsChildrenResources.CareResources)).Should(BeEquivalentTo(2))
-		revisionCR := stsChildrenResources.CareResources.Get(ResourceType{APIVersion: "apps/v1", Kind: "ControllerRevision"})
+		Expect(len(*stsChildrenResources.SubResources)).Should(BeEquivalentTo(2))
+		revisionCR := stsChildrenResources.SubResources.Get(ResourceType{APIVersion: "apps/v1", Kind: "ControllerRevision"})
 		Expect(revisionCR).ShouldNot(BeNil())
 		Expect(revisionCR.listOptions).Should(BeNil())
 


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

1. Add a  default tree rule: `DaemonSet->Pod`.
2. Add a default label selector function.
3. Support binding the default label selector for the custom rule.

Example:
```
- parentResourceType:
    group: apps.kruise.io
    kind: CloneSet
  childrenResourceType:
    - apiVersion: v1
      kind: Pod
      defaultLabelSelector: true
```

This means querying the pod by label selector. If not, it will list all pods in the namespace and filter by OwnerReferences.
The requirement is the resource(CloneSet) has the field `spec.selector`.

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->