### PR TITLE
Feat: allow empty cluster for cluster selector

### DIFF
--- a/apis/core.oam.dev/v1alpha1/policy_types.go
+++ b/apis/core.oam.dev/v1alpha1/policy_types.go
@@ -49,6 +49,10 @@ type Placement struct {
 	// Exclusive to "clusters"
 	ClusterLabelSelector map[string]string `json:"clusterLabelSelector,omitempty"`
 
+	// AllowEmpty ignore empty cluster error when no cluster returned for label
+	// selector
+	AllowEmpty bool `json:"allowEmpty,omitempty"`
+
 	// DeprecatedClusterSelector is a depreciated alias for ClusterLabelSelector.
 	// Deprecated: Use clusterLabelSelector instead.
 	DeprecatedClusterSelector map[string]string `json:"clusterSelector,omitempty"`

--- a/charts/vela-core/templates/defwithtemplate/topology.yaml
+++ b/charts/vela-core/templates/defwithtemplate/topology.yaml
@@ -16,6 +16,8 @@ spec:
         	clusters?: [...string]
         	// +usage=Specify the label selector for clusters
         	clusterLabelSelector?: [string]: string
+        	// +usage=Ignore empty cluster error
+        	allowEmpty?: bool
         	// +usage=Deprecated: Use clusterLabelSelector instead.
         	clusterSelector?: [string]: string
         	// +usage=Specify the target namespace to deploy in the selected clusters, default inherit the original namespace.

--- a/charts/vela-minimal/templates/defwithtemplate/topology.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/topology.yaml
@@ -16,6 +16,8 @@ spec:
         	clusters?: [...string]
         	// +usage=Specify the label selector for clusters
         	clusterLabelSelector?: [string]: string
+        	// +usage=Ignore empty cluster error
+        	allowEmpty?: bool
         	// +usage=Deprecated: Use clusterLabelSelector instead.
         	clusterSelector?: [string]: string
         	// +usage=Specify the target namespace to deploy in the selected clusters, default inherit the original namespace.

--- a/pkg/policy/topology.go
+++ b/pkg/policy/topology.go
@@ -46,7 +46,7 @@ func GetClusterLabelSelectorInTopology(topology *v1alpha1.TopologyPolicySpec) ma
 
 // GetPlacementsFromTopologyPolicies get placements from topology policies with provided client
 func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, appNs string, policies []v1beta1.AppPolicy, allowCrossNamespace bool) ([]v1alpha1.PlacementDecision, error) {
-	var placements []v1alpha1.PlacementDecision
+	placements := make([]v1alpha1.PlacementDecision, 0)
 	placementMap := map[string]struct{}{}
 	addCluster := func(cluster string, ns string, validateCluster bool) error {
 		if validateCluster {
@@ -89,7 +89,7 @@ func GetPlacementsFromTopologyPolicies(ctx context.Context, cli client.Client, a
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to find clusters in topology %s", policy.Name)
 				}
-				if len(clusterList.Items) == 0 {
+				if len(clusterList.Items) == 0 && !topologySpec.AllowEmpty {
 					return nil, errors.New("failed to find any cluster matches given labels")
 				}
 				for _, cluster := range clusterList.Items {

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -112,6 +112,14 @@ func TestGetClusterLabelSelectorInTopology(t *testing.T) {
 			}},
 			Error: "failed to find any cluster matches given labels",
 		},
+		"topology-by-cluster-selector-ignore-404": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterSelector":{"key":"bad-value"},"allowEmpty":true}`)},
+			}},
+			Outputs: []v1alpha1.PlacementDecision{},
+		},
 		"topology-by-cluster-selector": {
 			Inputs: []v1beta1.AppPolicy{{
 				Name:       "topology-policy",

--- a/vela-templates/definitions/internal/policy/topology.cue
+++ b/vela-templates/definitions/internal/policy/topology.cue
@@ -12,6 +12,8 @@ template: {
 		clusters?: [...string]
 		// +usage=Specify the label selector for clusters
 		clusterLabelSelector?: [string]: string
+		// +usage=Ignore empty cluster error
+		allowEmpty?: bool
 		// +usage=Deprecated: Use clusterLabelSelector instead.
 		clusterSelector?: [string]: string
 		// +usage=Specify the target namespace to deploy in the selected clusters, default inherit the original namespace.


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In the past, if no cluster is selected from clusterLabelSelector, an error will be thrown.

In addon, now we have one scenario where only non-control-plane clusters are selected and used, which means in single cluster mode there will be no cluster selected for this selector. To prevent the error, this PR adds an `allowEmpty` field to bypass the empty cluster error.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->