### PR TITLE
Chore: Add v1.23 to regular CI test

### DIFF
--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -19,7 +19,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.20\"]'
+  K3D_IMAGE_VERSION: '[\"v1.24\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -19,7 +19,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.24\"]'
+  K3D_IMAGE_VERSION: '[\"v1.23\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -137,6 +137,8 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
+
 
       - name: Setup K3d (Worker)
         uses: nolar/setup-k3d-k3s@v1.0.8
@@ -144,7 +146,8 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg --egress-selector-mode=disabled@server:0
+
 
       - name: Kind Cluster (Worker)
         run: |

--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -111,7 +111,7 @@ jobs:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true
 
     steps:
@@ -157,7 +157,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default {${{ env.EGRESS_ARG }}}
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default ${{ env.EGRESS_ARG }}
 
 
       - name: Kind Cluster (Worker)

--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -19,8 +19,8 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.23\"]'
-  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
+  K3D_IMAGE_VERSION: '[\"v1.20\",\"v1.23\"]'
+  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.23\"]'
 
 jobs:
 
@@ -110,6 +110,9 @@ jobs:
     strategy:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Set up Go
@@ -132,12 +135,20 @@ jobs:
           k3d cluster delete || true
           k3d cluster delete worker || true
 
+      - name: Calculate K3d args
+        run: |
+          EGRESS_ARG=""
+          if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
+            EGRESS_ARG="--k3s-arg --egress-selector-mode=disabled@server:0"
+          fi
+          echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
+
       - name: Setup K3d (Hub)
         uses: nolar/setup-k3d-k3s@v1.0.8
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: ${{ env.EGRESS_ARG }}
 
 
       - name: Setup K3d (Worker)
@@ -146,7 +157,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default {${{ env.EGRESS_ARG }}}
 
 
       - name: Kind Cluster (Worker)

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.20\"]'
+  K3D_IMAGE_VERSION: '[\"v1.24\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -90,7 +90,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg=--egress-selector-mode=disabled@server:0
 
       - name: Generating internal worker kubeconfig
         run: |

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.24\"]'
+  K3D_IMAGE_VERSION: '[\"v1.23\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
 
       - name: Setup K3d (Worker)
         uses: nolar/setup-k3d-k3s@v1.0.8

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -90,7 +90,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg=--egress-selector-mode=disabled@server:0
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg "--egress-selector-mode=disabled@server:0"
 
       - name: Generating internal worker kubeconfig
         run: |

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -90,7 +90,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg "--egress-selector-mode=disabled@server:0"
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg --egress-selector-mode=disabled@server:0
 
       - name: Generating internal worker kubeconfig
         run: |

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true
 
 
@@ -102,7 +102,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default {{ env.EGRESS_ARG }}
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default ${{ env.EGRESS_ARG }}
 
       - name: Generating internal worker kubeconfig
         run: |

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -17,8 +17,8 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.23\"]'
-  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
+  K3D_IMAGE_VERSION: '[\"v1.20\",\"v1.23\"]'
+  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.23\"]'
 
 jobs:
 
@@ -58,6 +58,9 @@ jobs:
     strategy:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
 
     steps:
@@ -78,12 +81,20 @@ jobs:
           k3d cluster delete || true
           k3d cluster delete worker || true
 
+      - name: Calculate K3d args
+        run: |
+          EGRESS_ARG=""
+          if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
+            EGRESS_ARG="--k3s-arg --egress-selector-mode=disabled@server:0"
+          fi
+          echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
+
       - name: Setup K3d (Hub)
         uses: nolar/setup-k3d-k3s@v1.0.8
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: ${{ env.EGRESS_ARG }}
 
       - name: Setup K3d (Worker)
         uses: nolar/setup-k3d-k3s@v1.0.8
@@ -91,7 +102,7 @@ jobs:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-name: worker
-          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: --kubeconfig-update-default=false --network=k3d-k3s-default {{ env.EGRESS_ARG }}
 
       - name: Generating internal worker kubeconfig
         run: |

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.20\"]'
+  K3D_IMAGE_VERSION: '[\"v1.24\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.24\"]'
+  K3D_IMAGE_VERSION: '[\"v1.23\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
 
       - name: Load image to k3d cluster
         run: make image-load image-load-runtime-cluster

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.23\"]'
+  K3D_IMAGE_VERSION: '[\"v1.20\",\"v1.23\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -18,7 +18,7 @@ env:
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
   K3D_IMAGE_VERSION: '[\"v1.20\",\"v1.23\"]'
-  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
+  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.23\"]'
 
 jobs:
 
@@ -57,6 +57,10 @@ jobs:
     strategy:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
 
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true
 
 

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           EGRESS_ARG=""
           if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
-            EGRESS_ARG="--egress-selector-mode=disabled@server:0"
+            EGRESS_ARG="--k3s-arg --egress-selector-mode=disabled@server:0"
           fi
           echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
 
@@ -89,7 +89,7 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: --k3s-arg ${{ env.EGRESS_ARG }}
+          k3d-args: ${{ env.EGRESS_ARG }}
 
       - name: Load image to k3d cluster
         run: make image-load image-load-runtime-cluster

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -81,6 +81,7 @@ jobs:
           EGRESS_ARG=""
           if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
             EGRESS_ARG="--egress-selector-mode=disabled@server:0"
+          fi
           echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
 
       - name: Setup K3d

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -76,12 +76,19 @@ jobs:
           k3d cluster delete || true
           k3d cluster delete worker || true
 
+      - name: Calculate K3d args
+        run: |
+          EGRESS_ARG=""
+          if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
+            EGRESS_ARG="--egress-selector-mode=disabled@server:0"
+          echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
+
       - name: Setup K3d
         uses: nolar/setup-k3d-k3s@v1.0.8
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: --k3s-arg ${{ env.EGRESS_ARG }}
 
       - name: Load image to k3d cluster
         run: make image-load image-load-runtime-cluster

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.20\"]'
+  K3D_IMAGE_VERSION: '[\"v1.24\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
 
       - name: Load image to k3d cluster
         run: make image-load

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,7 +17,7 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.24\"]'
+  K3D_IMAGE_VERSION: '[\"v1.23\"]'
   K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
 
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true
 
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,8 +17,8 @@ env:
   # Common versions
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.38'
-  K3D_IMAGE_VERSION: '[\"v1.23\"]'
-  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.22\"]'
+  K3D_IMAGE_VERSION: '[\"v1.20\",\"v1.23\"]'
+  K3D_IMAGE_VERSIONS: '[\"v1.20\",\"v1.23\"]'
 
 jobs:
 
@@ -57,6 +57,10 @@ jobs:
     strategy:
       matrix:
         k8s-version: ${{ fromJson(needs.set-k8s-matrix.outputs.matrix) }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
 
     steps:
       - name: Check out code into the Go module directory
@@ -76,12 +80,20 @@ jobs:
           k3d cluster delete || true
           k3d cluster delete worker || true
 
+      - name: Calculate K3d args
+        run: |
+          EGRESS_ARG=""
+          if [[ "${{ matrix.k8s-version }}" == v1.23 ]]; then
+            EGRESS_ARG="--k3s-arg --egress-selector-mode=disabled@server:0"
+          fi
+          echo "EGRESS_ARG=${EGRESS_ARG}" >> $GITHUB_ENV 
+
       - name: Setup K3d
         uses: nolar/setup-k3d-k3s@v1.0.8
         with:
           version: ${{ matrix.k8s-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: --k3s-arg --egress-selector-mode=disabled@server:0
+          k3d-args: ${{ env.EGRESS_ARG }}
 
       - name: Load image to k3d cluster
         run: make image-load

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -43,7 +43,12 @@ import (
 )
 
 var _ = Describe("Test multicluster standalone scenario", func() {
-
+	waitObject := func(ctx context.Context, un *unstructured.Unstructured) {
+		var obj client.Object
+		Eventually(func(g Gomega) error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(un), obj)
+		}, 10*time.Second).Should(Succeed())
+	}
 	var namespace string
 	var hubCtx context.Context
 	var workerCtx context.Context
@@ -116,13 +121,13 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 
 		deploy := readFile("deployment.yaml")
 		Expect(k8sClient.Create(hubCtx, deploy)).Should(Succeed())
-		WaitObject(hubCtx, deploy)
+		waitObject(hubCtx, deploy)
 		workflow := readFile("workflow-suspend.yaml")
 		Expect(k8sClient.Create(hubCtx, workflow)).Should(Succeed())
-		WaitObject(hubCtx, workflow)
+		waitObject(hubCtx, workflow)
 		policy := readFile("policy-zero-replica.yaml")
 		Expect(k8sClient.Create(hubCtx, policy)).Should(Succeed())
-		WaitObject(hubCtx, policy)
+		waitObject(hubCtx, policy)
 		app := readFile("app-with-publish-version.yaml")
 		Expect(k8sClient.Create(hubCtx, app)).Should(Succeed())
 		appKey := client.ObjectKeyFromObject(app)
@@ -364,10 +369,3 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 		Expect(k8sClient.Get(hubCtx, key, &corev1.ConfigMap{})).Should(Satisfy(errors.IsNotFound))
 	})
 })
-
-func WaitObject(ctx context.Context, un *unstructured.Unstructured) {
-	var obj client.Object
-	Eventually(func(g Gomega) {
-		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(un), obj)).Should(Succeed())
-	}, 10*time.Second).Should(Succeed())
-}

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -44,9 +44,9 @@ import (
 
 var _ = Describe("Test multicluster standalone scenario", func() {
 	waitObject := func(ctx context.Context, un *unstructured.Unstructured) {
-		var obj client.Object
+		var obj unstructured.Unstructured
 		Eventually(func(g Gomega) error {
-			return k8sClient.Get(ctx, client.ObjectKeyFromObject(un), obj)
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(un), &obj)
 		}, 10*time.Second).Should(Succeed())
 	}
 	var namespace string

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -43,10 +43,9 @@ import (
 )
 
 var _ = Describe("Test multicluster standalone scenario", func() {
-	waitObject := func(ctx context.Context, un *unstructured.Unstructured) {
-		var obj unstructured.Unstructured
+	waitObject := func(ctx context.Context, un unstructured.Unstructured) {
 		Eventually(func(g Gomega) error {
-			return k8sClient.Get(ctx, client.ObjectKeyFromObject(un), &obj)
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(&un), &un)
 		}, 10*time.Second).Should(Succeed())
 	}
 	var namespace string
@@ -121,13 +120,13 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 
 		deploy := readFile("deployment.yaml")
 		Expect(k8sClient.Create(hubCtx, deploy)).Should(Succeed())
-		waitObject(hubCtx, deploy)
+		waitObject(hubCtx, *deploy)
 		workflow := readFile("workflow-suspend.yaml")
 		Expect(k8sClient.Create(hubCtx, workflow)).Should(Succeed())
-		waitObject(hubCtx, workflow)
+		waitObject(hubCtx, *workflow)
 		policy := readFile("policy-zero-replica.yaml")
 		Expect(k8sClient.Create(hubCtx, policy)).Should(Succeed())
-		waitObject(hubCtx, policy)
+		waitObject(hubCtx, *policy)
 		app := readFile("app-with-publish-version.yaml")
 		Expect(k8sClient.Create(hubCtx, app)).Should(Succeed())
 		appKey := client.ObjectKeyFromObject(app)

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -116,10 +116,13 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 
 		deploy := readFile("deployment.yaml")
 		Expect(k8sClient.Create(hubCtx, deploy)).Should(Succeed())
+		WaitObject(hubCtx, deploy)
 		workflow := readFile("workflow-suspend.yaml")
 		Expect(k8sClient.Create(hubCtx, workflow)).Should(Succeed())
+		WaitObject(hubCtx, workflow)
 		policy := readFile("policy-zero-replica.yaml")
 		Expect(k8sClient.Create(hubCtx, policy)).Should(Succeed())
+		WaitObject(hubCtx, policy)
 		app := readFile("app-with-publish-version.yaml")
 		Expect(k8sClient.Create(hubCtx, app)).Should(Succeed())
 		appKey := client.ObjectKeyFromObject(app)
@@ -361,3 +364,10 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 		Expect(k8sClient.Get(hubCtx, key, &corev1.ConfigMap{})).Should(Satisfy(errors.IsNotFound))
 	})
 })
+
+func WaitObject(ctx context.Context, un *unstructured.Unstructured) {
+	var obj client.Object
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(un), obj)).Should(Succeed())
+	}, 10*time.Second).Should(Succeed())
+}


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

1. Add v1.23 to regular CI test.
2. Add concurrency constraints to make efficient use of self-hosted machines.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->