### PR TITLE
Fix: update namespace only if it doesn't have the env label

### DIFF
--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -79,7 +79,7 @@ func MergeNoConflictLabels(labels map[string]string) MutateOption {
 func CreateOrUpdateNamespace(ctx context.Context, kubeClient client.Client, name string, options ...MutateOption) error {
 	err := CreateNamespace(ctx, kubeClient, name, options...)
 	// only if namespace don't have the env label that we need to update it
-	if err != nil && apierrors.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
 		return UpdateNamespace(ctx, kubeClient, name, options...)
 	}
 	return err

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -78,10 +78,11 @@ func MergeNoConflictLabels(labels map[string]string) MutateOption {
 // It will report an error if the labels conflict while it will override the annotations
 func CreateOrUpdateNamespace(ctx context.Context, kubeClient client.Client, name string, options ...MutateOption) error {
 	err := CreateNamespace(ctx, kubeClient, name, options...)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+	// only if namespace don't have the env label that we need to update it
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		return UpdateNamespace(ctx, kubeClient, name, options...)
 	}
-	return UpdateNamespace(ctx, kubeClient, name, options...)
+	return err
 }
 
 // CreateNamespace will create a namespace with mutate option


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>


### Description of your changes
update namespace only if it doesn't have the env label
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4929 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->