### PR TITLE
Feat: add controller parameters for apply-once

### DIFF
--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -96,6 +96,7 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 | `featureGates.enableLegacyComponentRevision`      | if disabled, only component with rollout trait will create component revisions                                                                                                       | `false` |
 | `featureGates.gzipResourceTracker`                | if enabled, resourceTracker will be compressed using gzip before being stored                                                                                                        | `false` |
 | `featureGates.zstdResourceTracker`                | if enabled, resourceTracker will be compressed using zstd before being stored. It is much faster and more efficient than gzip. If both gzip and zstd are enabled, zstd will be used. | `false` |
+| `featureGates.applyOnce`                          | if enabled, the apply-once feature will be applied to all applications, no state-keep and no resource data storage in ResourceTracker                                                | `false` |
 
 
 ### MultiCluster parameters

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -220,6 +220,7 @@ spec:
             - "--feature-gates=LegacyComponentRevision={{- .Values.featureGates.enableLegacyComponentRevision | toString -}}"
             - "--feature-gates=GzipResourceTracker={{- .Values.featureGates.gzipResourceTracker | toString -}}"
             - "--feature-gates=ZstdResourceTracker={{- .Values.featureGates.zstdResourceTracker | toString -}}"
+            - "--feature-gates=ApplyOnce={{- .Values.featureGates.applyOnce | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}
             - "--authentication-with-user"

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -112,10 +112,12 @@ optimize:
 ##@param featureGates.enableLegacyComponentRevision if disabled, only component with rollout trait will create component revisions
 ##@param featureGates.gzipResourceTracker if enabled, resourceTracker will be compressed using gzip before being stored
 ##@param featureGates.zstdResourceTracker if enabled, resourceTracker will be compressed using zstd before being stored. It is much faster and more efficient than gzip. If both gzip and zstd are enabled, zstd will be used.
+##@param featureGates.applyOnce if enabled, the apply-once feature will be applied to all applications, no state-keep and no resource data storage in ResourceTracker
 featureGates:
   enableLegacyComponentRevision: false
   gzipResourceTracker: false
   zstdResourceTracker: false
+  applyOnce: false
 
 ## @section MultiCluster parameters
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -286,6 +286,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) stateKeep(logCtx monitorContext.Context, handler *AppHandler, app *v1beta1.Application) {
+	if feature.DefaultMutableFeatureGate.Enabled(features.ApplyOnce) {
+		return
+	}
 	if err := handler.resourceKeeper.StateKeep(logCtx); err != nil {
 		logCtx.Error(err, "Failed to run prevent-configuration-drift")
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedStateKeep, err))

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -70,6 +70,11 @@ const (
 	// If dealing with smaller ResourceTrackers (10KB - 1MB), the performance
 	// penalties are minimal.
 	ZstdResourceTracker featuregate.Feature = "ZstdResourceTracker"
+
+	// ApplyOnce enable the apply-once feature for all applications
+	// If enabled, no StateKeep will be run, ResourceTracker will also disable the storage of all resource data, only
+	// metadata will be kept
+	ApplyOnce featuregate.Feature = "ApplyOnce"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -85,6 +90,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 	GzipResourceTracker:           {Default: false, PreRelease: featuregate.Alpha},
 	ZstdResourceTracker:           {Default: false, PreRelease: featuregate.Alpha},
+	ApplyOnce:                     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/resourcekeeper/dispatch.go
+++ b/pkg/resourcekeeper/dispatch.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/pkg/auth"
+	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/resourcetracker"
@@ -56,7 +58,8 @@ func newDispatchConfig(options ...DispatchOption) *dispatchConfig {
 
 // Dispatch dispatch resources
 func (h *resourceKeeper) Dispatch(ctx context.Context, manifests []*unstructured.Unstructured, applyOpts []apply.ApplyOption, options ...DispatchOption) (err error) {
-	if h.applyOncePolicy != nil && h.applyOncePolicy.Enable && h.applyOncePolicy.Rules == nil {
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.ApplyOnce) ||
+		(h.applyOncePolicy != nil && h.applyOncePolicy.Enable && h.applyOncePolicy.Rules == nil) {
 		options = append(options, MetaOnlyOption{})
 	}
 	h.ClearNamespaceForClusterScopedResources(manifests)


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4642

Add FeatureFlag `ApplyOnce` which will enable the apply-once feature for all applications. This will
1. Disable the storage of resource data in ResourceTracker (only metadata is kept).
2. Skip the StateKeep stage in application controller.
3. The re-sync period for application is set to the informer sync period (by default 10 hours).

The re-sync period for application is also configuration in controller now. (Not available in helm chart since it is not recommended to configure for the most time. The default value of 10 hours is aligned with the [controller-runtime settings](https://github.com/kubernetes-sigs/controller-runtime/blob/bf71fc56485f6bf03e95ef6b0233ff36c695d4c9/pkg/cache/cache.go#L133).)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->