### PR TITLE
Feat: report the manifest name when addon enabling failed

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -683,7 +683,7 @@ func RenderDefinitions(addon *InstallPackage, config *rest.Config) ([]*unstructu
 	for _, def := range addon.Definitions {
 		obj, err := renderObject(def)
 		if err != nil {
-			return nil, fmt.Errorf("error rendering file %s: %w", def.Name, err)
+			return nil, errors.Wrapf(err, "render definition file %s", def.Name)
 		}
 		// we should ignore the namespace defined in definition yaml, override the filed by DefaultKubeVelaNS
 		obj.SetNamespace(types.DefaultKubeVelaNS)
@@ -712,7 +712,7 @@ func RenderDefinitionSchema(addon *InstallPackage) ([]*unstructured.Unstructured
 	for _, teml := range addon.DefSchemas {
 		u, err := renderSchemaConfigmap(teml)
 		if err != nil {
-			return nil, fmt.Errorf("error rendering file %s: %w", teml.Name, err)
+			return nil, errors.Wrapf(err, "render uiSchema file %s", teml.Name)
 		}
 		schemaConfigmaps = append(schemaConfigmaps, u)
 	}
@@ -725,14 +725,14 @@ func RenderViews(addon *InstallPackage) ([]*unstructured.Unstructured, error) {
 	for _, view := range addon.YAMLViews {
 		obj, err := renderObject(view)
 		if err != nil {
-			return nil, fmt.Errorf("error rendering file %s: %w", view.Name, err)
+			return nil, errors.Wrapf(err, "render velaQL view file %s", view.Name)
 		}
 		views = append(views, obj)
 	}
 	for _, view := range addon.CUEViews {
 		obj, err := renderCUEView(view)
 		if err != nil {
-			return nil, fmt.Errorf("error rendering file %s: %w", view.Name, err)
+			return nil, errors.Wrapf(err, "render velaQL view file %s", view.Name)
 		}
 		views = append(views, obj)
 	}
@@ -796,7 +796,7 @@ func renderK8sObjectsComponent(elems []ElementFile, addonName string) (*common2.
 	for _, elem := range elems {
 		obj, err := renderObject(elem)
 		if err != nil {
-			return nil, fmt.Errorf("error rendering file %s: %w", elem.Name, err)
+			return nil, errors.Wrapf(err, "render resource file %s", elem.Name)
 		}
 		objects = append(objects, obj)
 	}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -683,7 +683,7 @@ func RenderDefinitions(addon *InstallPackage, config *rest.Config) ([]*unstructu
 	for _, def := range addon.Definitions {
 		obj, err := renderObject(def)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering file %s: %w", def.Name, err)
 		}
 		// we should ignore the namespace defined in definition yaml, override the filed by DefaultKubeVelaNS
 		obj.SetNamespace(types.DefaultKubeVelaNS)
@@ -712,7 +712,7 @@ func RenderDefinitionSchema(addon *InstallPackage) ([]*unstructured.Unstructured
 	for _, teml := range addon.DefSchemas {
 		u, err := renderSchemaConfigmap(teml)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering file %s: %w", teml.Name, err)
 		}
 		schemaConfigmaps = append(schemaConfigmaps, u)
 	}
@@ -725,14 +725,14 @@ func RenderViews(addon *InstallPackage) ([]*unstructured.Unstructured, error) {
 	for _, view := range addon.YAMLViews {
 		obj, err := renderObject(view)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering file %s: %w", view.Name, err)
 		}
 		views = append(views, obj)
 	}
 	for _, view := range addon.CUEViews {
 		obj, err := renderCUEView(view)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering file %s: %w", view.Name, err)
 		}
 		views = append(views, obj)
 	}
@@ -796,7 +796,7 @@ func renderK8sObjectsComponent(elems []ElementFile, addonName string) (*common2.
 	for _, elem := range elems {
 		obj, err := renderObject(elem)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error rendering file %s: %w", elem.Name, err)
 		}
 		objects = append(objects, obj)
 	}

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -328,7 +328,7 @@ func renderResources(addon *InstallPackage, args map[string]interface{}) ([]comm
 	if len(addon.YAMLTemplates) != 0 {
 		comp, err := renderK8sObjectsComponent(addon.YAMLTemplates, addon.Name)
 		if err != nil {
-			return nil, errors.Wrap(err, "fail to render yaml template")
+			return nil, errors.Wrapf(err, "render components from yaml template")
 		}
 		resources = append(resources, *comp)
 	}

--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -328,7 +328,7 @@ func renderResources(addon *InstallPackage, args map[string]interface{}) ([]comm
 	if len(addon.YAMLTemplates) != 0 {
 		comp, err := renderK8sObjectsComponent(addon.YAMLTemplates, addon.Name)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "fail to render yaml template")
 		}
 		resources = append(resources, *comp)
 	}

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -461,7 +461,7 @@ func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*uns
 			}
 		}
 		if err != nil && !errors2.IsNotFound(err) {
-			return nil, fmt.Errorf("error checking definition %s: %w", def.GetName(), err)
+			return nil,  errors.Wrapf(err, "check definition %s", def.GetName())
 		}
 	}
 	return res, nil

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -461,7 +461,7 @@ func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*uns
 			}
 		}
 		if err != nil && !errors2.IsNotFound(err) {
-			return nil,  errors.Wrapf(err, "check definition %s", def.GetName())
+			return nil, errors.Wrapf(err, "check definition %s", def.GetName())
 		}
 	}
 	return res, nil

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -461,7 +461,7 @@ func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*uns
 			}
 		}
 		if err != nil && !errors2.IsNotFound(err) {
-			return nil, err
+			return nil, fmt.Errorf("error checking definition %s: %w", def.GetName(), err)
 		}
 	}
 	return res, nil


### PR DESCRIPTION
Signed-off-by: ghostloda <78798447@qq.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #2982

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
./vela addon enable catalog-master/addons/velaux/
enable addon by local dir: catalog-master/addons/velaux/ 
W0803 10:13:47.394796   41115 render.go:194] Application name velaux will be overwritten with addon-velaux. Consider removing metadata.name in template.
Error: render addon definitions' schema fail: error rendering file addon-uischema-velaux.yaml: yaml: mapping values are not allowed in this context

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->