### PR TITLE
Fix: vela def wrongly use annotation to store user label

### DIFF
--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -237,7 +237,7 @@ func (def *Definition) FromCUE(val *cue.Value, templateString string) error {
 	labels := map[string]string{}
 	for k, v := range def.GetLabels() {
 		if !strings.HasPrefix(k, UserPrefix) {
-			annotations[k] = v
+			labels[k] = v
 		}
 	}
 	spec, ok := def.Object["spec"].(map[string]interface{})


### PR DESCRIPTION
fix bug, use labels to replace annotation


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->