### PR TITLE
Fix: remove the owner references

### DIFF
--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -555,12 +555,6 @@ func (k *kubeConfigFactory) CreateOrUpdateConfig(ctx context.Context, i *Config,
 		return fmt.Errorf("fail to apply the secret: %w", err)
 	}
 	for key, obj := range i.OutputObjects {
-		obj.SetOwnerReferences([]metav1.OwnerReference{{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Name:       i.Secret.Name,
-			UID:        i.Secret.UID,
-		}})
 		if err := k.apiApply.Apply(ctx, obj, apply.Quiet()); err != nil {
 			return fmt.Errorf("fail to apply the object %s: %w", key, err)
 		}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

The output objects of the config maybe are cluster scope resources or belong to other namespaces. So, cannot set the owner references.

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->