### PR TITLE
Fix: forbid 302 request to avoid SSRF

### DIFF
--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -69,7 +69,7 @@ func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, sec
 	}
 	charts, err := d.helper.ListChartsFromRepo(repoURL, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch charts repo: %s", utils.Sanitize(repoURL))
+		log.Logger.Errorf("cannot fetch charts repo: %s, error: %s", utils.Sanitize(repoURL), err.Error())
 		return nil, bcode.ErrListHelmChart
 	}
 	return charts, nil
@@ -89,7 +89,7 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	}
 	chartVersions, err := d.helper.ListVersions(repoURL, chartName, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName))
+		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), err.Error())
 		return nil, bcode.ErrListHelmVersions
 	}
 	if len(chartVersions) == 0 {
@@ -113,7 +113,7 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version))
+		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
 		return nil, bcode.ErrGetChartValues
 	}
 	res := make(map[string]interface{}, len(v))

--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -69,7 +69,7 @@ func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, sec
 	}
 	charts, err := d.helper.ListChartsFromRepo(repoURL, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch charts repo: %s, error: %s", utils.Sanitize(repoURL), err.Error())
+		log.Logger.Errorf("cannot fetch charts repo: %s", utils.Sanitize(repoURL))
 		return nil, bcode.ErrListHelmChart
 	}
 	return charts, nil
@@ -89,7 +89,7 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	}
 	chartVersions, err := d.helper.ListVersions(repoURL, chartName, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), err.Error())
+		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName))
 		return nil, bcode.ErrListHelmVersions
 	}
 	if len(chartVersions) == 0 {
@@ -113,7 +113,7 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
+		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version))
 		return nil, bcode.ErrGetChartValues
 	}
 	res := make(map[string]interface{}, len(v))

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -232,7 +232,7 @@ func TestHttpGetForbidRedirect(t *testing.T) {
 	testServer := &http.Server{Addr: ":19090"}
 
 	http.HandleFunc("/redirect", func(writer http.ResponseWriter, request *http.Request) {
-		http.Redirect(writer, request, "http://www.google.com", 302)
+		http.Redirect(writer, request, "http://192.168.1.1", 302)
 	})
 
 	go func() {

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -225,14 +225,11 @@ func TestHttpGetCaFile(t *testing.T) {
 }
 
 func TestHttpGetForbidRedirect(t *testing.T) {
-	type want struct {
-		data string
-	}
 	var ctx = context.Background()
 	testServer := &http.Server{Addr: ":19090"}
 
 	http.HandleFunc("/redirect", func(writer http.ResponseWriter, request *http.Request) {
-		http.Redirect(writer, request, "http://192.168.1.1", 302)
+		http.Redirect(writer, request, "http://192.168.1.1", http.StatusFound)
 	})
 
 	go func() {

--- a/pkg/utils/helm/helm_helper.go
+++ b/pkg/utils/helm/helm_helper.go
@@ -225,7 +225,7 @@ func (h *Helper) GetIndexInfo(repoURL string, skipCache bool, opts *common.HTTPO
 	}
 	i := &repo.IndexFile{}
 	if err := yaml.UnmarshalStrict(body, i); err != nil {
-		return nil, fmt.Errorf("parse index file from %s failure %w", repoURL, err)
+		return nil, fmt.Errorf("parse index file from %s failure", repoURL)
 	}
 
 	if h.cache != nil {


### PR DESCRIPTION
forbid 302 request to avoid SSRF of list helm chart endpoint of apiServer.

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->