### PR TITLE
Feat: Refer to the generation when checking the application status

### DIFF
--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -292,7 +292,7 @@ func (c *applicationServiceImpl) GetApplicationStatus(ctx context.Context, appmo
 		return nil, err
 	}
 	if !app.DeletionTimestamp.IsZero() {
-		app.Status.Phase = "deleting"
+		app.Status.Phase = common.ApplicationDeleting
 	}
 	if app.Generation > app.Status.ObservedGeneration {
 		app.Status.Phase = common.ApplicationStarting

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -291,11 +291,11 @@ func (c *applicationServiceImpl) GetApplicationStatus(ctx context.Context, appmo
 		}
 		return nil, err
 	}
-	if !app.DeletionTimestamp.IsZero() {
-		app.Status.Phase = common.ApplicationDeleting
-	}
 	if app.Generation > app.Status.ObservedGeneration {
 		app.Status.Phase = common.ApplicationStarting
+	}
+	if !app.DeletionTimestamp.IsZero() {
+		app.Status.Phase = common.ApplicationDeleting
 	}
 	return &app.Status, nil
 }

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -294,6 +294,9 @@ func (c *applicationServiceImpl) GetApplicationStatus(ctx context.Context, appmo
 	if !app.DeletionTimestamp.IsZero() {
 		app.Status.Phase = "deleting"
 	}
+	if app.Generation > app.Status.ObservedGeneration {
+		app.Status.Phase = common.ApplicationStarting
+	}
 	return &app.Status, nil
 }
 

--- a/pkg/apiserver/domain/service/application_test.go
+++ b/pkg/apiserver/domain/service/application_test.go
@@ -442,6 +442,11 @@ var _ = Describe("Test application service function", func() {
 		Expect(err).Should(BeNil())
 		Expect(revision.DeployUser.Name).Should(Equal(model.DefaultAdminUserName))
 		Expect(revision.DeployUser.Alias).Should(Equal(model.DefaultAdminUserAlias))
+
+		appStats, err := appService.GetApplicationStatus(context.TODO(), appModel, "app-dev")
+		Expect(err).Should(BeNil())
+		Expect(appStats.Phase).Should(Equal(common.ApplicationStarting))
+
 		err = envBindingService.ApplicationEnvRecycle(context.TODO(), &model.Application{
 			Name: testApp,
 		}, &model.EnvBinding{Name: "app-dev"})


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

After we apply the application, the controller may be can not reconcile it timely. At this time the generation is greater than the observed generation. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->