### PR TITLE
Fix: deprecated resolve reference in gen open API

### DIFF
--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -71,7 +71,7 @@ annotations: {
 
 parameter: [string]: string
 `,
-			want: want{data: "{\"type\":\"object\"}", err: nil},
+			want: want{data: `{"additionalProperties":{"type":"string"},"type":"object"}`, err: nil},
 		},
 		"parameter in cue is a string type,": {
 			reason: "Prepare a normal parameter cue file",
@@ -166,7 +166,7 @@ patch: {
 
 parameter: [string]: string
 `,
-			want: want{data: "{\"type\":\"object\"}", err: nil},
+			want: want{data: `{"additionalProperties":{"type":"string"},"type":"object"}`, err: nil},
 		},
 	}
 

--- a/pkg/cue/script/schema.go
+++ b/pkg/cue/script/schema.go
@@ -47,7 +47,7 @@ func (c CUE) ParsePropertiesToSchema(templateFieldPath ...string) (*openapi3.Sch
 			return nil, fmt.Errorf("%w cue script: %s", err, c)
 		}
 	}
-	data, err := common.GenOpenAPI(template.CueValue())
+	data, err := common.GenOpenAPI(template)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/common/testdata/workload1.cue
+++ b/pkg/utils/common/testdata/workload1.cue
@@ -7,6 +7,8 @@ parameter: {
 	cmd?: [...string]
 
 	cpu?: string
+
+	http: [string]: int
 }
 
 #routeName: "\(context.appName)-\(context.name)"

--- a/pkg/utils/common/testdata/workload1.json
+++ b/pkg/utils/common/testdata/workload1.json
@@ -10,7 +10,8 @@
          "parameter": {
             "type": "object",
             "required": [
-               "image"
+               "image",
+               "http"
             ],
             "properties": {
                "image": {
@@ -26,6 +27,12 @@
                },
                "cpu": {
                   "type": "string"
+               },
+               "http": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "type": "integer"
+                  }
                }
             }
          }


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->