### PR TITLE
Fix: vela CLI provider compatibility

### DIFF
--- a/pkg/apiserver/domain/service/config.go
+++ b/pkg/apiserver/domain/service/config.go
@@ -72,7 +72,7 @@ func (u *configServiceImpl) ListConfigTypes(ctx context.Context, query string) (
 	defs := &v1beta1.ComponentDefinitionList{}
 	if err := u.KubeClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
 		client.MatchingLabels{
-			configCatalog: types.VelaCoreConfig,
+			definition.ConfigCatalog: types.VelaCoreConfig,
 		}); err != nil {
 		return nil, err
 	}
@@ -85,13 +85,13 @@ func (u *configServiceImpl) ListConfigTypes(ctx context.Context, query string) (
 	if err := u.KubeClient.List(ctx, defsLegacy, client.InNamespace(types.DefaultKubeVelaNS),
 		client.MatchingLabels{
 			// leave here as the legacy format to test the compatibility
-			definition.UserPrefix + configCatalog: types.VelaCoreConfig,
+			definition.UserPrefix + definition.ConfigCatalog: types.VelaCoreConfig,
 		}); err != nil {
 		return nil, err
 	}
 	// filter repeated config,due to new labels that exist at the same time
 	for _, legacy := range defsLegacy.Items {
-		if legacy.Labels[configCatalog] == types.VelaCoreConfig {
+		if legacy.Labels[definition.ConfigCatalog] == types.VelaCoreConfig {
 			continue
 		}
 		items = append(items, legacy)

--- a/pkg/apiserver/domain/service/config_test.go
+++ b/pkg/apiserver/domain/service/config_test.go
@@ -57,8 +57,8 @@ func TestListConfigTypes(t *testing.T) {
 			Name:      "def1",
 			Namespace: types.DefaultKubeVelaNS,
 			Labels: map[string]string{
-				configCatalog:  types.VelaCoreConfig,
-				definitionType: types.TerraformProvider,
+				definition.ConfigCatalog:  types.VelaCoreConfig,
+				definition.DefinitionType: types.TerraformProvider,
 			},
 		},
 	}
@@ -71,10 +71,10 @@ func TestListConfigTypes(t *testing.T) {
 			Name:      "def2",
 			Namespace: types.DefaultKubeVelaNS,
 			Annotations: map[string]string{
-				definitionAlias: "Def2",
+				definition.DefinitionAlias: "Def2",
 			},
 			Labels: map[string]string{
-				configCatalog: types.VelaCoreConfig,
+				definition.ConfigCatalog: types.VelaCoreConfig,
 			},
 		},
 	}
@@ -153,10 +153,10 @@ func TestGetConfigType(t *testing.T) {
 			Name:      "def2",
 			Namespace: types.DefaultKubeVelaNS,
 			Annotations: map[string]string{
-				definitionAlias: "Def2",
+				definition.DefinitionAlias: "Def2",
 			},
 			Labels: map[string]string{
-				definition.UserPrefix + configCatalog: types.VelaCoreConfig,
+				definition.UserPrefix + definition.ConfigCatalog: types.VelaCoreConfig,
 			},
 		},
 	}

--- a/pkg/apiserver/domain/service/tags.go
+++ b/pkg/apiserver/domain/service/tags.go
@@ -18,22 +18,16 @@ package service
 
 import "github.com/oam-dev/kubevela/pkg/definition"
 
-const (
-	definitionAlias = "alias.config.oam.dev"
-	definitionType  = "type.config.oam.dev"
-	configCatalog   = "catalog.config.oam.dev"
-)
-
 // DefinitionAlias will get definitionAlias value from tags
 func DefinitionAlias(tags map[string]string) string {
 	if tags == nil {
 		return ""
 	}
-	val := tags[definitionAlias]
+	val := tags[definition.DefinitionAlias]
 	if val != "" {
 		return val
 	}
-	return tags[definition.UserPrefix+definitionAlias]
+	return tags[definition.UserPrefix+definition.DefinitionAlias]
 }
 
 // DefinitionType will get definitionType value from tags
@@ -41,11 +35,11 @@ func DefinitionType(tags map[string]string) string {
 	if tags == nil {
 		return ""
 	}
-	val := tags[definitionType]
+	val := tags[definition.DefinitionType]
 	if val != "" {
 		return val
 	}
-	return tags[definition.UserPrefix+definitionType]
+	return tags[definition.UserPrefix+definition.DefinitionType]
 }
 
 // ConfigCatalog will get configCatalog value from tags
@@ -53,9 +47,9 @@ func ConfigCatalog(tags map[string]string) string {
 	if tags == nil {
 		return ""
 	}
-	val := tags[configCatalog]
+	val := tags[definition.ConfigCatalog]
 	if val != "" {
 		return val
 	}
-	return tags[definition.UserPrefix+configCatalog]
+	return tags[definition.UserPrefix+definition.ConfigCatalog]
 }

--- a/pkg/apiserver/domain/service/tags_test.go
+++ b/pkg/apiserver/domain/service/tags_test.go
@@ -19,20 +19,22 @@ package service
 import (
 	"testing"
 
+	"github.com/oam-dev/kubevela/pkg/definition"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompatiblleTag(t *testing.T) {
+func TestCompatibleTag(t *testing.T) {
 	tg := map[string]string{
-		"alias.config.oam.dev":   "abc",
-		"type.config.oam.dev":    "image-registry",
-		"catalog.config.oam.dev": "cata",
+		definition.DefinitionAlias: "abc",
+		definition.DefinitionType:  "image-registry",
+		definition.ConfigCatalog:   "cata",
 	}
 
 	tgOld := map[string]string{
-		"custom.definition.oam.dev/alias.config.oam.dev":   "abc-2",
-		"custom.definition.oam.dev/type.config.oam.dev":    "image-registry-2",
-		"custom.definition.oam.dev/catalog.config.oam.dev": "cata-2",
+		definition.UserPrefix + definition.DefinitionAlias: "abc-2",
+		definition.UserPrefix + definition.DefinitionType:  "image-registry-2",
+		definition.UserPrefix + definition.ConfigCatalog:   "cata-2",
 	}
 
 	assert.Equal(t, DefinitionAlias(nil), "")

--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -54,6 +54,12 @@ const (
 	AliasKey = "definition.oam.dev/alias"
 	// UserPrefix defines the prefix of user customized label or annotation
 	UserPrefix = "custom.definition.oam.dev/"
+	// DefinitionAlias is alias of definition
+	DefinitionAlias = "alias.config.oam.dev"
+	// DefinitionType marks definition's usage type, like image-registry
+	DefinitionType = "type.config.oam.dev"
+	// ConfigCatalog marks definition is a catalog
+	ConfigCatalog = "catalog.config.oam.dev"
 )
 
 var (

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -301,13 +301,13 @@ func getTerraformProviderTypes(ctx context.Context, k8sClient client.Client) ([]
 	legacyDefs := &v1beta1.ComponentDefinitionList{}
 	err := k8sClient.List(ctx, legacyDefs, client.InNamespace(types.DefaultKubeVelaNS),
 		client.MatchingLabels{definition.UserPrefix + definition.DefinitionType: types.TerraformProvider})
-	if err != nil && kerrors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return nil, err
 	}
 	defs := &v1beta1.ComponentDefinitionList{}
 	err = k8sClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
 		client.MatchingLabels{definition.DefinitionType: types.TerraformProvider})
-	if err != nil {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return nil, err
 	}
 

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -299,15 +299,13 @@ func listProviders(ctx context.Context, k8sClient client.Client, ioStreams cmdut
 func getTerraformProviderTypes(ctx context.Context, k8sClient client.Client) ([]v1beta1.ComponentDefinition, error) {
 	// keep compatibility with old version of terraform-xxx provider definition
 	legacyDefs := &v1beta1.ComponentDefinitionList{}
-	err := k8sClient.List(ctx, legacyDefs, client.InNamespace(types.DefaultKubeVelaNS),
-		client.MatchingLabels{definition.UserPrefix + definition.DefinitionType: types.TerraformProvider})
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err := k8sClient.List(ctx, legacyDefs, client.InNamespace(types.DefaultKubeVelaNS),
+		client.MatchingLabels{definition.UserPrefix + definition.DefinitionType: types.TerraformProvider}); err != nil {
 		return nil, err
 	}
 	defs := &v1beta1.ComponentDefinitionList{}
-	err = k8sClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
-		client.MatchingLabels{definition.DefinitionType: types.TerraformProvider})
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err := k8sClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
+		client.MatchingLabels{definition.DefinitionType: types.TerraformProvider}); err != nil {
 		return nil, err
 	}
 

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -297,12 +297,27 @@ func listProviders(ctx context.Context, k8sClient client.Client, ioStreams cmdut
 // getTerraformProviderTypes retrieves all ComponentDefinition for Terraform Cloud Providers which are delivered by
 // Terraform Cloud provider addons
 func getTerraformProviderTypes(ctx context.Context, k8sClient client.Client) ([]v1beta1.ComponentDefinition, error) {
-	defs := &v1beta1.ComponentDefinitionList{}
-	if err := k8sClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
-		client.MatchingLabels{definition.UserPrefix + "type.config.oam.dev": types.TerraformProvider}); err != nil {
+	// keep compatibility with old version of terraform-xxx provider definition
+	legacyDefs := &v1beta1.ComponentDefinitionList{}
+	err := k8sClient.List(ctx, legacyDefs, client.InNamespace(types.DefaultKubeVelaNS),
+		client.MatchingLabels{definition.UserPrefix + definition.DefinitionType: types.TerraformProvider})
+	if err != nil && kerrors.IsNotFound(err) {
 		return nil, err
 	}
-	return defs.Items, nil
+	defs := &v1beta1.ComponentDefinitionList{}
+	err = k8sClient.List(ctx, defs, client.InNamespace(types.DefaultKubeVelaNS),
+		client.MatchingLabels{definition.DefinitionType: types.TerraformProvider})
+	if err != nil {
+		return nil, err
+	}
+
+	var result []v1beta1.ComponentDefinition
+	result = append(result, legacyDefs.Items...)
+	result = append(result, defs.Items...)
+	if len(result) == 0 {
+		return nil, errors.New("no Terraform Cloud Provider ComponentDefinition found")
+	}
+	return result, nil
 }
 
 // getTerraformProviderType retrieves the ComponentDefinition for a Terraform Cloud Provider which is delivered by

--- a/references/cli/provider_test.go
+++ b/references/cli/provider_test.go
@@ -21,11 +21,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pkg/errors"
-
-	"github.com/oam-dev/kubevela/pkg/definition"
-
 	terraformapi "github.com/oam-dev/terraform-controller/api/v1beta1"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +32,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/definition"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 


### PR DESCRIPTION
Signed-off-by: qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

### Description of your changes

In vela CLI < v1.5.0, `vela addon enable` will add a prefix ("custom.definition.oam.dev") to label of definition came with addon.  This logic is removed in v1.5.0

However it effect `vela provider list` behavior. Which still reading ComponentDefinition with Label `"custom.definition.oam.dev:type.config.oam.dev": terraform-xxx`. This PR make provider command compatible with both type of label.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4558

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

UT added

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->