### PR TITLE
Feat: support context.cluster in applyComponent

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	pkgmulticluster "github.com/kubevela/pkg/multicluster"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/oam-dev/kubevela/pkg/features"
@@ -425,6 +426,10 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 		}
 		if rk := replicaKeyFromContext(ctx); rk != "" {
 			ctxData.ReplicaKey = rk
+		}
+		ctxData.Cluster = pkgmulticluster.Local
+		if cluster, ok := pkgmulticluster.ClusterFrom(ctx); ok && cluster != "" {
+			ctxData.Cluster = cluster
 		}
 	})
 	if err != nil {

--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -28,6 +28,7 @@ import (
 // ContextData is the core data of process context
 type ContextData struct {
 	Namespace       string
+	Cluster         string
 	AppName         string
 	CompName        string
 	StepName        string
@@ -66,5 +67,6 @@ func NewContext(data ContextData) process.Context {
 	ctx.PushData(ContextReplicaKey, data.ReplicaKey)
 	revNum, _ := util.ExtractRevisionNum(data.AppRevisionName, "-")
 	ctx.PushData(ContextAppRevisionNum, revNum)
+	ctx.PushData(ContextCluster, data.Cluster)
 	return ctx
 }

--- a/pkg/cue/process/keyword.go
+++ b/pkg/cue/process/keyword.go
@@ -39,6 +39,8 @@ const (
 	ContextAppAnnotations = "appAnnotations"
 	// ContextNamespace is the namespace of the app
 	ContextNamespace = "namespace"
+	// ContextCluster is the cluster currently focusing on
+	ContextCluster = "cluster"
 	// ContextPublishVersion is the publish version of the app
 	ContextPublishVersion = "publishVersion"
 	// ContextWorkflowName is the name of the workflow

--- a/test/e2e-multicluster-test/testdata/app/app-component-with-cluster-context.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-component-with-cluster-context.yaml
@@ -1,0 +1,13 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-component-with-cluster-context
+spec:
+  components:
+    - name: test
+      type: cluster-config
+  policies:
+    - name: topology
+      type: topology
+      properties:
+        clusters: ["local", "cluster-worker"]

--- a/test/e2e-multicluster-test/testdata/def/cluster-config.yaml
+++ b/test/e2e-multicluster-test/testdata/def/cluster-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: cluster-config
+spec:
+  schematic:
+    cue:
+      template: |
+        output: {
+            apiVersion: "v1"
+            kind: "ConfigMap"
+            metadata: name: context.name
+            data: cluster: context.cluster
+        }
+        parameter: {}
+  workload:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

```cue
output: {
    apiVersion: "v1"
    kind: "ConfigMap"
    metadata: name: context.name
    data: cluster: context.cluster
}
parameter: {}
```

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: app-component-with-cluster-context
spec:
  components:
    - name: test
      type: cluster-config
  policies:
    - name: topology
      type: topology
      properties:
        clusterLabelSelector: {}
```

The above application will create a ConfigMap in each cluster. The data in the ConfigMap contains the name of the corresponding cluster.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->