### PR TITLE
Fix: it does not check the same name for 'vela env init'

### DIFF
--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -73,6 +73,17 @@ func CreateEnv(envArgs *types.EnvMeta) error {
 		}
 	}
 	ctx := context.TODO()
+
+	var nsList v1.NamespaceList
+	err = c.List(ctx, &nsList, client.MatchingLabels{oam.LabelControlPlaneNamespaceUsage: oam.VelaNamespaceUsageEnv,
+		oam.LabelNamespaceOfEnvName: envArgs.Name})
+	if err != nil {
+		return err
+	}
+	if len(nsList.Items) > 0 {
+		return fmt.Errorf("env name %s already exists", envArgs.Name)
+	}
+
 	namespace, err := utils.GetNamespace(ctx, c, envArgs.Namespace)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>


### Description of your changes
Add duplicate name check when creating env through vela env init

Fixes #4793 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

### Special notes for your reviewer
