### PR TITLE
Fix: use value instead of instance in openapi.gen

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -32,7 +32,7 @@ import (
 	"text/template"
 	"time"
 
-	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v32/github"
 	"github.com/imdario/mergo"
@@ -589,18 +589,16 @@ func unmarshalToContent(content []byte) (fileContent *github.RepositoryContent, 
 	return nil, nil, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %w", fileUnmarshalError, directoryUnmarshalError)
 }
 
-// nolint:staticcheck
 func genAddonAPISchema(addonRes *UIData) error {
 	param, err := utils2.PrepareParameterCue(addonRes.Name, addonRes.Parameters)
 	if err != nil {
 		return err
 	}
-	var r cue.Runtime
-	cueInst, err := r.Compile("-", param)
+	val := cuecontext.New().CompileString(param)
 	if err != nil {
 		return err
 	}
-	data, err := common.GenOpenAPI(cueInst)
+	data, err := common.GenOpenAPI(val)
 	if err != nil {
 		return err
 	}

--- a/pkg/addon/init.go
+++ b/pkg/addon/init.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/format"
 	"cuelang.org/go/encoding/gocode/gocodec"
 	"github.com/fatih/color"
@@ -240,8 +241,7 @@ func (cmd *InitCmd) createURLComponent() error {
 // toCUEResourceString formats object to CUE string used in addons
 // nolint:staticcheck
 func toCUEResourceString(obj interface{}) (string, error) {
-	r := cue.Runtime{}
-	v, err := gocodec.New(&r, nil).Decode(obj)
+	v, err := gocodec.New((*cue.Runtime)(cuecontext.New()), nil).Decode(obj)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/appfile/helm/schema.go
+++ b/pkg/appfile/helm/schema.go
@@ -84,7 +84,6 @@ func GetChartValuesJSONSchema(ctx context.Context, h *common.Helm) ([]byte, erro
 
 // generateSchemaFromValues generate OpenAPIv3 schema based on Chart Values
 // file.
-// nolint:staticcheck
 func generateSchemaFromValues(values []byte) ([]byte, error) {
 	valuesIdentifier := "values"
 	cuectx := cuecontext.New()
@@ -104,13 +103,12 @@ func generateSchemaFromValues(values []byte) ([]byte, error) {
 	// an identifier manually
 	valuesStr := fmt.Sprintf("#%s:{\n%s\n}", valuesIdentifier, string(c))
 
-	r := cue.Runtime{}
-	inst, err := r.Compile("-", valuesStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "cannot compile CUE generated from Values.yaml")
+	val := cuecontext.New().CompileString(valuesStr)
+	if val.Err() != nil {
+		return nil, errors.Wrap(val.Err(), "cannot compile CUE generated from Values.yaml")
 	}
 	// generate OpenAPIv3 schema through cue openapi encoder
-	rawSchema, err := openapi.Gen(inst, &openapi.Config{})
+	rawSchema, err := openapi.Gen(val, &openapi.Config{})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot generate OpenAPIv3 schema")
 	}

--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -164,8 +164,7 @@ func (def *Definition) ToCUE() (*cue.Value, string, error) {
 			"attributes":  spec,
 		},
 	}
-	r := &cue.Runtime{}
-	codec := gocodec.New(r, &gocodec.Config{})
+	codec := gocodec.New((*cue.Runtime)(cuecontext.New()), &gocodec.Config{})
 	val, err := codec.Decode(obj)
 	if err != nil {
 		return nil, "", err

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/encoding/gocode/gocodec"
 	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 	"github.com/pkg/errors"
@@ -142,7 +143,7 @@ func buildTemplateFromYAML(templateYAML string, def *pkgdef.Definition) error {
 			templateObject[process.OutputsFieldName].(map[string]interface{})[name] = yamlObject
 		}
 	}
-	codec := gocodec.New(&cue.Runtime{}, &gocodec.Config{})
+	codec := gocodec.New((*cue.Runtime)(cuecontext.New()), &gocodec.Config{})
 	val, err := codec.Decode(templateObject)
 	if err != nil {
 		return errors.Wrapf(err, "failed to decode template into cue")


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix: use value instead of instance in openapi.gen

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->