### PR TITLE
Fix: disable workflow rerun when appspec struct change (v1.5)

### DIFF
--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -122,7 +122,8 @@ var _ = Describe("Test Workflow", func() {
 				Type: "success",
 			},
 		})
-
+		revision = revision.DeepCopy()
+		revision.Name = "app-v2"
 		app.Status.Workflow = workflowStatus
 		wf = NewWorkflow(app, k8sClient, common.WorkflowModeStep, false, nil)
 		state, err = wf.ExecuteSteps(ctx, revision, runners)


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Bug: Workflow will rerun when application struct in go changes, this is the hash library's feature.
Fix: do not compare application spec hash, instead, only compare application revision name.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->