### PR TITLE
Feat: gc orphan resources

### DIFF
--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -243,3 +243,7 @@ const (
 	// ResourceTopologyFormatJSON mark the format of resource topology is json.
 	ResourceTopologyFormatJSON = "json"
 )
+
+// FinalizerOrphanResource indicates that the gc process should orphan managed
+// resources instead of deleting them
+const FinalizerOrphanResource = "app.oam.dev/orphan-resource"

--- a/pkg/resourcekeeper/cache.go
+++ b/pkg/resourcekeeper/cache.go
@@ -113,7 +113,7 @@ func (cache *resourceCache) exists(manifest *unstructured.Unstructured) bool {
 		return true
 	}
 	appKey, controlledBy := apply.GetAppKey(cache.app), apply.GetControlledBy(manifest)
-	if appKey == controlledBy || manifest.GetResourceVersion() == "" {
+	if appKey == controlledBy || (manifest.GetResourceVersion() == "" && !hasOrphanFinalizer(cache.app)) {
 		return true
 	}
 	annotations := manifest.GetAnnotations()

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -364,7 +364,7 @@ func (h *gcHandler) deleteManagedResource(ctx context.Context, mr v1beta1.Manage
 				return nil
 			}
 		}
-		if mr.SkipGC {
+		if mr.SkipGC || hasOrphanFinalizer(h.app) {
 			if labels := entry.obj.GetLabels(); labels != nil {
 				delete(labels, oam.LabelAppName)
 				delete(labels, oam.LabelAppNamespace)

--- a/pkg/resourcekeeper/utils.go
+++ b/pkg/resourcekeeper/utils.go
@@ -18,7 +18,10 @@ package resourcekeeper
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/strings/slices"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
@@ -50,4 +53,9 @@ func (h *resourceKeeper) isReadOnly(manifest *unstructured.Unstructured) bool {
 		return false
 	}
 	return h.readOnlyPolicy.FindStrategy(manifest)
+}
+
+// hasOrphanFinalizer checks if the target application should orphan child resources
+func hasOrphanFinalizer(app *v1beta1.Application) bool {
+	return slices.Contains(app.GetFinalizers(), oam.FinalizerOrphanResource)
 }

--- a/references/cli/delete.go
+++ b/references/cli/delete.go
@@ -61,16 +61,15 @@ func NewDeleteCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams)
 		if len(args) < 1 {
 			return errors.New("must specify name for the app")
 		}
-		wait, err := cmd.Flags().GetBool("wait")
-		if err != nil {
+		if o.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
 			return err
 		}
-		o.Wait = wait
-		force, err := cmd.Flags().GetBool("force")
-		if err != nil {
+		if o.ForceDelete, err = cmd.Flags().GetBool("force"); err != nil {
 			return err
 		}
-		o.ForceDelete = force
+		if o.Orphan, err = cmd.Flags().GetBool("orphan"); err != nil {
+			return err
+		}
 		for _, app := range args {
 			o.AppName = app
 			userInput := NewUserInput()
@@ -90,6 +89,7 @@ func NewDeleteCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams)
 
 	cmd.PersistentFlags().BoolVarP(&o.Wait, "wait", "w", false, "wait util the application is deleted completely")
 	cmd.PersistentFlags().BoolVarP(&o.ForceDelete, "force", "f", false, "force to delete the application")
+	cmd.PersistentFlags().BoolVarP(&o.Orphan, "orphan", "o", false, "delete the application and orphan managed resources")
 	addNamespaceAndEnvArg(cmd)
 	return cmd
 }

--- a/test/e2e-multicluster-test/testdata/app/app-orphan-delete.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-orphan-delete.yaml
@@ -1,0 +1,21 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-orphan-delete
+spec:
+  components:
+    - type: k8s-objects
+      name: orphan-test
+      properties:
+        objects:
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: orphan-cm
+            data:
+              key: val
+  policies:
+    - type: topology
+      name: remote
+      properties:
+        clusters: ["cluster-worker"]


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support `vela delete --orphan <appname>`. This will only remove the owner label in managed resources while deleting application, instead of recycling resources.

Users can also add `app.oam.dev/orphan-resource` to finalizers.

NOTE: `kubectl delete app <appname> --orphan` is handled by Kubernetes internal controller, so we are unable to reuse the official command by far.

Fixes #4694

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->