### PR TITLE
Fix: Update Ingress APIVersion form v1beta1 to v1 in test case

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -34,7 +34,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	v12 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3611,7 +3611,7 @@ var _ = Describe("Test Application Controller", func() {
 		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
 
 		By("Check ingress Created with the expected trait-gateway spec")
-		ingress := &v12.Ingress{}
+		ingress := &networkingv1.Ingress{}
 		Expect(k8sClient.Get(ctx, client.ObjectKey{
 			Namespace: ns.Name,
 			Name:      app.Spec.Components[0].Name,

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -34,7 +34,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta12 "k8s.io/api/networking/v1beta1"
+	v12 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -605,7 +605,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Create(ctx, &expWorkloadTrait)).Should(BeNil())
 
 		expTrait := unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": "networking.k8s.io/v1beta1",
+			"apiVersion": "networking.k8s.io/v1",
 			"kind":       "Ingress",
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
@@ -3611,7 +3611,7 @@ var _ = Describe("Test Application Controller", func() {
 		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
 
 		By("Check ingress Created with the expected trait-gateway spec")
-		ingress := &v1beta12.Ingress{}
+		ingress := &v12.Ingress{}
 		Expect(k8sClient.Get(ctx, client.ObjectKey{
 			Namespace: ns.Name,
 			Name:      app.Spec.Components[0].Name,
@@ -4216,7 +4216,7 @@ spec:
       template: |
         import (
         	kubev1 "k8s.io/core/v1"
-        	network "k8s.io/networking/v1beta1"
+        	network "k8s.io/networking/v1"
         )
 
         parameter: {
@@ -4578,7 +4578,7 @@ spec:
         	}
         }
         outputs: ingress: {
-        	apiVersion: "networking.k8s.io/v1beta1"
+        	apiVersion: "networking.k8s.io/v1"
         	kind:       "Ingress"
         	metadata:
         		name: context.name
@@ -4589,9 +4589,14 @@ spec:
         				paths: [
         					for k, v in parameter.http {
         						path: k
+                                pathType: "Prefix"
         						backend: {
-        							serviceName: context.name
-        							servicePort: v
+        							service: {
+                                        name: context.name
+                                        port: {
+                                            number: v
+                                        }
+                                    }
         						}
         					},
         				]

--- a/pkg/controller/core.oam.dev/v1alpha2/application/gc_policy_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/gc_policy_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
-	v12 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -216,7 +216,7 @@ var _ = Describe("Test Application with GC options", func() {
 				deploy.SetNamespace(ns.Name)
 				Expect(k8sClient.Delete(ctx, deploy))
 
-				ingress := new(v12.Ingress)
+				ingress := new(networkingv1.Ingress)
 				ingress.SetName(fmt.Sprintf("worker-v%d", i))
 				ingress.SetNamespace(ns.Name)
 				Expect(k8sClient.Delete(ctx, ingress))

--- a/pkg/controller/core.oam.dev/v1alpha2/application/gc_policy_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/gc_policy_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
-	v1beta12 "k8s.io/api/networking/v1beta1"
+	v12 "k8s.io/api/networking/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -216,7 +216,7 @@ var _ = Describe("Test Application with GC options", func() {
 				deploy.SetNamespace(ns.Name)
 				Expect(k8sClient.Delete(ctx, deploy))
 
-				ingress := new(v1beta12.Ingress)
+				ingress := new(v12.Ingress)
 				ingress.SetName(fmt.Sprintf("worker-v%d", i))
 				ingress.SetNamespace(ns.Name)
 				Expect(k8sClient.Delete(ctx, ingress))
@@ -621,7 +621,7 @@ spec:
         	}
         }
         outputs: ingress: {
-        	apiVersion: "networking.k8s.io/v1beta1"
+        	apiVersion: "networking.k8s.io/v1"
         	kind:       "Ingress"
         	metadata:
         		name: context.name
@@ -632,9 +632,14 @@ spec:
         				paths: [
         					for k, v in parameter.http {
         						path: k
+                                pathType: "Prefix"
         						backend: {
-        							serviceName: context.name
-        							servicePort: v
+        							service: {
+                                        name: context.name
+                                        port: {
+                                            number: v
+                                        }
+                                    }
         						}
         					},
         				]


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4818 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Pass the application_controller_test which was failed before in testenv 1.24.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->