### PR TITLE
Fix: prevent workflow rerun when app spec struct change

### DIFF
--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/controller/utils"
-	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 var (
@@ -38,22 +36,6 @@ const (
 	// MessageSuspendFailedAfterRetries is the message of failed after retries
 	MessageSuspendFailedAfterRetries = "The workflow suspends automatically because the failed times of steps have reached the limit"
 )
-
-// ComputeWorkflowRevisionHash compute workflow revision.
-func ComputeWorkflowRevisionHash(rev string, app *oamcore.Application) (string, error) {
-	version := ""
-	if annos := app.Annotations; annos != nil {
-		version = annos[oam.AnnotationPublishVersion]
-	}
-	if version == "" {
-		specHash, err := utils.ComputeSpecHash(app.Spec)
-		if err != nil {
-			return "", err
-		}
-		version = fmt.Sprintf("%s:%s", rev, specHash)
-	}
-	return version, nil
-}
 
 // IsFailedAfterRetry check if application is hang due to FailedAfterRetry
 func IsFailedAfterRetry(app *oamcore.Application) bool {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Bug: Workflow will rerun when application struct in go changes, this is the hash library's feature.
Fix: do not compare application spec hash, instead, only compare application revision name.

NOTE: release-1.5 uses #4754.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

P.S. This PR is for master (v1.6+), for v1.5 and before, refer to #4754.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->