### PR TITLE
Feat: add nodeport in webservice

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -306,6 +306,9 @@ spec:
         		if v.name == _|_ {
         			name: "port-" + strconv.FormatInt(v.port, 10)
         		}
+        		if v.nodePort != _|_ && parameter.exposeType == "NodePort" {
+        			nodePort: v.nodePort
+        		}
         	},
         ]
         outputs: {
@@ -354,6 +357,8 @@ spec:
         		protocol: *"TCP" | "UDP" | "SCTP"
         		// +usage=Specify if the port should be exposed
         		expose: *false | bool
+        		// +usage=exposed node port. Only Valid when exposeType is NodePort
+        		nodePort?: int
         	}]
 
         	// +ignore

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -306,6 +306,9 @@ spec:
         		if v.name == _|_ {
         			name: "port-" + strconv.FormatInt(v.port, 10)
         		}
+        		if v.nodePort != _|_ && parameter.exposeType == "NodePort" {
+        			nodePort: v.nodePort
+        		}
         	},
         ]
         outputs: {
@@ -354,6 +357,8 @@ spec:
         		protocol: *"TCP" | "UDP" | "SCTP"
         		// +usage=Specify if the port should be exposed
         		expose: *false | bool
+        		// +usage=exposed node port. Only Valid when exposeType is NodePort
+        		nodePort?: int
         	}]
 
         	// +ignore

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -351,6 +351,9 @@ template: {
 			if v.name == _|_ {
 				name: "port-" + strconv.FormatInt(v.port, 10)
 			}
+			if v.nodePort != _|_ && parameter.exposeType == "NodePort" {
+				nodePort: v.nodePort
+			}
 		},
 	]
 
@@ -401,6 +404,8 @@ template: {
 			protocol: *"TCP" | "UDP" | "SCTP"
 			// +usage=Specify if the port should be exposed
 			expose: *false | bool
+			// +usage=exposed node port. Only Valid when exposeType is NodePort
+			nodePort?: int
 		}]
 
 		// +ignore


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

Enable user to specify nodePort if use nodePort type Service.
 
### Description of your changes

Adding this argument because we want to expose VelaUX with fixed nodeport. See https://github.com/kubevela/catalog/pull/461

Finally, rewrite the installation part of kubevela.io

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->