### PR TITLE
Feat: ignore control check for resource from aggregate apiserver without resource version

### DIFF
--- a/pkg/utils/apply/apply.go
+++ b/pkg/utils/apply/apply.go
@@ -299,7 +299,10 @@ func MustBeControlledByApp(app *v1beta1.Application) ApplyOption {
 			return nil
 		}
 		appKey, controlledBy := GetAppKey(app), GetControlledBy(existing)
-		if controlledBy == "" && !utilfeature.DefaultMutableFeatureGate.Enabled(features.LegacyResourceOwnerValidation) {
+		// if the existing object has no resource version, it means this resource is an API response not directly from
+		// an etcd object but from some external services, such as vela-prism. Then the response does not necessarily
+		// contain the owner
+		if controlledBy == "" && !utilfeature.DefaultMutableFeatureGate.Enabled(features.LegacyResourceOwnerValidation) && existing.GetResourceVersion() != "" {
 			return fmt.Errorf("%s %s/%s exists but not managed by any application now", existing.GetObjectKind().GroupVersionKind().Kind, existing.GetNamespace(), existing.GetName())
 		}
 		if controlledBy != "" && controlledBy != appKey {

--- a/pkg/utils/apply/apply_test.go
+++ b/pkg/utils/apply/apply_test.go
@@ -380,18 +380,20 @@ func TestMustBeControlledByApp(t *testing.T) {
 			hasError: false,
 		},
 		"old app has no label": {
-			existing: &appsv1.Deployment{},
+			existing: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "-"}},
 			hasError: true,
 		},
 		"old app has no app label": {
 			existing: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{},
+				Labels:          map[string]string{},
+				ResourceVersion: "-",
 			}},
 			hasError: true,
 		},
 		"old app has no app ns label": {
 			existing: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{oam.LabelAppName: "app"},
+				Labels:          map[string]string{oam.LabelAppName: "app"},
+				ResourceVersion: "-",
 			}},
 			hasError: true,
 		},
@@ -412,6 +414,18 @@ func TestMustBeControlledByApp(t *testing.T) {
 				Labels: map[string]string{oam.LabelAppName: "app", oam.LabelAppNamespace: "ns"},
 			}},
 			hasError: true,
+		},
+		"old app has no resource version but with bad app key": {
+			existing: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{oam.LabelAppName: "app", oam.LabelAppNamespace: "ns"},
+			}},
+			hasError: true,
+		},
+		"old app has no resource version": {
+			existing: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			}},
+			hasError: false,
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

To handle resources from AggregatedServer like vela-prism that has no resource version (like GrafanaDashboard and GrafanaDatasource), ignore the owner label check while dispatching resource.

Work around for issue https://github.com/kubevela/prism/issues/23.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->