### PR TITLE
Fix: exit waiting after the workflow failed

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -1002,7 +1002,7 @@ func waitApplicationRunning(k8sClient client.Client, addonName string) error {
 		case common2.ApplicationWorkflowSuspending:
 			fmt.Printf("Enabling suspend, please run \"vela workflow resume %s -n vela-system\" to continue", addonutil.Addon2AppName(addonName))
 			return nil
-		case common2.ApplicationWorkflowTerminated:
+		case common2.ApplicationWorkflowTerminated, common2.ApplicationWorkflowFailed:
 			return errors.Errorf("Enabling failed, please run \"vela status %s -n vela-system\" to check the status of the addon", addonutil.Addon2AppName(addonName))
 		default:
 		}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

The workflow is already failed, but the CLI still waiting it.

![image](https://user-images.githubusercontent.com/18493394/196351461-202f5e9c-3e77-4d2c-8a7e-d21c1e31f94d.png)


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->