### PR TITLE
Revert "[Backport release-1.5] Fix: prevent rerun app while upgrade due to old apprev lack app workflow"

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -23,8 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-version"
-	"github.com/kubevela/pkg/util/k8s"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -524,25 +522,6 @@ func deepEqualWorkflow(old, new v1alpha1.Workflow) bool {
 	return apiequality.Semantic.DeepEqual(old.Steps, new.Steps)
 }
 
-const velaVersionNumberToCompareWorkflow = "v1.5.7"
-
-func deepEqualAppSpec(old, new *v1beta1.Application) bool {
-	oldSpec, newSpec := old.Spec.DeepCopy(), new.Spec.DeepCopy()
-	// legacy code: KubeVela version before v1.5.7 & v1.6.0-alpha.4 does not
-	// record workflow in application spec in application revision. The comparison
-	// need to bypass the equality check of workflow to prevent unintended rerun
-	curVerNum := k8s.GetAnnotation(old, oam.AnnotationKubeVelaVersion)
-	publishVersion := k8s.GetAnnotation(old, oam.AnnotationPublishVersion)
-	if publishVersion == "" && curVerNum != "" {
-		cmpVer, _ := version.NewVersion(velaVersionNumberToCompareWorkflow)
-		if curVer, err := version.NewVersion(curVerNum); err == nil && curVer.LessThan(cmpVer) {
-			oldSpec.Workflow = nil
-			newSpec.Workflow = nil
-		}
-	}
-	return apiequality.Semantic.DeepEqual(oldSpec, newSpec)
-}
-
 func deepEqualAppInRevision(old, new *v1beta1.ApplicationRevision) bool {
 	if len(old.Spec.Policies) != len(new.Spec.Policies) {
 		return false
@@ -560,7 +539,8 @@ func deepEqualAppInRevision(old, new *v1beta1.ApplicationRevision) bool {
 			return false
 		}
 	}
-	return deepEqualAppSpec(&old.Spec.Application, &new.Spec.Application)
+	return apiequality.Semantic.DeepEqual(filterSkipAffectAppRevTrait(old.Spec.Application.Spec, old.Spec.TraitDefinitions),
+		filterSkipAffectAppRevTrait(new.Spec.Application.Spec, new.Spec.TraitDefinitions))
 }
 
 // HandleComponentsRevision manages Component revisions

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
@@ -22,13 +22,10 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"testing"
 	"time"
 
-	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1174,21 +1171,3 @@ status: {}
 		}()).Should(BeTrue())
 	})
 })
-
-func TestDeepEqualAppInRevision(t *testing.T) {
-	oldRev := &v1beta1.ApplicationRevision{}
-	newRev := &v1beta1.ApplicationRevision{}
-	newRev.Spec.Application.Spec.Workflow = &v1beta1.Workflow{
-		Steps: []workflowv1alpha1.WorkflowStep{{
-			WorkflowStepBase: workflowv1alpha1.WorkflowStepBase{
-				Type: "deploy",
-				Name: "deploy",
-			},
-		}},
-	}
-	require.False(t, deepEqualAppInRevision(oldRev, newRev))
-	metav1.SetMetaDataAnnotation(&oldRev.Spec.Application.ObjectMeta, oam.AnnotationKubeVelaVersion, "v1.6.0-alpha.5")
-	require.False(t, deepEqualAppInRevision(oldRev, newRev))
-	metav1.SetMetaDataAnnotation(&oldRev.Spec.Application.ObjectMeta, oam.AnnotationKubeVelaVersion, "v1.5.0")
-	require.True(t, deepEqualAppInRevision(oldRev, newRev))
-}


### PR DESCRIPTION
Reverts kubevela/kubevela#4865

The kubevela/pkg library is not included in release-1.5.