### PR TITLE
Fix: resolve an issue where uninstallation continues even if user says no

### DIFF
--- a/references/cli/uninstall_test.go
+++ b/references/cli/uninstall_test.go
@@ -19,14 +19,20 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	pkgutils "github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
 var _ = Describe("Test Install Command", func() {
@@ -62,6 +68,17 @@ var _ = Describe("Test Install Command", func() {
 		}, 1*time.Minute, 5*time.Second).Should(BeNil())
 	})
 })
+
+func TestUninstall(t *testing.T) {
+	// Test answering NO when prompted. Should just exit.
+	cmd := NewUnInstallCommand(common.Args{}, "", pkgutils.IOStreams{
+		Out: os.Stdout,
+		In:  strings.NewReader("n\n"),
+	})
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Nil(t, err, "should just exit if answer is no")
+}
 
 var fluxcdYaml = `
 apiVersion: core.oam.dev/v1beta1


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

Issue: when running `vela uninstall`, the uninstallation process **continues** even when the user said **NO**.

![Screenshot from 2022-09-12 18-47-29](https://user-images.githubusercontent.com/55270174/189635514-1325969f-e520-4591-a0bb-b5dc97dcd313.png)

This PR fixes this issue.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->