### PR TITLE
Fix: reject applications with empty policy properties

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -382,7 +382,7 @@ func (p *Parser) parsePoliciesFromRevision(ctx context.Context, af *Appfile) (er
 	}
 	for _, policy := range af.Policies {
 		if policy.Properties == nil {
-			return fmt.Errorf("policy name %s must not have empty properties", policy.Name)
+			return fmt.Errorf("policy %s named %s must not have empty properties", policy.Type, policy.Name)
 		}
 		switch policy.Type {
 		case v1alpha1.GarbageCollectPolicyType:
@@ -411,7 +411,7 @@ func (p *Parser) parsePolicies(ctx context.Context, af *Appfile) (err error) {
 	}
 	for _, policy := range af.Policies {
 		if policy.Properties == nil {
-			return fmt.Errorf("policy name %s must not have empty properties", policy.Name)
+			return fmt.Errorf("policy %s named %s must not have empty properties", policy.Type, policy.Name)
 		}
 		switch policy.Type {
 		case v1alpha1.GarbageCollectPolicyType:

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -381,6 +381,9 @@ func (p *Parser) parsePoliciesFromRevision(ctx context.Context, af *Appfile) (er
 		return err
 	}
 	for _, policy := range af.Policies {
+		if policy.Properties == nil {
+			return fmt.Errorf("policy name %s must not have empty properties", policy.Name)
+		}
 		switch policy.Type {
 		case v1alpha1.GarbageCollectPolicyType:
 		case v1alpha1.ApplyOncePolicyType:
@@ -407,6 +410,9 @@ func (p *Parser) parsePolicies(ctx context.Context, af *Appfile) (err error) {
 		return err
 	}
 	for _, policy := range af.Policies {
+		if policy.Properties == nil {
+			return fmt.Errorf("policy name %s must not have empty properties", policy.Name)
+		}
 		switch policy.Type {
 		case v1alpha1.GarbageCollectPolicyType:
 		case v1alpha1.ApplyOncePolicyType:

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -381,7 +381,7 @@ func (p *Parser) parsePoliciesFromRevision(ctx context.Context, af *Appfile) (er
 		return err
 	}
 	for _, policy := range af.Policies {
-		if policy.Properties == nil {
+		if policy.Properties == nil && policy.Type != v1alpha1.DebugPolicyType {
 			return fmt.Errorf("policy %s named %s must not have empty properties", policy.Type, policy.Name)
 		}
 		switch policy.Type {
@@ -410,7 +410,7 @@ func (p *Parser) parsePolicies(ctx context.Context, af *Appfile) (err error) {
 		return err
 	}
 	for _, policy := range af.Policies {
-		if policy.Properties == nil {
+		if policy.Properties == nil && policy.Type != v1alpha1.DebugPolicyType {
 			return fmt.Errorf("policy %s named %s must not have empty properties", policy.Type, policy.Name)
 		}
 		switch policy.Type {

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -269,6 +269,20 @@ spec:
         image: "busybox"
 `
 
+const appfileYamlEmptyPolicy = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: application-sample
+  namespace: default
+spec:
+  components: []
+  policies:
+    - type: garbage-collect
+      name: somename
+      properties:
+`
+
 var _ = Describe("Test application parser", func() {
 	It("Test we can parse an application to an appFile", func() {
 		o := v1beta1.Application{}
@@ -314,6 +328,14 @@ var _ = Describe("Test application parser", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = NewApplicationParser(&tclient, dm, pd).GenerateAppFile(context.TODO(), &notfound)
 		Expect(err).Should(HaveOccurred())
+
+		By("app with empty policy")
+		emptyPolicy := v1beta1.Application{}
+		err = yaml.Unmarshal([]byte(appfileYamlEmptyPolicy), &emptyPolicy)
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = NewApplicationParser(&tclient, dm, pd).GenerateAppFile(context.TODO(), &emptyPolicy)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).Should(ContainSubstring("have empty properties"))
 	})
 })
 

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler.go
@@ -96,7 +96,9 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	switch req.Operation {
 	case admissionv1.Create:
 		if allErrs := h.ValidateCreate(ctx, app); len(allErrs) > 0 {
-			return admission.Errored(http.StatusUnprocessableEntity, mergeErrors(allErrs))
+			// http.StatusUnprocessableEntity will NOT report any error descriptions to the client,
+			// use generic http.StatusBadRequest instead.
+			return admission.Errored(http.StatusBadRequest, mergeErrors(allErrs))
 		}
 	case admissionv1.Update:
 		oldApp := &v1beta1.Application{}
@@ -105,7 +107,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		}
 		if app.ObjectMeta.DeletionTimestamp.IsZero() {
 			if allErrs := h.ValidateUpdate(ctx, app, oldApp); len(allErrs) > 0 {
-				return admission.Errored(http.StatusUnprocessableEntity, mergeErrors(allErrs))
+				return admission.Errored(http.StatusBadRequest, mergeErrors(allErrs))
 			}
 		}
 	default:

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler.go
@@ -96,8 +96,8 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	switch req.Operation {
 	case admissionv1.Create:
 		if allErrs := h.ValidateCreate(ctx, app); len(allErrs) > 0 {
-			// http.StatusUnprocessableEntity will NOT report any error descriptions to the client,
-			// use generic http.StatusBadRequest instead.
+			// http.StatusUnprocessableEntity will NOT report any error descriptions
+			// to the client, use generic http.StatusBadRequest instead.
 			return admission.Errored(http.StatusBadRequest, mergeErrors(allErrs))
 		}
 	case admissionv1.Update:

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validating_handler_test.go
@@ -452,4 +452,21 @@ var _ = Describe("Test Application Validator", func() {
 		resp = handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeFalse())
 	})
+
+	It("Test Application with empty policy", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"kind":"Application","metadata":{"name":"app-with-empty-policy-webhook-test", "namespace":"default"},
+"spec":{"components":[],"policies":[{"name":"2345","type":"garbage-collect","properties":null}]}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeFalse())
+	})
 })

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/validating_handler.go
@@ -118,13 +118,14 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, oldApp); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-
 		if allErrs := h.ValidateUpdate(ctx, app, oldApp); len(allErrs) > 0 {
-			return admission.Errored(http.StatusUnprocessableEntity, allErrs.ToAggregate())
+			// http.StatusUnprocessableEntity will NOT report any error descriptions
+			// to the client, use generic http.StatusBadRequest instead.
+			return admission.Errored(http.StatusBadRequest, allErrs.ToAggregate())
 		}
 	case admissionv1.Create:
 		if allErrs := h.ValidateCreate(ctx, app); len(allErrs) > 0 {
-			return admission.Errored(http.StatusUnprocessableEntity, allErrs.ToAggregate())
+			return admission.Errored(http.StatusBadRequest, allErrs.ToAggregate())
 		}
 	default:
 		// Do nothing for CONNECT


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

This PR is a follow up of: https://github.com/kubevela/kubevela/pull/4473

Previously, applying such app will succeed.

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app
spec:
  components: []
  policies:
    - name: target-default
      type: topology
      properties:
```

Now, it will be rejected by validating admission webhooks:

```
Error from server: error when creating "vela.yaml": \
admission webhook "validating.core.oam.dev.v1beta1.applications" denied the request: \
field "spec": Invalid value error encountered, \
failed to parsePolicies: policy topology named target-default must not have empty properties. 
```

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->