### PR TITLE
Fix: vela cluster join reports 'resource name may not be empty' error

### DIFF
--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -410,7 +410,7 @@ func JoinClusterByKubeConfig(ctx context.Context, cli client.Client, kubeconfigP
 		}
 	}
 	if cfg, ok := ctx.Value(KubeConfigContext).(*rest.Config); ok {
-		if err = SetClusterVersionInfo(ctx, cfg, clusterName); err != nil {
+		if err = SetClusterVersionInfo(ctx, cfg, clusterConfig.ClusterName); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #4994 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->