### PR TITLE
Fix: enabling addon cannot update definition bug

### DIFF
--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -418,9 +418,12 @@ var _ = Describe("test override defs of addon", func() {
 		u := unstructured.Unstructured{Object: compUnstructured}
 		u.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 		u.SetKind(v1beta1.ComponentDefinitionKind)
+		u.SetLabels(map[string]string{"testUpdateLabel": "test"})
 		c, err := checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app.GetName())
 		Expect(err).Should(BeNil())
 		Expect(len(c)).Should(BeEquivalentTo(1))
+		// guarantee checkConflictDefs won't change source definition
+		Expect(u.GetLabels()["testUpdateLabel"]).Should(BeEquivalentTo("test"))
 
 		u.SetName("rollout")
 		c, err = checkConflictDefs(ctx, k8sClient, []*unstructured.Unstructured{&u}, app.GetName())

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -444,20 +444,21 @@ func generateAnnotation(meta *Meta) map[string]string {
 func checkConflictDefs(ctx context.Context, k8sClient client.Client, defs []*unstructured.Unstructured, appName string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, def := range defs {
-		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(def), def)
+		checkDef := def.DeepCopy()
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(checkDef), checkDef)
 		if err == nil {
-			owner := metav1.GetControllerOf(def)
+			owner := metav1.GetControllerOf(checkDef)
 			if owner == nil || owner.Kind != v1beta1.ApplicationKind {
-				res[def.GetName()] = fmt.Sprintf("definition: %s already exist and not belong to any addon \n", def.GetName())
+				res[checkDef.GetName()] = fmt.Sprintf("definition: %s already exist and not belong to any addon \n", checkDef.GetName())
 				continue
 			}
 			if owner.Name != appName {
 				// if addon not belong to an addon or addon name is another one, we should put them in result
-				res[def.GetName()] = fmt.Sprintf("definition: %s in this addon already exist in %s \n", def.GetName(), addon.AppName2Addon(appName))
+				res[checkDef.GetName()] = fmt.Sprintf("definition: %s in this addon already exist in %s \n", checkDef.GetName(), addon.AppName2Addon(appName))
 			}
 		}
 		if err != nil && !errors2.IsNotFound(err) {
-			return nil, errors.Wrapf(err, "check definition %s", def.GetName())
+			return nil, errors.Wrapf(err, "check definition %s", checkDef.GetName())
 		}
 	}
 	return res, nil


### PR DESCRIPTION
fix bug of enabling addon cannot update definition

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->