### PR TITLE
Feat: Check def binding to a component

### DIFF
--- a/e2e/addon/mock/testdata/mock-addon/definitions/json-patch.cue
+++ b/e2e/addon/mock/testdata/mock-addon/definitions/json-patch.cue
@@ -1,0 +1,50 @@
+"kustomize-json-patch": {
+	attributes: {
+		podDisruptive: false
+	}
+	description: "A list of JSON6902 patch to selected target"
+	labels: {
+		"ui-hidden": "true"
+	}
+	type: "trait"
+}
+
+template: {
+	patch: {
+		spec: {
+			patches: parameter.patchesJson
+		}
+	}
+
+	parameter: {
+		// +usage=A list of JSON6902 patch.
+		patchesJson: [...#jsonPatchItem]
+	}
+
+	// +usage=Contains a JSON6902 patch
+	#jsonPatchItem: {
+		target: #selector
+		patch: [...{
+			// +usage=operation to perform
+			op: string | "add" | "remove" | "replace" | "move" | "copy" | "test"
+			// +usage=operate path e.g. /foo/bar
+			path: string
+			// +usage=specify source path when op is copy/move
+			from?: string
+			// +usage=specify opraation value when op is test/add/replace
+			value?: string
+		}]
+	}
+
+	// +usage=Selector specifies a set of resources
+	#selector: {
+		group?:              string
+		version?:            string
+		kind?:               string
+		namespace?:          string
+		name?:               string
+		annotationSelector?: string
+		labelSelector?:      string
+	}
+
+}

--- a/e2e/addon/mock/testdata/mock-addon/definitions/json-patch.cue
+++ b/e2e/addon/mock/testdata/mock-addon/definitions/json-patch.cue
@@ -1,4 +1,4 @@
-"kustomize-json-patch": {
+"kustomize-json-patch-mock-adddon": {
 	attributes: {
 		podDisruptive: false
 	}

--- a/e2e/addon/mock/testdata/mock-addon/readme.md
+++ b/e2e/addon/mock/testdata/mock-addon/readme.md
@@ -1,0 +1,1 @@
+Test addon readme.md file

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1107,13 +1107,14 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	}
 
 	for _, def := range defs {
+		if !checkBondComponentExist(*def, *app) {
+			continue
+		}
+		// if binding component exist, apply the definition
 		addOwner(def, app)
-		if checkObjectBindingComponent(*def, *app) {
-			// if binding component exist, apply the definition
-			err = h.apply.Apply(h.ctx, def, apply.DisableUpdateAnnotation())
-			if err != nil {
-				return err
-			}
+		err = h.apply.Apply(h.ctx, def, apply.DisableUpdateAnnotation())
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1134,12 +1135,13 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	}
 
 	for _, o := range auxiliaryOutputs {
-		if checkObjectBindingComponent(*o, *app) {
-			addOwner(o, app)
-			err = h.apply.Apply(h.ctx, o, apply.DisableUpdateAnnotation())
-			if err != nil {
-				return err
-			}
+		if !checkBondComponentExist(*o, *app) {
+			continue
+		}
+		addOwner(o, app)
+		err = h.apply.Apply(h.ctx, o, apply.DisableUpdateAnnotation())
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -79,7 +79,7 @@ const (
 	// ReadmeFileName is the addon readme file name
 	ReadmeFileName string = "README.md"
 
-	// LegacyFineName is the addon readme lower case file name
+	// LegacyReadmeFileName is the addon readme lower case file name
 	LegacyReadmeFileName string = "readme.md"
 
 	// MetadataFileName is the addon meatadata.yaml file name

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -59,6 +59,10 @@ const (
 func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Application) error {
 	var comps, traits, workflowSteps, policies []string
 	for _, def := range defs {
+		if !checkObjectBindingComponent(*def, *app) {
+			// if the definition binding a component, and the component not exist, skip recording.
+			continue
+		}
 		switch def.GetObjectKind().GroupVersionKind().Kind {
 		case v1beta1.ComponentDefinitionKind:
 			comps = append(comps, def.GetName())

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -52,14 +52,13 @@ const (
 	traitMapKey               = "trait"
 	wfStepMapKey              = "wfStep"
 	policyMapKey              = "policy"
-	annotationBindCompKey     = "addon.oam.dev/ignore-without-component"
 )
 
 // parse addon's created x-defs in addon-app's annotation, this will be used to check whether app still using it while disabling.
 func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Application) error {
 	var comps, traits, workflowSteps, policies []string
 	for _, def := range defs {
-		if !checkObjectBindingComponent(*def, *app) {
+		if !checkBondComponentExist(*def, *app) {
 			// if the definition binding a component, and the component not exist, skip recording.
 			continue
 		}
@@ -480,17 +479,17 @@ func produceDefConflictError(conflictDefs map[string]string) error {
 	return errors.New(errorInfo)
 }
 
-// checkObjectRelatedComponent will check the ready-to-apply object(def or auxiliary outputs) whether bind to a component
+// checkBondComponentExistt will check the ready-to-apply object(def or auxiliary outputs) whether bind to a component
 // if the target component not exist, return false.
-func checkObjectBindingComponent(u unstructured.Unstructured, app v1beta1.Application) bool {
-	comp, existKey := u.GetAnnotations()[annotationBindCompKey]
+func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Application) bool {
+	comp, existKey := u.GetAnnotations()[oam.AnnotationIgnoreWithoutCompKey]
 	if !existKey {
 		// if an object(def or auxiliary outputs ) binding no components return true
 		return true
 	}
 	for _, component := range app.Spec.Components {
 		if component.Name == comp {
-			// find the match component, return ture
+			// the bond component exists, return ture
 			return true
 		}
 	}

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -52,6 +52,7 @@ const (
 	traitMapKey               = "trait"
 	wfStepMapKey              = "wfStep"
 	policyMapKey              = "policy"
+	annotationBindCompKey     = "addon.oam.dev/ignore-without-component"
 )
 
 // parse addon's created x-defs in addon-app's annotation, this will be used to check whether app still using it while disabling.
@@ -473,4 +474,21 @@ func produceDefConflictError(conflictDefs map[string]string) error {
 	}
 	errorInfo += "if you want override them, please use argument '--override-definitions' to enable \n"
 	return errors.New(errorInfo)
+}
+
+// checkObjectRelatedComponent will check the ready-to-apply object(def or auxiliary outputs) whether bind to a component
+// if the target component not exist, return false.
+func checkObjectBindingComponent(u unstructured.Unstructured, app v1beta1.Application) bool {
+	comp, existKey := u.GetAnnotations()[annotationBindCompKey]
+	if !existKey {
+		// if an object(def or auxiliary outputs ) binding no components return true
+		return true
+	}
+	for _, component := range app.Spec.Components {
+		if component.Name == comp {
+			// find the match component, return ture
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -290,7 +290,7 @@ func TestMakeChart(t *testing.T) {
 
 func TestCheckObjectBindingComponent(t *testing.T) {
 	existingBindingDef := unstructured.Unstructured{}
-	existingBindingDef.SetAnnotations(map[string]string{annotationBindCompKey: "kustomize"})
+	existingBindingDef.SetAnnotations(map[string]string{oam.AnnotationIgnoreWithoutCompKey: "kustomize"})
 
 	emptyAnnoDef := unstructured.Unstructured{}
 	emptyAnnoDef.SetAnnotations(map[string]string{"test": "onlyForTest"})
@@ -313,7 +313,7 @@ func TestCheckObjectBindingComponent(t *testing.T) {
 			res: false},
 	}
 	for _, s := range testCases {
-		result := checkObjectBindingComponent(s.object, s.app)
+		result := checkBondComponentExist(s.object, s.app)
 		assert.Equal(t, result, s.res)
 	}
 }

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	velatypes "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -285,6 +286,36 @@ func TestMakeChart(t *testing.T) {
 	isChartDir, err = chartutil.IsChartDir(filepath.Join("testdata", "testaddon"))
 	assert.NoError(t, err)
 	assert.Equal(t, isChartDir, true)
+}
+
+func TestCheckObjectBindingComponent(t *testing.T) {
+	existingBindingDef := unstructured.Unstructured{}
+	existingBindingDef.SetAnnotations(map[string]string{annotationBindCompKey: "kustomize"})
+
+	emptyAnnoDef := unstructured.Unstructured{}
+	emptyAnnoDef.SetAnnotations(map[string]string{"test": "onlyForTest"})
+	testCases := map[string]struct {
+		object unstructured.Unstructured
+		app    v1beta1.Application
+		res    bool
+	}{
+		"bindingExist": {object: existingBindingDef,
+			app: v1beta1.Application{Spec: v1beta1.ApplicationSpec{Components: []common.ApplicationComponent{{Name: "kustomize"}}}},
+			res: true},
+		"NotExisting": {object: existingBindingDef,
+			app: v1beta1.Application{Spec: v1beta1.ApplicationSpec{Components: []common.ApplicationComponent{{Name: "helm"}}}},
+			res: false},
+		"NoBidingAnnotation": {object: emptyAnnoDef,
+			app: v1beta1.Application{Spec: v1beta1.ApplicationSpec{Components: []common.ApplicationComponent{{Name: "kustomize"}}}},
+			res: true},
+		"EmptyApp": {object: existingBindingDef,
+			app: v1beta1.Application{Spec: v1beta1.ApplicationSpec{Components: []common.ApplicationComponent{}}},
+			res: false},
+	}
+	for _, s := range testCases {
+		result := checkObjectBindingComponent(s.object, s.app)
+		assert.Equal(t, result, s.res)
+	}
 }
 
 const (

--- a/pkg/addon/versioned_registry.go
+++ b/pkg/addon/versioned_registry.go
@@ -86,6 +86,7 @@ func (i *versionedRegistry) GetAddonUIData(ctx context.Context, addonName, versi
 		Detail:            wholePackage.Detail,
 		Definitions:       wholePackage.Definitions,
 		AvailableVersions: wholePackage.AvailableVersions,
+		CUEDefinitions:    wholePackage.CUEDefinitions,
 	}, nil
 }
 

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -226,6 +226,9 @@ const (
 
 	// AnnotationResourceURL records the source url of the Kubernetes object
 	AnnotationResourceURL = "app.oam.dev/resource-url"
+
+	// AnnotationIgnoreWithoutCompKey indicates the bond component
+	AnnotationIgnoreWithoutCompKey = "addon.oam.dev/ignore-without-component"
 )
 
 const (

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Test addon rest api", func() {
 			Expect(addon.Name).Should(BeEquivalentTo("mock-addon"))
 			Expect(addon.Detail).Should(BeEquivalentTo("Test addon readme.md file"))
 			Expect(len(addon.Definitions)).Should(BeEquivalentTo(1))
-			Expect(addon.Definitions[0].Name).Should(BeEquivalentTo("kustomize-json-patch"))
+			Expect(addon.Definitions[0].Name).Should(BeEquivalentTo("kustomize-json-patch-mock-adddon"))
 		})
 
 		It("enable addon ", func() {

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -101,6 +101,9 @@ var _ = Describe("Test addon rest api", func() {
 			var addon apisv1.DetailAddonResponse
 			Expect(decodeResponseBody(res, &addon)).Should(Succeed())
 			Expect(addon.Name).Should(BeEquivalentTo("mock-addon"))
+			Expect(addon.Detail).Should(BeEquivalentTo("Test addon readme.md file"))
+			Expect(len(addon.Definitions)).Should(BeEquivalentTo(1))
+			Expect(addon.Definitions[0].Name).Should(BeEquivalentTo("kustomize-json-patch"))
 		})
 
 		It("enable addon ", func() {


### PR DESCRIPTION
1. addon check definition whether binding a  component, if this component not exist don't apply it.
2. apiserver show readme.md
3. apiserver show cue definition

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->