### PR TITLE
Feat: add new system info to system info board and optimize code

### DIFF
--- a/references/cli/top/component/app.go
+++ b/references/cli/top/component/app.go
@@ -27,7 +27,7 @@ import (
 type App struct {
 	*tview.Application
 	actions    model.KeyActions
-	Components map[string]tview.Primitive
+	components map[string]tview.Primitive
 	Main       *Pages
 }
 
@@ -38,7 +38,7 @@ func NewApp() *App {
 		actions:     make(model.KeyActions),
 		Main:        NewPages(),
 	}
-	a.Components = map[string]tview.Primitive{
+	a.components = map[string]tview.Primitive{
 		"info":   NewInfo(),
 		"menu":   NewMenu(),
 		"logo":   NewLogo(),
@@ -78,22 +78,27 @@ func (a *App) QueueUpdateDraw(f func()) {
 	}()
 }
 
-// InfoBoard return system info component
-func (a *App) InfoBoard() *InfoBoard {
-	return a.Components["info"].(*InfoBoard)
+// Components return the application root components.
+func (a *App) Components() map[string]tview.Primitive {
+	return a.components
 }
 
 // Logo return logo component
 func (a *App) Logo() *Logo {
-	return a.Components["logo"].(*Logo)
+	return a.components["logo"].(*Logo)
 }
 
 // Menu return key action menu component
 func (a *App) Menu() *Menu {
-	return a.Components["menu"].(*Menu)
+	return a.components["menu"].(*Menu)
 }
 
 // Crumbs return the crumbs component
 func (a *App) Crumbs() *Crumbs {
-	return a.Components["crumbs"].(*Crumbs)
+	return a.components["crumbs"].(*Crumbs)
+}
+
+// InfoBoard return system info component
+func (a *App) InfoBoard() *InfoBoard {
+	return a.Components()["info"].(*InfoBoard)
 }

--- a/references/cli/top/component/app_test.go
+++ b/references/cli/top/component/app_test.go
@@ -28,7 +28,7 @@ import (
 func TestApp(t *testing.T) {
 	app := NewApp()
 	assert.Equal(t, len(app.actions), 0)
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	t.Run("app init", func(t *testing.T) {
 		app.Init()
 		app.QueueUpdateDraw(func() {})

--- a/references/cli/top/component/info.go
+++ b/references/cli/top/component/info.go
@@ -39,34 +39,109 @@ func NewInfo() *InfoBoard {
 
 // Init info component init
 func (board *InfoBoard) Init(restConf *rest.Config) {
-	var row int
-	info := model.NewInfo()
+	board.layout()
+	board.UpdateInfo(restConf)
+}
+
+func (board *InfoBoard) layout() {
+	row := 0
 	board.SetCell(row, 0, board.sectionCell("Context").SetTextColor(config.InfoSectionColor))
-	board.SetCell(row, 1, infoCell(info.CurrentContext()).SetTextColor(config.InfoTextColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 0, board.sectionCell("K8S Version").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 0, board.sectionCell("VelaCLI Version").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 0, board.sectionCell("VelaCore Version").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
 	row++
 
 	board.SetCell(row, 0, board.sectionCell("Cluster Num").SetTextColor(config.InfoSectionColor))
-	board.SetCell(row, 1, infoCell(info.ClusterNum()).SetTextColor(config.InfoTextColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 0, board.sectionCell("App Running Num").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 2, infoCell("|").SetTextColor(config.InfoSectionColor))
+
+	row = 0
+	board.SetCell(row, 3, infoCell("").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 4, infoCell("VelaCore").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 5, infoCell("ClusterGateway").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 3, infoCell("").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 4, infoCell("").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 5, infoCell("").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 3, board.sectionCell("CPU Requests").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 3, board.sectionCell("CPU Limits").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 3, board.sectionCell("MEM Requests").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+	row++
+
+	board.SetCell(row, 3, board.sectionCell("MEM Limits").SetTextColor(config.InfoSectionColor))
+	board.SetCell(row, 6, infoCell("|").SetTextColor(config.InfoSectionColor))
+}
+
+// UpdateInfo update the info of system info board
+func (board *InfoBoard) UpdateInfo(restConf *rest.Config) {
+	row := 0
+	info := model.NewInfo()
+	board.SetCell(row, 1, infoCell(info.CurrentContext()).SetTextColor(config.InfoTextColor))
 	row++
 
 	k8s := model.K8SVersion(restConf)
-	board.SetCell(row, 0, board.sectionCell("K8S Version").SetTextColor(config.InfoSectionColor))
 	board.SetCell(row, 1, infoCell(k8s).SetTextColor(config.InfoTextColor))
 	row++
 
 	velaCLI := model.VelaCLIVersion()
-	board.SetCell(row, 0, board.sectionCell("VelaCLI Version").SetTextColor(config.InfoSectionColor))
 	board.SetCell(row, 1, infoCell(velaCLI).SetTextColor(config.InfoTextColor))
 	row++
 
 	velaCore := model.VelaCoreVersion()
-	board.SetCell(row, 0, board.sectionCell("VelaCore Version").SetTextColor(config.InfoSectionColor))
 	board.SetCell(row, 1, infoCell(velaCore).SetTextColor(config.InfoTextColor))
 	row++
 
-	goVersion := model.GOLangVersion()
-	board.SetCell(row, 0, board.sectionCell("Golang Version").SetTextColor(config.InfoSectionColor))
-	board.SetCell(row, 1, infoCell(goVersion).SetTextColor(config.InfoTextColor))
+	clusterNum := info.ClusterNum()
+	board.SetCell(row, 1, infoCell(clusterNum).SetTextColor(config.InfoTextColor))
+	row++
+
+	appNum := model.ApplicationRunningNum(restConf)
+	board.SetCell(row, 1, infoCell(appNum).SetTextColor(config.InfoTextColor))
+
+	velaCoreCPULimit, velaCoreMEMLimit, velaCoreCPURequest, velaCoreMEMRequest := model.VelaCoreRatio(restConf)
+	gatewayCPULimit, gatewayMEMLimit, gatewayCPURequest, gatewayMEMRequest := model.CLusterGatewayRatio(restConf)
+
+	row = 2
+
+	board.SetCell(row, 4, infoCell(velaCoreCPURequest).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	board.SetCell(row, 5, infoCell(gatewayCPURequest).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	row++
+
+	board.SetCell(row, 4, infoCell(velaCoreCPULimit).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	board.SetCell(row, 5, infoCell(gatewayCPULimit).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	row++
+
+	board.SetCell(row, 4, infoCell(velaCoreMEMRequest).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	board.SetCell(row, 5, infoCell(gatewayMEMRequest).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	row++
+
+	board.SetCell(row, 4, infoCell(velaCoreMEMLimit).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
+	board.SetCell(row, 5, infoCell(gatewayMEMLimit).SetTextColor(config.InfoTextColor).SetAlign(tview.AlignCenter))
 }
 
 func (board *InfoBoard) sectionCell(t string) *tview.TableCell {

--- a/references/cli/top/component/info_test.go
+++ b/references/cli/top/component/info_test.go
@@ -35,7 +35,7 @@ func TestInfo(t *testing.T) {
 	assert.NoError(t, err)
 	info := NewInfo()
 	info.Init(cfg)
-	assert.Equal(t, info.GetColumnCount(), 2)
+	assert.Equal(t, info.GetColumnCount(), 7)
 	assert.Equal(t, info.GetRowCount(), 6)
 	assert.Equal(t, info.GetCell(0, 0).Text, "Context:")
 }

--- a/references/cli/top/config/size.go
+++ b/references/cli/top/config/size.go
@@ -18,13 +18,11 @@ package config
 
 const (
 	// HeaderRowNum ui header max row num
-	HeaderRowNum = 8
+	HeaderRowNum = 7
 	// FooterRowNum ui footer max row num
 	FooterRowNum = 1
 	// MenuRowNum menu component max row num
 	MenuRowNum = 6
-	// InfoColumnNum info component max column num
-	InfoColumnNum = 30
 	// LogoColumnNum logo component max column num
 	LogoColumnNum = 50
 )

--- a/references/cli/top/model/application_test.go
+++ b/references/cli/top/model/application_test.go
@@ -23,9 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
 
 func TestApplicationList_Header(t *testing.T) {
@@ -40,15 +37,25 @@ func TestApplicationList_Body(t *testing.T) {
 }
 
 var _ = Describe("test Application", func() {
-	var err error
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &CtxKeyNamespace, "")
 
-	It("list applications", func() {
-		k8sClient, err = client.New(cfg, client.Options{Scheme: common.Scheme})
+	It("application num", func() {
+		num, err := applicationNum(ctx, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-
-		applicationsList := ListApplications(ctx, k8sClient)
+		Expect(num).To(Equal(1))
+	})
+	It("running application num", func() {
+		num, err := runningApplicationNum(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(num).To(Equal(1))
+	})
+	It("application running ratio", func() {
+		num := ApplicationRunningNum(cfg)
+		Expect(num).To(Equal("1/1"))
+	})
+	It("list applications", func() {
+		applicationsList, err := ListApplications(ctx, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(applicationsList.Header()).To(Equal([]string{"Name", "Namespace", "Phase", "CreateTime"}))
 		Expect(len(applicationsList.Body())).To(Equal(1))

--- a/references/cli/top/model/cluster.go
+++ b/references/cli/top/model/cluster.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"strings"
 
-	prismclusterv1alpha1 "github.com/kubevela/prism/pkg/apis/cluster/v1alpha1"
 	"github.com/oam-dev/cluster-gateway/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	prismclusterv1alpha1 "github.com/kubevela/prism/pkg/apis/cluster/v1alpha1"
 
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 )
@@ -57,7 +58,7 @@ func (l *ClusterList) Body() [][]string {
 }
 
 // ListClusters list clusters where application deploys resource
-func ListClusters(ctx context.Context, c client.Client) *ClusterList {
+func ListClusters(ctx context.Context, c client.Client) (*ClusterList, error) {
 	list := &ClusterList{
 		title: []string{"Name", "Alias", "Type", "EndPoint", "Labels"},
 		data:  []Cluster{{"all", "*", "*", "*", "*"}},
@@ -66,7 +67,7 @@ func ListClusters(ctx context.Context, c client.Client) *ClusterList {
 	ns := ctx.Value(&CtxKeyNamespace).(string)
 	app, err := LoadApplication(c, name, ns)
 	if err != nil {
-		return list
+		return list, err
 	}
 	clusterSet := make(map[string]interface{})
 
@@ -98,5 +99,5 @@ func ListClusters(ctx context.Context, c client.Client) *ClusterList {
 			list.data = append(list.data, clusterInfo)
 		}
 	}
-	return list
+	return list, nil
 }

--- a/references/cli/top/model/cluster_namespace_test.go
+++ b/references/cli/top/model/cluster_namespace_test.go
@@ -28,15 +28,16 @@ var _ = Describe("test cluster namespace", func() {
 	ctx = context.WithValue(ctx, &CtxKeyAppName, "first-vela-app")
 	ctx = context.WithValue(ctx, &CtxKeyNamespace, "default")
 	It("list cluster namespace", func() {
-		cnsList := ListClusterNamespaces(ctx, k8sClient)
+		cnsList, err := ListClusterNamespaces(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(len(cnsList.Header())).To(Equal(3))
 		Expect(cnsList.Header()).To(Equal([]string{"Name", "Status", "Age"}))
-
 		Expect(len(cnsList.Body())).To(Equal(2))
 		Expect(cnsList.Body()[1][0]).To(Equal("default"))
 	})
 	It("load cluster namespace detail info", func() {
-		ns := LoadNamespaceDetail(ctx, k8sClient, "default")
+		ns, err := LoadNamespaceDetail(ctx, k8sClient, "default")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(string(ns.Status.Phase)).To(Equal("Active"))
 	})
 })

--- a/references/cli/top/model/cluster_test.go
+++ b/references/cli/top/model/cluster_test.go
@@ -42,7 +42,8 @@ var _ = Describe("test cluster", func() {
 	ctx = context.WithValue(ctx, &CtxKeyNamespace, "default")
 
 	It("list clusters", func() {
-		clusterList := ListClusters(ctx, k8sClient)
+		clusterList, err := ListClusters(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(len(clusterList.Header())).To(Equal(5))
 		Expect(clusterList.Header()).To(Equal([]string{"Name", "Alias", "Type", "EndPoint", "Labels"}))
 		Expect(len(clusterList.Body())).To(Equal(2))

--- a/references/cli/top/model/managed_resource_test.go
+++ b/references/cli/top/model/managed_resource_test.go
@@ -26,13 +26,13 @@ import (
 )
 
 func TestK8SObjectList_Header(t *testing.T) {
-	list := K8SObjectList{title: []string{"name", "namespace", "kind", "APIVersion", "cluster", "status"}}
+	list := ManagedResourceList{title: []string{"name", "namespace", "kind", "APIVersion", "cluster", "status"}}
 	assert.Equal(t, len(list.Header()), 6)
 	assert.Equal(t, list.Header(), []string{"name", "namespace", "kind", "APIVersion", "cluster", "status"})
 }
 
 func TestK8SObjectList_Body(t *testing.T) {
-	list := K8SObjectList{data: []K8SObject{{"", "", "", "", "", ""}}}
+	list := ManagedResourceList{data: []ManagedResource{{"", "", "", "", "", ""}}}
 	assert.Equal(t, len(list.Body()), 1)
 	assert.Equal(t, list.Body(), [][]string{{"", "", "", "", "", ""}})
 }
@@ -44,7 +44,8 @@ var _ = Describe("test k8s object", func() {
 	ctx = context.WithValue(ctx, &CtxKeyCluster, "local")
 
 	It("list k8s object", func() {
-		list := ListObjects(ctx, k8sClient)
+		list, err := ListManagedResource(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(len(list.Header())).To(Equal(6))
 		Expect(len(list.Body())).To(Equal(2))
 	})

--- a/references/cli/top/model/namespace.go
+++ b/references/cli/top/model/namespace.go
@@ -34,12 +34,6 @@ type Namespace struct {
 	Age    string
 }
 
-// NamespaceList is namespace list
-type NamespaceList struct {
-	title []string
-	data  []Namespace
-}
-
 // AllNamespace is the key which represents all namespaces
 const AllNamespace = "all"
 

--- a/references/cli/top/model/namespace_test.go
+++ b/references/cli/top/model/namespace_test.go
@@ -18,7 +18,6 @@ package model
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -59,8 +58,7 @@ var _ = Describe("test namespace", func() {
 		nsList := ListNamespaces(ctx, k8sClient)
 		Expect(len(nsList.Header())).To(Equal(3))
 		Expect(nsList.Header()).To(Equal([]string{"Name", "Status", "Age"}))
-		fmt.Println(nsList.Body())
-		Expect(len(nsList.Body())).To(Equal(5))
+		Expect(len(nsList.Body())).To(Equal(6))
 		Expect(nsList.Body()[0]).To(Equal([]string{"all", "*", "*"}))
 	})
 })

--- a/references/cli/top/utils/metrics.go
+++ b/references/cli/top/utils/metrics.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"math"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+const (
+	// NA Not available.
+	NA = "N/A"
+)
+
+// Metric including requests and limits metrics
+type Metric struct {
+	CPU, Mem   int64
+	Lcpu, Lmem int64
+}
+
+// GatherPodMX return the usage metrics of a pod and specified metric including requests and limits metrics
+func GatherPodMX(pod *v1.Pod, mx *v1beta1.PodMetrics) (c, r Metric) {
+	rcpu, rmem := podRequests(pod.Spec)
+	lcpu, lmem := podLimits(pod.Spec)
+	r.CPU, r.Lcpu, r.Mem, r.Lmem = rcpu.MilliValue(), lcpu.MilliValue(), rmem.Value(), lmem.Value()
+
+	if mx != nil {
+		ccpu, cmem := podUsage(mx)
+		c.CPU, c.Mem = ccpu.MilliValue(), cmem.Value()
+	}
+	return
+}
+
+func podUsage(metrics *v1beta1.PodMetrics) (*resource.Quantity, *resource.Quantity) {
+	cpu, mem := new(resource.Quantity), new(resource.Quantity)
+	for _, co := range metrics.Containers {
+		usage := co.Usage
+
+		if len(usage) == 0 {
+			continue
+		}
+		if usage.Cpu() != nil {
+			cpu.Add(*usage.Cpu())
+		}
+		if co.Usage.Memory() != nil {
+			mem.Add(*usage.Memory())
+		}
+	}
+	return cpu, mem
+}
+
+func podLimits(spec v1.PodSpec) (*resource.Quantity, *resource.Quantity) {
+	cpu, mem := new(resource.Quantity), new(resource.Quantity)
+	for _, co := range spec.Containers {
+		limits := co.Resources.Limits
+		if len(limits) == 0 {
+			continue
+		}
+		if limits.Cpu() != nil {
+			cpu.Add(*limits.Cpu())
+		}
+		if limits.Memory() != nil {
+			mem.Add(*limits.Memory())
+		}
+	}
+	return cpu, mem
+}
+
+func podRequests(spec v1.PodSpec) (*resource.Quantity, *resource.Quantity) {
+	cpu, mem := new(resource.Quantity), new(resource.Quantity)
+	for _, co := range spec.Containers {
+		req := co.Resources.Requests
+		if len(req) == 0 {
+			continue
+		}
+		if req.Cpu() != nil {
+			cpu.Add(*req.Cpu())
+		}
+		if req.Memory() != nil {
+			mem.Add(*req.Memory())
+		}
+	}
+	return cpu, mem
+}
+
+// ToPercentage computes percentage as string otherwise n/aa.
+func ToPercentage(v1, v2 int64) int {
+	if v2 == 0 {
+		return 0
+	}
+	return int(math.Floor((float64(v1) / float64(v2)) * 100))
+}
+
+// ToPercentageStr computes percentage, but if v2 is 0, it will return NAValue instead of 0.
+func ToPercentageStr(v1, v2 int64) string {
+	if v2 == 0 {
+		return NA
+	}
+	return strconv.Itoa(ToPercentage(v1, v2)) + "%"
+}

--- a/references/cli/top/utils/metrics_test.go
+++ b/references/cli/top/utils/metrics_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+func TestToPercentageStr(t *testing.T) {
+	var v1, v2 int64
+	v1, v2 = 10, 100
+	assert.Equal(t, ToPercentageStr(v1, v2), "10%")
+	v1, v2 = 10, 0
+	assert.Equal(t, ToPercentageStr(v1, v2), NA)
+}
+
+func TestGatherPodMX(t *testing.T) {
+	quantityLimitsCPU, _ := resource.ParseQuantity("10m")
+	quantityLimitsMemory, _ := resource.ParseQuantity("10Mi")
+	quantityRequestsCPU, _ := resource.ParseQuantity("100m")
+	quantityRequestsMemory, _ := resource.ParseQuantity("50Mi")
+	quantityUsageCPU, _ := resource.ParseQuantity("8m")
+	quantityUsageMemory, _ := resource.ParseQuantity("20Mi")
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{"memory": quantityRequestsMemory, "cpu": quantityRequestsCPU},
+						Limits:   map[v1.ResourceName]resource.Quantity{"memory": quantityLimitsMemory, "cpu": quantityLimitsCPU},
+					},
+				},
+			},
+		},
+	}
+	podMetric := &v1beta1.PodMetrics{
+		Containers: []v1beta1.ContainerMetrics{
+			{
+				Name: "",
+				Usage: map[v1.ResourceName]resource.Quantity{
+					"memory": quantityUsageMemory, "cpu": quantityUsageCPU,
+				},
+			},
+		},
+	}
+
+	c, r := GatherPodMX(pod, podMetric)
+	assert.Equal(t, c.CPU, int64(8))
+	assert.Equal(t, c.Mem, int64(20971520))
+	assert.Equal(t, r.Lcpu, int64(10))
+	assert.Equal(t, r.Lmem, int64(10485760))
+	assert.Equal(t, r.CPU, int64(100))
+	assert.Equal(t, r.Mem, int64(52428800))
+}

--- a/references/cli/top/view/app_test.go
+++ b/references/cli/top/view/app_test.go
@@ -40,7 +40,7 @@ func TestApp(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 
 	t.Run("init", func(t *testing.T) {
 		app.Init()

--- a/references/cli/top/view/application_view_test.go
+++ b/references/cli/top/view/application_view_test.go
@@ -42,7 +42,7 @@ func TestApplicationView(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
 	view := NewApplicationView(ctx, app)
@@ -75,7 +75,7 @@ func TestApplicationView(t *testing.T) {
 
 	t.Run("object view", func(t *testing.T) {
 		appView.Table.Table.Table = appView.Table.Select(1, 1)
-		assert.Empty(t, appView.k8sObjectView(nil))
+		assert.Empty(t, appView.managedResourceView(nil))
 	})
 
 }

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -19,6 +19,7 @@ package view
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/gdamore/tcell/v2"
 
@@ -55,7 +56,11 @@ func (v *ClusterNamespaceView) Init() {
 
 // ListClusterNamespaces return the namespace of application's resource
 func (v *ClusterNamespaceView) ListClusterNamespaces() model.ResourceList {
-	return model.ListClusterNamespaces(v.ctx, v.app.client)
+	list, err := model.ListClusterNamespaces(v.ctx, v.app.client)
+	if err != nil {
+		log.Println(err)
+	}
+	return list
 }
 
 // Hint return key action menu hints of the cluster namespace view
@@ -71,14 +76,14 @@ func (v *ClusterNamespaceView) Name() string {
 func (v *ClusterNamespaceView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.k8sObjectView, Visible: true, Shared: true},
+		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.managedResourceView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
 	})
 }
 
-// k8sObjectView switch cluster namespace view to k8s object view
-func (v *ClusterNamespaceView) k8sObjectView(event *tcell.EventKey) *tcell.EventKey {
+// managedResourceView switch cluster namespace view to managed resource view
+func (v *ClusterNamespaceView) managedResourceView(event *tcell.EventKey) *tcell.EventKey {
 	row, _ := v.GetSelection()
 	if row == 0 {
 		return event
@@ -89,6 +94,6 @@ func (v *ClusterNamespaceView) k8sObjectView(event *tcell.EventKey) *tcell.Event
 		clusterNamespace = ""
 	}
 	v.ctx = context.WithValue(v.ctx, &model.CtxKeyClusterNamespace, clusterNamespace)
-	v.app.command.run(v.ctx, "k8s")
+	v.app.command.run(v.ctx, "resource")
 	return event
 }

--- a/references/cli/top/view/cluster_namespace_view_test.go
+++ b/references/cli/top/view/cluster_namespace_view_test.go
@@ -41,7 +41,7 @@ func TestClusterNamespaceView(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyAppName, "")
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
@@ -61,6 +61,6 @@ func TestClusterNamespaceView(t *testing.T) {
 
 	t.Run("object view", func(t *testing.T) {
 		cnsView.Table.Table.Table = cnsView.Table.Select(1, 1)
-		assert.Empty(t, cnsView.k8sObjectView(nil))
+		assert.Empty(t, cnsView.managedResourceView(nil))
 	})
 }

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -19,6 +19,7 @@ package view
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/gdamore/tcell/v2"
 
@@ -55,7 +56,11 @@ func (v *ClusterView) Init() {
 
 // ListClusters list clusters where application deployed
 func (v *ClusterView) ListClusters() model.ResourceList {
-	return model.ListClusters(v.ctx, v.app.client)
+	list, err := model.ListClusters(v.ctx, v.app.client)
+	if err != nil {
+		log.Println(err)
+	}
+	return list
 }
 
 // Name return cluster view name
@@ -71,14 +76,14 @@ func (v *ClusterView) Hint() []model.MenuHint {
 func (v *ClusterView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Goto", Action: v.k8sObjectView, Visible: true, Shared: true},
+		tcell.KeyEnter:    model.KeyAction{Description: "Goto", Action: v.managedResourceView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
 	})
 }
 
-// k8sObjectView switch cluster view to k8s object view
-func (v *ClusterView) k8sObjectView(event *tcell.EventKey) *tcell.EventKey {
+// managedResourceView switch cluster view to managed resource view
+func (v *ClusterView) managedResourceView(event *tcell.EventKey) *tcell.EventKey {
 	row, _ := v.GetSelection()
 	if row == 0 {
 		return event
@@ -89,6 +94,6 @@ func (v *ClusterView) k8sObjectView(event *tcell.EventKey) *tcell.EventKey {
 		clusterName = ""
 	}
 	v.ctx = context.WithValue(v.ctx, &model.CtxKeyCluster, clusterName)
-	v.app.command.run(v.ctx, "k8s")
+	v.app.command.run(v.ctx, "resource")
 	return event
 }

--- a/references/cli/top/view/cluster_view_test.go
+++ b/references/cli/top/view/cluster_view_test.go
@@ -42,7 +42,7 @@ func TestClusterView(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyAppName, "")
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
@@ -67,6 +67,6 @@ func TestClusterView(t *testing.T) {
 		}
 		assert.Equal(t, clusterView.GetCell(1, 0).Text, "local")
 		clusterView.Table.Table.Table = clusterView.Table.Select(1, 1)
-		assert.Empty(t, clusterView.k8sObjectView(nil))
+		assert.Empty(t, clusterView.managedResourceView(nil))
 	})
 }

--- a/references/cli/top/view/help_view_test.go
+++ b/references/cli/top/view/help_view_test.go
@@ -39,7 +39,7 @@ func TestHelpView(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	helpView := NewHelpView(app)
 
 	t.Run("init", func(t *testing.T) {

--- a/references/cli/top/view/managed_resource_view_test.go
+++ b/references/cli/top/view/managed_resource_view_test.go
@@ -42,19 +42,19 @@ func TestK8SView(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyAppName, "")
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
 	ctx = context.WithValue(ctx, &model.CtxKeyCluster, "")
 
-	view := NewK8SView(ctx, app)
-	k8sView, ok := (view).(*K8SView)
+	view := NewManagedResourceView(ctx, app)
+	k8sView, ok := (view).(*ManagedResourceView)
 	assert.Equal(t, ok, true)
 
 	t.Run("init", func(t *testing.T) {
 		k8sView.Init()
-		assert.Equal(t, k8sView.Table.GetTitle(), "[ K8S-Object (all/all) ]")
+		assert.Equal(t, k8sView.Table.GetTitle(), "[ Managed Resource (all/all) ]")
 		assert.Equal(t, k8sView.GetCell(0, 0).Text, "Name")
 	})
 

--- a/references/cli/top/view/page_stack_test.go
+++ b/references/cli/top/view/page_stack_test.go
@@ -39,7 +39,7 @@ func TestPageStack(t *testing.T) {
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
-	assert.Equal(t, len(app.Components), 4)
+	assert.Equal(t, len(app.Components()), 4)
 
 	stack := NewPageStack(app)
 	stack.Init()

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -44,8 +44,8 @@ var ResourceMap = map[string]ResourceViewer{
 	"cluster": {
 		viewFunc: NewClusterView,
 	},
-	"k8s": {
-		viewFunc: NewK8SView,
+	"resource": {
+		viewFunc: NewManagedResourceView,
 	},
 	"ns": {
 		viewFunc: NewNamespaceView,
@@ -97,7 +97,7 @@ func (v *ResourceView) buildTableBody(body [][]string) {
 	}
 }
 
-// Name return view name
+// Name return the name of view
 func (v *ResourceView) Name() string {
 	return "Resource"
 }


### PR DESCRIPTION

Signed-off-by: HanMengnan <1448189829@qq.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add more system performance info to the system info board, the system info will refresh every 10 seconds, info including:
1. application running number / application number
2. vela core  performance:
   - CPU usage / CPU limit
   - CPU usage / CPU request
   - MEM usage / MEM limit
   - MEM usage / MEM request
3. vela core cluster gateway performance:
   - CPU usage / CPU limit
   - CPU usage / CPU request
   - MEM usage / MEM limit
   - MEM usage / MEM request

<img width="1886" alt="屏幕截图 2022-08-22 102138" src="https://user-images.githubusercontent.com/30918851/185827049-8d01801f-a7be-402a-a29b-179355eb4adb.png">

---
What's more:
1. expose the error during get the resource list.
2. update the name of k8s object view to managed resource view

Fixes #4639

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->