### PR TITLE
Fix: memory leak of the apiserver

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -94,7 +94,7 @@ func main() {
 	defer cancel()
 
 	if s.serverConfig.PprofAddr != "" {
-		go utils.EnablePprof(ctx, s.serverConfig.PprofAddr)
+		go utils.EnablePprof(s.serverConfig.PprofAddr, errChan)
 	}
 
 	go func() {

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -162,7 +162,7 @@ func main() {
 
 	if pprofAddr != "" {
 		// Start pprof server if enabled
-		go pkgutils.EnablePprof(context.Background(), pprofAddr)
+		go pkgutils.EnablePprof(pprofAddr, nil)
 	}
 
 	if logFilePath != "" {

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -22,8 +22,6 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
-	"net/http"
-	"net/http/pprof"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -57,6 +55,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
+	pkgutils "github.com/oam-dev/kubevela/pkg/utils"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
@@ -163,36 +162,7 @@ func main() {
 
 	if pprofAddr != "" {
 		// Start pprof server if enabled
-		mux := http.NewServeMux()
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		pprofServer := http.Server{
-			Addr:    pprofAddr,
-			Handler: mux,
-		}
-		klog.InfoS("Starting debug HTTP server", "addr", pprofServer.Addr)
-
-		go func() {
-			go func() {
-				ctx := context.Background()
-				<-ctx.Done()
-
-				ctx, cancelFunc := context.WithTimeout(context.Background(), 60*time.Minute)
-				defer cancelFunc()
-
-				if err := pprofServer.Shutdown(ctx); err != nil {
-					klog.Error(err, "Failed to shutdown debug HTTP server")
-				}
-			}()
-
-			if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
-				klog.Error(err, "Failed to start debug HTTP server")
-				panic(err)
-			}
-		}()
+		go pkgutils.EnablePprof(context.Background(), pprofAddr)
 	}
 
 	if logFilePath != "" {

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -46,6 +46,9 @@ type Config struct {
 
 	// KubeQPS the QPS of kube client
 	KubeQPS float64
+
+	// PprofAddr the address for pprof to use while exporting profiling results.
+	PprofAddr string
 }
 
 type leaderConfig struct {

--- a/pkg/utils/pprof.go
+++ b/pkg/utils/pprof.go
@@ -39,7 +39,8 @@ func EnablePprof(ctx context.Context, pprofAddr string) {
 		Addr:    pprofAddr,
 		Handler: mux,
 	}
-	defer func() {
+	go func() {
+		<-ctx.Done()
 		ctx, cancelFunc := context.WithTimeout(ctx, 60*time.Second)
 		defer cancelFunc()
 

--- a/pkg/utils/pprof.go
+++ b/pkg/utils/pprof.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+)
+
+// EnablePprof listen to the pprofAddr and export the profiling results
+func EnablePprof(ctx context.Context, pprofAddr string) {
+	// Start pprof server if enabled
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	pprofServer := http.Server{
+		Addr:    pprofAddr,
+		Handler: mux,
+	}
+	defer func() {
+		ctx, cancelFunc := context.WithTimeout(ctx, 60*time.Second)
+		defer cancelFunc()
+
+		if err := pprofServer.Shutdown(ctx); err != nil {
+			klog.Error(err, "Failed to shutdown debug HTTP server")
+		}
+	}()
+
+	klog.InfoS("Starting debug HTTP server", "addr", pprofServer.Addr)
+
+	if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+		klog.Error(err, "Failed to start debug HTTP server")
+		panic(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

There are two points:

1. The `json.Marshal` and `json.Unmarshal` consume much memory.
2. Not call the `Done` function of the queue. The app object will pile up in a queue.

Now:

![image](https://user-images.githubusercontent.com/18493394/191477721-6109e72a-a410-40e4-93a7-356a56abd1f4.png)

![image](https://user-images.githubusercontent.com/18493394/191477844-7f0988f0-d0d9-4263-98f2-b1f65b1404ee.png)

|  Item  | Before | Now |
|  ----  | ----  | ----  |
| Application Number  | 700+ |  1.4K |
| Application Create/Update  | 3 request/second |   10 request/second |
| KubeVela Core Memory  | 600Mi+ | 1057Mi |
| APIServer Memory(Master) | 900Mi+ | 300Mi | 


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->