### PR TITLE
Fix: open basic lit fails lookup path to KubeVela 1.5

### DIFF
--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -394,6 +394,11 @@ func jsonPatch(base cue.Value, patch cue.Value) (string, error) {
 	return output, nil
 }
 
+func isEllipsis(elt ast.Node) bool {
+	_, ok := elt.(*ast.Ellipsis)
+	return ok
+}
+
 func openJSON(data string) (string, error) {
 	f, err := parser.ParseFile("-", data, parser.ParseComments)
 	if err != nil {
@@ -405,9 +410,13 @@ func openJSON(data string) (string, error) {
 			v := field.Value
 			switch lit := v.(type) {
 			case *ast.StructLit:
-				lit.Elts = append(lit.Elts, &ast.Ellipsis{})
+				if len(lit.Elts) == 0 || !isEllipsis(lit.Elts[len(lit.Elts)-1]) {
+					lit.Elts = append(lit.Elts, &ast.Ellipsis{})
+				}
 			case *ast.ListLit:
-				lit.Elts = append(lit.Elts, &ast.Ellipsis{})
+				if len(lit.Elts) == 0 || !isEllipsis(lit.Elts[len(lit.Elts)-1]) {
+					lit.Elts = append(lit.Elts, &ast.Ellipsis{})
+				}
 			}
 		}
 		return true

--- a/pkg/cue/model/sets/utils.go
+++ b/pkg/cue/model/sets/utils.go
@@ -182,7 +182,7 @@ func peelCloseExpr(node ast.Node) ast.Node {
 
 func lookField(node ast.Node, key string) ast.Node {
 	if field, ok := node.(*ast.Field); ok {
-		if labelStr(field.Label) == key {
+		if strings.Trim(labelStr(field.Label), `"`) == key {
 			return field.Value
 		}
 	}

--- a/pkg/cue/model/sets/utils.go
+++ b/pkg/cue/model/sets/utils.go
@@ -182,7 +182,8 @@ func peelCloseExpr(node ast.Node) ast.Node {
 
 func lookField(node ast.Node, key string) ast.Node {
 	if field, ok := node.(*ast.Field); ok {
-		if strings.Trim(labelStr(field.Label), `"`) == key {
+		// Note: the trim here has side effect: "\(v)" will be trimmed to \(v), only used for comparing fields
+		if strings.Trim(labelStr(field.Label), `"`) == strings.Trim(key, `"`) {
 			return field.Value
 		}
 	}

--- a/test/e2e-multicluster-test/testdata/app/app-with-env-labels-storage.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-with-env-labels-storage.yaml
@@ -1,0 +1,35 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: test
+spec:
+  components:
+    - name: test
+      properties:
+        cmd:
+          - sleep
+          - -c
+          - "86400"
+        env:
+          - name: testKey
+            value: testValue
+        image: busybox
+        imagePullPolicy: IfNotPresent
+      traits:
+        - properties:
+            key: val
+          type: labels
+        - properties:
+            pvc:
+              - accessModes:
+                  - ReadWriteOnce
+                mountOnly: false
+                mountPath: /data
+                name: lvhyca
+                resources:
+                  requests:
+                    storage: 4096Mi
+                storageClassName: default
+                volumeMode: Filesystem
+          type: storage
+      type: webservice


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When env exists in webservice component, the use of labels + storage traits will eliminate the env field in webservice.

For example:

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: test
spec:
  components:
    - name: test
      properties:
        cmd:
          - sleep
          - -c
          - "86400"
        env:
          - name: testKey
            value: testValue
        image: busybox
        imagePullPolicy: IfNotPresent
      traits:
        - properties:
            key: val
          type: labels
        - properties:
            pvc:
              - accessModes:
                  - ReadWriteOnce
                mountOnly: false
                mountPath: /data
                name: lvhyca
                resources:
                  requests:
                    storage: 4096Mi
                storageClassName: default
                volumeMode: Filesystem
          type: storage
      type: webservice
```

The reason is that when `labels` trait patches, it uses `json-merge-patch`, which convert CUE into JSON and patch, then convert JSON to CUE. However, while converting JSON to CUE, the previous OpenBasicLit function will do the following conversion.
```cue
// before
"y": {
  "x": ["a", "b"]
}
// after
{
  "y": *{
    "x": *["a", "b"] | [...]
  } | _
}
``` 

This will make the `lookup` function unable to find `.y.x`. This PR fixes it by doing the following conversion.

```cue
// before
"y": {
  "x": ["a", "b"]
}
// after
"y": {
  "x": ["a", "b", ...]
  ...
}
```

Notice this problem also exists for CUE 0.4, therefore this fix need to be cherry-picked to master branch. But since we have made CUE upgrade from KubeVela v1.5 -> v1.6, there will be conflicts. So this fix cannot be automatically backported, need to be manually cherry-picked.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->