### PR TITLE
Feat: add the feature of viewing log of pod in `vela top`

### DIFF
--- a/references/cli/top/model/log.go
+++ b/references/cli/top/model/log.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"text/template"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	"github.com/wercker/stern/stern"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+)
+
+// PrintLogOfPod print the log during 48h of aimed pod
+func PrintLogOfPod(ctx context.Context, config *rest.Config, cluster, namespace, podName, containerName string) (chan string, error) {
+	if cluster != "local" {
+		ctx = multicluster.ContextWithClusterName(ctx, cluster)
+	}
+	pod, err := regexp.Compile(podName + ".*")
+	if err != nil {
+		return nil, fmt.Errorf("fail to compile '%s' for logs query", podName+".*")
+	}
+	container := regexp.MustCompile(".*")
+	if containerName != "" {
+		container = regexp.MustCompile(containerName + ".*")
+	}
+	selector := labels.NewSelector()
+
+	logC := make(chan string, 1024)
+
+	go podLog(ctx, config, namespace, pod, container, selector, logC)
+
+	return logC, nil
+}
+
+func podLog(ctx context.Context, config *rest.Config, namespace string, pod, container *regexp.Regexp, selector labels.Selector, logC chan string) {
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logC <- err.Error()
+		return
+	}
+
+	added, removed, err := stern.Watch(ctx,
+		clientSet.CoreV1().Pods(namespace),
+		pod,
+		container,
+		nil,
+		[]stern.ContainerState{stern.RUNNING, stern.TERMINATED},
+		selector,
+	)
+	if err != nil {
+		logC <- err.Error()
+		return
+	}
+
+	tails := make(map[string]*stern.Tail)
+
+	var t string
+	if color.NoColor {
+		t = "{{.ContainerName}} {{.Message}}"
+	} else {
+		t = "{{color .ContainerColor .ContainerName}} {{.Message}}"
+	}
+
+	funs := map[string]interface{}{
+		"color": func(color color.Color, text string) string {
+			return color.SprintFunc()(text)
+		},
+	}
+	template, err := template.New("log").Funcs(funs).Parse(t)
+	if err != nil {
+		if err != nil {
+			logC <- errors.Wrap(err, "unable to parse template").Error()
+			return
+		}
+	}
+
+	go func() {
+		for p := range added {
+			id := p.GetID()
+			if tails[id] != nil {
+				continue
+			}
+			// 48h
+			dur, _ := time.ParseDuration("48h")
+			tail := stern.NewTail(p.Namespace, p.Pod, p.Container, template, &stern.TailOptions{
+				Timestamps:   true,
+				SinceSeconds: int64(dur.Seconds()),
+				Exclude:      nil,
+				Include:      nil,
+				Namespace:    false,
+				TailLines:    nil, // default for all logs
+			})
+			tails[id] = tail
+
+			tail.Start(ctx, clientSet.CoreV1().Pods(p.Namespace), logC)
+		}
+	}()
+
+	go func() {
+		for p := range removed {
+			id := p.GetID()
+			if tails[id] == nil {
+				continue
+			}
+			tails[id].Close()
+			delete(tails, id)
+		}
+	}()
+
+	<-ctx.Done()
+}

--- a/references/cli/top/model/log_test.go
+++ b/references/cli/top/model/log_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("test log output", func() {
+	var logC chan string
+	var err error
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	It("generate channel", func() {
+		logC, err = PrintLogOfPod(ctx, cfg, "local", "default", "pod1", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(logC)).To(Equal(0))
+
+		flag := false
+		select {
+		case <-ctx.Done():
+			flag = true
+		default:
+		}
+		Expect(flag).To(Equal(false))
+	})
+
+	It("close channel", func() {
+		cancelFunc()
+		flag := false
+		select {
+		case <-ctx.Done():
+			flag = true
+		default:
+		}
+		Expect(flag).To(Equal(true))
+	})
+})

--- a/references/cli/top/model/pod_test.go
+++ b/references/cli/top/model/pod_test.go
@@ -32,6 +32,7 @@ func TestPodList_ToTableBody(t *testing.T) {
 	pod := Pod{
 		Name:      "",
 		Namespace: "",
+		Cluster:   "",
 		Ready:     "",
 		Status:    "",
 		CPU:       "",
@@ -68,6 +69,7 @@ var _ = Describe("test pod", func() {
 				Name:              "pod",
 				Namespace:         "ns",
 				CreationTimestamp: metav1.Time{Time: time.Now()},
+				ClusterName:       "",
 			},
 			Spec: v1.PodSpec{
 				NodeName: "node-1",

--- a/references/cli/top/model/suit_test.go
+++ b/references/cli/top/model/suit_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func(done Done) {
 			},
 		},
 	}
-	err = k8sClient.Create(context.TODO(), testApp)
+	err = k8sClient.Create(context.Background(), testApp)
 	Expect(err).Should(BeNil())
 	testApp.Status = common2.AppStatus{
 		Phase: common2.ApplicationRunning,
@@ -161,7 +161,7 @@ var _ = BeforeSuite(func(done Done) {
 			},
 		},
 	}
-	err = k8sClient.Status().Update(context.TODO(), testApp)
+	err = k8sClient.Status().Update(context.Background(), testApp)
 	Expect(err).Should(BeNil())
 	// create service
 	svc := &corev1.Service{
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	svcRaw, err := json.Marshal(svc)
 	Expect(err).Should(Succeed())
-	Expect(k8sClient.Create(context.TODO(), svc)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), svc)).Should(BeNil())
 	// create deploy
 	dply := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -204,7 +204,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	dplyRaw, err := json.Marshal(dply)
 	Expect(err).Should(Succeed())
-	Expect(k8sClient.Create(context.TODO(), dply)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), dply)).Should(BeNil())
 	//create replicaSet
 	var rsNum int32 = 2
 	rs := &appsv1.ReplicaSet{
@@ -235,7 +235,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	rsRaw, err := json.Marshal(rs)
 	Expect(err).Should(Succeed())
-	Expect(k8sClient.Create(context.TODO(), rs)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), rs)).Should(BeNil())
 	// create pod
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -256,7 +256,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	podRaw, err := json.Marshal(pod)
 	Expect(err).Should(Succeed())
-	Expect(k8sClient.Create(context.TODO(), pod)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), pod)).Should(BeNil())
 	// create resourceTracker
 	rt := &v1beta1.ResourceTracker{
 		ObjectMeta: metav1.ObjectMeta{
@@ -335,9 +335,9 @@ var _ = BeforeSuite(func(done Done) {
 			Type: v1beta1.ResourceTrackerTypeVersioned,
 		},
 	}
-	Expect(k8sClient.Create(context.TODO(), rt)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), rt)).Should(BeNil())
 
-	err = k8sClient.Create(context.TODO(), &corev1.Namespace{
+	err = k8sClient.Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: types.DefaultKubeVelaNS,
 		},
@@ -362,7 +362,7 @@ var _ = BeforeSuite(func(done Done) {
 			},
 		}},
 	}
-	Expect(k8sClient.Create(context.TODO(), pod1)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), pod1)).Should(BeNil())
 	pod2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "vela-core-cluster-gateway", Namespace: "vela-system", Labels: map[string]string{"app.kubernetes.io/name": "vela-core-cluster-gateway"}},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{
@@ -376,7 +376,7 @@ var _ = BeforeSuite(func(done Done) {
 			},
 		}},
 	}
-	Expect(k8sClient.Create(context.TODO(), pod2)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), pod2)).Should(BeNil())
 
 	close(done)
 }, 240)

--- a/references/cli/top/model/type.go
+++ b/references/cli/top/model/type.go
@@ -62,6 +62,8 @@ var (
 	CtxKeyComponentName = "componentName"
 	// CtxKeyGVR request context key of GVR
 	CtxKeyGVR = "gvr"
+	// CtxKeyPod request context key of pod
+	CtxKeyPod = "pod"
 )
 
 const (

--- a/references/cli/top/view/command.go
+++ b/references/cli/top/view/command.go
@@ -53,6 +53,8 @@ func (c *Command) run(ctx context.Context, cmd string) {
 		component = NewYamlView(ctx, c.app)
 	case cmd == "topology":
 		component = NewTopologyView(ctx, c.app)
+	case cmd == "log":
+		component = NewLogView(ctx, c.app)
 	default:
 		if resourceView, ok := ResourceViewMap[cmd]; ok {
 			resourceView.InitView(ctx, c.app)

--- a/references/cli/top/view/help_view.go
+++ b/references/cli/top/view/help_view.go
@@ -18,6 +18,8 @@ package view
 
 import (
 	"fmt"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 
 	"github.com/oam-dev/kubevela/references/cli/top/component"
 	"github.com/oam-dev/kubevela/references/cli/top/config"
@@ -26,8 +28,9 @@ import (
 
 // HelpView is the view which display help tips about how to use app
 type HelpView struct {
-	*component.Table
-	app *App
+	*tview.TextView
+	app     *App
+	actions model.KeyActions
 }
 
 var (
@@ -36,28 +39,58 @@ var (
 
 // NewHelpView return a new help view
 func NewHelpView(app *App) model.View {
-	if helpViewInstance.Table == nil {
-		helpViewInstance.Table = component.NewTable()
+	if helpViewInstance.TextView == nil {
+		helpViewInstance.TextView = tview.NewTextView()
 		helpViewInstance.app = app
+		helpViewInstance.actions = make(model.KeyActions)
 	}
 	return helpViewInstance
 }
 
 // Init help view init
 func (v *HelpView) Init() {
-	v.Table.Init()
 	title := fmt.Sprintf("[ %s ]", v.Name())
+	v.SetDynamicColors(true)
 	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
+	v.SetBorder(true)
+	v.SetBorderAttributes(tcell.AttrItalic)
+	v.SetBorderPadding(1, 1, 3, 3)
 	v.bindKeys()
 }
+
+func (v *HelpView) Start() {
+	v.SetText(`
+[blue:]vela top[white:] is a UI based CLI tool provided in KubeVela. By using it, you can obtain the overview information of the platform and diagnose the resource status of the application.
+
+At present, the tool has provided the following feature:
+
+[blue:]*[white:] Platform information overview
+[blue:]*[white:] Display of resource status information at Application, Managed Resource and Pod levels
+[blue:]*[white:] Application Resource Topology
+[blue:]*[white:] Resource YAML text display
+
+This information panel component in UI header will display the performance information of the KubeVela system.
+
+Resource tables are in the UI body, three levels resource are displayed here. You can use the ENTER key to enter the next resource level or the Q key to return to the previous level.
+
+The crumbs component in the footer indicates the current resource level.
+`)
+}
+
+func (v *HelpView) Stop() {}
 
 // Name return help view name
 func (v *HelpView) Name() string {
 	return "Help"
 }
 
+// Hint return the menu hints of yaml view
+func (v *HelpView) Hint() []model.MenuHint {
+	return v.actions.Hint()
+}
+
 func (v *HelpView) bindKeys() {
-	v.Actions().Add(model.KeyActions{
+	v.actions.Add(model.KeyActions{
 		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 		component.KeyHelp: model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
 	})

--- a/references/cli/top/view/help_view.go
+++ b/references/cli/top/view/help_view.go
@@ -18,6 +18,7 @@ package view
 
 import (
 	"fmt"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
@@ -54,10 +55,11 @@ func (v *HelpView) Init() {
 	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
 	v.SetBorder(true)
 	v.SetBorderAttributes(tcell.AttrItalic)
-	v.SetBorderPadding(1, 1, 3, 3)
+	v.SetBorderPadding(1, 1, 2, 2)
 	v.bindKeys()
 }
 
+// Start the help view
 func (v *HelpView) Start() {
 	v.SetText(`
 [blue:]vela top[white:] is a UI based CLI tool provided in KubeVela. By using it, you can obtain the overview information of the platform and diagnose the resource status of the application.
@@ -77,6 +79,7 @@ The crumbs component in the footer indicates the current resource level.
 `)
 }
 
+// Stop the help view
 func (v *HelpView) Stop() {}
 
 // Name return help view name

--- a/references/cli/top/view/help_view_test.go
+++ b/references/cli/top/view/help_view_test.go
@@ -47,5 +47,13 @@ func TestHelpView(t *testing.T) {
 	t.Run("init", func(t *testing.T) {
 		helpView.Init()
 		assert.Equal(t, helpView.GetTitle(), "[ Help ]")
+		assert.Equal(t, helpView.Hint(), 2)
+	})
+
+	t.Run("start", func(t *testing.T) {
+		assert.Equal(t, helpView.GetText(false), "")
+		helpView.Start()
+		assert.Equal(t, helpView.GetTitle(), "[ Help ]")
+		assert.NotEqual(t, helpView.GetText(false), "")
 	})
 }

--- a/references/cli/top/view/log_view.go
+++ b/references/cli/top/view/log_view.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/oam-dev/kubevela/references/cli/top/component"
+	"github.com/oam-dev/kubevela/references/cli/top/config"
+	"github.com/oam-dev/kubevela/references/cli/top/model"
+)
+
+// LogView is the log view, this view display log of pod
+type LogView struct {
+	*tview.TextView
+	app        *App
+	actions    model.KeyActions
+	ctx        context.Context
+	writer     io.Writer
+	cancelFunc func()
+}
+
+var (
+	logViewInstance = new(LogView)
+)
+
+// NewLogView return a new log view
+func NewLogView(ctx context.Context, app *App) model.View {
+	logViewInstance.ctx = ctx
+	if logViewInstance.TextView == nil {
+		logViewInstance.TextView = tview.NewTextView()
+		logViewInstance.app = app
+		logViewInstance.actions = make(model.KeyActions)
+		logViewInstance.writer = tview.ANSIWriter(logViewInstance.TextView)
+	}
+	return logViewInstance
+}
+
+// Init the log view
+func (v *LogView) Init() {
+	title := fmt.Sprintf("[ %s ]", v.Name())
+	v.SetDynamicColors(true)
+	v.SetBorder(true)
+	v.SetBorderAttributes(tcell.AttrItalic)
+	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
+	v.SetBorderPadding(1, 1, 2, 2)
+	v.bindKeys()
+	v.SetInputCapture(v.keyboard)
+}
+
+// Start the log view
+func (v *LogView) Start() {
+	var ctx context.Context
+	ctx, v.cancelFunc = context.WithCancel(context.Background())
+
+	cluster := v.ctx.Value(&model.CtxKeyCluster).(string)
+	pod := v.ctx.Value(&model.CtxKeyPod).(string)
+	namespace := v.ctx.Value(&model.CtxKeyNamespace).(string)
+
+	logC, err := model.PrintLogOfPod(ctx, v.app.config.RestConfig, cluster, namespace, pod, "")
+	if err != nil {
+		return
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case line := <-logC:
+				v.app.QueueUpdateDraw(func() {
+					_, _ = v.writer.Write([]byte(line))
+				})
+			default:
+				time.Sleep(time.Second)
+			}
+		}
+	}()
+}
+
+// Stop the log view
+func (v *LogView) Stop() {
+	v.cancelFunc()
+	v.Clear()
+}
+
+// Name return the name of log view
+func (v *LogView) Name() string {
+	return "Log"
+}
+
+// Hint return the menu hints of log view
+func (v *LogView) Hint() []model.MenuHint {
+	return v.actions.Hint()
+}
+
+func (v *LogView) keyboard(event *tcell.EventKey) *tcell.EventKey {
+	key := event.Key()
+	if key == tcell.KeyUp || key == tcell.KeyDown {
+		return event
+	}
+	if a, ok := v.actions[component.StandardizeKey(event)]; ok {
+		return a.Action(event)
+	}
+	return event
+}
+
+func (v *LogView) bindKeys() {
+	v.actions.Delete([]tcell.Key{tcell.KeyEnter})
+	v.actions.Add(model.KeyActions{
+		component.KeyQ:    model.KeyAction{Description: "Back", Action: v.app.Back, Visible: true, Shared: true},
+		component.KeyHelp: model.KeyAction{Description: "Help", Action: v.app.helpView, Visible: true, Shared: true},
+	})
+}

--- a/references/cli/top/view/log_view_test.go
+++ b/references/cli/top/view/log_view_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package view
 
 import (
+	"context"
+
 	"testing"
 	"time"
 
@@ -26,9 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/references/cli/top/model"
 )
 
-func TestHelpView(t *testing.T) {
+func TestLogView(t *testing.T) {
 	testEnv := &envtest.Environment{
 		ControlPlaneStartTimeout: time.Minute * 3,
 		ControlPlaneStopTimeout:  time.Minute,
@@ -40,20 +43,36 @@ func TestHelpView(t *testing.T) {
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
 	assert.Equal(t, len(app.Components()), 4)
-	view := NewHelpView(app)
-	helpView, ok := (view).(*HelpView)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, &model.CtxKeyCluster, "")
+	ctx = context.WithValue(ctx, &model.CtxKeyPod, "")
+	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "")
+
+	view := NewLogView(ctx, app)
+	logView, ok := (view).(*LogView)
 	assert.Equal(t, ok, true)
 
 	t.Run("init", func(t *testing.T) {
-		helpView.Init()
-		assert.Equal(t, helpView.GetTitle(), "[ Help ]")
-		assert.Equal(t, len(helpView.Hint()), 2)
+		logView.Init()
+		assert.Equal(t, logView.GetTitle(), "[ Log ]")
+	})
+
+	t.Run("hint", func(t *testing.T) {
+		assert.Equal(t, len(logView.Hint()), 2)
 	})
 
 	t.Run("start", func(t *testing.T) {
-		assert.Equal(t, helpView.GetText(false), "")
-		helpView.Start()
-		assert.Equal(t, helpView.GetTitle(), "[ Help ]")
-		assert.NotEqual(t, helpView.GetText(false), "")
+		logView.Start()
+		assert.NotEmpty(t, logView.writer)
+		logView.writer.Write([]byte("test"))
+		content := logView.TextView.GetText(true)
+		assert.NotEmpty(t, content)
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		logView.Stop()
+		content := logView.TextView.GetText(true)
+		assert.Empty(t, content)
 	})
 }

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -85,7 +85,7 @@ func (v *PodView) Update() {
 
 // BuildHeader render the header of table
 func (v *PodView) BuildHeader() {
-	header := []string{"Name", "Namespace", "Ready", "Status", "CPU", "MEM", "%CPU/R", "%CPU/L", "%MEM/R", "%MEM/L", "IP", "Node", "Age"}
+	header := []string{"Name", "Namespace", "Cluster", "Ready", "Status", "CPU", "MEM", "%CPU/R", "%CPU/L", "%MEM/R", "%MEM/L", "IP", "Node", "Age"}
 	v.CommonResourceView.BuildHeader(header)
 }
 
@@ -104,7 +104,7 @@ func (v *PodView) BuildBody() {
 // ColorizePhaseText colorize the phase column text
 func (v *PodView) ColorizePhaseText(rowNum int) {
 	for i := 1; i < rowNum+1; i++ {
-		phase := v.Table.GetCell(i, 3).Text
+		phase := v.Table.GetCell(i, 4).Text
 		switch v1.PodPhase(phase) {
 		case v1.PodPending:
 			phase = config.PodPendingPhaseColor + phase
@@ -116,7 +116,7 @@ func (v *PodView) ColorizePhaseText(rowNum int) {
 			phase = config.PodFailedPhase + phase
 		default:
 		}
-		v.Table.GetCell(i, 3).SetText(phase)
+		v.Table.GetCell(i, 4).SetText(phase)
 	}
 }
 

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -125,6 +125,7 @@ func (v *PodView) bindKeys() {
 	v.Actions().Add(model.KeyActions{
 		component.KeyY: model.KeyAction{Description: "Yaml", Action: v.yamlView, Visible: true, Shared: true},
 		component.KeyR: model.KeyAction{Description: "Refresh", Action: v.Refresh, Visible: true, Shared: true},
+		component.KeyL: model.KeyAction{Description: "Log", Action: v.logView, Visible: true, Shared: true},
 	})
 }
 
@@ -145,5 +146,21 @@ func (v *PodView) yamlView(event *tcell.EventKey) *tcell.EventKey {
 	}
 	ctx := context.WithValue(v.app.ctx, &model.CtxKeyGVR, &gvr)
 	v.app.command.run(ctx, "yaml")
+	return nil
+}
+
+func (v *PodView) logView(event *tcell.EventKey) *tcell.EventKey {
+	row, _ := v.GetSelection()
+	if row == 0 {
+		return event
+	}
+	name, namespace, cluster := v.GetCell(row, 0).Text, v.GetCell(row, 1).Text, v.GetCell(row, 2).Text
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, &model.CtxKeyPod, name)
+	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, namespace)
+	ctx = context.WithValue(ctx, &model.CtxKeyCluster, cluster)
+
+	v.app.command.run(ctx, "log")
 	return nil
 }

--- a/references/cli/top/view/pod_view_test.go
+++ b/references/cli/top/view/pod_view_test.go
@@ -99,6 +99,6 @@ func TestPodView(t *testing.T) {
 	})
 
 	t.Run("hint", func(t *testing.T) {
-		assert.Equal(t, len(podView.Hint()), 4)
+		assert.Equal(t, len(podView.Hint()), 5)
 	})
 }

--- a/references/cli/top/view/pod_view_test.go
+++ b/references/cli/top/view/pod_view_test.go
@@ -81,10 +81,10 @@ func TestPodView(t *testing.T) {
 
 	t.Run("colorize text", func(t *testing.T) {
 		testData := [][]string{
-			{"app", "ns", "1/1", "Running", "", "", "", "", "", "", "", "", ""},
-			{"app", "ns", "1/1", "Pending", "", "", "", "", "", "", "", "", ""},
-			{"app", "ns", "1/1", "Succeeded", "", "", "", "", "", "", "", "", ""},
-			{"app", "ns", "1/1", "Failed", "", "", "", "", "", "", "", "", ""},
+			{"app", "ns", "", "1/1", "Running", "", "", "", "", "", "", "", "", ""},
+			{"app", "ns", "", "1/1", "Pending", "", "", "", "", "", "", "", "", ""},
+			{"app", "ns", "", "1/1", "Succeeded", "", "", "", "", "", "", "", "", ""},
+			{"app", "ns", "", "1/1", "Failed", "", "", "", "", "", "", "", "", ""},
 		}
 		for i := 0; i < len(testData); i++ {
 			for j := 0; j < len(testData[i]); j++ {
@@ -92,10 +92,10 @@ func TestPodView(t *testing.T) {
 			}
 		}
 		podView.ColorizePhaseText(5)
-		assert.Equal(t, podView.GetCell(1, 3).Text, "[green::]Running")
-		assert.Equal(t, podView.GetCell(2, 3).Text, "[yellow::]Pending")
-		assert.Equal(t, podView.GetCell(3, 3).Text, "[purple::]Succeeded")
-		assert.Equal(t, podView.GetCell(4, 3).Text, "[red::]Failed")
+		assert.Equal(t, podView.GetCell(1, 4).Text, "[green::]Running")
+		assert.Equal(t, podView.GetCell(2, 4).Text, "[yellow::]Pending")
+		assert.Equal(t, podView.GetCell(3, 4).Text, "[purple::]Succeeded")
+		assert.Equal(t, podView.GetCell(4, 4).Text, "[red::]Failed")
 	})
 
 	t.Run("hint", func(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. add the feature of viewing log of pod in `vela top`
![demo](https://user-images.githubusercontent.com/30918851/195972413-1637d0a7-0c79-4c5d-b0ea-e6f4630a3ce8.gif)

2. add content to help view
3. add cluster data field to pod view

Fixes #4869

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->