### PR TITLE
Fix: wrong endpoint for LoadBalancer type service

### DIFF
--- a/pkg/velaql/providers/query/endpoint.go
+++ b/pkg/velaql/providers/query/endpoint.go
@@ -210,10 +210,10 @@ func generatorFromService(service corev1.Service, selectorNodeIP func() string, 
 			appp := judgeAppProtocol(port.Port)
 			for _, ingress := range service.Status.LoadBalancer.Ingress {
 				if ingress.Hostname != "" {
-					serviceEndpoints = append(serviceEndpoints, formatEndpoint(ingress.Hostname, appp, port.Protocol, port.Port, false))
+					serviceEndpoints = append(serviceEndpoints, formatEndpoint(ingress.Hostname, appp, port.Protocol, port.NodePort, false))
 				}
 				if ingress.IP != "" {
-					serviceEndpoints = append(serviceEndpoints, formatEndpoint(ingress.IP, appp, port.Protocol, port.Port, false))
+					serviceEndpoints = append(serviceEndpoints, formatEndpoint(ingress.IP, appp, port.Protocol, port.NodePort, false))
 				}
 			}
 		}

--- a/pkg/velaql/providers/query/endpoint_test.go
+++ b/pkg/velaql/providers/query/endpoint_test.go
@@ -149,9 +149,25 @@ var _ = Describe("Test Query Provider", func() {
 					"type": corev1.ServiceTypeClusterIP,
 				},
 				{
+					"name": "load-balancer",
+					"ports": []corev1.ServicePort{
+						{Port: 8080, TargetPort: intstr.FromInt(8080), Name: "8080port", NodePort: 30020},
+					},
+					"type": corev1.ServiceTypeLoadBalancer,
+					"status": corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{
+									IP: "2.2.2.2",
+								},
+							},
+						},
+					},
+				},
+				{
 					"name": "seldon-ambassador-2",
 					"ports": []corev1.ServicePort{
-						{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port"},
+						{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30010},
 					},
 					"type": corev1.ServiceTypeLoadBalancer,
 					"status": corev1.ServiceStatus{
@@ -235,10 +251,11 @@ var _ = Describe("Test Query Provider", func() {
 			Expect(err).Should(BeNil())
 
 			urls := []string{
-				"http://1.1.1.1/seldon/default/sdep2",
+				"http://1.1.1.1:30010/seldon/default/sdep2",
 				"http://clusterip-2.default",
 				"clusterip-2.default:81",
-				"http://1.1.1.1",
+				"http://2.2.2.2:30020",
+				"http://1.1.1.1:30010",
 			}
 			endValue, err := v.Field("list")
 			Expect(err).Should(BeNil())

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -664,8 +664,8 @@ options: {
 			{
 				"name": "loadbalancer",
 				"ports": []corev1.ServicePort{
-					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port"},
-					{Port: 81, TargetPort: intstr.FromInt(81), Name: "81port"},
+					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30080},
+					{Port: 81, TargetPort: intstr.FromInt(81), Name: "81port", NodePort: 30081},
 				},
 				"type": corev1.ServiceTypeLoadBalancer,
 				"status": corev1.ServiceStatus{
@@ -695,7 +695,7 @@ options: {
 			{
 				"name": "seldon-ambassador",
 				"ports": []corev1.ServicePort{
-					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port"},
+					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30010},
 				},
 				"type": corev1.ServiceTypeLoadBalancer,
 				"status": corev1.ServiceStatus{
@@ -946,13 +946,13 @@ options: {
 			"https://ingress.domain.path/test",
 			"https://ingress.domain.path/test2",
 			fmt.Sprintf("http://%s:30229", gatewayIP),
-			"http://10.10.10.10",
-			"http://text.example.com",
-			"10.10.10.10:81",
-			"text.example.com:81",
+			"http://10.10.10.10:30080",
+			"http://text.example.com:30080",
+			"10.10.10.10:30081",
+			"text.example.com:30081",
 			fmt.Sprintf("http://%s:30002", gatewayIP),
 			"http://ingress.domain.helm",
-			"http://1.1.1.1/seldon/default/sdep",
+			"http://1.1.1.1:30010/seldon/default/sdep",
 			"http://gateway.domain",
 			"http://gateway.domain/api",
 			"https://demo.kubevela.net",

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -695,7 +695,7 @@ options: {
 			{
 				"name": "seldon-ambassador",
 				"ports": []corev1.ServicePort{
-					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30010},
+					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30011},
 				},
 				"type": corev1.ServiceTypeLoadBalancer,
 				"status": corev1.ServiceStatus{
@@ -952,7 +952,7 @@ options: {
 			"text.example.com:30081",
 			fmt.Sprintf("http://%s:30002", gatewayIP),
 			"http://ingress.domain.helm",
-			"http://1.1.1.1:30010/seldon/default/sdep",
+			"http://1.1.1.1:30011/seldon/default/sdep",
 			"http://gateway.domain",
 			"http://gateway.domain/api",
 			"https://demo.kubevela.net",

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -65,6 +65,9 @@ func (s *ServiceEndpoint) String() string {
 	if protocol == "tcp" {
 		return fmt.Sprintf("%s:%d%s", s.Endpoint.Host, s.Endpoint.Port, path)
 	}
+	if s.Endpoint.Port == 0 {
+		return fmt.Sprintf("%s://%s%s", protocol, s.Endpoint.Host, path)
+	}
 	return fmt.Sprintf("%s://%s:%d%s", protocol, s.Endpoint.Host, s.Endpoint.Port, path)
 }
 

--- a/references/cli/velaql_test.go
+++ b/references/cli/velaql_test.go
@@ -215,8 +215,8 @@ var _ = Describe("Test velaQL", func() {
 			{
 				"name": "loadbalancer",
 				"ports": []corev1.ServicePort{
-					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port"},
-					{Port: 81, TargetPort: intstr.FromInt(81), Name: "81port"},
+					{Port: 80, TargetPort: intstr.FromInt(80), Name: "80port", NodePort: 30180},
+					{Port: 81, TargetPort: intstr.FromInt(81), Name: "81port", NodePort: 30181},
 				},
 				"type": corev1.ServiceTypeLoadBalancer,
 				"status": corev1.ServiceStatus{
@@ -436,10 +436,10 @@ var _ = Describe("Test velaQL", func() {
 			"https://ingress.domain.path/test",
 			"https://ingress.domain.path/test2",
 			fmt.Sprintf("http://%s:30229", gatewayIP),
-			"http://10.10.10.10",
-			"http://text.example.com",
-			"10.10.10.10:81",
-			"text.example.com:81",
+			"http://10.10.10.10:30180",
+			"http://text.example.com:30180",
+			"10.10.10.10:30181",
+			"text.example.com:30181",
 			// helmRelease
 			fmt.Sprintf("http://%s:30002", gatewayIP),
 			"http://ingress.domain.helm",


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

When service type is LoadBalancer, the actual exposed port is `port.nodePort` in status. per https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec

Test: 

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/47812250/190161513-df8e7b55-713d-4d21-934f-b5f9cbff05ad.png">
<img width="925" alt="image" src="https://user-images.githubusercontent.com/47812250/190161644-3e5abbba-4d4a-4d4e-9731-589213e093c7.png">

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->