### PR TITLE
Feat: add resource topology view in `vela top`

### DIFF
--- a/references/cli/top/component/tree_node.go
+++ b/references/cli/top/component/tree_node.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package component
+
+import (
+	"fmt"
+
+	"github.com/kubevela/workflow/api/v1alpha1"
+
+	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+)
+
+const (
+	component           = "🧩"
+	workflow            = "👟"
+	policy              = "📜"
+	trait               = "🔧"
+	app                 = "🎯"
+	other               = "🚓"
+	workflowStepSucceed = "✅"
+)
+
+const colorFmt = "%s [%s::b]%s[::]"
+
+// EmojiFormat format the name with the emoji
+func EmojiFormat(name string, kind string) string {
+	switch kind {
+	case "app":
+		return fmt.Sprintf(colorFmt, app, "red", name)
+	case "workflow":
+		return fmt.Sprintf(colorFmt, workflow, "yellow", name)
+	case "component":
+		return fmt.Sprintf(colorFmt, component, "green", name)
+	case "policy":
+		return fmt.Sprintf(colorFmt, policy, "orange", name)
+	case "trait":
+		return fmt.Sprintf(colorFmt, trait, "lightseagreen", name)
+	default:
+		return fmt.Sprintf(colorFmt, other, "blue", name)
+	}
+}
+
+const workflowStepFmt = "[::b]%s %s[::]"
+
+// WorkflowStepFormat format the workflow step text with the emoji
+func WorkflowStepFormat(name string, status v1alpha1.WorkflowStepPhase) string {
+	switch status {
+	case v1alpha1.WorkflowStepPhaseSucceeded:
+		return fmt.Sprintf(workflowStepFmt, name, workflowStepSucceed)
+	default:
+		return name
+	}
+}
+
+const statusColorFmt = "[%s::b]%s[::]"
+
+// ColorizeStatus colorize the status text
+func ColorizeStatus(status types.HealthStatusCode) string {
+	switch status {
+	case types.HealthStatusHealthy:
+		return fmt.Sprintf(statusColorFmt, "green", status)
+	case types.HealthStatusUnHealthy:
+		return fmt.Sprintf(statusColorFmt, "red", status)
+	case types.HealthStatusProgressing:
+		return fmt.Sprintf(statusColorFmt, "orange", status)
+	default:
+		return fmt.Sprintf(statusColorFmt, "gray", status)
+	}
+}
+
+const kindColorFmt = "[%s::b]%s[::]"
+
+// ColorizeKind colorize the kind text
+func ColorizeKind(kind string) string {
+	return fmt.Sprintf(kindColorFmt, "orange", kind)
+}

--- a/references/cli/top/component/tree_node_test.go
+++ b/references/cli/top/component/tree_node_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package component
+
+import (
+	"testing"
+
+	"github.com/kubevela/workflow/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+)
+
+func TestEmojiFormat(t *testing.T) {
+	assert.Contains(t, EmojiFormat("app", "app"), "red")
+	assert.Contains(t, EmojiFormat("app", "app"), "🎯")
+
+	assert.Contains(t, EmojiFormat("workflow", "workflow"), "yellow")
+	assert.Contains(t, EmojiFormat("workflow", "workflow"), "👟")
+
+	assert.Contains(t, EmojiFormat("component", "component"), "green")
+	assert.Contains(t, EmojiFormat("component", "component"), "🧩")
+
+	assert.Contains(t, EmojiFormat("policy", "policy"), "orange")
+	assert.Contains(t, EmojiFormat("policy", "policy"), "📜")
+
+	assert.Contains(t, EmojiFormat("trait", "trait"), "lightseagreen")
+	assert.Contains(t, EmojiFormat("trait", "trait"), "🔧")
+
+	assert.Contains(t, EmojiFormat("service", "service"), "blue")
+	assert.Contains(t, EmojiFormat("service", "service"), "🚓")
+}
+
+func TestColorizeKind(t *testing.T) {
+	assert.Contains(t, ColorizeKind("Pod"), "orange")
+}
+
+func TestColorizeStatus(t *testing.T) {
+	assert.Contains(t, ColorizeStatus(types.HealthStatusHealthy), "green")
+	assert.Contains(t, ColorizeStatus(types.HealthStatusUnHealthy), "red")
+	assert.Contains(t, ColorizeStatus(types.HealthStatusProgressing), "orange")
+	assert.Contains(t, ColorizeStatus(types.HealthStatusUnKnown), "gray")
+}
+
+func TestWorkflowStepFormat(t *testing.T) {
+	assert.Contains(t, WorkflowStepFormat("step1", v1alpha1.WorkflowStepPhaseSucceeded), "✅")
+	assert.NotContains(t, WorkflowStepFormat("step2", v1alpha1.WorkflowStepPhaseFailed), "✅")
+}

--- a/references/cli/top/model/application_test.go
+++ b/references/cli/top/model/application_test.go
@@ -61,4 +61,9 @@ var _ = Describe("test Application", func() {
 		Expect(application.ClusterName).To(Equal(""))
 		Expect(len(application.Spec.Components)).To(Equal(1))
 	})
+	It("application resource topology", func() {
+		topology, err := ApplicationResourceTopology(k8sClient, "first-vela-app", "default")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(topology)).To(Equal(4))
+	})
 })

--- a/references/cli/top/model/suit_test.go
+++ b/references/cli/top/model/suit_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/kubevela/workflow/api/v1alpha1"
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"

--- a/references/cli/top/model/suit_test.go
+++ b/references/cli/top/model/suit_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/kubevela/workflow/api/v1alpha1"
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
@@ -238,8 +238,12 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient.Create(context.TODO(), rs)).Should(BeNil())
 	// create pod
 	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod",
+			Name:      "pod1",
 			Namespace: namespace,
 			Labels:    map[string]string{"app": "test"},
 		},
@@ -316,7 +320,7 @@ var _ = BeforeSuite(func(done Done) {
 					ClusterObjectReference: common2.ClusterObjectReference{
 						Cluster: "",
 						ObjectReference: corev1.ObjectReference{
-							APIVersion: "apps/v1",
+							APIVersion: "v1",
 							Kind:       "Pod",
 							Namespace:  namespace,
 							Name:       "pod1",

--- a/references/cli/top/view/application_topology_view.go
+++ b/references/cli/top/view/application_topology_view.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+	"github.com/oam-dev/kubevela/references/cli/top/component"
+	"github.com/oam-dev/kubevela/references/cli/top/config"
+	"github.com/oam-dev/kubevela/references/cli/top/model"
+)
+
+// TopologyView display the resource topology of application
+type TopologyView struct {
+	*tview.Grid
+	app           *App
+	actions       model.KeyActions
+	ctx           context.Context
+	focusTopology bool
+}
+
+type topologyTree struct {
+	*tview.TreeView
+}
+
+var (
+	topologyViewInstance     = new(TopologyView)
+	appTopologyInstance      = new(topologyTree)
+	resourceTopologyInstance = new(topologyTree)
+)
+
+// NewTopologyView return a new topology view
+func NewTopologyView(ctx context.Context, app *App) model.View {
+	topologyViewInstance.app = app
+	topologyViewInstance.ctx = ctx
+
+	if topologyViewInstance.Grid == nil {
+		topologyViewInstance.Grid = tview.NewGrid()
+		topologyViewInstance.actions = make(model.KeyActions)
+		topologyViewInstance.Init()
+	}
+	return topologyViewInstance
+}
+
+// Init the topology view
+func (v *TopologyView) Init() {
+	title := fmt.Sprintf("[ %s ]", v.Name())
+	v.SetRows(0).SetColumns(-1, -1)
+	v.SetBorder(true)
+	v.SetBorderAttributes(tcell.AttrItalic)
+	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
+	v.bindKeys()
+	v.SetInputCapture(v.keyboard)
+}
+
+// Start the topology view
+func (v *TopologyView) Start() {
+	appTopology := v.NewAppTopologyView()
+	resourceTopology := v.NewResourceTopologyView()
+
+	v.Grid.AddItem(appTopology, 0, 0, 1, 1, 0, 0, true)
+	v.Grid.AddItem(resourceTopology, 0, 1, 1, 1, 0, 0, true)
+
+	v.app.SetFocus(appTopology)
+}
+
+// Stop the topology view
+func (v *TopologyView) Stop() {
+	v.Grid.Clear()
+}
+
+// Hint return the menu hints of topology view
+func (v *TopologyView) Hint() []model.MenuHint {
+	return v.actions.Hint()
+}
+
+// Name return the name of topology view
+func (v *TopologyView) Name() string {
+	return "Topology"
+}
+
+func (v *TopologyView) keyboard(event *tcell.EventKey) *tcell.EventKey {
+	key := event.Key()
+	if key == tcell.KeyUp || key == tcell.KeyDown {
+		return event
+	}
+	if a, ok := v.actions[component.StandardizeKey(event)]; ok {
+		return a.Action(event)
+	}
+	return event
+}
+
+func (v *TopologyView) bindKeys() {
+	v.actions.Delete([]tcell.Key{tcell.KeyEnter})
+	v.actions.Add(model.KeyActions{
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
+		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+		tcell.KeyTAB:      model.KeyAction{Description: "Switch", Action: v.switchTopology, Visible: true, Shared: true},
+	})
+}
+
+// NewResourceTopologyView return a new resource topology view
+func (v *TopologyView) NewResourceTopologyView() tview.Primitive {
+	if resourceTopologyInstance.TreeView == nil {
+		resourceTopologyInstance.TreeView = tview.NewTreeView()
+		resourceTopologyInstance.SetGraphics(true)
+		resourceTopologyInstance.SetGraphicsColor(tcell.ColorCadetBlue)
+		resourceTopologyInstance.SetBorder(true)
+		resourceTopologyInstance.SetTitle(fmt.Sprintf("[ %s ]", "Resource"))
+	}
+
+	appName := v.ctx.Value(&model.CtxKeyAppName).(string)
+	namespace := v.ctx.Value(&model.CtxKeyNamespace).(string)
+
+	root := tview.NewTreeNode(component.EmojiFormat(fmt.Sprintf("%s (%s)", appName, namespace), "app")).SetSelectable(true)
+	resourceTopologyInstance.SetRoot(root)
+
+	resourceTree, err := model.ApplicationResourceTopology(v.app.client, appName, namespace)
+	if err != nil {
+		return resourceTopologyInstance
+	}
+	for _, resource := range resourceTree {
+		root.AddChild(buildTopology(resource.ResourceTree))
+	}
+
+	return resourceTopologyInstance
+}
+
+// NewAppTopologyView return a new app topology view
+func (v *TopologyView) NewAppTopologyView() tview.Primitive {
+	if appTopologyInstance.TreeView == nil {
+		appTopologyInstance.TreeView = tview.NewTreeView()
+		appTopologyInstance.SetGraphics(true)
+		appTopologyInstance.SetGraphicsColor(tcell.ColorCadetBlue)
+		appTopologyInstance.SetBorder(true)
+		appTopologyInstance.SetTitle(fmt.Sprintf("[ %s ]", "App"))
+	}
+
+	appName := v.ctx.Value(&model.CtxKeyAppName).(string)
+	namespace := v.ctx.Value(&model.CtxKeyNamespace).(string)
+
+	root := tview.NewTreeNode(component.EmojiFormat(fmt.Sprintf("%s (%s)", appName, namespace), "app")).SetSelectable(true)
+
+	appTopologyInstance.SetRoot(root)
+
+	app, err := model.LoadApplication(v.app.client, appName, namespace)
+	if err != nil {
+		return appTopologyInstance
+	}
+
+	// workflow
+	workflowNode := tview.NewTreeNode(component.EmojiFormat("WorkFlow", "workflow")).SetSelectable(true)
+	root.AddChild(workflowNode)
+	for _, step := range app.Status.Workflow.Steps {
+		stepNode := tview.NewTreeNode(component.WorkflowStepFormat(step.Name, step.Phase))
+		for _, subStep := range step.SubStepsStatus {
+			subStepNode := tview.NewTreeNode(subStep.Name)
+			stepNode.AddChild(subStepNode)
+		}
+		workflowNode.AddChild(stepNode)
+	}
+
+	// component
+	componentTitleNode := tview.NewTreeNode(component.EmojiFormat("Component", "component")).SetSelectable(true)
+	root.AddChild(componentTitleNode)
+	for _, c := range app.Spec.Components {
+		cNode := tview.NewTreeNode(c.Name)
+		attrNode := tview.NewTreeNode("Attributes")
+		attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("Type: %s", c.Type)))
+		cNode.AddChild(attrNode)
+
+		if len(c.Traits) > 0 {
+			traitTitleNode := tview.NewTreeNode(component.EmojiFormat("Trait", "trait")).SetSelectable(true)
+			cNode.AddChild(traitTitleNode)
+			for _, trait := range c.Traits {
+				traitNode := tview.NewTreeNode(trait.Type)
+				traitTitleNode.AddChild(traitNode)
+			}
+		}
+
+		componentTitleNode.AddChild(cNode)
+	}
+
+	// policy
+	policyNode := tview.NewTreeNode(component.EmojiFormat("Policy", "policy")).SetSelectable(true)
+	root.AddChild(policyNode)
+	for _, policy := range app.Spec.Policies {
+		policyNode.AddChild(tview.NewTreeNode(policy.Name))
+	}
+
+	return appTopologyInstance
+}
+
+func (v *TopologyView) switchTopology(_ *tcell.EventKey) *tcell.EventKey {
+	if v.focusTopology {
+		v.app.SetFocus(appTopologyInstance)
+	} else {
+		v.app.SetFocus(resourceTopologyInstance)
+	}
+	v.focusTopology = !v.focusTopology
+	return nil
+}
+
+func buildTopology(node *types.ResourceTreeNode) *tview.TreeNode {
+	if node == nil {
+		return tview.NewTreeNode("?")
+	}
+	rootNode := tview.NewTreeNode(component.EmojiFormat(node.Name, node.Kind)).SetSelectable(true)
+
+	attrNode := tview.NewTreeNode("Attributes")
+	attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("Kind: %s", component.ColorizeKind(node.Kind))))
+	attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("API Version: %s", node.APIVersion)))
+	attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("Namespace: %s", node.Namespace)))
+	attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("Cluster: %s", node.Cluster)))
+	attrNode.AddChild(tview.NewTreeNode(fmt.Sprintf("Status: %s", component.ColorizeStatus(node.HealthStatus.Status))))
+
+	rootNode.AddChild(attrNode)
+	if len(node.LeafNodes) > 0 {
+		subNode := tview.NewTreeNode("Sub Resource")
+		rootNode.AddChild(subNode)
+
+		for _, sub := range node.LeafNodes {
+			subNode.AddChild(buildTopology(sub))
+		}
+	}
+
+	return rootNode
+}

--- a/references/cli/top/view/application_topology_view_test.go
+++ b/references/cli/top/view/application_topology_view_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/references/cli/top/model"
+)
+
+func TestTopologyView(t *testing.T) {
+	testEnv := &envtest.Environment{
+		ControlPlaneStartTimeout: time.Minute * 3,
+		ControlPlaneStopTimeout:  time.Minute,
+		UseExistingCluster:       pointer.BoolPtr(false),
+	}
+	cfg, err := testEnv.Start()
+	assert.NoError(t, err)
+	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
+	assert.NoError(t, err)
+	app := NewApp(testClient, cfg, "")
+	assert.Equal(t, len(app.Components()), 4)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, &model.CtxKeyAppName, "app")
+	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "default")
+
+	view := NewTopologyView(ctx, app)
+	topologyView, ok := (view).(*TopologyView)
+	assert.Equal(t, ok, true)
+
+	t.Run("init", func(t *testing.T) {
+		topologyView.Init()
+		assert.Equal(t, topologyView.GetTitle(), "[ Topology ]")
+	})
+
+	t.Run("hint", func(t *testing.T) {
+		assert.Equal(t, len(topologyView.Hint()), 3)
+	})
+
+	t.Run("start", func(t *testing.T) {
+		appTopologyView := topologyView.NewAppTopologyView()
+		assert.Equal(t, appTopologyView.HasFocus(), false)
+		topologyView.Start()
+		assert.Equal(t, appTopologyView.HasFocus(), true)
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		topologyView.Stop()
+	})
+
+}

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -65,11 +65,9 @@ func (v *ApplicationView) Hint() []model.MenuHint {
 
 // InitView return a new application view
 func (v *ApplicationView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 
@@ -139,6 +137,7 @@ func (v *ApplicationView) bindKeys() {
 		component.KeyN: model.KeyAction{Description: "Select Namespace", Action: v.namespaceView, Visible: true, Shared: true},
 		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
 		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		component.KeyT: model.KeyAction{Description: "Topology", Action: v.topologyView, Visible: true, Shared: true},
 	})
 }
 
@@ -177,5 +176,22 @@ func (v *ApplicationView) yamlView(event *tcell.EventKey) *tcell.EventKey {
 	}
 	ctx := context.WithValue(v.app.ctx, &model.CtxKeyGVR, &gvr)
 	v.app.command.run(ctx, "yaml")
+	return nil
+}
+
+func (v *ApplicationView) topologyView(event *tcell.EventKey) *tcell.EventKey {
+	row, _ := v.GetSelection()
+	if row == 0 {
+		return event
+	}
+	name, namespace := v.GetCell(row, 0).Text, v.GetCell(row, 1).Text
+
+	ctx := context.WithValue(context.Background(), &model.CtxKeyAppName, name)
+	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, namespace)
+
+	appName := ctx.Value(&model.CtxKeyAppName).(string)
+	fmt.Println(appName)
+
+	v.app.command.run(ctx, "topology")
 	return nil
 }

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -189,9 +189,6 @@ func (v *ApplicationView) topologyView(event *tcell.EventKey) *tcell.EventKey {
 	ctx := context.WithValue(context.Background(), &model.CtxKeyAppName, name)
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, namespace)
 
-	appName := ctx.Value(&model.CtxKeyAppName).(string)
-	fmt.Println(appName)
-
 	v.app.command.run(ctx, "topology")
 	return nil
 }

--- a/references/cli/top/view/application_view_test.go
+++ b/references/cli/top/view/application_view_test.go
@@ -46,9 +46,11 @@ func TestApplicationView(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
+
 	appView := new(ApplicationView)
 
 	t.Run("init view", func(t *testing.T) {
+		assert.Empty(t, appView.CommonResourceView)
 		appView.InitView(ctx, app)
 		assert.NotEmpty(t, appView.CommonResourceView)
 	})
@@ -88,7 +90,7 @@ func TestApplicationView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(appView.Hint()), 7)
+		assert.Equal(t, len(appView.Hint()), 8)
 	})
 
 	t.Run("managed resource view", func(t *testing.T) {

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -65,11 +65,9 @@ func (v *ClusterNamespaceView) Hint() []model.MenuHint {
 
 // InitView init a new cluster namespace view
 func (v *ClusterNamespaceView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -64,11 +64,9 @@ func (v *ClusterView) Hint() []model.MenuHint {
 
 // InitView init a new cluster view
 func (v *ClusterView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 

--- a/references/cli/top/view/command.go
+++ b/references/cli/top/view/command.go
@@ -51,6 +51,8 @@ func (c *Command) run(ctx context.Context, cmd string) {
 		component = NewHelpView(c.app)
 	case cmd == "yaml":
 		component = NewYamlView(ctx, c.app)
+	case cmd == "topology":
+		component = NewTopologyView(ctx, c.app)
 	default:
 		if resourceView, ok := ResourceViewMap[cmd]; ok {
 			resourceView.InitView(ctx, c.app)

--- a/references/cli/top/view/help_view.go
+++ b/references/cli/top/view/help_view.go
@@ -30,13 +30,17 @@ type HelpView struct {
 	app *App
 }
 
+var (
+	helpViewInstance = new(HelpView)
+)
+
 // NewHelpView return a new help view
-func NewHelpView(app *App) *HelpView {
-	v := &HelpView{
-		Table: component.NewTable(),
-		app:   app,
+func NewHelpView(app *App) model.View {
+	if helpViewInstance.Table == nil {
+		helpViewInstance.Table = component.NewTable()
+		helpViewInstance.app = app
 	}
-	return v
+	return helpViewInstance
 }
 
 // Init help view init

--- a/references/cli/top/view/help_view_test.go
+++ b/references/cli/top/view/help_view_test.go
@@ -40,7 +40,9 @@ func TestHelpView(t *testing.T) {
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
 	assert.Equal(t, len(app.Components()), 4)
-	helpView := NewHelpView(app)
+	view := NewHelpView(app)
+	helpView, ok := (view).(*HelpView)
+	assert.Equal(t, ok, true)
 
 	t.Run("init", func(t *testing.T) {
 		helpView.Init()

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -79,11 +79,9 @@ func (v *ManagedResourceView) Title() string {
 
 // InitView init a new managed resource view
 func (v *ManagedResourceView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 

--- a/references/cli/top/view/namespace_view.go
+++ b/references/cli/top/view/namespace_view.go
@@ -65,11 +65,9 @@ func (v *NamespaceView) Hint() []model.MenuHint {
 
 // InitView init a new namespace view
 func (v *NamespaceView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -65,11 +65,9 @@ func (v *PodView) Init() {
 
 // InitView init a new pod view
 func (v *PodView) InitView(ctx context.Context, app *App) {
+	v.ctx = ctx
 	if v.CommonResourceView == nil {
 		v.CommonResourceView = NewCommonView(app)
-		v.ctx = ctx
-	} else {
-		v.ctx = ctx
 	}
 }
 

--- a/references/cli/top/view/yaml_view.go
+++ b/references/cli/top/view/yaml_view.go
@@ -55,7 +55,7 @@ func NewYamlView(ctx context.Context, app *App) model.View {
 	yamlViewInstance.ctx = ctx
 	if yamlViewInstance.TextView == nil {
 		yamlViewInstance.TextView = tview.NewTextView()
-		yamlViewInstance.actions = make(model.KeyActions, 0)
+		yamlViewInstance.actions = make(model.KeyActions)
 		yamlViewInstance.app = app
 	}
 	return yamlViewInstance

--- a/references/cli/top/view/yaml_view.go
+++ b/references/cli/top/view/yaml_view.go
@@ -39,8 +39,9 @@ type YamlView struct {
 }
 
 var (
-	keyValRX = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s(.+)\z`)
-	keyRX    = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s*\z`)
+	keyValRX         = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s(.+)\z`)
+	keyRX            = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s*\z`)
+	yamlViewInstance = new(YamlView)
 )
 
 const (
@@ -51,13 +52,15 @@ const (
 
 // NewYamlView return  a new yaml view
 func NewYamlView(ctx context.Context, app *App) model.View {
-	v := &YamlView{
-		TextView: tview.NewTextView(),
-		actions:  map[tcell.Key]model.KeyAction{},
-		app:      app,
-		ctx:      ctx,
+	if yamlViewInstance.TextView == nil {
+		yamlViewInstance.TextView = tview.NewTextView()
+		yamlViewInstance.actions = make(model.KeyActions, 0)
+		yamlViewInstance.app = app
+		yamlViewInstance.ctx = ctx
+	} else {
+		yamlViewInstance.ctx = ctx
 	}
-	return v
+	return yamlViewInstance
 }
 
 // Init the yaml view
@@ -70,11 +73,11 @@ func (v *YamlView) Init() {
 	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
 	v.bindKeys()
 	v.SetInputCapture(v.keyboard)
-	v.Start()
 }
 
 // Start the yaml view
 func (v *YamlView) Start() {
+	v.Clear()
 	gvr, ok := v.ctx.Value(&model.CtxKeyGVR).(*model.GVR)
 	if ok {
 		obj, err := model.GetResourceObject(v.app.client, gvr)
@@ -96,6 +99,7 @@ func (v *YamlView) Start() {
 
 // Stop the yaml view
 func (v *YamlView) Stop() {
+	v.Clear()
 }
 
 // Name return the name of yaml view

--- a/references/cli/top/view/yaml_view.go
+++ b/references/cli/top/view/yaml_view.go
@@ -50,15 +50,13 @@ const (
 	yamlValueFmt = "[val::]%s"
 )
 
-// NewYamlView return  a new yaml view
+// NewYamlView return a new yaml view
 func NewYamlView(ctx context.Context, app *App) model.View {
+	yamlViewInstance.ctx = ctx
 	if yamlViewInstance.TextView == nil {
 		yamlViewInstance.TextView = tview.NewTextView()
 		yamlViewInstance.actions = make(model.KeyActions, 0)
 		yamlViewInstance.app = app
-		yamlViewInstance.ctx = ctx
-	} else {
-		yamlViewInstance.ctx = ctx
 	}
 	return yamlViewInstance
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Every application deployment plan can be composed by multiple components with attachable operational behaviors (traits), deployment policy and workflow. So, the first topology we show is to show the four components of the application, this topology is called the "App Topology".

In addition, these components will actually eventually be loaded as native resources or CRDs in Kubernetes, and these resources constitute another resource topology. As a user, you must want to know whether the sub-resources of the application are correctly deployed as required, you can get the answer from this topology, which we call the "Resource Topology".

<img width="1899" alt="image" src="https://user-images.githubusercontent.com/30918851/192206249-a33cd9df-250f-435e-964e-340abe1fa737.png">


Fixes #4787

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->