### PR TITLE
Fix: app contains app override the child app with parent app label

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -329,7 +329,7 @@ func (af *Appfile) generateAndFilterCommonLabels(compName string) map[string]str
 		oam.LabelAppComponent: compName,
 	}
 	// merge application's all labels
-	finalLabels := util.MergeMapOverrideWithDst(Labels, af.AppLabels)
+	finalLabels := util.MergeMapOverrideWithDst(af.AppLabels, Labels)
 	filterLabels, ok := af.AppAnnotations[oam.AnnotationFilterLabelKeys]
 	if ok {
 		filter(finalLabels, strings.Split(filterLabels, ","))


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When parent application creates child application, the resource of child application will carry the parent application label, due to the incorrect label inheritence.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->