### PR TITLE
Fix: panic when properties empty

### DIFF
--- a/pkg/workflow/step/generator.go
+++ b/pkg/workflow/step/generator.go
@@ -193,7 +193,9 @@ func (g *DeployPreApproveWorkflowStepGenerator) Generate(app *v1beta1.Applicatio
 	for _, step := range existingSteps {
 		if step.Type == "deploy" && !lastSuspend {
 			props := DeployWorkflowStepSpec{}
-			_ = utils.StrictUnmarshal(step.Properties.Raw, &props)
+			if step.Properties != nil {
+				_ = utils.StrictUnmarshal(step.Properties.Raw, &props)
+			}
 			if props.Auto != nil && !*props.Auto {
 				steps = append(steps, workflowv1alpha1.WorkflowStep{
 					WorkflowStepBase: workflowv1alpha1.WorkflowStepBase{


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

WorkflowStepGenerator will panic (DeployPreApproveWorkflowStepGenerator) when deploy step properties is not set.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->