### PR TITLE
Fix: gc resource without resourceversion

### DIFF
--- a/pkg/resourcekeeper/cache.go
+++ b/pkg/resourcekeeper/cache.go
@@ -113,7 +113,7 @@ func (cache *resourceCache) exists(manifest *unstructured.Unstructured) bool {
 		return true
 	}
 	appKey, controlledBy := apply.GetAppKey(cache.app), apply.GetControlledBy(manifest)
-	if appKey == controlledBy {
+	if appKey == controlledBy || manifest.GetResourceVersion() == "" {
 		return true
 	}
 	annotations := manifest.GetAnnotations()

--- a/pkg/resourcekeeper/cache_test.go
+++ b/pkg/resourcekeeper/cache_test.go
@@ -139,8 +139,9 @@ func TestResourceCacheExistenceCheck(t *testing.T) {
 	createResource := func(appName, appNs, sharedBy string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"labels":      map[string]interface{}{oam.LabelAppName: appName, oam.LabelAppNamespace: appNs},
-				"annotations": map[string]interface{}{oam.AnnotationAppSharedBy: sharedBy},
+				"labels":          map[string]interface{}{oam.LabelAppName: appName, oam.LabelAppNamespace: appNs},
+				"annotations":     map[string]interface{}{oam.AnnotationAppSharedBy: sharedBy},
+				"resourceVersion": "-",
 			},
 		}}
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

While recycling resources, the old logic ignores the resource that does not have the correct owner label, which will make it unable to recycle GrafanaDashboard/GrafanaDatasource. This PR disable this check when resource has no ResourceVersion.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->