### PR TITLE
Feat: support addon dry-run to get the yaml results

### DIFF
--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -24,13 +24,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -272,7 +272,12 @@ func SkipValidateVersion(installer *Installer) {
 	installer.skipVersionValidate = true
 }
 
-// OverrideDefinitions menas override definitions within this addon if some of them already exist
+// DryRunAddon means only generate yaml for addon instead of installing it
+func DryRunAddon(installer *Installer) {
+	installer.dryRun = true
+}
+
+// OverrideDefinitions means override definitions within this addon if some of them already exist
 func OverrideDefinitions(installer *Installer) {
 	installer.overrideDefs = true
 }
@@ -476,7 +481,7 @@ func produceDefConflictError(conflictDefs map[string]string) error {
 	return errors.New(errorInfo)
 }
 
-// checkBondComponentExistt will check the ready-to-apply object(def or auxiliary outputs) whether bind to a component
+// checkBondComponentExist will check the ready-to-apply object(def or auxiliary outputs) whether bind to a component
 // if the target component not exist, return false.
 func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Application) bool {
 	var comp string


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4371

Ref: https://github.com/kubevela/kubevela/discussions/4366

Users can use like this:

```
vela addon enable velaux --dry-run > test.yaml
kubectl apply -f test.yaml
```

or 

```
vela addon enable velaux --dry-run | kubectl apply -f -
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->