### PR TITLE
Feat: Add more data field to application view and managed resource view in vela top

### DIFF
--- a/references/cli/top/model/application_test.go
+++ b/references/cli/top/model/application_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestApplicationList_ToTableBody(t *testing.T) {
-	appList := &ApplicationList{{"Name", "Namespace", "Phase", "CreateTime"}}
-	assert.Equal(t, appList.ToTableBody(), [][]string{{"Name", "Namespace", "Phase", "CreateTime"}})
+	appList := &ApplicationList{{"Name", "Namespace", "Phase", "", "", "", "CreateTime"}}
+	assert.Equal(t, appList.ToTableBody(), [][]string{{"Name", "Namespace", "Phase", "", "", "", "CreateTime"}})
 }
 
 var _ = Describe("test Application", func() {

--- a/references/cli/top/model/managed_resource_test.go
+++ b/references/cli/top/model/managed_resource_test.go
@@ -26,14 +26,14 @@ import (
 )
 
 func TestListManagedResource(t *testing.T) {
-	list := ManagedResourceList{{"", "", "", "", "", ""}}
-	assert.Equal(t, list.ToTableBody(), [][]string{{"", "", "", "", "", ""}})
+	list := ManagedResourceList{{"", "", "", "", "", "", ""}}
+	assert.Equal(t, list.ToTableBody(), [][]string{{"", "", "", "", "", "", ""}})
 }
 
 func TestManagedResourceList_FilterCluster(t *testing.T) {
 	list := ManagedResourceList{
-		{"", "", "", "", "1", ""},
-		{"", "", "", "", "2", ""},
+		{"", "", "", "", "1", "", ""},
+		{"", "", "", "", "2", "", ""},
 	}
 	list.FilterCluster("1")
 	assert.Equal(t, len(list), 1)
@@ -41,8 +41,8 @@ func TestManagedResourceList_FilterCluster(t *testing.T) {
 
 func TestManagedResourceList_FilterClusterNamespace(t *testing.T) {
 	list := ManagedResourceList{
-		{"", "1", "", "", "1", ""},
-		{"", "2", "", "", "2", ""},
+		{"", "1", "", "", "1", "", ""},
+		{"", "2", "", "", "2", "", ""},
 	}
 	list.FilterClusterNamespace("2")
 	assert.Equal(t, len(list), 1)

--- a/references/cli/top/model/suit_test.go
+++ b/references/cli/top/model/suit_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
+	"github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -91,6 +91,20 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).Should(BeNil())
 	testApp.Status = common2.AppStatus{
 		Phase: common2.ApplicationRunning,
+		Workflow: &common2.WorkflowStatus{
+			AppRevision:    "",
+			Mode:           "DAG",
+			Phase:          "",
+			Message:        "",
+			Suspend:        false,
+			SuspendState:   "",
+			Terminated:     false,
+			Finished:       false,
+			ContextBackend: nil,
+			Steps:          []v1alpha1.WorkflowStepStatus{},
+			StartTime:      metav1.Time{},
+			EndTime:        metav1.Time{},
+		},
 		AppliedResources: []common2.ClusterObjectReference{
 			{
 				Cluster: "",

--- a/references/cli/top/view/app.go
+++ b/references/cli/top/view/app.go
@@ -146,7 +146,7 @@ func (a *App) inject(v model.View) {
 
 func (a *App) bindKeys() {
 	a.AddAction(model.KeyActions{
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: a.Back, Visible: true, Shared: true},
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: a.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: a.helpView, Visible: true, Shared: true},
 	})
 }
@@ -181,5 +181,11 @@ func (a *App) Back(_ *tcell.EventKey) *tcell.EventKey {
 	if !a.content.IsLastView() {
 		a.content.PopView()
 	}
+	return nil
+}
+
+// Exist the app
+func (a *App) Exist(_ *tcell.EventKey) *tcell.EventKey {
+	a.Stop()
 	return nil
 }

--- a/references/cli/top/view/app_test.go
+++ b/references/cli/top/view/app_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/references/cli/top/component"
 )
 
 func TestApp(t *testing.T) {
@@ -45,7 +46,7 @@ func TestApp(t *testing.T) {
 	t.Run("init", func(t *testing.T) {
 		app.Init()
 		assert.Equal(t, app.Main.HasPage("main"), true)
-		_, ok := app.HasAction(tcell.KeyESC)
+		_, ok := app.HasAction(component.KeyQ)
 		assert.Equal(t, ok, true)
 		app.content.Stack.RemoveListener(app.Crumbs())
 		assert.NotEmpty(t, app.content.Stack.TopView())
@@ -53,7 +54,7 @@ func TestApp(t *testing.T) {
 		assert.Equal(t, app.content.Stack.IsLastView(), true)
 	})
 	t.Run("keyboard", func(t *testing.T) {
-		evt1 := tcell.NewEventKey(tcell.KeyEsc, '/', 0)
+		evt1 := tcell.NewEventKey(component.KeyQ, '/', 0)
 		assert.Empty(t, app.keyboard(evt1))
 		evt2 := tcell.NewEventKey(tcell.KeyTAB, '/', 0)
 		assert.NotEmpty(t, app.keyboard(evt2))

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -87,7 +87,7 @@ func (v *ApplicationView) Update() {
 
 // BuildHeader render the header of table
 func (v *ApplicationView) BuildHeader() {
-	header := []string{"Name", "Namespace", "Phase", "CreateTime"}
+	header := []string{"Name", "Namespace", "Phase", "WorkflowMode", "Workflow", "Service", "CreateTime"}
 	v.CommonResourceView.BuildHeader(header)
 }
 
@@ -134,6 +134,7 @@ func (v *ApplicationView) Title() string {
 func (v *ApplicationView) bindKeys() {
 	v.Actions().Delete([]tcell.Key{tcell.KeyEnter})
 	v.Actions().Add(model.KeyActions{
+		tcell.KeyESC:   model.KeyAction{Description: "Exist", Action: v.app.Exist, Visible: true, Shared: true},
 		tcell.KeyEnter: model.KeyAction{Description: "Enter", Action: v.managedResourceView, Visible: true, Shared: true},
 		component.KeyN: model.KeyAction{Description: "Select Namespace", Action: v.namespaceView, Visible: true, Shared: true},
 		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},

--- a/references/cli/top/view/application_view_test.go
+++ b/references/cli/top/view/application_view_test.go
@@ -88,7 +88,7 @@ func TestApplicationView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(appView.Hint()), 6)
+		assert.Equal(t, len(appView.Hint()), 7)
 	})
 
 	t.Run("managed resource view", func(t *testing.T) {

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -137,6 +137,7 @@ func (v *ClusterNamespaceView) managedResourceView(event *tcell.EventKey) *tcell
 		clusterNamespace = ""
 	}
 	v.app.content.PopView()
+	v.app.content.PopView()
 	v.ctx = context.WithValue(v.ctx, &model.CtxKeyClusterNamespace, clusterNamespace)
 	v.app.command.run(v.ctx, "resource")
 	return event

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -119,6 +119,7 @@ func (v *ClusterView) managedResourceView(event *tcell.EventKey) *tcell.EventKey
 		clusterName = ""
 	}
 	v.app.content.PopView()
+	v.app.content.PopView()
 	v.ctx = context.WithValue(v.ctx, &model.CtxKeyCluster, clusterName)
 	v.app.command.run(v.ctx, "resource")
 	return event

--- a/references/cli/top/view/help_view.go
+++ b/references/cli/top/view/help_view.go
@@ -19,8 +19,6 @@ package view
 import (
 	"fmt"
 
-	"github.com/gdamore/tcell/v2"
-
 	"github.com/oam-dev/kubevela/references/cli/top/component"
 	"github.com/oam-dev/kubevela/references/cli/top/config"
 	"github.com/oam-dev/kubevela/references/cli/top/model"
@@ -56,7 +54,7 @@ func (v *HelpView) Name() string {
 
 func (v *HelpView) bindKeys() {
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 	})
 }

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -149,14 +149,12 @@ func (v *ManagedResourceView) bindKeys() {
 
 // clusterView switch managed resource view to the cluster view
 func (v *ManagedResourceView) clusterView(event *tcell.EventKey) *tcell.EventKey {
-	v.app.content.PopView()
 	v.app.command.run(v.ctx, "cluster")
 	return event
 }
 
 // clusterView switch managed resource view to the cluster Namespace view
 func (v *ManagedResourceView) clusterNamespaceView(event *tcell.EventKey) *tcell.EventKey {
-	v.app.content.PopView()
 	v.app.command.run(v.ctx, "cns")
 	return event
 }

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -101,7 +101,7 @@ func (v *ManagedResourceView) Update() {
 
 // BuildHeader render the header of table
 func (v *ManagedResourceView) BuildHeader() {
-	header := []string{"Name", "Namespace", "Kind", "APIVersion", "Cluster", "Status"}
+	header := []string{"Name", "Namespace", "Kind", "APIVersion", "Cluster", "Component", "Status"}
 	v.CommonResourceView.BuildHeader(header)
 }
 

--- a/references/cli/top/view/resource_view.go
+++ b/references/cli/top/view/resource_view.go
@@ -139,8 +139,9 @@ func (v *CommonResourceView) AutoRefresh(update func()) {
 }
 
 func (v *CommonResourceView) bindKeys() {
+	v.Actions().Delete([]tcell.Key{tcell.KeyESC})
 	v.Actions().Add(model.KeyActions{
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
 	})
 }

--- a/references/cli/top/view/yaml_view.go
+++ b/references/cli/top/view/yaml_view.go
@@ -154,7 +154,7 @@ func (v *YamlView) keyboard(event *tcell.EventKey) *tcell.EventKey {
 func (v *YamlView) bindKeys() {
 	v.actions.Delete([]tcell.Key{tcell.KeyEnter})
 	v.actions.Add(model.KeyActions{
-		tcell.KeyESC:      model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
 	})
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

At present, the data in the app view and managed resource view are relatively thin. We should add some fields to these fields.

About application, add:

- workflow step mode
- finished workflow / total workflow
- running service / total service

![image](https://user-images.githubusercontent.com/30918851/192129236-70e51dff-50b1-4b4c-9fd4-157bb6e198cd.png)


About managed resource, add:

- of which component

![image](https://user-images.githubusercontent.com/30918851/192129242-b5701db1-ac79-45ab-8b49-5b6bc270e5ad.png)


---

And more, change the key to return to the previous view to **Q** key, the function of the ESC key is to exit on the home page.

Fixes #4780

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->