### PR TITLE
Fix: useless log when enabling addon

### DIFF
--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -614,7 +614,7 @@ func svcAdditionalInfo(obj unstructured.Unstructured) (map[string]interface{}, e
 // the logic of this func totaly copy from the source-code of kubernetes tableConvertor
 // https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/printers/internalversion/printers.go#L740
 // The result is same with the output of kubectl.
-// nolint
+//nolint
 func podAdditionalInfo(obj unstructured.Unstructured) (map[string]interface{}, error) {
 	pod := v12.Pod{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &pod)
@@ -820,7 +820,7 @@ func iterateListSubResources(ctx context.Context, cluster string, k8sClient clie
 			items, err := listItemByRule(clusterCTX, k8sClient, resource, *parentObject, specifiedFunc, rule.DefaultGenListOptionFunc, rule.DisableFilterByOwnerReference)
 			if err != nil {
 				if meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) {
-					klog.Warningf("error to list sub-resources: %s err: %v", resource.Kind, err)
+					klog.Warningf("not listing sub-resources: %s err: %v", resource.Kind, err)
 					continue
 				}
 				return nil, err

--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -614,7 +614,7 @@ func svcAdditionalInfo(obj unstructured.Unstructured) (map[string]interface{}, e
 // the logic of this func totaly copy from the source-code of kubernetes tableConvertor
 // https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/printers/internalversion/printers.go#L740
 // The result is same with the output of kubectl.
-//nolint
+// nolint
 func podAdditionalInfo(obj unstructured.Unstructured) (map[string]interface{}, error) {
 	pod := v12.Pod{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &pod)
@@ -820,7 +820,7 @@ func iterateListSubResources(ctx context.Context, cluster string, k8sClient clie
 			items, err := listItemByRule(clusterCTX, k8sClient, resource, *parentObject, specifiedFunc, rule.DefaultGenListOptionFunc, rule.DisableFilterByOwnerReference)
 			if err != nil {
 				if meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) {
-					klog.Errorf("error to list sub-resources: %s err: %v", resource.Kind, err)
+					klog.Warningf("error to list sub-resources: %s err: %v", resource.Kind, err)
 					continue
 				}
 				return nil, err


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Change the logging level of `error to list sub-resources` from "error" to "warning".

Fixes #4614 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This PR just changes the logging level. No need to add extra tests.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->