### PR TITLE
Fix: gc legacy rt with regularization

### DIFF
--- a/pkg/resourcekeeper/utils.go
+++ b/pkg/resourcekeeper/utils.go
@@ -17,18 +17,15 @@ limitations under the License.
 package resourcekeeper
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
 // ClearNamespaceForClusterScopedResources clear namespace for cluster scoped resources
 func (h *resourceKeeper) ClearNamespaceForClusterScopedResources(manifests []*unstructured.Unstructured) {
 	for _, manifest := range manifests {
-		mappings, err := h.Client.RESTMapper().RESTMappings(manifest.GroupVersionKind().GroupKind(), manifest.GroupVersionKind().Version)
-		if err != nil {
-			continue
-		}
-		if len(mappings) > 0 && mappings[0].Scope.Name() == meta.RESTScopeNameRoot {
+		if ok, err := utils.IsClusterScope(manifest.GroupVersionKind(), h.Client.RESTMapper()); err == nil && ok {
 			manifest.SetNamespace("")
 		}
 	}

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -26,7 +26,9 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -188,4 +190,11 @@ func CreateOrUpdate(ctx context.Context, cli client.Client, obj client.Object) (
 // EscapeResourceNameToLabelValue parse characters in resource name to label valid name
 func EscapeResourceNameToLabelValue(resourceName string) string {
 	return strings.ReplaceAll(resourceName, ":", "_")
+}
+
+// IsClusterScope check if the gvk is cluster scoped
+func IsClusterScope(gvk schema.GroupVersionKind, mapper meta.RESTMapper) (bool, error) {
+	mappings, err := mapper.RESTMappings(gvk.GroupKind(), gvk.Version)
+	isClusterScope := len(mappings) > 0 && mappings[0].Scope.Name() == meta.RESTScopeNameRoot
+	return isClusterScope, err
 }

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -161,5 +162,14 @@ var _ = Describe("Test Create Or Update Namespace functions", func() {
 		for k, v := range noconflictLabels {
 			Expect(gotNS.Labels).Should(HaveKeyWithValue(k, v))
 		}
+	})
+
+	It("Test IsClusterScope", func() {
+		ok, err := IsClusterScope(v1.SchemeGroupVersion.WithKind("ConfigMap"), k8sClient.RESTMapper())
+		Expect(err).Should(Succeed())
+		Expect(ok).Should(BeFalse())
+		ok, err = IsClusterScope(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"), k8sClient.RESTMapper())
+		Expect(err).Should(Succeed())
+		Expect(ok).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The legacy ResourceTracker records resources without the removal of `namespace` field for cluster-scoped resources. Like fluxcd addon records `helmrelease` CRD in ResourceTracker with namespace `vela-system` which is inaccurate. 

PR #4193 fixes this but leave a comparison between legacy RTs and latest RTs. In latest fluxcd addon, when upgraded with v1.5+, the `helmrelease` CRD is recorded without the recording of namespace `vela-system` and therefore the controller mis-recognize the `helmrelease` CRD 'in vela-system' is not in-use so it is removed.

This PR adds a ResourceTracker regularization process before GC and therefore help keep compatibility between legacy RTs and latest RTs.

Fixes:
- https://github.com/kubevela/catalog/issues/470)

Might related and probably fixed (not sure if the detail issue reproduction scenario)
- https://github.com/kubevela/kubevela/issues/4737

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->