### PR TITLE
Feat: support context.clusterVersion for definition graceful upgrade

### DIFF
--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -51,3 +51,6 @@ type ClusterVersion struct {
 	GitVersion string `json:"gitVersion,omitempty"`
 	Platform   string `json:"platform,omitempty"`
 }
+
+// ControlPlaneClusterVersion will be the default value of cluster info if managed cluster version get error, it will have value when vela-core started.
+var ControlPlaneClusterVersion ClusterVersion

--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -48,8 +48,6 @@ var (
 type ClusterVersion struct {
 	Major      string `json:"major"`
 	Minor      string `json:"minor"`
-	GitVersion string `json:"gitVersion"`
-	GoVersion  string `json:"goVersion,omitempty"`
-	Compiler   string `json:"compiler,omitempty"`
+	GitVersion string `json:"gitVersion,omitempty"`
 	Platform   string `json:"platform,omitempty"`
 }

--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -39,4 +39,17 @@ const (
 var (
 	// AnnotationClusterAlias the annotation key for cluster alias
 	AnnotationClusterAlias = config.MetaApiGroupName + "/cluster-alias"
+
+	// AnnotationClusterVersion the annotation key for cluster version
+	AnnotationClusterVersion = config.MetaApiGroupName + "/cluster-version"
 )
+
+// ClusterVersion defines the Version info of managed clusters.
+type ClusterVersion struct {
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
+	GitVersion string `json:"gitVersion"`
+	GoVersion  string `json:"goVersion,omitempty"`
+	Compiler   string `json:"compiler,omitempty"`
+	Platform   string `json:"platform,omitempty"`
+}

--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -31,8 +31,13 @@ spec:
         	}
         }
         outputs: ingress: {
-        	apiVersion: "networking.k8s.io/v1"
-        	kind:       "Ingress"
+        	if context.clusterVersion.minor < 19 {
+        		apiVersion: "networking.k8s.io/v1beta1"
+        	}
+        	if context.clusterVersion.minor >= 19 {
+        		apiVersion: "networking.k8s.io/v1"
+        	}
+        	kind: "Ingress"
         	metadata: {
         		name: context.name
         		annotations: {

--- a/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
@@ -31,8 +31,13 @@ spec:
         	}
         }
         outputs: ingress: {
-        	apiVersion: "networking.k8s.io/v1"
-        	kind:       "Ingress"
+        	if context.clusterVersion.minor < 19 {
+        		apiVersion: "networking.k8s.io/v1beta1"
+        	}
+        	if context.clusterVersion.minor >= 19 {
+        		apiVersion: "networking.k8s.io/v1"
+        	}
+        	kind: "Ingress"
         	metadata: {
         		name: context.name
         		annotations: {

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -202,6 +202,7 @@ func main() {
 			}
 		}
 	}
+
 	ctrl.SetLogger(klogr.New())
 
 	if utilfeature.DefaultMutableFeatureGate.Enabled(features.ApplyOnce) {
@@ -276,6 +277,11 @@ func main() {
 
 	if err = standardcontroller.Setup(mgr, disableCaps, controllerArgs); err != nil {
 		klog.ErrorS(err, "Unable to setup the vela core controller")
+		os.Exit(1)
+	}
+
+	if err = multicluster.InitClusterInfo(restConfig); err != nil {
+		klog.ErrorS(err, "Init control plane cluster info")
 		os.Exit(1)
 	}
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -431,6 +431,7 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 		if cluster, ok := pkgmulticluster.ClusterFrom(ctx); ok && cluster != "" {
 			ctxData.Cluster = cluster
 		}
+		ctxData.ClusterVersion = multicluster.GetVersionInfoFromObject(ctx, h.r.Client, ctxData.Cluster)
 	})
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "GenerateComponentManifest")

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -431,7 +431,8 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 		if cluster, ok := pkgmulticluster.ClusterFrom(ctx); ok && cluster != "" {
 			ctxData.Cluster = cluster
 		}
-		ctxData.ClusterVersion = multicluster.GetVersionInfoFromObject(ctx, h.r.Client, ctxData.Cluster)
+		// cluster info are secrets stored in the control plane cluster
+		ctxData.ClusterVersion = multicluster.GetVersionInfoFromObject(pkgmulticluster.WithCluster(ctx, types.ClusterLocalName), h.r.Client, ctxData.Cluster)
 	})
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "GenerateComponentManifest")
@@ -442,7 +443,6 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 	if err := h.HandleComponentsRevision(contextWithComponent(ctx, &comp), []*types.ComponentManifest{manifest}); err != nil {
 		return nil, nil, errors.WithMessage(err, "HandleComponentsRevision")
 	}
-
 	return wl, manifest, nil
 }
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	// +kubebuilder:scaffold:imports
 )
@@ -169,6 +170,7 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 	close(done)
 	Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.LegacyComponentRevision))).Should(Succeed())
+	multicluster.InitClusterInfo(cfg)
 }, 120)
 
 var _ = AfterSuite(func() {

--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -216,6 +216,24 @@ parameter: {
 			}},
 			hasCompileErr: true,
 		},
+		"cluster version info": {
+			workloadTemplate: `
+output:{
+  if context.clusterVersion.minor <  19 {
+    apiVersion: "networking.k8s.io/v1beta1"
+  }
+  if context.clusterVersion.minor >= 19 {
+    apiVersion: "networking.k8s.io/v1"
+  }
+  "kind":       "Ingress",
+}
+`,
+			params: map[string]interface{}{},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "networking.k8s.io/v1",
+				"kind":       "Ingress",
+			}},
+		},
 	}
 
 	for _, v := range testCases {
@@ -224,6 +242,7 @@ parameter: {
 			CompName:        "test",
 			Namespace:       "default",
 			AppRevisionName: "myapp-v1",
+			ClusterVersion:  types.ClusterVersion{Minor: "19"},
 		})
 		wt := NewWorkloadAbstractEngine("testWorkload", &packages.PackageDiscover{})
 		err := wt.Complete(ctx, v.workloadTemplate, v.params)

--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -242,7 +242,7 @@ output:{
 			CompName:        "test",
 			Namespace:       "default",
 			AppRevisionName: "myapp-v1",
-			ClusterVersion:  types.ClusterVersion{Minor: "19"},
+			ClusterVersion:  types.ClusterVersion{Minor: "19+"},
 		})
 		wt := NewWorkloadAbstractEngine("testWorkload", &packages.PackageDiscover{})
 		err := wt.Complete(ctx, v.workloadTemplate, v.params)

--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -18,6 +18,7 @@ package process
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/kubevela/workflow/pkg/cue/process"
 
@@ -71,6 +72,14 @@ func NewContext(data ContextData) process.Context {
 	revNum, _ := util.ExtractRevisionNum(data.AppRevisionName, "-")
 	ctx.PushData(ContextAppRevisionNum, revNum)
 	ctx.PushData(ContextCluster, data.Cluster)
-	ctx.PushData(ContextClusterVersion, data.ClusterVersion)
+
+	minor, _ := strconv.ParseInt(data.ClusterVersion.Minor, 10, 64)
+	cv := map[string]interface{}{
+		"major":      data.ClusterVersion.Major,
+		"gitVersion": data.ClusterVersion.GitVersion,
+		"platform":   data.ClusterVersion.Platform,
+		"minor":      minor,
+	}
+	ctx.PushData(ContextClusterVersion, cv)
 	return ctx
 }

--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubevela/workflow/pkg/cue/process"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -44,6 +45,8 @@ type ContextData struct {
 
 	AppLabels      map[string]string
 	AppAnnotations map[string]string
+
+	ClusterVersion types.ClusterVersion
 }
 
 // NewContext creates a new process context
@@ -68,5 +71,6 @@ func NewContext(data ContextData) process.Context {
 	revNum, _ := util.ExtractRevisionNum(data.AppRevisionName, "-")
 	ctx.PushData(ContextAppRevisionNum, revNum)
 	ctx.PushData(ContextCluster, data.Cluster)
+	ctx.PushData(ContextClusterVersion, data.ClusterVersion)
 	return ctx
 }

--- a/pkg/cue/process/handle_test.go
+++ b/pkg/cue/process/handle_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kubevela/workflow/pkg/cue/model"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
 	"github.com/kubevela/workflow/pkg/cue/process"
+
+	"github.com/oam-dev/kubevela/apis/types"
 )
 
 func TestContext(t *testing.T) {
@@ -166,4 +168,14 @@ image: "myserver"
 	arbitraryData, err := ctxInst.LookupPath(value.FieldPath("context", "arbitraryData")).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"bool\":false,\"int\":10,\"map\":{\"key\":\"value\"},\"slice\":[\"str1\",\"str2\",\"str3\"],\"string\":\"mytxt\"}", string(arbitraryData))
+}
+
+func TestParseClusterVersion(t *testing.T) {
+	types.ControlPlaneClusterVersion = types.ClusterVersion{Minor: "18+"}
+	got := parseClusterVersion(types.ClusterVersion{})
+	assert.Equal(t, got["minor"], int64(18))
+
+	types.ControlPlaneClusterVersion = types.ClusterVersion{Minor: "22-"}
+	got = parseClusterVersion(types.ClusterVersion{})
+	assert.Equal(t, got["minor"], int64(22))
 }

--- a/pkg/cue/process/keyword.go
+++ b/pkg/cue/process/keyword.go
@@ -41,6 +41,8 @@ const (
 	ContextNamespace = "namespace"
 	// ContextCluster is the cluster currently focusing on
 	ContextCluster = "cluster"
+	// ContextClusterVersion is the version object info of cluster
+	ContextClusterVersion = "clusterVersion"
 	// ContextPublishVersion is the publish version of the app
 	ContextPublishVersion = "publishVersion"
 	// ContextWorkflowName is the name of the workflow

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -48,6 +48,12 @@ import (
 	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
+// ContextKey defines the key in context
+type ContextKey string
+
+// KubeConfigContext marks the kubeConfig object in context
+const KubeConfigContext ContextKey = "kubeConfig"
+
 // KubeClusterConfig info for cluster management
 type KubeClusterConfig struct {
 	FilePath        string
@@ -401,6 +407,11 @@ func JoinClusterByKubeConfig(ctx context.Context, cli client.Client, kubeconfigP
 		}
 		if err = clusterConfig.RegisterClusterManagedByOCM(ctx, cli, args); err != nil {
 			return clusterConfig, err
+		}
+	}
+	if cfg, ok := ctx.Value(KubeConfigContext).(*rest.Config); ok {
+		if err = SetClusterVersionInfo(ctx, cfg, clusterName); err != nil {
+			return nil, err
 		}
 	}
 	return clusterConfig, nil

--- a/pkg/multicluster/cluster_metrics_management_test.go
+++ b/pkg/multicluster/cluster_metrics_management_test.go
@@ -45,6 +45,7 @@ const (
 )
 
 func TestRefresh(t *testing.T) {
+	ClusterGatewaySecretNamespace = "default"
 	fakeClient := NewFakeClient(fake.NewClientBuilder().
 		WithScheme(common.Scheme).
 		WithRuntimeObjects(FakeManagedCluster("managed-cluster")).
@@ -138,6 +139,7 @@ func FakeNode(name string, cpu string, memory string) *corev1.Node {
 func FakeSecret(name string) *corev1.Secret {
 	secret := &corev1.Secret{}
 	secret.Name = name
+	secret.Namespace = ClusterGatewaySecretNamespace
 	secret.Labels = map[string]string{
 		clustercommon.LabelKeyClusterCredentialType: "ServiceAccountToken",
 	}

--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -47,14 +47,11 @@ import (
 	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 )
 
-// ControlPlaneClusterVersion will be the default value of cluster info if managed cluster version get error, it will have value when vela-core started.
-var ControlPlaneClusterVersion types.ClusterVersion
-
 // InitClusterInfo will initialize control plane cluster info
 func InitClusterInfo(cfg *rest.Config) error {
 	ctx := context.Background()
 	var err error
-	ControlPlaneClusterVersion, err = GetVersionInfoFromCluster(ctx, ClusterLocalName, cfg)
+	types.ControlPlaneClusterVersion, err = GetVersionInfoFromCluster(ctx, ClusterLocalName, cfg)
 	if err != nil {
 		return err
 	}
@@ -337,7 +334,7 @@ func SetClusterVersionInfo(ctx context.Context, cfg *rest.Config, clusterName st
 		return err
 	}
 	setClusterVersion(vc.Object, cv)
-	klog.Infof("updating version info for %s version %s", clusterName, cv.Major+"."+cv.Minor+"-"+cv.GitVersion)
+	klog.Infof("joining cluster %s with version: %s", clusterName, cv.GitVersion)
 	return cli.Update(ctx, vc.Object)
 }
 
@@ -346,12 +343,12 @@ func GetVersionInfoFromObject(ctx context.Context, cli client.Client, clusterNam
 	vc, err := GetVirtualCluster(ctx, cli, clusterName)
 	if err != nil {
 		klog.Warningf("get virtual cluster for %s err %v, using control plane cluster version", clusterName, err)
-		return ControlPlaneClusterVersion
+		return types.ControlPlaneClusterVersion
 	}
 	cv, err := getClusterVersionFromObject(vc.Object)
 	if err != nil {
 		klog.Warningf("get version info for %s err %v, using control plane cluster version", clusterName, err)
-		return ControlPlaneClusterVersion
+		return types.ControlPlaneClusterVersion
 	}
 	return cv
 }
@@ -371,7 +368,7 @@ func setClusterVersion(o client.Object, info types.ClusterVersion) {
 
 func getClusterVersionFromObject(o client.Object) (types.ClusterVersion, error) {
 	if o == nil {
-		return ControlPlaneClusterVersion, nil
+		return types.ControlPlaneClusterVersion, nil
 	}
 	var cv types.ClusterVersion
 	ann := o.GetAnnotations()

--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -18,17 +18,23 @@ package multicluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/oam-dev/cluster-gateway/pkg/generated/clientset/versioned"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	apilabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/scheme"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -37,8 +43,37 @@ import (
 	clustercommon "github.com/oam-dev/cluster-gateway/pkg/common"
 
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 )
+
+// ControlPlaneClusterVersion will be the default value of cluster info if managed cluster version get error, it will have value when vela-core started.
+var ControlPlaneClusterVersion types.ClusterVersion
+
+// InitClusterInfo will initialize control plane cluster info
+func InitClusterInfo(cfg *rest.Config) error {
+	ctx := context.Background()
+	var err error
+	ControlPlaneClusterVersion, err = GetVersionInfoFromCluster(ctx, ClusterLocalName, cfg)
+	if err != nil {
+		return err
+	}
+	client, err := client.New(cfg, client.Options{Scheme: common.Scheme})
+	if err != nil {
+		return err
+	}
+	clusters, err := prismclusterv1alpha1.NewClusterClient(client).List(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fail to get registered clusters")
+	}
+	for _, cluster := range clusters.Items {
+		if err = SetClusterVersionInfo(ctx, cfg, cluster.Name); err != nil {
+			klog.Warningf("set cluster version for %s: %v, skip it...", cluster.Name, err)
+			continue
+		}
+	}
+	return nil
+}
 
 // VirtualCluster contains base info of cluster, it unifies the difference between different cluster implementations
 // like cluster secret or ocm managed cluster
@@ -136,6 +171,9 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 func GetVirtualCluster(ctx context.Context, c client.Client, clusterName string) (vc *VirtualCluster, err error) {
 	if clusterName == ClusterLocalName {
 		return NewVirtualClusterFromLocal(), nil
+	}
+	if ClusterGatewaySecretNamespace == "" {
+		ClusterGatewaySecretNamespace = types.DefaultKubeVelaNS
 	}
 	secret := &corev1.Secret{}
 	err = c.Get(ctx, apitypes.NamespacedName{
@@ -274,4 +312,104 @@ func NewClusterNameMapper(ctx context.Context, c client.Client) (ClusterNameMapp
 		cm[cluster.Name] = cluster.Alias
 	}
 	return cm, nil
+}
+
+// SetClusterVersionInfo update cluster version info into virtual cluster object
+func SetClusterVersionInfo(ctx context.Context, cfg *rest.Config, clusterName string) error {
+	cli, err := client.New(cfg, client.Options{Scheme: common.Scheme})
+	if err != nil {
+		return err
+	}
+	if clusterName == ClusterLocalName {
+		return nil
+	}
+	vc, err := GetVirtualCluster(ctx, cli, clusterName)
+	if err != nil {
+		return errors.Wrap(err, "get virtual cluster")
+	}
+	_, err = getClusterVersionFromObject(vc.Object)
+	if err == nil {
+		// info already exist
+		return nil
+	}
+	cv, err := GetVersionInfoFromCluster(ctx, clusterName, cfg)
+	if err != nil {
+		return err
+	}
+	setClusterVersion(vc.Object, cv)
+	klog.Infof("updating version info for %s version %s", clusterName, cv.Major+"."+cv.Minor+"-"+cv.GitVersion)
+	return cli.Update(ctx, vc.Object)
+}
+
+// GetVersionInfoFromObject will get cluster version info from virtual cluster, it will fall back to control plane cluster version if any error occur
+func GetVersionInfoFromObject(ctx context.Context, cli client.Client, clusterName string) types.ClusterVersion {
+	vc, err := GetVirtualCluster(ctx, cli, clusterName)
+	if err != nil {
+		klog.Warningf("get virtual cluster for %s err %v, using control plane cluster version", clusterName, err)
+		return ControlPlaneClusterVersion
+	}
+	cv, err := getClusterVersionFromObject(vc.Object)
+	if err != nil {
+		klog.Warningf("get version info for %s err %v, using control plane cluster version", clusterName, err)
+		return ControlPlaneClusterVersion
+	}
+	return cv
+}
+
+func setClusterVersion(o client.Object, info types.ClusterVersion) {
+	if o == nil {
+		return
+	}
+	ann := o.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	content, _ := json.Marshal(info)
+	ann[types.AnnotationClusterVersion] = string(content)
+	o.SetAnnotations(ann)
+}
+
+func getClusterVersionFromObject(o client.Object) (types.ClusterVersion, error) {
+	if o == nil {
+		return ControlPlaneClusterVersion, nil
+	}
+	var cv types.ClusterVersion
+	ann := o.GetAnnotations()
+	if ann == nil {
+		return cv, errors.New("no cluster version info")
+	}
+	versionRaw := ann[types.AnnotationClusterVersion]
+	err := json.Unmarshal([]byte(versionRaw), &cv)
+	return cv, err
+}
+
+// GetVersionInfoFromCluster will add remote cluster version info into secret annotation
+func GetVersionInfoFromCluster(ctx context.Context, clusterName string, cfg *rest.Config) (types.ClusterVersion, error) {
+	var cv types.ClusterVersion
+	content, err := RequestRawK8sAPIForCluster(ctx, "version", clusterName, cfg)
+	if err != nil {
+		return cv, err
+	}
+	if err = json.Unmarshal(content, &cv); err != nil {
+		return cv, err
+	}
+	return cv, nil
+}
+
+// RequestRawK8sAPIForCluster will request multi-cluster K8s API with raw client, such as /healthz, /version, etc
+func RequestRawK8sAPIForCluster(ctx context.Context, path, clusterName string, cfg *rest.Config) ([]byte, error) {
+	cfg.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
+	cfg.NegotiatedSerializer = scheme.Codecs
+	defer func() {
+		cfg.GroupVersion = nil
+		cfg.NegotiatedSerializer = nil
+	}()
+	if clusterName == ClusterLocalName {
+		restClient, err := rest.RESTClientFor(cfg)
+		if err != nil {
+			return nil, errors.Wrap(err, "fail to get local cluster")
+		}
+		return restClient.Get().AbsPath(path).DoRaw(ctx)
+	}
+	return versioned.NewForConfigOrDie(cfg).ClusterV1alpha1().ClusterGateways().RESTClient(clusterName).Get().AbsPath(path).DoRaw(ctx)
 }

--- a/pkg/multicluster/virtual_cluster_test.go
+++ b/pkg/multicluster/virtual_cluster_test.go
@@ -146,6 +146,15 @@ var _ = Describe("Test Virtual Cluster", func() {
 		_, err = NewClusterNameMapper(ctx, cli)
 		Expect(err).ShouldNot(Succeed())
 	})
+	It("Test Cluster Version Get and Set", func() {
+		ClusterGatewaySecretNamespace = "vela-system2"
+		ctx := context.Background()
+		Expect(k8sClient.Create(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ClusterGatewaySecretNamespace}})).Should(Succeed())
+		cv, err := GetVersionInfoFromCluster(ctx, "local", cfg)
+		Expect(err).Should(BeNil())
+		Expect(cv.Minor).Should(Not(BeEquivalentTo("")))
+		Expect(cv.Major).Should(BeEquivalentTo("1"))
+	})
 
 })
 

--- a/pkg/workflow/operation/operation.go
+++ b/pkg/workflow/operation/operation.go
@@ -95,7 +95,7 @@ func (wo wfOperator) Resume(ctx context.Context, app *v1beta1.Application) error
 		return err
 	}
 	if !rolloutResumed && !app.Status.Workflow.Suspend {
-		return wo.writeOutput("the workflow is not suspending")
+		return wo.writeOutputF("workflow %s is not suspended.\n", app.Name)
 	}
 
 	if app.Status.Workflow.Suspend {
@@ -224,7 +224,7 @@ func (wo wfOperator) Rollback(ctx context.Context, app *v1beta1.Application) err
 	}
 
 	if rollback {
-		err = wo.writeOutput("Successfully rollback rollout")
+		err = wo.writeOutput("Successfully rollback app.\n")
 		if err != nil {
 			return err
 		}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -32,7 +32,6 @@ import (
 	pkgmulticluster "github.com/kubevela/pkg/multicluster"
 	prismclusterv1alpha1 "github.com/kubevela/prism/pkg/apis/cluster/v1alpha1"
 	"github.com/oam-dev/cluster-gateway/pkg/config"
-	"github.com/oam-dev/cluster-gateway/pkg/generated/clientset/versioned"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
@@ -292,14 +291,11 @@ func NewClusterProbeCommand(c *common.Args) *cobra.Command {
 		Args:  cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
-			if clusterName == multicluster.ClusterLocalName {
-				return errors.New("you must specify a remote cluster name")
-			}
 			config, err := c.GetConfig()
 			if err != nil {
 				return err
 			}
-			content, err := versioned.NewForConfigOrDie(config).ClusterV1alpha1().ClusterGateways().RESTClient(clusterName).Get().AbsPath("healthz").DoRaw(context.TODO())
+			content, err := multicluster.RequestRawK8sAPIForCluster(context.TODO(), "healthz", clusterName, config)
 			if err != nil {
 				return errors.Wrapf(err, "failed connect cluster %s", clusterName)
 			}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -182,7 +182,8 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 			}
 
 			managedClusterKubeConfig := args[0]
-			clusterConfig, err := multicluster.JoinClusterByKubeConfig(context.Background(), client, managedClusterKubeConfig, clusterName,
+			ctx := context.WithValue(context.Background(), multicluster.KubeConfigContext, restConfig)
+			clusterConfig, err := multicluster.JoinClusterByKubeConfig(ctx, client, managedClusterKubeConfig, clusterName,
 				multicluster.JoinClusterCreateNamespaceOption(createNamespace),
 				multicluster.JoinClusterEngineOption(clusterManagementType),
 				multicluster.JoinClusterOCMOptions{

--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
+	multicluster2 "github.com/oam-dev/kubevela/pkg/multicluster"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
@@ -79,6 +80,12 @@ var _ = BeforeSuite(func() {
 	// join worker cluster
 	_, err = execCommand("cluster", "join", WorkerClusterKubeConfigPath, "--name", WorkerClusterName)
 	Expect(err).Should(Succeed())
+	cv, err := multicluster2.GetVersionInfoFromCluster(context.Background(), WorkerClusterName, config)
+	Expect(err).Should(Succeed())
+	Expect(cv.Minor).Should(Not(BeEquivalentTo("")))
+	Expect(cv.Major).Should(BeEquivalentTo("1"))
+	ocv := multicluster2.GetVersionInfoFromObject(context.Background(), k8sClient, WorkerClusterName)
+	Expect(ocv).Should(BeEquivalentTo(cv))
 })
 
 var _ = AfterSuite(func() {

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -56,8 +56,13 @@ template: {
 	}
 
 	outputs: ingress: {
-		apiVersion: "networking.k8s.io/v1"
-		kind:       "Ingress"
+		if context.clusterVersion.minor < 19 {
+			apiVersion: "networking.k8s.io/v1beta1"
+		}
+		if context.clusterVersion.minor >= 19 {
+			apiVersion: "networking.k8s.io/v1"
+		}
+		kind: "Ingress"
 		metadata: {
 			name: context.name
 			annotations: {


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4785

1. Use case 1: use minor version to judge api

```
 outputs: ingress: {
        	if context.clusterVersion.minor < 19 {
        		apiVersion: "networking.k8s.io/v1beta1"
        	}
        	if context.clusterVersion.minor >= 19 {
        		apiVersion: "networking.k8s.io/v1"
        	}
        	kind: "Ingress"
}
```

2. Use case 2: use gitVersion to judge provider

```
import "strings"

if strings.Contains(context.clusterVersion.gitVersion, "k3s") {
     provider: "k3s"
}
if strings.Contains(context.clusterVersion.gitVersion, "aliyun") {
     provider: "aliyun"
}
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->