### PR TITLE
Fix: the create time of the synced policies is zero

### DIFF
--- a/pkg/apiserver/event/sync/store.go
+++ b/pkg/apiserver/event/sync/store.go
@@ -54,9 +54,11 @@ func StoreProject(ctx context.Context, name string, ds datastore.DataStore, proj
 
 // StoreAppMeta will sync application metadata from CR to datastore
 func StoreAppMeta(ctx context.Context, app *model.DataStoreApp, ds datastore.DataStore) error {
-	err := ds.Get(ctx, &model.Application{Name: app.AppMeta.Name})
+	oldApp := &model.Application{Name: app.AppMeta.Name}
+	err := ds.Get(ctx, oldApp)
 	if err == nil {
 		// it means the record already exists
+		app.AppMeta.CreateTime = oldApp.CreateTime
 		return ds.Put(ctx, app.AppMeta)
 	}
 	if !errors.Is(err, datastore.ErrRecordNotExist) {
@@ -75,6 +77,7 @@ func StoreEnv(ctx context.Context, app *model.DataStoreApp, ds datastore.DataSto
 		if utils.EqualSlice(curEnv.Targets, app.Env.Targets) {
 			return nil
 		}
+		app.Env.CreateTime = curEnv.CreateTime
 		return ds.Put(ctx, app.Env)
 	}
 	if !errors.Is(err, datastore.ErrRecordNotExist) {
@@ -119,9 +122,11 @@ func StoreComponents(ctx context.Context, appPrimaryKey string, expComps []*mode
 		return err
 	}
 	var originCompNames []string
-	for _, entity := range originComps {
-		comp := entity.(*model.ApplicationComponent)
+	var existComponentMap = make(map[string]*model.ApplicationComponent)
+	for i := range originComps {
+		comp := originComps[i].(*model.ApplicationComponent)
 		originCompNames = append(originCompNames, comp.Name)
+		existComponentMap[comp.Name] = comp
 	}
 
 	var targetCompNames []string
@@ -154,6 +159,9 @@ func StoreComponents(ctx context.Context, appPrimaryKey string, expComps []*mode
 		if utils.StringsContain(readyToAdd, comp.Name) {
 			err = ds.Add(ctx, comp)
 		} else {
+			if old := existComponentMap[comp.Name]; old != nil {
+				comp.CreateTime = old.CreateTime
+			}
 			err = ds.Put(ctx, comp)
 		}
 		if err != nil {
@@ -172,9 +180,11 @@ func StorePolicy(ctx context.Context, appPrimaryKey string, expPolicies []*model
 		return err
 	}
 	var originPolicyNames []string
-	for _, entity := range originPolicies {
-		plc := entity.(*model.ApplicationPolicy)
+	var policyMap = make(map[string]*model.ApplicationPolicy)
+	for i := range originPolicies {
+		plc := originPolicies[i].(*model.ApplicationPolicy)
 		originPolicyNames = append(originPolicyNames, plc.Name)
+		policyMap[plc.Name] = plc
 	}
 
 	var targetPLCNames []string
@@ -209,6 +219,9 @@ func StorePolicy(ctx context.Context, appPrimaryKey string, expPolicies []*model
 		if utils.StringsContain(readyToAdd, plc.Name) {
 			err = ds.Add(ctx, plc)
 		} else {
+			if existPolicy := policyMap[plc.Name]; existPolicy != nil {
+				plc.CreateTime = existPolicy.CreateTime
+			}
 			err = ds.Put(ctx, plc)
 		}
 		if err != nil {
@@ -221,8 +234,10 @@ func StorePolicy(ctx context.Context, appPrimaryKey string, expPolicies []*model
 
 // StoreWorkflow will sync workflow application CR to datastore, it updates the only one workflow from the application with specified name
 func StoreWorkflow(ctx context.Context, dsApp *model.DataStoreApp, ds datastore.DataStore) error {
-	err := ds.Get(ctx, &model.Workflow{AppPrimaryKey: dsApp.AppMeta.Name, Name: dsApp.Workflow.Name})
+	old := &model.Workflow{AppPrimaryKey: dsApp.AppMeta.Name, Name: dsApp.Workflow.Name}
+	err := ds.Get(ctx, old)
 	if err == nil {
+		dsApp.Workflow.CreateTime = old.CreateTime
 		// it means the record already exists, update it
 		return ds.Put(ctx, dsApp.Workflow)
 	}
@@ -254,8 +269,10 @@ func StoreApplicationRevision(ctx context.Context, dsApp *model.DataStoreApp, ds
 	if dsApp.Revision == nil {
 		return nil
 	}
-	err := ds.Get(ctx, &model.ApplicationRevision{AppPrimaryKey: dsApp.AppMeta.Name, Version: dsApp.Revision.Version})
+	old := &model.ApplicationRevision{AppPrimaryKey: dsApp.AppMeta.Name, Version: dsApp.Revision.Version}
+	err := ds.Get(ctx, old)
 	if err == nil {
+		dsApp.Revision.CreateTime = old.CreateTime
 		return ds.Put(ctx, dsApp.Revision)
 	}
 	if !errors.Is(err, datastore.ErrRecordNotExist) {

--- a/pkg/apiserver/event/sync/worker_test.go
+++ b/pkg/apiserver/event/sync/worker_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Test Worker CR sync to datastore", func() {
 
 		comp1 := model.ApplicationComponent{AppPrimaryKey: app1.Name, Name: "nginx"}
 		Expect(ds.Get(ctx, &comp1)).Should(BeNil())
+		Expect(comp1.CreateTime.IsZero()).Should(BeFalse())
 		Expect(comp1.Properties).Should(BeEquivalentTo(&model.JSONStruct{"image": "nginx"}))
 
 		comp2 := model.ApplicationComponent{AppPrimaryKey: app1.Name, Name: "nginx2"}
@@ -96,10 +97,12 @@ var _ = Describe("Test Worker CR sync to datastore", func() {
 
 		env := model.Env{Project: appNS1, Name: model.AutoGenEnvNamePrefix + appNS1}
 		Expect(ds.Get(ctx, &env)).Should(BeNil())
+		Expect(env.CreateTime.IsZero()).Should(BeFalse())
 		Expect(len(env.Targets)).Should(Equal(2))
 
 		appPlc1 := model.ApplicationPolicy{AppPrimaryKey: app1.Name, Name: "topology-beijing-demo"}
 		Expect(ds.Get(ctx, &appPlc1)).Should(BeNil())
+		Expect(appPlc1.CreateTime.IsZero()).Should(BeFalse())
 		appPlc2 := model.ApplicationPolicy{AppPrimaryKey: app1.Name, Name: "topology-local"}
 		Expect(ds.Get(ctx, &appPlc2)).Should(BeNil())
 		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: model.AutoGenWorkflowNamePrefix + app1.Name}

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
@@ -36,8 +36,10 @@ import (
 var _ = Describe("Test kubeapi datastore driver", func() {
 
 	It("Test add function", func() {
-		err := kubeStore.Add(context.TODO(), &model.Application{Name: "kubevela-app", Description: "default"})
+		app := &model.Application{Name: "kubevela-app", Description: "default"}
+		err := kubeStore.Add(context.TODO(), app)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(app.CreateTime.IsZero()).Should(BeFalse())
 	})
 
 	It("Test batch add function", func() {

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -224,7 +224,7 @@ func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient cli
 		fmt.Println()
 		fmt.Println(`    vela port-forward -n vela-system addon-velaux 9082:80`)
 		fmt.Println()
-		fmt.Println(`Select "Cluster: local | Namespace: vela-system | Kind: Service | Name: velaux" from the prompt.`)
+		fmt.Println(`Select "local | velaux | velaux" from the prompt.`)
 		fmt.Println()
 		fmt.Println(`Please refer to https://kubevela.io/docs/reference/addons/velaux for more VelaUX addon installation and visiting method.`)
 	}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Before updating the policy should assign the create time by the old data.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

/cc @wonderflow 