### PR TITLE
Fix: explicit error info for enabling addon with velaux

### DIFF
--- a/e2e/addon/mock/testdata/not-match-addon/metadata.yaml
+++ b/e2e/addon/mock/testdata/not-match-addon/metadata.yaml
@@ -1,0 +1,19 @@
+name: not-match-addon
+version: 1.0.0
+description: Extended workload to do continuous and progressive delivery
+icon: https://raw.githubusercontent.com/fluxcd/flux/master/docs/_files/weave-flux.png
+url: https://fluxcd.io
+
+tags:
+  - mock
+dependencies: []
+#- name: addon_name
+
+# set invisible means this won't be list and will be enabled when depended on
+# for example, terraform-alibaba depends on terraform which is invisible,
+# when terraform-alibaba is enabled, terraform will be enabled automatically
+# default: false
+invisible: false
+
+system:
+  kubernetes: "<=v1.3.0"

--- a/pkg/apiserver/domain/service/addon.go
+++ b/pkg/apiserver/domain/service/addon.go
@@ -419,7 +419,9 @@ func (u *addonServiceImpl) EnableAddon(ctx context.Context, name string, args ap
 
 		// wrap this error with special bcode
 		if errors.As(err, &pkgaddon.VersionUnMatchError{}) {
-			return bcode.ErrAddonSystemVersionMismatch
+			berr := bcode.ErrAddonSystemVersionMismatch
+			berr.Message = err.Error()
+			return berr
 		}
 		// except `addon not found`, other errors should return directly
 		return err


### PR DESCRIPTION
Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>

Enabling an addon with velaux, if system requirement not match explicit error info.

![image](https://user-images.githubusercontent.com/77846369/198022242-6baa2877-3a81-4985-b812-2d4338e07931.png)


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->