### PR TITLE
Fix: remove the reference of  v1beta1 ingress

### DIFF
--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkv1beta1 "k8s.io/api/networking/v1beta1"
+	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -743,25 +743,30 @@ options: {
 			}
 		}
 
-		var prefixbeta = networkv1beta1.PathTypePrefix
+		var prefixbeta = networkv1.PathTypePrefix
 		testIngress := []client.Object{
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-http",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					Rules: []networkv1beta1.IngressRule{
+				Spec: networkv1.IngressSpec{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -772,28 +777,33 @@ options: {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-https",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					TLS: []networkv1beta1.IngressTLS{
+				Spec: networkv1.IngressSpec{
+					TLS: []networkv1.IngressTLS{
 						{
 							SecretName: "https-secret",
 						},
 					},
-					Rules: []networkv1beta1.IngressRule{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.https",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -804,36 +814,46 @@ options: {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-paths",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					TLS: []networkv1beta1.IngressTLS{
+				Spec: networkv1.IngressSpec{
+					TLS: []networkv1.IngressTLS{
 						{
 							SecretName: "https-secret",
 						},
 					},
-					Rules: []networkv1beta1.IngressRule{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.path",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/test",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
 										{
 											Path: "/test2",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -844,7 +864,7 @@ options: {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "networking.k8s.io/v1beta1",
 				},
@@ -856,18 +876,23 @@ options: {
 						"helm.toolkit.fluxcd.io/namespace": "default",
 					},
 				},
-				Spec: networkv1beta1.IngressSpec{
-					Rules: []networkv1beta1.IngressRule{
+				Spec: networkv1.IngressSpec{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.helm",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -763,7 +763,6 @@ options: {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -800,7 +799,6 @@ options: {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -837,7 +835,6 @@ options: {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -850,7 +847,6 @@ options: {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -889,7 +885,6 @@ options: {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},

--- a/references/cli/velaql_test.go
+++ b/references/cli/velaql_test.go
@@ -287,7 +287,6 @@ var _ = Describe("Test velaQL", func() {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -324,7 +323,6 @@ var _ = Describe("Test velaQL", func() {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -361,7 +359,6 @@ var _ = Describe("Test velaQL", func() {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -374,7 +371,6 @@ var _ = Describe("Test velaQL", func() {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},
@@ -413,7 +409,6 @@ var _ = Describe("Test velaQL", func() {
 												Service: &networkv1.IngressServiceBackend{
 													Name: "clusterip",
 													Port: networkv1.ServiceBackendPort{
-														Name:   "Http",
 														Number: 80,
 													},
 												},

--- a/references/cli/velaql_test.go
+++ b/references/cli/velaql_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	networkv1beta1 "k8s.io/api/networking/v1beta1"
+	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -267,25 +267,30 @@ var _ = Describe("Test velaQL", func() {
 				Expect(err).Should(BeNil())
 			}
 		}
-		var prefixbeta = networkv1beta1.PathTypePrefix
+		var prefixbeta = networkv1.PathTypePrefix
 		testIngress := []client.Object{
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-http",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					Rules: []networkv1beta1.IngressRule{
+				Spec: networkv1.IngressSpec{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -296,28 +301,33 @@ var _ = Describe("Test velaQL", func() {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-https",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					TLS: []networkv1beta1.IngressTLS{
+				Spec: networkv1.IngressSpec{
+					TLS: []networkv1.IngressTLS{
 						{
 							SecretName: "https-secret",
 						},
 					},
-					Rules: []networkv1beta1.IngressRule{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.https",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -328,36 +338,46 @@ var _ = Describe("Test velaQL", func() {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-paths",
 					Namespace: "default",
 				},
-				Spec: networkv1beta1.IngressSpec{
-					TLS: []networkv1beta1.IngressTLS{
+				Spec: networkv1.IngressSpec{
+					TLS: []networkv1.IngressTLS{
 						{
 							SecretName: "https-secret",
 						},
 					},
-					Rules: []networkv1beta1.IngressRule{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.path",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/test",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
 										{
 											Path: "/test2",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},
@@ -368,7 +388,7 @@ var _ = Describe("Test velaQL", func() {
 					},
 				},
 			},
-			&networkv1beta1.Ingress{
+			&networkv1.Ingress{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "networking.k8s.io/v1beta1",
 				},
@@ -380,18 +400,23 @@ var _ = Describe("Test velaQL", func() {
 						"helm.toolkit.fluxcd.io/namespace": "default",
 					},
 				},
-				Spec: networkv1beta1.IngressSpec{
-					Rules: []networkv1beta1.IngressRule{
+				Spec: networkv1.IngressSpec{
+					Rules: []networkv1.IngressRule{
 						{
 							Host: "ingress.domain.helm",
-							IngressRuleValue: networkv1beta1.IngressRuleValue{
-								HTTP: &networkv1beta1.HTTPIngressRuleValue{
-									Paths: []networkv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkv1.IngressRuleValue{
+								HTTP: &networkv1.HTTPIngressRuleValue{
+									Paths: []networkv1.HTTPIngressPath{
 										{
 											Path: "/",
-											Backend: networkv1beta1.IngressBackend{
-												ServiceName: "clusterip",
-												ServicePort: intstr.FromInt(80),
+											Backend: networkv1.IngressBackend{
+												Service: &networkv1.IngressServiceBackend{
+													Name: "clusterip",
+													Port: networkv1.ServiceBackendPort{
+														Name:   "Http",
+														Number: 80,
+													},
+												},
 											},
 											PathType: &prefixbeta,
 										},


### PR DESCRIPTION
Remove the reference of  v1beta1 ingress. The main logic hasn't used v1beta1 ingress yet, this pr just remove all references from test.

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->