### PR TITLE
Fix: prevent rerun app while upgrade due to old apprev lack app workflow

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
@@ -22,10 +22,13 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"testing"
 	"time"
 
+	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1085,3 +1088,21 @@ status: {}
 		}()).Should(BeTrue())
 	})
 })
+
+func TestDeepEqualAppInRevision(t *testing.T) {
+	oldRev := &v1beta1.ApplicationRevision{}
+	newRev := &v1beta1.ApplicationRevision{}
+	newRev.Spec.Application.Spec.Workflow = &v1beta1.Workflow{
+		Steps: []workflowv1alpha1.WorkflowStep{{
+			WorkflowStepBase: workflowv1alpha1.WorkflowStepBase{
+				Type: "deploy",
+				Name: "deploy",
+			},
+		}},
+	}
+	require.False(t, deepEqualAppInRevision(oldRev, newRev))
+	metav1.SetMetaDataAnnotation(&oldRev.Spec.Application.ObjectMeta, oam.AnnotationKubeVelaVersion, "v1.6.0-alpha.5")
+	require.False(t, deepEqualAppInRevision(oldRev, newRev))
+	metav1.SetMetaDataAnnotation(&oldRev.Spec.Application.ObjectMeta, oam.AnnotationKubeVelaVersion, "v1.5.0")
+	require.True(t, deepEqualAppInRevision(oldRev, newRev))
+}


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In version before v1.6.0-alpha.4, applications with revision under v1.5.7 (not released yet) and revision under v1.6.0-alpha.4 (released), application revision (without PublishVersion) does not record workflow in Application Spec inside, which will lead to inequality with revisions created by latest KubeVela.

This PR adds additional rules for bypassing the comparing application workflow when
1. PublishVersion is not used
2. Application is created under KubeVela version v1.5.7. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->