### PR TITLE
Fix: vela show panic for component markdown format

### DIFF
--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -186,4 +186,14 @@ var (
 			})
 		})
 	}
+
+	ShowCapabilityReferenceMarkdown = func(context string, capabilityName string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("should show capability reference in markdown", func() {
+				cli := fmt.Sprintf("vela show %s --format=markdown", capabilityName)
+				_, err := Exec(cli)
+				gomega.Expect(err).Should(gomega.BeNil())
+			})
+		})
+	}
 )

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -28,6 +28,7 @@ var _ = ginkgo.Describe("Trait", func() {
 
 var _ = ginkgo.Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show ingress", "ingress")
+	e2e.ShowCapabilityReferenceMarkdown("show ingress markdown", "ingress")
 
 	env := "namespace-xxxfwrr23erfm"
 	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Workload", func() {
 
 var _ = Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show webservice", "webservice")
+	e2e.ShowCapabilityReferenceMarkdown("show webservice markdown", "webservice")
 
 	env := "namespace-xxxfwrr23erfm"
 	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -186,6 +186,10 @@ func startReferenceDocsSite(ctx context.Context, ns string, c common.Args, ioStr
 	if err != nil {
 		return err
 	}
+	ref.DiscoveryMapper, err = c.GetDiscoveryMapper()
+	if err != nil {
+		return err
+	}
 	if err := ref.CreateMarkdown(ctx, capabilities, docsPath, true, pd); err != nil {
 		return err
 	}
@@ -454,6 +458,10 @@ func ShowReferenceMarkdown(ctx context.Context, c common.Args, ioStreams cmdutil
 		return err
 	}
 	ref.ParseReference = paserRef
+	ref.DiscoveryMapper, err = c.GetDiscoveryMapper()
+	if err != nil {
+		return err
+	}
 	if err := ref.GenerateReferenceDocs(ctx, c, outputPath); err != nil {
 		return errors.Wrap(err, "failed to generate reference docs")
 	}

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -171,13 +171,6 @@ func startReferenceDocsSite(ctx context.Context, ns string, c common.Args, ioStr
 	if err != nil {
 		return err
 	}
-	ref := &docgen.MarkdownReference{
-		ParseReference: docgen.ParseReference{
-			Client: cli,
-			I18N:   &docgen.En,
-		},
-	}
-
 	config, err := c.GetConfig()
 	if err != nil {
 		return err
@@ -186,10 +179,18 @@ func startReferenceDocsSite(ctx context.Context, ns string, c common.Args, ioStr
 	if err != nil {
 		return err
 	}
-	ref.DiscoveryMapper, err = c.GetDiscoveryMapper()
+	dm, err := c.GetDiscoveryMapper()
 	if err != nil {
 		return err
 	}
+	ref := &docgen.MarkdownReference{
+		ParseReference: docgen.ParseReference{
+			Client: cli,
+			I18N:   &docgen.En,
+		},
+		DiscoveryMapper: dm,
+	}
+
 	if err := ref.CreateMarkdown(ctx, capabilities, docsPath, true, pd); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

```
docgen/GenrateReerenceDocs  (dm already init) ----> CreateMarkdown -> GenerateMakrdownForCap (Need DiscoveryMapper)
show/startReferenceDocsSite (add dm init here) --|
show/ShowReferenceMarkdown (add dm init here)  --|
```

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4697

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Add e2e test for markdown format

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
