### PR TITLE
Fix: mongodb can not decode runtime.Object

### DIFF
--- a/pkg/apiserver/domain/model/pipeline.go
+++ b/pkg/apiserver/domain/model/pipeline.go
@@ -32,37 +32,7 @@ func init() {
 // WorkflowSpec defines workflow steps and other attributes
 type WorkflowSpec struct {
 	Mode  *v1alpha1.WorkflowExecuteMode `json:"mode,omitempty"`
-	Steps []WorkflowStepSpec            `json:"steps,omitempty"`
-}
-
-// WorkflowStepSpec defines how to execute a workflow step.
-type WorkflowStepSpec struct {
-	WorkflowStepBaseSpec `json:",inline"`
-	SubSteps             []WorkflowStepBaseSpec `json:"subSteps,omitempty"`
-}
-
-// WorkflowStepBaseSpec defines the workflow step base
-type WorkflowStepBaseSpec struct {
-	// Name is the unique name of the workflow step.
-	Name string `json:"name"`
-	// Type is the type of the workflow step.
-	Type string `json:"type"`
-	// Meta is the meta data of the workflow step.
-	Meta *v1alpha1.WorkflowStepMeta `json:"meta,omitempty"`
-	// If is the if condition of the step
-	If string `json:"if,omitempty"`
-	// Timeout is the timeout of the step
-	Timeout string `json:"timeout,omitempty"`
-	// DependsOn is the dependency of the step
-	DependsOn []string `json:"dependsOn,omitempty"`
-	// Inputs is the inputs of the step
-	Inputs v1alpha1.StepInputs `json:"inputs,omitempty"`
-	// Outputs is the outputs of the step
-	Outputs v1alpha1.StepOutputs `json:"outputs,omitempty"`
-
-	// Properties is the properties of the step
-	// +kubebuilder:pruning:PreserveUnknownFields
-	Properties *JSONStruct `json:"properties,omitempty"`
+	Steps []WorkflowStep                `json:"steps,omitempty"`
 }
 
 // Pipeline is the model of pipeline

--- a/pkg/apiserver/domain/model/pipeline.go
+++ b/pkg/apiserver/domain/model/pipeline.go
@@ -27,10 +27,48 @@ func init() {
 	RegisterModel(&Pipeline{})
 }
 
+// Structs copied from workflow/api/v1alpha1/types.go
+
+// WorkflowSpec defines workflow steps and other attributes
+type WorkflowSpec struct {
+	Mode  *v1alpha1.WorkflowExecuteMode `json:"mode,omitempty"`
+	Steps []WorkflowStepSpec            `json:"steps,omitempty"`
+}
+
+// WorkflowStepSpec defines how to execute a workflow step.
+type WorkflowStepSpec struct {
+	WorkflowStepBaseSpec `json:",inline"`
+	SubSteps             []WorkflowStepBaseSpec `json:"subSteps,omitempty"`
+}
+
+// WorkflowStepBaseSpec defines the workflow step base
+type WorkflowStepBaseSpec struct {
+	// Name is the unique name of the workflow step.
+	Name string `json:"name"`
+	// Type is the type of the workflow step.
+	Type string `json:"type"`
+	// Meta is the meta data of the workflow step.
+	Meta *v1alpha1.WorkflowStepMeta `json:"meta,omitempty"`
+	// If is the if condition of the step
+	If string `json:"if,omitempty"`
+	// Timeout is the timeout of the step
+	Timeout string `json:"timeout,omitempty"`
+	// DependsOn is the dependency of the step
+	DependsOn []string `json:"dependsOn,omitempty"`
+	// Inputs is the inputs of the step
+	Inputs v1alpha1.StepInputs `json:"inputs,omitempty"`
+	// Outputs is the outputs of the step
+	Outputs v1alpha1.StepOutputs `json:"outputs,omitempty"`
+
+	// Properties is the properties of the step
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Properties *JSONStruct `json:"properties,omitempty"`
+}
+
 // Pipeline is the model of pipeline
 type Pipeline struct {
 	BaseModel
-	Spec        v1alpha1.WorkflowSpec
+	Spec        WorkflowSpec
 	Name        string `json:"name"`
 	Project     string `json:"project"`
 	Alias       string `json:"alias"`

--- a/pkg/apiserver/domain/service/pipeline.go
+++ b/pkg/apiserver/domain/service/pipeline.go
@@ -673,12 +673,16 @@ func getResourceLogs(ctx context.Context, config *rest.Config, cli client.Client
 					}
 					break
 				}
+				shouldPrint := true
 				if len(filters) != 0 {
 					for _, f := range filters {
-						if strings.Contains(s, f) {
-							buf.WriteString(s)
+						if !strings.Contains(s, f) {
+							shouldPrint = false
 						}
 					}
+				}
+				if shouldPrint {
+					buf.WriteString(s)
 				}
 			}
 			if readErr != nil {

--- a/pkg/apiserver/domain/service/pipeline.go
+++ b/pkg/apiserver/domain/service/pipeline.go
@@ -705,7 +705,7 @@ func getResourceLogs(ctx context.Context, config *rest.Config, cli client.Client
 	return logBuilder.String(), nil
 }
 
-func pipelineStep2WorkflowStep(step model.WorkflowStepSpec) v1alpha1.WorkflowStep {
+func pipelineStep2WorkflowStep(step model.WorkflowStep) v1alpha1.WorkflowStep {
 	res := v1alpha1.WorkflowStep{
 		WorkflowStepBase: v1alpha1.WorkflowStepBase{
 			Name:       step.Name,

--- a/pkg/apiserver/domain/service/pipeline.go
+++ b/pkg/apiserver/domain/service/pipeline.go
@@ -705,6 +705,48 @@ func getResourceLogs(ctx context.Context, config *rest.Config, cli client.Client
 	return logBuilder.String(), nil
 }
 
+func pipelineStep2WorkflowStep(step model.WorkflowStepSpec) v1alpha1.WorkflowStep {
+	res := v1alpha1.WorkflowStep{
+		WorkflowStepBase: v1alpha1.WorkflowStepBase{
+			Name:       step.Name,
+			Type:       step.Type,
+			Meta:       step.Meta,
+			If:         step.If,
+			Timeout:    step.Timeout,
+			DependsOn:  step.DependsOn,
+			Inputs:     step.Inputs,
+			Outputs:    step.Outputs,
+			Properties: step.Properties.RawExtension(),
+		},
+		SubSteps: make([]v1alpha1.WorkflowStepBase, 0),
+	}
+	for _, subStep := range step.SubSteps {
+		res.SubSteps = append(res.SubSteps, v1alpha1.WorkflowStepBase{
+			Name:       subStep.Name,
+			Type:       subStep.Type,
+			Meta:       subStep.Meta,
+			If:         subStep.If,
+			Timeout:    subStep.Timeout,
+			DependsOn:  subStep.DependsOn,
+			Inputs:     subStep.Inputs,
+			Outputs:    subStep.Outputs,
+			Properties: subStep.Properties.RawExtension(),
+		})
+	}
+	return res
+}
+
+func pipelineSpec2WorkflowSpec(spec model.WorkflowSpec) *v1alpha1.WorkflowSpec {
+	res := &v1alpha1.WorkflowSpec{
+		Mode:  spec.Mode,
+		Steps: make([]v1alpha1.WorkflowStep, 0),
+	}
+	for _, step := range spec.Steps {
+		res.Steps = append(res.Steps, pipelineStep2WorkflowStep(step))
+	}
+	return res
+}
+
 // RunPipeline will run a pipeline
 func (p pipelineServiceImpl) RunPipeline(ctx context.Context, pipeline apis.PipelineBase, req apis.RunPipelineRequest) (*apis.PipelineRun, error) {
 	if err := checkRunMode(&req.Mode); err != nil {
@@ -714,9 +756,10 @@ func (p pipelineServiceImpl) RunPipeline(ctx context.Context, pipeline apis.Pipe
 	run := v1alpha1.WorkflowRun{}
 	version := utils.GenerateVersion("")
 	name := fmt.Sprintf("%s-%s", pipeline.Name, version)
+	s := pipeline.Spec
 	run.Name = name
 	run.Namespace = project.GetNamespace()
-	run.Spec.WorkflowSpec = &pipeline.Spec
+	run.Spec.WorkflowSpec = pipelineSpec2WorkflowSpec(s)
 	run.Spec.Mode = &req.Mode
 
 	run.SetLabels(map[string]string{
@@ -884,7 +927,7 @@ func (p pipelineRunServiceImpl) GetPipelineRun(ctx context.Context, meta apis.Pi
 			}
 			return nil, err
 		}
-		run.Spec.WorkflowSpec = &pipeline.Spec
+		run.Spec.WorkflowSpec = pipelineSpec2WorkflowSpec(pipeline.Spec)
 
 	}
 	return workflowRun2PipelineRun(run, project, p.ContextService)
@@ -1239,7 +1282,7 @@ func (p pipelineRunServiceImpl) terminatePipelineRun(ctx context.Context, run *v
 
 }
 
-func checkPipelineSpec(spec v1alpha1.WorkflowSpec) error {
+func checkPipelineSpec(spec model.WorkflowSpec) error {
 	if len(spec.Steps) == 0 {
 		return bcode.ErrNoSteps
 	}

--- a/pkg/apiserver/domain/service/pipeline_test.go
+++ b/pkg/apiserver/domain/service/pipeline_test.go
@@ -70,9 +70,9 @@ var _ = Describe("Test pipeline service functions", func() {
 		props := model.JSONStruct{
 			"url": "https://api.github.com/repos/kubevela/kubevela",
 		}
-		testPipelineSteps := []model.WorkflowStepSpec{
+		testPipelineSteps := []model.WorkflowStep{
 			{
-				SubSteps: []model.WorkflowStepBaseSpec{
+				SubSteps: []model.WorkflowStepBase{
 					{
 						Name: "request",
 						Type: "request",
@@ -85,7 +85,7 @@ var _ = Describe("Test pipeline service functions", func() {
 						Properties: &props,
 					},
 				},
-				WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
+				WorkflowStepBase: model.WorkflowStepBase{
 					Name: "step-group",
 					Type: "step-group",
 				},

--- a/pkg/apiserver/domain/service/pipeline_test.go
+++ b/pkg/apiserver/domain/service/pipeline_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kubevela/workflow/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
@@ -68,10 +67,12 @@ var _ = Describe("Test pipeline service functions", func() {
 	})
 
 	It("Test create pipeline", func() {
-		rawProps := []byte(`{"url":"https://api.github.com/repos/kubevela/kubevela"}`)
-		testPipelineSteps := []v1alpha1.WorkflowStep{
+		props := model.JSONStruct{
+			"url": "https://api.github.com/repos/kubevela/kubevela",
+		}
+		testPipelineSteps := []model.WorkflowStepSpec{
 			{
-				SubSteps: []v1alpha1.WorkflowStepBase{
+				SubSteps: []model.WorkflowStepBaseSpec{
 					{
 						Name: "request",
 						Type: "request",
@@ -81,12 +82,10 @@ var _ = Describe("Test pipeline service functions", func() {
 								Name:      "stars",
 							},
 						},
-						Properties: &runtime.RawExtension{
-							Raw: rawProps,
-						},
+						Properties: &props,
 					},
 				},
-				WorkflowStepBase: v1alpha1.WorkflowStepBase{
+				WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
 					Name: "step-group",
 					Type: "step-group",
 				},
@@ -96,7 +95,7 @@ var _ = Describe("Test pipeline service functions", func() {
 		By("create pipeline with sub-steps")
 		pipeline, err := pipelineService.CreatePipeline(ctx, apisv1.CreatePipelineRequest{
 			Name: pipelineName,
-			Spec: v1alpha1.WorkflowSpec{
+			Spec: model.WorkflowSpec{
 				Steps: testPipelineSteps,
 			},
 		})

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -1564,7 +1564,7 @@ type PipelineMeta struct {
 // PipelineBase is the base info of pipeline
 type PipelineBase struct {
 	PipelineMeta `json:",inline"`
-	Spec         workflowv1alpha1.WorkflowSpec `json:"spec"`
+	Spec         model.WorkflowSpec `json:"spec"`
 }
 
 // RunStatInfo is the pipeline run statistics info
@@ -1583,10 +1583,10 @@ type RunStat struct {
 
 // CreatePipelineRequest is the request body of creating pipeline
 type CreatePipelineRequest struct {
-	Name        string                        `json:"name" validate:"checkname"`
-	Alias       string                        `json:"alias" validate:"checkalias" optional:"true"`
-	Description string                        `json:"description" optional:"true"`
-	Spec        workflowv1alpha1.WorkflowSpec `json:"spec"`
+	Name        string             `json:"name" validate:"checkname"`
+	Alias       string             `json:"alias" validate:"checkalias" optional:"true"`
+	Description string             `json:"description" optional:"true"`
+	Spec        model.WorkflowSpec `json:"spec"`
 }
 
 // PipelineMetaResponse is the response body contains PipelineMeta
@@ -1615,9 +1615,9 @@ type PipelineListItem struct {
 
 // UpdatePipelineRequest is the request body of updating pipeline
 type UpdatePipelineRequest struct {
-	Alias       string                        `json:"alias" validate:"checkalias" optional:"true"`
-	Description string                        `json:"description" optional:"true"`
-	Spec        workflowv1alpha1.WorkflowSpec `json:"spec" optional:"true"`
+	Alias       string             `json:"alias" validate:"checkalias" optional:"true"`
+	Description string             `json:"description" optional:"true"`
+	Spec        model.WorkflowSpec `json:"spec" optional:"true"`
 }
 
 // GetPipelineResponse is the response body of getting pipeline

--- a/test/e2e-apiserver-test/pipeline_test.go
+++ b/test/e2e-apiserver-test/pipeline_test.go
@@ -24,24 +24,24 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubevela/workflow/api/v1alpha1"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/dto/v1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-var testPipelineSteps []v1alpha1.WorkflowStep
+var (
+	testPipelineSteps []model.WorkflowStepSpec
+	props             = model.JSONStruct{"url": "https://api.github.com/repos/kubevela/kubevela"}
+)
 
 func init() {
-	rawProps := []byte(`{"url":"https://api.github.com/repos/kubevela/kubevela"}`)
-	testPipelineSteps = []v1alpha1.WorkflowStep{
+	testPipelineSteps = []model.WorkflowStepSpec{
 		{
-			WorkflowStepBase: v1alpha1.WorkflowStepBase{
+			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
 				Name: "request",
 				Type: "request",
 				Outputs: v1alpha1.StepOutputs{
@@ -50,9 +50,7 @@ func init() {
 						Name:      "stars",
 					},
 				},
-				Properties: &runtime.RawExtension{
-					Raw: rawProps,
-				},
+				Properties: &props,
 			},
 		},
 	}
@@ -93,7 +91,7 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 		var req = apisv1.CreatePipelineRequest{
 			Name:        pipelineName,
 			Description: description,
-			Spec: v1alpha1.WorkflowSpec{
+			Spec: model.WorkflowSpec{
 				Steps: testPipelineSteps,
 			},
 		}
@@ -150,10 +148,9 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 	})
 
 	It("update pipeline", func() {
-		rawProps := []byte(`{"url":"https://api.github.com/repos/kubevela/kubevela"}`)
-		newSteps := make([]v1alpha1.WorkflowStep, 0)
-		newSteps = append(newSteps, v1alpha1.WorkflowStep{
-			SubSteps: []v1alpha1.WorkflowStepBase{
+		newSteps := make([]model.WorkflowStepSpec, 0)
+		newSteps = append(newSteps, model.WorkflowStepSpec{
+			SubSteps: []model.WorkflowStepBaseSpec{
 				{
 					Name: "request1",
 					Type: "request",
@@ -163,9 +160,7 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 							Name:      "stars",
 						},
 					},
-					Properties: &runtime.RawExtension{
-						Raw: rawProps,
-					},
+					Properties: &props,
 				},
 				{
 					Name: "request2",
@@ -176,18 +171,16 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 							Name:      "stars-copy",
 						},
 					},
-					Properties: &runtime.RawExtension{
-						Raw: rawProps,
-					},
+					Properties: &props,
 				},
 			},
-			WorkflowStepBase: v1alpha1.WorkflowStepBase{
+			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
 				Name: "request-group",
 				Type: "step-group",
 			},
 		})
-		newSteps = append(newSteps, v1alpha1.WorkflowStep{
-			WorkflowStepBase: v1alpha1.WorkflowStepBase{
+		newSteps = append(newSteps, model.WorkflowStepSpec{
+			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
 				Name: "log",
 				Type: "log",
 				Inputs: v1alpha1.StepInputs{
@@ -200,7 +193,7 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 		})
 		var req = apisv1.UpdatePipelineRequest{
 			Description: description,
-			Spec: v1alpha1.WorkflowSpec{
+			Spec: model.WorkflowSpec{
 				Steps: newSteps,
 			},
 		}
@@ -310,10 +303,10 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 	It("stop pipeline", func() {
 		By("update pipeline so that it will run for a while")
 		var req = apisv1.UpdatePipelineRequest{
-			Spec: v1alpha1.WorkflowSpec{
-				Steps: []v1alpha1.WorkflowStep{
+			Spec: model.WorkflowSpec{
+				Steps: []model.WorkflowStepSpec{
 					{
-						WorkflowStepBase: v1alpha1.WorkflowStepBase{
+						WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
 							Name:      "request",
 							Type:      "request",
 							Timeout:   "20s",

--- a/test/e2e-apiserver-test/pipeline_test.go
+++ b/test/e2e-apiserver-test/pipeline_test.go
@@ -24,24 +24,25 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubevela/workflow/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/dto/v1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var (
-	testPipelineSteps []model.WorkflowStepSpec
+	testPipelineSteps []model.WorkflowStep
 	props             = model.JSONStruct{"url": "https://api.github.com/repos/kubevela/kubevela"}
 )
 
 func init() {
-	testPipelineSteps = []model.WorkflowStepSpec{
+	testPipelineSteps = []model.WorkflowStep{
 		{
-			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
+			WorkflowStepBase: model.WorkflowStepBase{
 				Name: "request",
 				Type: "request",
 				Outputs: v1alpha1.StepOutputs{
@@ -148,9 +149,9 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 	})
 
 	It("update pipeline", func() {
-		newSteps := make([]model.WorkflowStepSpec, 0)
-		newSteps = append(newSteps, model.WorkflowStepSpec{
-			SubSteps: []model.WorkflowStepBaseSpec{
+		newSteps := make([]model.WorkflowStep, 0)
+		newSteps = append(newSteps, model.WorkflowStep{
+			SubSteps: []model.WorkflowStepBase{
 				{
 					Name: "request1",
 					Type: "request",
@@ -174,13 +175,13 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 					Properties: &props,
 				},
 			},
-			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
+			WorkflowStepBase: model.WorkflowStepBase{
 				Name: "request-group",
 				Type: "step-group",
 			},
 		})
-		newSteps = append(newSteps, model.WorkflowStepSpec{
-			WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
+		newSteps = append(newSteps, model.WorkflowStep{
+			WorkflowStepBase: model.WorkflowStepBase{
 				Name: "log",
 				Type: "log",
 				Inputs: v1alpha1.StepInputs{
@@ -304,9 +305,9 @@ var _ = Describe("Test the rest api about the pipeline", func() {
 		By("update pipeline so that it will run for a while")
 		var req = apisv1.UpdatePipelineRequest{
 			Spec: model.WorkflowSpec{
-				Steps: []model.WorkflowStepSpec{
+				Steps: []model.WorkflowStep{
 					{
-						WorkflowStepBaseSpec: model.WorkflowStepBaseSpec{
+						WorkflowStepBase: model.WorkflowStepBase{
 							Name:      "request",
 							Type:      "request",
 							Timeout:   "20s",


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

1. fix mongodb can not decode runtime.Object, use JSONStruct instead.
2. no logs return when no filter passed to `getResourceLog`

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->