### PR TITLE
Fix: compare resource without version

### DIFF
--- a/apis/core.oam.dev/v1beta1/resourcetracker_types.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types.go
@@ -123,12 +123,13 @@ func (in ManagedResource) NamespacedName() types.NamespacedName {
 
 // ResourceKey computes the key for managed resource, resources with the same key points to the same resource
 func (in ManagedResource) ResourceKey() string {
-	gv, kind := in.GroupVersionKind().ToAPIVersionAndKind()
+	group := in.GroupVersionKind().Group
+	kind := in.GroupVersionKind().Kind
 	cluster := in.Cluster
 	if cluster == "" {
 		cluster = velatypes.ClusterLocalName
 	}
-	return strings.Join([]string{gv, kind, cluster, in.Namespace, in.Name}, "/")
+	return strings.Join([]string{group, kind, cluster, in.Namespace, in.Name}, "/")
 }
 
 // ComponentKey computes the key for the component which managed resource belongs to

--- a/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
@@ -125,7 +125,7 @@ func TestManagedResourceKeys(t *testing.T) {
 		},
 	}
 	r.Equal("namespace/name", input.NamespacedName().String())
-	r.Equal("apps/v1/Deployment/cluster/namespace/name", input.ResourceKey())
+	r.Equal("apps/Deployment/cluster/namespace/name", input.ResourceKey())
 	r.Equal("env/component", input.ComponentKey())
 	r.Equal("Deployment name (Cluster: cluster, Namespace: namespace)", input.DisplayName())
 	var deploy1, deploy2 v12.Deployment


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When application upgrades, sometimes, resources also have version upgrade but different version of the resource are still one identical resource. For example, application v1 dispatch `networking.k8s.io/v1beta1` Ingress and v2 dispatch `networking.k8s.io/v1` Ingress, although they are the same, since ResourceTracker compares resource with version previously, they are treated as different resources and therefore delete the old Ingress.

This PR skips the check for equality for version but only compares the APIGroup and Kind.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->