### PR TITLE
Fix: do not change the workflow after the env changed

### DIFF
--- a/pkg/apiserver/domain/service/application_test.go
+++ b/pkg/apiserver/domain/service/application_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Test application service function", func() {
 		Expect(cmp.Diff(compareResponse.TargetAppYAML, "")).Should(BeEmpty())
 		Expect(cmp.Diff(compareResponse.BaseAppYAML, "")).ShouldNot(BeEmpty())
 
-		By("compare when app's env add target, should return true")
+		By("compare when app's env add target, should return false")
 		_, err = targetService.CreateTarget(context.TODO(), v1.CreateTargetRequest{Name: "dev-target1", Project: appModel.Project, Cluster: &v1.ClusterTarget{ClusterName: "local", Namespace: "dev-target1"}})
 		Expect(err).Should(BeNil())
 		_, err = envService.UpdateEnv(context.TODO(), "app-dev",
@@ -548,7 +548,8 @@ var _ = Describe("Test application service function", func() {
 			},
 		})
 		Expect(err).Should(BeNil())
-		check(compareResponse, true)
+		// Existing applications are not affected after update env.
+		check(compareResponse, false)
 
 		By("compare when update app's trait, should return true")
 		// reset app config

--- a/pkg/apiserver/domain/service/env_test.go
+++ b/pkg/apiserver/domain/service/env_test.go
@@ -25,8 +25,11 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
 	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/dto/v1"
@@ -52,6 +55,8 @@ var _ = Describe("Test env service functions", func() {
 	It("Test Create/Get/Delete Env function", func() {
 		// create target
 		err := ds.Add(context.TODO(), &model.Target{Name: "env-test"})
+		Expect(err).Should(BeNil())
+		err = ds.Add(context.TODO(), &model.Target{Name: "env-test-2"})
 		Expect(err).Should(BeNil())
 
 		req := apisv1.CreateEnvRequest{
@@ -112,6 +117,35 @@ var _ = Describe("Test env service functions", func() {
 		env, err := envService.UpdateEnv(context.TODO(), "test-env-2", req5)
 		Expect(err).Should(BeNil())
 		Expect(cmp.Diff(env.Description, req5.Description)).Should(BeEmpty())
+
+		By("Test update the targets of the env")
+		req6 := apisv1.UpdateEnvRequest{
+			Description: "this is a env description update",
+			Targets:     []string{"env-test", "env-test-2"},
+		}
+		env, err = envService.UpdateEnv(context.TODO(), "test-env-2", req6)
+		Expect(err).Should(BeNil())
+		Expect(cmp.Diff(len(env.Targets), len(req6.Targets))).Should(BeEmpty())
+
+		Expect(k8sClient.Create(context.TODO(), &v1beta1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "env-app",
+				Namespace: env.Namespace,
+				Labels: map[string]string{
+					model.LabelSourceOfTruth: model.FromUX,
+				},
+			},
+			Spec: v1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{},
+			},
+		})).Should(BeNil())
+
+		req7 := apisv1.UpdateEnvRequest{
+			Description: "this is a env description update",
+			Targets:     []string{"env-test"},
+		}
+		_, err = envService.UpdateEnv(context.TODO(), "test-env-2", req7)
+		Expect(err).Should(Equal(bcode.ErrEnvTargetNotAllowDelete))
 
 		// clean up the env
 		err = envService.DeleteEnv(context.TODO(), "test-env")

--- a/pkg/apiserver/utils/bcode/011_env.go
+++ b/pkg/apiserver/utils/bcode/011_env.go
@@ -33,3 +33,6 @@ var ErrDeleteEnvButAppExist = NewBcode(400, 11005, "env can't be deleted as app 
 
 // ErrEnvTargetConflict in one project, one target can only belong to one env
 var ErrEnvTargetConflict = NewBcode(400, 11006, "in one project, one target can only belong to one env.")
+
+// ErrEnvTargetNotAllowDelete means can not remove existing targets from this environment, because there are applications deployed.
+var ErrEnvTargetNotAllowDelete = NewBcode(400, 11007, "target can not be deleted, because there are applications deployed.")


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Enable users to edit the workflow to determine targets for the application to be published to the environment.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->