### PR TITLE
Feat: add feature of refreshing resource view and fix the bug of stucking

### DIFF
--- a/references/cli/top/component/app.go
+++ b/references/cli/top/component/app.go
@@ -68,6 +68,16 @@ func (a *App) DelAction(keys []tcell.Key) {
 	a.actions.Delete(keys)
 }
 
+// QueueUpdate queues up a ui action.
+func (a *App) QueueUpdate(f func()) {
+	if a.Application == nil {
+		return
+	}
+	go func() {
+		a.Application.QueueUpdate(f)
+	}()
+}
+
 // QueueUpdateDraw queues up a ui action and redraw the ui.
 func (a *App) QueueUpdateDraw(f func()) {
 	if a.Application == nil {

--- a/references/cli/top/component/crumbs.go
+++ b/references/cli/top/component/crumbs.go
@@ -50,8 +50,8 @@ func (c *Crumbs) StackPop(_, _ model.View) {
 }
 
 // StackPush change itself when accept "push" notify from app's main view
-func (c *Crumbs) StackPush(_, component model.View) {
-	name := component.Name()
+func (c *Crumbs) StackPush(_, new model.View) {
+	name := new.Name()
 	t := tview.NewTextView()
 	t.SetBackgroundColor(config.CrumbsBackgroundColor)
 	t.SetTextAlign(tview.AlignCenter)

--- a/references/cli/top/component/crumbs.go
+++ b/references/cli/top/component/crumbs.go
@@ -50,7 +50,7 @@ func (c *Crumbs) StackPop(_, _ model.View) {
 }
 
 // StackPush change itself when accept "push" notify from app's main view
-func (c *Crumbs) StackPush(component model.View) {
+func (c *Crumbs) StackPush(_, component model.View) {
 	name := component.Name()
 	t := tview.NewTextView()
 	t.SetBackgroundColor(config.CrumbsBackgroundColor)

--- a/references/cli/top/component/crumbs_test.go
+++ b/references/cli/top/component/crumbs_test.go
@@ -27,7 +27,7 @@ func TestCrumbs(t *testing.T) {
 	assert.Equal(t, crumbs.GetItemCount(), 0)
 	t.Run("stack push", func(t *testing.T) {
 		p := NewPages()
-		crumbs.StackPush(p)
+		crumbs.StackPush(nil, p)
 		assert.Equal(t, crumbs.GetItemCount(), 2)
 	})
 	t.Run("stack pop", func(t *testing.T) {

--- a/references/cli/top/component/menu.go
+++ b/references/cli/top/component/menu.go
@@ -51,8 +51,8 @@ func (m *Menu) StackPop(_, new model.View) {
 }
 
 // StackPush change itself when accept "push" notify from app's main view
-func (m *Menu) StackPush(_, component model.View) {
-	m.UpdateMenu(component.Hint())
+func (m *Menu) StackPush(_, new model.View) {
+	m.UpdateMenu(new.Hint())
 }
 
 // UpdateMenu update menu component

--- a/references/cli/top/component/menu.go
+++ b/references/cli/top/component/menu.go
@@ -41,7 +41,7 @@ func NewMenu() *Menu {
 }
 
 // StackPop change itself when accept "pop" notify from app's main view
-func (m *Menu) StackPop(old, new model.View) {
+func (m *Menu) StackPop(_, new model.View) {
 	if new == nil {
 		m.UpdateMenu([]model.MenuHint{})
 	} else {
@@ -51,7 +51,7 @@ func (m *Menu) StackPop(old, new model.View) {
 }
 
 // StackPush change itself when accept "push" notify from app's main view
-func (m *Menu) StackPush(component model.View) {
+func (m *Menu) StackPush(_, component model.View) {
 	m.UpdateMenu(component.Hint())
 }
 

--- a/references/cli/top/component/menu_test.go
+++ b/references/cli/top/component/menu_test.go
@@ -38,7 +38,7 @@ func TestMenu(t *testing.T) {
 				Shared:      false,
 			},
 		})
-		menu.StackPush(table)
+		menu.StackPush(nil, table)
 		assert.Equal(t, menu.GetCell(0, 0).Text, " [blue:-:b]<Enter>    [:-:b] ")
 	})
 	t.Run("stack pop", func(t *testing.T) {

--- a/references/cli/top/component/pages.go
+++ b/references/cli/top/component/pages.go
@@ -65,8 +65,8 @@ func (p *Pages) StackPop(old, _ model.View) {
 }
 
 // StackPush change itself when accept "push" notify from app's main view
-func (p *Pages) StackPush(component model.View) {
-	p.addAndShow(component)
+func (p *Pages) StackPush(_, new model.View) {
+	p.addAndShow(new)
 }
 
 // AddAndShow adds a new page and bring it to front.

--- a/references/cli/top/component/pages_test.go
+++ b/references/cli/top/component/pages_test.go
@@ -43,7 +43,7 @@ func TestPages(t *testing.T) {
 		assert.Contains(t, componentID(table), "table")
 	})
 	t.Run("stack push", func(t *testing.T) {
-		pages.StackPush(table)
+		pages.StackPush(nil, table)
 		assert.Equal(t, pages.HasPage(componentID(table)), true)
 	})
 	t.Run("stack pop", func(t *testing.T) {

--- a/references/cli/top/component/table.go
+++ b/references/cli/top/component/table.go
@@ -74,7 +74,7 @@ func (t *Table) keyboard(event *tcell.EventKey) *tcell.EventKey {
 	if key == tcell.KeyUp || key == tcell.KeyDown {
 		return event
 	}
-	if a, ok := t.Actions()[tcell.Key(event.Rune())]; ok {
+	if a, ok := t.Actions()[StandardizeKey(event)]; ok {
 		return a.Action(event)
 	}
 	return event

--- a/references/cli/top/model/info_test.go
+++ b/references/cli/top/model/info_test.go
@@ -31,7 +31,7 @@ func TestInfo_CurrentContext(t *testing.T) {
 
 func TestInfo_ClusterNum(t *testing.T) {
 	info := NewInfo()
-	assert.NotEqual(t, info.ClusterNum(), "0")
+	assert.NotEmpty(t, info.ClusterNum())
 }
 
 func TestInfo_VelaCLIVersion(t *testing.T) {
@@ -47,6 +47,10 @@ func TestInfo_GOLangVersion(t *testing.T) {
 }
 
 var _ = Describe("test info", func() {
+	It("running app num", func() {
+		Expect(ApplicationRunningNum(cfg)).To(Equal("1/1"))
+	})
+
 	It("test kubernetes version", func() {
 		Expect(K8SVersion(cfg) != "UNKNOWN").To(BeTrue())
 	})

--- a/references/cli/top/model/stack.go
+++ b/references/cli/top/model/stack.go
@@ -28,9 +28,9 @@ const (
 // ViewListener listen notify from the main view of app and render itself again
 type ViewListener interface {
 	// StackPop pop old component and render component
-	StackPop(View, View)
+	StackPop(old, new View)
 	// StackPush push a new component
-	StackPush(View)
+	StackPush(old, new View)
 }
 
 // Stack is a stack to store components and notify listeners of main view of app
@@ -91,16 +91,17 @@ func (s *Stack) PopView() {
 	s.views = s.views[:len(s.views)-1]
 	s.mutex.Unlock()
 
-	s.notifyListener(StackPop, removeComponent)
+	s.notifyListener(StackPop, removeComponent, s.TopView())
 }
 
 // PushView add a new view to stack
 func (s *Stack) PushView(component View) {
+	old := s.TopView()
 	s.mutex.Lock()
 	s.views = append(s.views, component)
 	s.mutex.Unlock()
 
-	s.notifyListener(stackPush, component)
+	s.notifyListener(stackPush, old, component)
 }
 
 // Empty return whether stack is empty
@@ -115,13 +116,13 @@ func (s *Stack) Clear() {
 	}
 }
 
-func (s *Stack) notifyListener(action int, component View) {
+func (s *Stack) notifyListener(action int, old, new View) {
 	for _, listener := range s.listeners {
 		switch action {
 		case stackPush:
-			listener.StackPush(component)
+			listener.StackPush(old, new)
 		case StackPop:
-			listener.StackPop(component, s.TopView())
+			listener.StackPop(old, new)
 		}
 	}
 }

--- a/references/cli/top/model/stack.go
+++ b/references/cli/top/model/stack.go
@@ -96,10 +96,6 @@ func (s *Stack) PopView() {
 
 // PushView add a new view to stack
 func (s *Stack) PushView(component View) {
-	if top := s.TopView(); top != nil {
-		top.Stop()
-	}
-
 	s.mutex.Lock()
 	s.views = append(s.views, component)
 	s.mutex.Unlock()

--- a/references/cli/top/model/stack_test.go
+++ b/references/cli/top/model/stack_test.go
@@ -30,7 +30,7 @@ type mockListener struct {
 func (l *mockListener) StackPop(_ View, _ View) {
 	l.data--
 }
-func (l *mockListener) StackPush(_ View) {
+func (l *mockListener) StackPush(_, _ View) {
 	l.data++
 }
 

--- a/references/cli/top/view/app.go
+++ b/references/cli/top/view/app.go
@@ -80,7 +80,6 @@ func (a *App) Init() {
 	a.SetInputCapture(a.keyboard)
 
 	a.defaultView(nil)
-
 }
 
 func (a *App) layout() {

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -71,6 +71,12 @@ func (v *ApplicationView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *ApplicationView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *ApplicationView) Update() {
 	v.BuildHeader()
@@ -131,6 +137,7 @@ func (v *ApplicationView) bindKeys() {
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
 		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -48,12 +48,14 @@ func (v *ApplicationView) Init() {
 
 // Start the application view
 func (v *ApplicationView) Start() {
+	v.Clear()
 	v.Update()
+	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
 // Stop the application view
 func (v *ApplicationView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the application view
@@ -73,7 +75,7 @@ func (v *ApplicationView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *ApplicationView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -132,12 +134,10 @@ func (v *ApplicationView) Title() string {
 func (v *ApplicationView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Enter", Action: v.managedResourceView, Visible: true, Shared: true},
-		component.KeyN:    model.KeyAction{Description: "Select Namespace", Action: v.namespaceView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		tcell.KeyEnter: model.KeyAction{Description: "Enter", Action: v.managedResourceView, Visible: true, Shared: true},
+		component.KeyN: model.KeyAction{Description: "Select Namespace", Action: v.namespaceView, Visible: true, Shared: true},
+		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -148,10 +148,9 @@ func (v *ApplicationView) managedResourceView(event *tcell.EventKey) *tcell.Even
 	}
 
 	name, namespace := v.GetCell(row, 0).Text, v.GetCell(row, 1).Text
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyAppName, name)
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyNamespace, namespace)
-
-	v.app.command.run(v.ctx, "resource")
+	ctx := context.WithValue(v.ctx, &model.CtxKeyAppName, name)
+	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, namespace)
+	v.app.command.run(ctx, "resource")
 	return event
 }
 

--- a/references/cli/top/view/application_view_test.go
+++ b/references/cli/top/view/application_view_test.go
@@ -49,7 +49,6 @@ func TestApplicationView(t *testing.T) {
 	appView := new(ApplicationView)
 
 	t.Run("init view", func(t *testing.T) {
-		assert.Empty(t, appView.CommonResourceView)
 		appView.InitView(ctx, app)
 		assert.NotEmpty(t, appView.CommonResourceView)
 	})
@@ -57,6 +56,11 @@ func TestApplicationView(t *testing.T) {
 	t.Run("init", func(t *testing.T) {
 		appView.Init()
 		assert.Equal(t, appView.Table.GetTitle(), "[ Application (all) ]")
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := appView.Refresh(nil)
+		assert.Empty(t, keyEvent)
 	})
 
 	t.Run("start", func(t *testing.T) {
@@ -84,7 +88,7 @@ func TestApplicationView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(appView.Hint()), 5)
+		assert.Equal(t, len(appView.Hint()), 6)
 	})
 
 	t.Run("managed resource view", func(t *testing.T) {

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -48,12 +48,14 @@ func (v *ClusterNamespaceView) Init() {
 
 // Start the cluster namespace view
 func (v *ClusterNamespaceView) Start() {
+	v.Clear()
 	v.Update()
+	v.AutoRefresh(v.Update)
 }
 
 // Stop the cluster namespace view
 func (v *ClusterNamespaceView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the cluster namespace view
@@ -73,7 +75,7 @@ func (v *ClusterNamespaceView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *ClusterNamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -118,10 +120,8 @@ func (v *ClusterNamespaceView) ColorizeStatusText(rowNum int) {
 func (v *ClusterNamespaceView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.managedResourceView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		tcell.KeyEnter: model.KeyAction{Description: "Select", Action: v.managedResourceView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -71,6 +71,12 @@ func (v *ClusterNamespaceView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *ClusterNamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *ClusterNamespaceView) Update() {
 	v.BuildHeader()
@@ -115,6 +121,7 @@ func (v *ClusterNamespaceView) bindKeys() {
 		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.managedResourceView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/cluster_namespace_view_test.go
+++ b/references/cli/top/view/cluster_namespace_view_test.go
@@ -60,6 +60,11 @@ func TestClusterNamespaceView(t *testing.T) {
 		assert.Equal(t, cnsView.GetTitle(), "[ ClusterNamespace ]")
 	})
 
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := cnsView.Refresh(nil)
+		assert.Empty(t, keyEvent)
+	})
+
 	t.Run("start", func(t *testing.T) {
 		cnsView.Start()
 		assert.Equal(t, cnsView.GetCell(0, 0).Text, "Name")
@@ -71,7 +76,7 @@ func TestClusterNamespaceView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(cnsView.Hint()), 3)
+		assert.Equal(t, len(cnsView.Hint()), 4)
 	})
 
 	t.Run("managed resource view", func(t *testing.T) {

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -47,12 +47,14 @@ func (v *ClusterView) Name() string {
 
 // Start the cluster view
 func (v *ClusterView) Start() {
+	v.Clear()
 	v.Update()
+	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
 // Stop the cluster view
 func (v *ClusterView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the cluster view
@@ -72,7 +74,7 @@ func (v *ClusterView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *ClusterView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -101,10 +103,8 @@ func (v *ClusterView) BuildBody() {
 func (v *ClusterView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Goto", Action: v.managedResourceView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		tcell.KeyEnter: model.KeyAction{Description: "Goto", Action: v.managedResourceView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -70,6 +70,12 @@ func (v *ClusterView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *ClusterView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *ClusterView) Update() {
 	v.BuildHeader()
@@ -98,6 +104,7 @@ func (v *ClusterView) bindKeys() {
 		tcell.KeyEnter:    model.KeyAction{Description: "Goto", Action: v.managedResourceView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/cluster_view_test.go
+++ b/references/cli/top/view/cluster_view_test.go
@@ -61,8 +61,13 @@ func TestClusterView(t *testing.T) {
 		assert.Equal(t, clusterView.Table.GetTitle(), "[ Cluster ]")
 	})
 
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := clusterView.Refresh(nil)
+		assert.Empty(t, keyEvent)
+	})
+
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(clusterView.Hint()), 3)
+		assert.Equal(t, len(clusterView.Hint()), 4)
 	})
 
 	t.Run("start", func(t *testing.T) {

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -85,6 +85,12 @@ func (v *ManagedResourceView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *ManagedResourceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *ManagedResourceView) Update() {
 	v.BuildHeader()
@@ -137,6 +143,7 @@ func (v *ManagedResourceView) bindKeys() {
 		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -167,11 +167,11 @@ func (v *ManagedResourceView) podView(event *tcell.EventKey) *tcell.EventKey {
 		return event
 	}
 	name, namespace, cluster := v.GetCell(row, 0).Text, v.GetCell(row, 1).Text, v.GetCell(row, 4).Text
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyCluster, cluster)
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyClusterNamespace, namespace)
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyComponentName, name)
 
-	v.app.command.run(v.ctx, "pod")
+	ctx := context.WithValue(v.ctx, &model.CtxKeyCluster, cluster)
+	ctx = context.WithValue(ctx, &model.CtxKeyClusterNamespace, namespace)
+	ctx = context.WithValue(ctx, &model.CtxKeyComponentName, name)
+	v.app.command.run(ctx, "pod")
 	return nil
 }
 

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -49,12 +49,14 @@ func (v *ManagedResourceView) Init() {
 
 // Start the managed resource view
 func (v *ManagedResourceView) Start() {
+	v.Clear()
 	v.Update()
+	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
 // Stop the managed resource view
 func (v *ManagedResourceView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the managed resource view
@@ -87,7 +89,7 @@ func (v *ManagedResourceView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *ManagedResourceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -137,13 +139,11 @@ func (v *ManagedResourceView) ColorizeStatusText(rowNum int) {
 func (v *ManagedResourceView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Enter", Action: v.podView, Visible: true, Shared: true},
-		component.KeyC:    model.KeyAction{Description: "Select Cluster", Action: v.clusterView, Visible: true, Shared: true},
-		component.KeyN:    model.KeyAction{Description: "Select ClusterNS", Action: v.clusterNamespaceView, Visible: true, Shared: true},
-		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		tcell.KeyEnter: model.KeyAction{Description: "Enter", Action: v.podView, Visible: true, Shared: true},
+		component.KeyC: model.KeyAction{Description: "Select Cluster", Action: v.clusterView, Visible: true, Shared: true},
+		component.KeyN: model.KeyAction{Description: "Select ClusterNS", Action: v.clusterNamespaceView, Visible: true, Shared: true},
+		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/managed_resource_view_test.go
+++ b/references/cli/top/view/managed_resource_view_test.go
@@ -62,6 +62,11 @@ func TestManagedResourceView(t *testing.T) {
 		assert.Equal(t, resourceView.Table.GetTitle(), "[ Managed Resource (all/all) ]")
 	})
 
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := resourceView.Refresh(nil)
+		assert.Empty(t, keyEvent)
+	})
+
 	t.Run("start", func(t *testing.T) {
 		resourceView.Start()
 		assert.Equal(t, resourceView.GetCell(0, 0).Text, "Name")
@@ -91,7 +96,7 @@ func TestManagedResourceView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(resourceView.Hint()), 6)
+		assert.Equal(t, len(resourceView.Hint()), 7)
 	})
 
 	t.Run("select cluster", func(t *testing.T) {

--- a/references/cli/top/view/namespace_view.go
+++ b/references/cli/top/view/namespace_view.go
@@ -48,12 +48,14 @@ func (v *NamespaceView) Name() string {
 
 // Start the managed namespace view
 func (v *NamespaceView) Start() {
+	v.Clear()
 	v.Update()
+	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
 // Stop the managed namespace view
 func (v *NamespaceView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the k8s view
@@ -73,7 +75,7 @@ func (v *NamespaceView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *NamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -118,10 +120,8 @@ func (v *NamespaceView) ColorizeStatusText(rowNum int) {
 func (v *NamespaceView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.applicationView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		tcell.KeyEnter: model.KeyAction{Description: "Select", Action: v.applicationView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/namespace_view.go
+++ b/references/cli/top/view/namespace_view.go
@@ -135,7 +135,7 @@ func (v *NamespaceView) applicationView(event *tcell.EventKey) *tcell.EventKey {
 		ns = ""
 	}
 	v.app.content.PopView()
-	v.ctx = context.WithValue(v.ctx, &model.CtxKeyNamespace, ns)
-	v.app.command.run(v.ctx, "app")
+	ctx := context.WithValue(v.ctx, &model.CtxKeyNamespace, ns)
+	v.app.command.run(ctx, "app")
 	return event
 }

--- a/references/cli/top/view/namespace_view.go
+++ b/references/cli/top/view/namespace_view.go
@@ -71,6 +71,12 @@ func (v *NamespaceView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *NamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *NamespaceView) Update() {
 	v.BuildHeader()
@@ -115,6 +121,7 @@ func (v *NamespaceView) bindKeys() {
 		tcell.KeyEnter:    model.KeyAction{Description: "Select", Action: v.applicationView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/namespace_view_test.go
+++ b/references/cli/top/view/namespace_view_test.go
@@ -61,8 +61,13 @@ func TestNamespaceView(t *testing.T) {
 		assert.Equal(t, nsView.Table.GetTitle(), "[ Namespace ]")
 	})
 
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := nsView.Refresh(nil)
+		assert.Empty(t, keyEvent)
+	})
+
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(nsView.Hint()), 3)
+		assert.Equal(t, len(nsView.Hint()), 4)
 	})
 
 	t.Run("start", func(t *testing.T) {

--- a/references/cli/top/view/page_stack.go
+++ b/references/cli/top/view/page_stack.go
@@ -33,7 +33,6 @@ func NewPageStack(app *App) *PageStack {
 		Pages: component.NewPages(),
 		app:   app,
 	}
-	ps.Init()
 	return ps
 }
 
@@ -44,16 +43,19 @@ func (ps *PageStack) Init() {
 
 // StackPop change itself when accept "pop" notify from app's main view
 func (ps *PageStack) StackPop(old, new model.View) {
-	ps.app.QueueUpdate(old.Stop)
 	if new == nil {
 		return
 	}
-	ps.app.QueueUpdate(new.Start)
+	ps.app.QueueUpdateDraw(new.Start)
 	ps.app.SetFocus(new)
+	ps.app.QueueUpdate(old.Stop)
 }
 
 // StackPush change itself when accept "pop" notify from app's main view
-func (ps *PageStack) StackPush(component model.View) {
-	ps.app.QueueUpdateDraw(component.Start)
-	ps.app.SetFocus(component)
+func (ps *PageStack) StackPush(old, new model.View) {
+	ps.app.QueueUpdateDraw(new.Start)
+	ps.app.SetFocus(new)
+	if old != nil {
+		ps.app.QueueUpdate(old.Stop)
+	}
 }

--- a/references/cli/top/view/page_stack.go
+++ b/references/cli/top/view/page_stack.go
@@ -48,12 +48,11 @@ func (ps *PageStack) StackPop(old, new model.View) {
 	if new == nil {
 		return
 	}
-	new.Start()
 	ps.app.SetFocus(new)
 }
 
 // StackPush change itself when accept "pop" notify from app's main view
 func (ps *PageStack) StackPush(component model.View) {
-	component.Start()
+	ps.app.QueueUpdateDraw(component.Start)
 	ps.app.SetFocus(component)
 }

--- a/references/cli/top/view/page_stack.go
+++ b/references/cli/top/view/page_stack.go
@@ -44,10 +44,11 @@ func (ps *PageStack) Init() {
 
 // StackPop change itself when accept "pop" notify from app's main view
 func (ps *PageStack) StackPop(old, new model.View) {
-	old.Stop()
+	ps.app.QueueUpdate(old.Stop)
 	if new == nil {
 		return
 	}
+	ps.app.QueueUpdate(new.Start)
 	ps.app.SetFocus(new)
 }
 

--- a/references/cli/top/view/page_stack_test.go
+++ b/references/cli/top/view/page_stack_test.go
@@ -46,7 +46,7 @@ func TestPageStack(t *testing.T) {
 
 	t.Run("stack push", func(t *testing.T) {
 		helpView := NewHelpView(app)
-		stack.StackPush(helpView)
+		stack.StackPush(nil, helpView)
 	})
 	t.Run("stack pop", func(t *testing.T) {
 		helpView := NewHelpView(app)

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -41,12 +41,14 @@ func (v *PodView) Name() string {
 
 // Start the pod view
 func (v *PodView) Start() {
+	v.Clear()
 	v.Update()
+	v.AutoRefresh(v.Update)
 }
 
 // Stop the pod view
 func (v *PodView) Stop() {
-	v.Table.Stop()
+	v.CommonResourceView.Stop()
 }
 
 // Hint return key action menu hints of the pod view
@@ -73,7 +75,7 @@ func (v *PodView) InitView(ctx context.Context, app *App) {
 
 // Refresh the view content
 func (v *PodView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
-	v.CommonResourceView.Refresh(v.Update)
+	v.CommonResourceView.Refresh(true, v.Update)
 	return nil
 }
 
@@ -123,10 +125,8 @@ func (v *PodView) ColorizePhaseText(rowNum int) {
 func (v *PodView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
-		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
-		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
-		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
+		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -143,7 +143,6 @@ func (v *PodView) yamlView(event *tcell.EventKey) *tcell.EventKey {
 			Kind:      "Pod",
 			Name:      name,
 			Namespace: namespace,
-			//Cluster:   cluster,
 		},
 	}
 	ctx := context.WithValue(v.app.ctx, &model.CtxKeyGVR, &gvr)

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -71,6 +71,12 @@ func (v *PodView) InitView(ctx context.Context, app *App) {
 	}
 }
 
+// Refresh the view content
+func (v *PodView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
+	v.CommonResourceView.Refresh(v.Update)
+	return nil
+}
+
 // Update refresh the content of body of view
 func (v *PodView) Update() {
 	v.BuildHeader()
@@ -120,6 +126,7 @@ func (v *PodView) bindKeys() {
 		component.KeyY:    model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
 		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		component.KeyR:    model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
 	})
 }
 

--- a/references/cli/top/view/pod_view_test.go
+++ b/references/cli/top/view/pod_view_test.go
@@ -63,6 +63,12 @@ func TestPodView(t *testing.T) {
 		podView.Init()
 		assert.Equal(t, podView.Table.GetTitle(), "[ Pod ]")
 	})
+
+	t.Run("refresh", func(t *testing.T) {
+		keyEvent := podView.Refresh(nil)
+		assert.Empty(t, keyEvent)
+	})
+
 	t.Run("start", func(t *testing.T) {
 		podView.Start()
 		assert.Equal(t, podView.GetCell(0, 0).Text, "Name")
@@ -93,6 +99,6 @@ func TestPodView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(podView.Hint()), 3)
+		assert.Equal(t, len(podView.Hint()), 4)
 	})
 }

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -18,6 +18,7 @@ package view
 
 import (
 	"context"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -18,7 +18,7 @@ package view
 
 import (
 	"context"
-
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/oam-dev/kubevela/references/cli/top/component"
@@ -30,6 +30,7 @@ import (
 type ResourceView interface {
 	model.View
 	InitView(ctx context.Context, app *App)
+	Refresh(event *tcell.EventKey) *tcell.EventKey
 	Update()
 	BuildHeader()
 	BuildBody()
@@ -94,4 +95,10 @@ func (v *CommonResourceView) BuildBody(body [][]string) {
 			v.SetCell(i+1, j, c)
 		}
 	}
+}
+
+// Refresh the base resource view
+func (v *CommonResourceView) Refresh(update func()) {
+	v.Clear()
+	v.app.QueueUpdateDraw(update)
 }

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oam-dev/kubevela/references/cli/top/model"
 )
 
+// RefreshDelay is refresh delay
 const RefreshDelay = 10 * time.Second
 
 // ResourceView is the interface to abstract resource view

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -120,7 +120,7 @@ func (v *CommonResourceView) Refresh(clear bool, update func()) {
 	v.app.QueueUpdateDraw(update)
 }
 
-// AutoRefresh will refresh the view in every 5s delay
+// AutoRefresh will refresh the view in every RefreshDelay delay
 func (v *CommonResourceView) AutoRefresh(update func()) {
 	var ctx context.Context
 	ctx, v.cancelFunc = context.WithCancel(context.Background())

--- a/references/cli/top/view/resource_view_test.go
+++ b/references/cli/top/view/resource_view_test.go
@@ -19,10 +19,25 @@ package view
 import (
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResourceView_Name(t *testing.T) {
-	view := NewCommonView(nil)
+func TestResourceView(t *testing.T) {
+	app := NewApp(nil, nil, "")
+	view := NewCommonView(app)
 	assert.Equal(t, view.Name(), "Resource")
+
+	view.Init()
+	assert.Equal(t, view.GetBorderColor(), tcell.ColorWhite)
+
+	view.BuildHeader([]string{"Name", "Data"})
+	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
+
+	view.BuildBody([][]string{{"Name1", "Data1"}})
+	assert.Equal(t, view.GetCell(1, 0).Text, "Name1")
+	assert.Equal(t, view.GetCell(1, 1).Text, "Data1")
+
+	view.Refresh(func() {})
+	assert.Equal(t, view.GetCell(0, 0).Text, "")
 }

--- a/references/cli/top/view/resource_view_test.go
+++ b/references/cli/top/view/resource_view_test.go
@@ -43,9 +43,12 @@ func TestResourceView(t *testing.T) {
 	assert.Equal(t, view.GetCell(0, 0).Text, "")
 
 	view.BuildHeader([]string{"Name", "Data"})
+	view.Refresh(false, func() {})
+	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
+
+	view.BuildHeader([]string{"Name", "Data"})
 	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
 
 	view.Stop()
 	assert.Equal(t, view.GetCell(0, 0).Text, "")
-
 }

--- a/references/cli/top/view/resource_view_test.go
+++ b/references/cli/top/view/resource_view_test.go
@@ -30,6 +30,7 @@ func TestResourceView(t *testing.T) {
 
 	view.Init()
 	assert.Equal(t, view.GetBorderColor(), tcell.ColorWhite)
+	assert.Equal(t, len(view.Hint()), 2)
 
 	view.BuildHeader([]string{"Name", "Data"})
 	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
@@ -38,6 +39,13 @@ func TestResourceView(t *testing.T) {
 	assert.Equal(t, view.GetCell(1, 0).Text, "Name1")
 	assert.Equal(t, view.GetCell(1, 1).Text, "Data1")
 
-	view.Refresh(func() {})
+	view.Refresh(true, func() {})
 	assert.Equal(t, view.GetCell(0, 0).Text, "")
+
+	view.BuildHeader([]string{"Name", "Data"})
+	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
+
+	view.Stop()
+	assert.Equal(t, view.GetCell(0, 0).Text, "")
+
 }

--- a/references/cli/top/view/yaml_view.go
+++ b/references/cli/top/view/yaml_view.go
@@ -145,7 +145,7 @@ func (v *YamlView) keyboard(event *tcell.EventKey) *tcell.EventKey {
 	if key == tcell.KeyUp || key == tcell.KeyDown {
 		return event
 	}
-	if a, ok := v.actions[tcell.Key(event.Rune())]; ok {
+	if a, ok := v.actions[component.StandardizeKey(event)]; ok {
 		return a.Action(event)
 	}
 	return event


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. Add the key action R related to the refresh action. Users can press the key **R** to refresh the resource view. And more the view will refresh auto in every 10 second.

![view refresh](https://user-images.githubusercontent.com/30918851/190856653-5350b283-03f8-4517-a5c5-15ce9d1eed5a.gif)

2. I separate view initialization and data loading. Data loading uses a separate goroutine, and then the UI is redrawn after loading. On the user side, it seems that the view switching is responsive in seconds, but the data will be refreshed later.


Fixes #4741 
Fixes #4742

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->