### PR TITLE
Fix: the api schema can not be generated

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -612,10 +612,7 @@ func unmarshalToContent(content []byte) (fileContent *github.RepositoryContent, 
 }
 
 func genAddonAPISchema(addonRes *UIData) error {
-	cueScript, err := script.PrepareTemplateCUEScript([]byte(addonRes.Parameters))
-	if err != nil {
-		return err
-	}
+	cueScript := script.CUE([]byte(addonRes.Parameters))
 	schema, err := cueScript.ParsePropertiesToSchema()
 	if err != nil {
 		return err

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
@@ -100,6 +100,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if componentDefinition.Status.ConfigMapRef != cmName {
 		componentDefinition.Status.ConfigMapRef = cmName
+		// Override the conditions, which maybe include the error info.
+		componentDefinition.Status.Conditions = []condition.Condition{condition.ReconcileSuccess()}
+
 		if err := r.UpdateStatus(ctx, &componentDefinition); err != nil {
 			klog.InfoS("Could not update componentDefinition Status", "err", err)
 			r.record.Event(&componentDefinition, event.Warning("cannot update ComponentDefinition Status", err))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/test-data/webservice-cd.yaml
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/test-data/webservice-cd.yaml
@@ -1,0 +1,206 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: Describes long-running, scalable, containerized
+      services that have a stable network endpoint to receive external network traffic
+      from customers.
+  name: webservice
+  namespace: vela-system
+spec:
+  schematic:
+    cue:
+      template: "import (\n\t\"strconv\"\n)\n\nmountsArray: [\n\tif parameter.volumeMounts
+        != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc
+        {\n\t\t{\n\t\t\tmountPath: v.mountPath\n\t\t\tif v.subPath != _|_ {\n\t\t\t\tsubPath:
+        v.subPath\n\t\t\t}\n\t\t\tname: v.name\n\t\t}\n\t},\n\n\tif parameter.volumeMounts
+        != _|_ && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap
+        {\n\t\t{\n\t\t\tmountPath: v.mountPath\n\t\t\tif v.subPath != _|_ {\n\t\t\t\tsubPath:
+        v.subPath\n\t\t\t}\n\t\t\tname: v.name\n\t\t}\n\t},\n\n\tif parameter.volumeMounts
+        != _|_ && parameter.volumeMounts.secret != _|_ for v in parameter.volumeMounts.secret
+        {\n\t\t{\n\t\t\tmountPath: v.mountPath\n\t\t\tif v.subPath != _|_ {\n\t\t\t\tsubPath:
+        v.subPath\n\t\t\t}\n\t\t\tname: v.name\n\t\t}\n\t},\n\n\tif parameter.volumeMounts
+        != _|_ && parameter.volumeMounts.emptyDir != _|_ for v in parameter.volumeMounts.emptyDir
+        {\n\t\t{\n\t\t\tmountPath: v.mountPath\n\t\t\tif v.subPath != _|_ {\n\t\t\t\tsubPath:
+        v.subPath\n\t\t\t}\n\t\t\tname: v.name\n\t\t}\n\t},\n\n\tif parameter.volumeMounts
+        != _|_ && parameter.volumeMounts.hostPath != _|_ for v in parameter.volumeMounts.hostPath
+        {\n\t\t{\n\t\t\tmountPath: v.mountPath\n\t\t\tif v.subPath != _|_ {\n\t\t\t\tsubPath:
+        v.subPath\n\t\t\t}\n\t\t\tname: v.name\n\t\t}\n\t},\n]\nvolumesList: [\n\tif
+        parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in
+        parameter.volumeMounts.pvc {\n\t\t{\n\t\t\tname: v.name\n\t\t\tpersistentVolumeClaim:
+        claimName: v.claimName\n\t\t}\n\t},\n\n\tif parameter.volumeMounts != _|_
+        && parameter.volumeMounts.configMap != _|_ for v in parameter.volumeMounts.configMap
+        {\n\t\t{\n\t\t\tname: v.name\n\t\t\tconfigMap: {\n\t\t\t\tdefaultMode: v.defaultMode\n\t\t\t\tname:
+        \       v.cmName\n\t\t\t\tif v.items != _|_ {\n\t\t\t\t\titems: v.items\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t},\n\n\tif
+        parameter.volumeMounts != _|_ && parameter.volumeMounts.secret != _|_ for
+        v in parameter.volumeMounts.secret {\n\t\t{\n\t\t\tname: v.name\n\t\t\tsecret:
+        {\n\t\t\t\tdefaultMode: v.defaultMode\n\t\t\t\tsecretName:  v.secretName\n\t\t\t\tif
+        v.items != _|_ {\n\t\t\t\t\titems: v.items\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t},\n\n\tif
+        parameter.volumeMounts != _|_ && parameter.volumeMounts.emptyDir != _|_ for
+        v in parameter.volumeMounts.emptyDir {\n\t\t{\n\t\t\tname: v.name\n\t\t\temptyDir:
+        medium: v.medium\n\t\t}\n\t},\n\n\tif parameter.volumeMounts != _|_ && parameter.volumeMounts.hostPath
+        != _|_ for v in parameter.volumeMounts.hostPath {\n\t\t{\n\t\t\tname: v.name\n\t\t\thostPath:
+        path: v.path\n\t\t}\n\t},\n]\ndeDupVolumesArray: [\n\tfor val in [\n\t\tfor
+        i, vi in volumesList {\n\t\t\tfor j, vj in volumesList if j < i && vi.name
+        == vj.name {\n\t\t\t\t_ignore: true\n\t\t\t}\n\t\t\tvi\n\t\t},\n\t] if val._ignore
+        == _|_ {\n\t\tval\n\t},\n]\noutput: {\n\tapiVersion: \"apps/v1\"\n\tkind:
+        \      \"Deployment\"\n\tspec: {\n\t\tselector: matchLabels: \"app.oam.dev/component\":
+        context.name\n\n\t\ttemplate: {\n\t\t\tmetadata: {\n\t\t\t\tlabels: {\n\t\t\t\t\tif
+        parameter.labels != _|_ {\n\t\t\t\t\t\tparameter.labels\n\t\t\t\t\t}\n\t\t\t\t\tif
+        parameter.addRevisionLabel {\n\t\t\t\t\t\t\"app.oam.dev/revision\": context.revision\n\t\t\t\t\t}\n\t\t\t\t\t\"app.oam.dev/name\":
+        \     context.appName\n\t\t\t\t\t\"app.oam.dev/component\": context.name\n\t\t\t\t}\n\t\t\t\tif
+        parameter.annotations != _|_ {\n\t\t\t\t\tannotations: parameter.annotations\n\t\t\t\t}\n\t\t\t}\n\n\t\t\tspec:
+        {\n\t\t\t\tcontainers: [{\n\t\t\t\t\tname:  context.name\n\t\t\t\t\timage:
+        parameter.image\n\t\t\t\t\tif parameter[\"port\"] != _|_ && parameter[\"ports\"]
+        == _|_ {\n\t\t\t\t\t\tports: [{\n\t\t\t\t\t\t\tcontainerPort: parameter.port\n\t\t\t\t\t\t}]\n\t\t\t\t\t}\n\t\t\t\t\tif
+        parameter[\"ports\"] != _|_ {\n\t\t\t\t\t\tports: [ for v in parameter.ports
+        {\n\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\tcontainerPort: v.port\n\t\t\t\t\t\t\t\tprotocol:
+        \     v.protocol\n\t\t\t\t\t\t\t\tif v.name != _|_ {\n\t\t\t\t\t\t\t\t\tname:
+        v.name\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\tif v.name == _|_ {\n\t\t\t\t\t\t\t\t\tname:
+        \"port-\" + strconv.FormatInt(v.port, 10)\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}}]\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"imagePullPolicy\"] != _|_ {\n\t\t\t\t\t\timagePullPolicy: parameter.imagePullPolicy\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"cmd\"] != _|_ {\n\t\t\t\t\t\tcommand: parameter.cmd\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"env\"] != _|_ {\n\t\t\t\t\t\tenv: parameter.env\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        context[\"config\"] != _|_ {\n\t\t\t\t\t\tenv: context.config\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"cpu\"] != _|_ {\n\t\t\t\t\t\tresources: {\n\t\t\t\t\t\t\tlimits:
+        cpu:   parameter.cpu\n\t\t\t\t\t\t\trequests: cpu: parameter.cpu\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"memory\"] != _|_ {\n\t\t\t\t\t\tresources: {\n\t\t\t\t\t\t\tlimits:
+        memory:   parameter.memory\n\t\t\t\t\t\t\trequests: memory: parameter.memory\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"volumes\"] != _|_ && parameter[\"volumeMounts\"] == _|_ {\n\t\t\t\t\t\tvolumeMounts:
+        [ for v in parameter.volumes {\n\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\tmountPath:
+        v.mountPath\n\t\t\t\t\t\t\t\tname:      v.name\n\t\t\t\t\t\t\t}}]\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"volumeMounts\"] != _|_ {\n\t\t\t\t\t\tvolumeMounts: mountsArray\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"livenessProbe\"] != _|_ {\n\t\t\t\t\t\tlivenessProbe: parameter.livenessProbe\n\t\t\t\t\t}\n\n\t\t\t\t\tif
+        parameter[\"readinessProbe\"] != _|_ {\n\t\t\t\t\t\treadinessProbe: parameter.readinessProbe\n\t\t\t\t\t}\n\n\t\t\t\t}]\n\n\t\t\t\tif
+        parameter[\"hostAliases\"] != _|_ {\n\t\t\t\t\t// +patchKey=ip\n\t\t\t\t\thostAliases:
+        parameter.hostAliases\n\t\t\t\t}\n\n\t\t\t\tif parameter[\"imagePullSecrets\"]
+        != _|_ {\n\t\t\t\t\timagePullSecrets: [ for v in parameter.imagePullSecrets
+        {\n\t\t\t\t\t\tname: v\n\t\t\t\t\t},\n\t\t\t\t\t]\n\t\t\t\t}\n\n\t\t\t\tif
+        parameter[\"volumes\"] != _|_ && parameter[\"volumeMounts\"] == _|_ {\n\t\t\t\t\tvolumes:
+        [ for v in parameter.volumes {\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\tname: v.name\n\t\t\t\t\t\t\tif
+        v.type == \"pvc\" {\n\t\t\t\t\t\t\t\tpersistentVolumeClaim: claimName: v.claimName\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif
+        v.type == \"configMap\" {\n\t\t\t\t\t\t\t\tconfigMap: {\n\t\t\t\t\t\t\t\t\tdefaultMode:
+        v.defaultMode\n\t\t\t\t\t\t\t\t\tname:        v.cmName\n\t\t\t\t\t\t\t\t\tif
+        v.items != _|_ {\n\t\t\t\t\t\t\t\t\t\titems: v.items\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif
+        v.type == \"secret\" {\n\t\t\t\t\t\t\t\tsecret: {\n\t\t\t\t\t\t\t\t\tdefaultMode:
+        v.defaultMode\n\t\t\t\t\t\t\t\t\tsecretName:  v.secretName\n\t\t\t\t\t\t\t\t\tif
+        v.items != _|_ {\n\t\t\t\t\t\t\t\t\t\titems: v.items\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif
+        v.type == \"emptyDir\" {\n\t\t\t\t\t\t\t\temptyDir: medium: v.medium\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t}\n\t\t\t\t\t}]\n\t\t\t\t}\n\n\t\t\t\tif
+        parameter[\"volumeMounts\"] != _|_ {\n\t\t\t\t\tvolumes: deDupVolumesArray\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}\nexposePorts:
+        [\n\tif parameter.ports != _|_ for v in parameter.ports if v.expose == true
+        {\n\t\tport:       v.port\n\t\ttargetPort: v.port\n\t\tif v.name != _|_ {\n\t\t\tname:
+        v.name\n\t\t}\n\t\tif v.name == _|_ {\n\t\t\tname: \"port-\" + strconv.FormatInt(v.port,
+        10)\n\t\t}\n\t\tif v.nodePort != _|_ && parameter.exposeType == \"NodePort\"
+        {\n\t\t\tnodePort: v.nodePort\n\t\t}\n\t},\n]\noutputs: {\n\tif len(exposePorts)
+        != 0 {\n\t\twebserviceExpose: {\n\t\t\tapiVersion: \"v1\"\n\t\t\tkind:       \"Service\"\n\t\t\tmetadata:
+        name: context.name\n\t\t\tspec: {\n\t\t\t\tselector: \"app.oam.dev/component\":
+        context.name\n\t\t\t\tports: exposePorts\n\t\t\t\ttype:  parameter.exposeType\n\t\t\t}\n\t\t}\n\t}\n}\nparameter:
+        {\n\t// +usage=Specify the labels in the workload\n\tlabels?: [string]: string\n\n\t//
+        +usage=Specify the annotations in the workload\n\tannotations?: [string]:
+        string\n\n\t// +usage=Which image would you like to use for your service\n\t//
+        +short=i\n\timage: string\n\n\t// +usage=Specify image pull policy for your
+        service\n\timagePullPolicy?: \"Always\" | \"Never\" | \"IfNotPresent\"\n\n\t//
+        +usage=Specify image pull secrets for your service\n\timagePullSecrets?: [...string]\n\n\t//
+        +ignore\n\t// +usage=Deprecated field, please use ports instead\n\t// +short=p\n\tport?:
+        int\n\n\t// +usage=Which ports do you want customer traffic sent to, defaults
+        to 80\n\tports?: [...{\n\t\t// +usage=Number of port to expose on the pod's
+        IP address\n\t\tport: int\n\t\t// +usage=Name of the port\n\t\tname?: string\n\t\t//
+        +usage=Protocol for port. Must be UDP, TCP, or SCTP\n\t\tprotocol: *\"TCP\"
+        | \"UDP\" | \"SCTP\"\n\t\t// +usage=Specify if the port should be exposed\n\t\texpose:
+        *false | bool\n\t\t// +usage=exposed node port. Only Valid when exposeType
+        is NodePort\n\t\tnodePort?: int\n\t}]\n\n\t// +ignore\n\t// +usage=Specify
+        what kind of Service you want. options: \"ClusterIP\", \"NodePort\", \"LoadBalancer\"\n\texposeType:
+        *\"ClusterIP\" | \"NodePort\" | \"LoadBalancer\"\n\n\t// +ignore\n\t// +usage=If
+        addRevisionLabel is true, the revision label will be added to the underlying
+        pods\n\taddRevisionLabel: *false | bool\n\n\t// +usage=Commands to run in
+        the container\n\tcmd?: [...string]\n\n\t// +usage=Define arguments by using
+        environment variables\n\tenv?: [...{\n\t\t// +usage=Environment variable name\n\t\tname:
+        string\n\t\t// +usage=The value of the environment variable\n\t\tvalue?: string\n\t\t//
+        +usage=Specifies a source the value of this var should come from\n\t\tvalueFrom?:
+        {\n\t\t\t// +usage=Selects a key of a secret in the pod's namespace\n\t\t\tsecretKeyRef?:
+        {\n\t\t\t\t// +usage=The name of the secret in the pod's namespace to select
+        from\n\t\t\t\tname: string\n\t\t\t\t// +usage=The key of the secret to select
+        from. Must be a valid secret key\n\t\t\t\tkey: string\n\t\t\t}\n\t\t\t// +usage=Selects
+        a key of a config map in the pod's namespace\n\t\t\tconfigMapKeyRef?: {\n\t\t\t\t//
+        +usage=The name of the config map in the pod's namespace to select from\n\t\t\t\tname:
+        string\n\t\t\t\t// +usage=The key of the config map to select from. Must be
+        a valid secret key\n\t\t\t\tkey: string\n\t\t\t}\n\t\t}\n\t}]\n\n\t// +usage=Number
+        of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)\n\tcpu?:
+        string\n\n\t// +usage=Specifies the attributes of the memory resource required
+        for the container.\n\tmemory?: string\n\n\tvolumeMounts?: {\n\t\t// +usage=Mount
+        PVC type volume\n\t\tpvc?: [...{\n\t\t\tname:      string\n\t\t\tmountPath:
+        string\n\t\t\tsubPath?:  string\n\t\t\t// +usage=The name of the PVC\n\t\t\tclaimName:
+        string\n\t\t}]\n\t\t// +usage=Mount ConfigMap type volume\n\t\tconfigMap?:
+        [...{\n\t\t\tname:        string\n\t\t\tmountPath:   string\n\t\t\tsubPath?:
+        \   string\n\t\t\tdefaultMode: *420 | int\n\t\t\tcmName:      string\n\t\t\titems?:
+        [...{\n\t\t\t\tkey:  string\n\t\t\t\tpath: string\n\t\t\t\tmode: *511 | int\n\t\t\t}]\n\t\t}]\n\t\t//
+        +usage=Mount Secret type volume\n\t\tsecret?: [...{\n\t\t\tname:        string\n\t\t\tmountPath:
+        \  string\n\t\t\tsubPath?:    string\n\t\t\tdefaultMode: *420 | int\n\t\t\tsecretName:
+        \ string\n\t\t\titems?: [...{\n\t\t\t\tkey:  string\n\t\t\t\tpath: string\n\t\t\t\tmode:
+        *511 | int\n\t\t\t}]\n\t\t}]\n\t\t// +usage=Mount EmptyDir type volume\n\t\temptyDir?:
+        [...{\n\t\t\tname:      string\n\t\t\tmountPath: string\n\t\t\tsubPath?:  string\n\t\t\tmedium:
+        \   *\"\" | \"Memory\"\n\t\t}]\n\t\t// +usage=Mount HostPath type volume\n\t\thostPath?:
+        [...{\n\t\t\tname:      string\n\t\t\tmountPath: string\n\t\t\tsubPath?:  string\n\t\t\tpath:
+        \     string\n\t\t}]\n\t}\n\n\t// +usage=Deprecated field, use volumeMounts
+        instead.\n\tvolumes?: [...{\n\t\tname:      string\n\t\tmountPath: string\n\t\t//
+        +usage=Specify volume type, options: \"pvc\",\"configMap\",\"secret\",\"emptyDir\",
+        default to emptyDir\n\t\ttype: *\"emptyDir\" | \"pvc\" | \"configMap\" | \"secret\"\n\t\tif
+        type == \"pvc\" {\n\t\t\tclaimName: string\n\t\t}\n\t\tif type == \"configMap\"
+        {\n\t\t\tdefaultMode: *420 | int\n\t\t\tcmName:      string\n\t\t\titems?:
+        [...{\n\t\t\t\tkey:  string\n\t\t\t\tpath: string\n\t\t\t\tmode: *511 | int\n\t\t\t}]\n\t\t}\n\t\tif
+        type == \"secret\" {\n\t\t\tdefaultMode: *420 | int\n\t\t\tsecretName:  string\n\t\t\titems?:
+        [...{\n\t\t\t\tkey:  string\n\t\t\t\tpath: string\n\t\t\t\tmode: *511 | int\n\t\t\t}]\n\t\t}\n\t\tif
+        type == \"emptyDir\" {\n\t\t\tmedium: *\"\" | \"Memory\"\n\t\t}\n\t}]\n\n\t//
+        +usage=Instructions for assessing whether the container is alive.\n\tlivenessProbe?:
+        #HealthProbe\n\n\t// +usage=Instructions for assessing whether the container
+        is in a suitable state to serve traffic.\n\treadinessProbe?: #HealthProbe\n\n\t//
+        +usage=Specify the hostAliases to add\n\thostAliases?: [...{\n\t\tip: string\n\t\thostnames:
+        [...string]\n\t}]\n}\n#HealthProbe: {\n\n\t// +usage=Instructions for assessing
+        container health by executing a command. Either this attribute or the httpGet
+        attribute or the tcpSocket attribute MUST be specified. This attribute is
+        mutually exclusive with both the httpGet attribute and the tcpSocket attribute.\n\texec?:
+        {\n\t\t// +usage=A command to be executed inside the container to assess its
+        health. Each space delimited token of the command is a separate array element.
+        Commands exiting 0 are considered to be successful probes, whilst all other
+        exit codes are considered failures.\n\t\tcommand: [...string]\n\t}\n\n\t//
+        +usage=Instructions for assessing container health by executing an HTTP GET
+        request. Either this attribute or the exec attribute or the tcpSocket attribute
+        MUST be specified. This attribute is mutually exclusive with both the exec
+        attribute and the tcpSocket attribute.\n\thttpGet?: {\n\t\t// +usage=The endpoint,
+        relative to the port, to which the HTTP GET request should be directed.\n\t\tpath:
+        string\n\t\t// +usage=The TCP socket within the container to which the HTTP
+        GET request should be directed.\n\t\tport:    int\n\t\thost?:   string\n\t\tscheme?:
+        *\"HTTP\" | string\n\t\thttpHeaders?: [...{\n\t\t\tname:  string\n\t\t\tvalue:
+        string\n\t\t}]\n\t}\n\n\t// +usage=Instructions for assessing container health
+        by probing a TCP socket. Either this attribute or the exec attribute or the
+        httpGet attribute MUST be specified. This attribute is mutually exclusive
+        with both the exec attribute and the httpGet attribute.\n\ttcpSocket?: {\n\t\t//
+        +usage=The TCP socket within the container that should be probed to assess
+        container health.\n\t\tport: int\n\t}\n\n\t// +usage=Number of seconds after
+        the container is started before the first probe is initiated.\n\tinitialDelaySeconds:
+        *0 | int\n\n\t// +usage=How often, in seconds, to execute the probe.\n\tperiodSeconds:
+        *10 | int\n\n\t// +usage=Number of seconds after which the probe times out.\n\ttimeoutSeconds:
+        *1 | int\n\n\t// +usage=Minimum consecutive successes for the probe to be
+        considered successful after having failed.\n\tsuccessThreshold: *1 | int\n\n\t//
+        +usage=Number of consecutive failures required to determine the container
+        is not alive (liveness probe) or not ready (readiness probe).\n\tfailureThreshold:
+        *3 | int\n}\n"
+  status:
+    customStatus: "ready: {\n\treadyReplicas: *0 | int\n} & {\n\tif context.output.status.readyReplicas
+      != _|_ {\n\t\treadyReplicas: context.output.status.readyReplicas\n\t}\n}\nmessage:
+      \"Ready:\\(ready.readyReplicas)/\\(context.output.spec.replicas)\""
+    healthPolicy: "ready: {\n\tupdatedReplicas:    *0 | int\n\treadyReplicas:      *0
+      | int\n\treplicas:           *0 | int\n\tobservedGeneration: *0 | int\n} & {\n\tif
+      context.output.status.updatedReplicas != _|_ {\n\t\tupdatedReplicas: context.output.status.updatedReplicas\n\t}\n\tif
+      context.output.status.readyReplicas != _|_ {\n\t\treadyReplicas: context.output.status.readyReplicas\n\t}\n\tif
+      context.output.status.replicas != _|_ {\n\t\treplicas: context.output.status.replicas\n\t}\n\tif
+      context.output.status.observedGeneration != _|_ {\n\t\tobservedGeneration: context.output.status.observedGeneration\n\t}\n}\nisHealth:
+      (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas
+      == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas)
+      && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration
+      > context.output.metadata.generation)"
+  workload:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+    type: deployments.apps

--- a/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
@@ -104,6 +104,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if policyDefinition.Status.ConfigMapRef != cmName {
 		policyDefinition.Status.ConfigMapRef = cmName
+		// Override the conditions, which maybe include the error info.
+		policyDefinition.Status.Conditions = []condition.Condition{condition.ReconcileSuccess()}
+
 		if err := r.UpdateStatus(ctx, &policyDefinition); err != nil {
 			klog.InfoS("Could not update policyDefinition Status", "err", err)
 			r.record.Event(&policyDefinition, event.Warning("cannot update PolicyDefinition Status", err))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
@@ -108,6 +108,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if traitDefinition.Status.ConfigMapRef != cmName {
 		traitDefinition.Status.ConfigMapRef = cmName
+		// Override the conditions, which maybe include the error info.
+		traitDefinition.Status.Conditions = []condition.Condition{condition.ReconcileSuccess()}
 		if err := r.UpdateStatus(ctx, &traitDefinition); err != nil {
 			klog.ErrorS(err, "Could not update TraitDefinition Status", "traitDefinition", klog.KRef(req.Namespace, req.Name))
 			r.record.Event(&traitDefinition, event.Warning("Could not update TraitDefinition Status", err))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
@@ -108,6 +108,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if wfStepDefinition.Status.ConfigMapRef != cmName {
 		wfStepDefinition.Status.ConfigMapRef = cmName
+		// Override the conditions, which maybe include the error info.
+		wfStepDefinition.Status.Conditions = []condition.Condition{condition.ReconcileSuccess()}
 		if err := r.UpdateStatus(ctx, &wfStepDefinition); err != nil {
 			klog.ErrorS(err, "Could not update WorkflowStepDefinition Status", "workflowStepDefinition", klog.KRef(req.Namespace, req.Name))
 			r.record.Event(&wfStepDefinition, event.Warning("Could not update WorkflowStepDefinition Status", err))

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -687,14 +687,12 @@ func (def *CapabilityBaseDefinition) CreateOrUpdateConfigMap(ctx context.Context
 
 // getOpenAPISchema is the main function for GetDefinition API
 func getOpenAPISchema(capability types.Capability) ([]byte, error) {
-	cueTemplate, err := script.PrepareTemplateCUEScript([]byte(capability.CueTemplate))
-	if err != nil {
-		return nil, err
-	}
+	cueTemplate := script.CUE([]byte(capability.CueTemplate))
 	schema, err := cueTemplate.ParsePropertiesToSchema()
 	if err != nil {
 		return nil, err
 	}
+	klog.Infof("parsed %d properties by %s/%s", len(schema.Properties), capability.Type, capability.Name)
 	parameter, err := schema.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/pkg/cue/script/schema.go
+++ b/pkg/cue/script/schema.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
+	"github.com/kubevela/workflow/pkg/cue/model/value"
+
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -31,14 +33,19 @@ import (
 
 // ParsePropertiesToSchema parse the properties in cue script to the openapi schema
 // Read the template.parameter field
-func (c CUE) ParsePropertiesToSchema() (*openapi3.Schema, error) {
-	val, err := c.ParseToValue(false)
+func (c CUE) ParsePropertiesToSchema(templateFieldPath ...string) (*openapi3.Schema, error) {
+	val, err := c.ParseToValue()
 	if err != nil {
 		return nil, err
 	}
-	template, err := val.LookupValue("template")
-	if err != nil {
-		return nil, fmt.Errorf("%w cue script: %s", err, c)
+	var template *value.Value
+	if len(templateFieldPath) == 0 {
+		template = val
+	} else {
+		template, err = val.LookupValue(templateFieldPath...)
+		if err != nil {
+			return nil, fmt.Errorf("%w cue script: %s", err, c)
+		}
 	}
 	data, err := common.GenOpenAPI(template.CueValue())
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

We can not look up the values from the template CUE which maybe has incomplete values or context values. Because of this, the definition can not generate the API schema. This issue is introduced by #4794 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->