### PR TITLE
Feat: support vela up --wait and --timeout

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -189,8 +189,6 @@ type Status struct {
 type ApplicationPhase string
 
 const (
-	// ApplicationRollingOut means the app is in the middle of rolling out
-	ApplicationRollingOut ApplicationPhase = "rollingOut"
 	// ApplicationStarting means the app is preparing for reconcile
 	ApplicationStarting ApplicationPhase = "starting"
 	// ApplicationRendering means the app is rendering
@@ -205,8 +203,6 @@ const (
 	ApplicationWorkflowTerminated ApplicationPhase = "workflowTerminated"
 	// ApplicationWorkflowFailed means the app's workflow is failed
 	ApplicationWorkflowFailed ApplicationPhase = "workflowFailed"
-	// ApplicationWorkflowFinished means the app's workflow is finished
-	ApplicationWorkflowFinished ApplicationPhase = "workflowFinished"
 	// ApplicationRunning means the app finished rendering and applied result to the cluster
 	ApplicationRunning ApplicationPhase = "running"
 	// ApplicationUnhealthy means the app finished rendering and applied result to the cluster, but still unhealthy

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -47,6 +47,9 @@ var (
 	appbasicJsonAppFile         = `{"name":"app-basic","services":{"app-basic":{"type":"webservice","image":"nginx:1.9.4","ports":[{port: 80, expose: true}]}}}`
 	appbasicAddTraitJsonAppFile = `{"name":"app-basic","services":{"app-basic":{"type":"webservice","image":"nginx:1.9.4","ports":[{port: 80, expose: true}],"scaler":{"replicas":2}}}}`
 	velaQL                      = "test-component-pod-view{appNs=default,appName=nginx-vela,name=nginx}"
+
+	waitAppfileToSuccess = `{"name":"app-wait-success","services":{"app-basic1":{"type":"webservice","image":"nginx:1.9.4","ports":[{port: 80, expose: true}]}}}`
+	waitAppfileToFail    = `{"name":"app-wait-fail","services":{"app-basic2":{"type":"webservice","image":"nginx:fail","ports":[{port: 80, expose: true}]}}}`
 )
 
 var _ = ginkgo.Describe("Test Vela Application", func() {
@@ -75,6 +78,9 @@ var _ = ginkgo.Describe("Test Vela Application", func() {
 
 	e2e.JsonAppFileContext("json appfile apply", testDeleteJsonAppFile)
 	VelaQLPodListContext("ql", velaQL)
+
+	e2e.JsonAppFileContextWithWait("json appfile apply with wait", waitAppfileToSuccess)
+	e2e.JsonAppFileContextWithTimeout("json appfile apply with wait but timeout", waitAppfileToFail, "3s")
 })
 
 var ApplicationStatusContext = func(context string, applicationName string, workloadType string) bool {
@@ -182,7 +188,7 @@ var ApplicationInitIntercativeCliContext = func(context string, appName string, 
 				c.ExpectEOF()
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(output).To(gomega.ContainSubstring("Checking Status"))
+			gomega.Expect(output).To(gomega.ContainSubstring("Waiting app to be healthy"))
 		})
 	})
 }

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -84,6 +84,30 @@ var (
 		})
 	}
 
+	JsonAppFileContextWithWait = func(context, jsonAppFile string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("Start the application through the app file in JSON format.", func() {
+				writeStatus := os.WriteFile("vela.json", []byte(jsonAppFile), 0644)
+				gomega.Expect(writeStatus).NotTo(gomega.HaveOccurred())
+				output, err := Exec("vela up -f vela.json --wait")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(output).To(gomega.ContainSubstring("Application Deployed Successfully!"))
+			})
+		})
+	}
+
+	JsonAppFileContextWithTimeout = func(context, jsonAppFile, duration string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("Start the application through the app file in JSON format.", func() {
+				writeStatus := os.WriteFile("vela.json", []byte(jsonAppFile), 0644)
+				gomega.Expect(writeStatus).NotTo(gomega.HaveOccurred())
+				output, err := Exec("vela up -f vela.json --wait --timeout=" + duration)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(output).To(gomega.ContainSubstring("Timeout waiting Application to be healthy!"))
+			})
+		})
+	}
+
 	DeleteEnvFunc = func(context string, envName string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("should print env does not exist message", func() {

--- a/references/cli/init.go
+++ b/references/cli/init.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"cuelang.org/go/cue"
 	"github.com/AlecAivazis/survey/v2"
@@ -111,11 +112,11 @@ func NewInitCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *
 			if err != nil {
 				return err
 			}
-			deployStatus, err := printTrackingDeployStatus(c, o.IOStreams, o.appName, o.Namespace)
+			deployStatus, err := printTrackingDeployStatus(c, o.IOStreams, o.appName, o.Namespace, 300*time.Second)
 			if err != nil {
 				return err
 			}
-			if deployStatus != compStatusDeployed {
+			if deployStatus != appDeployedHealthy {
 				return nil
 			}
 			return printAppStatus(context.Background(), newClient, ioStreams, o.appName, o.Namespace, cmd, c, false)

--- a/references/cli/print.go
+++ b/references/cli/print.go
@@ -50,11 +50,11 @@ func newUITable() *uitable.Table {
 }
 
 func newTrackingSpinnerWithDelay(suffix string, interval time.Duration) *spinner.Spinner {
-	suffixColor := color.New(color.Bold, color.FgGreen)
+	suffixColor := color.New(color.Bold, color.FgWhite)
 	return spinner.New(
 		spinner.CharSets[14],
 		interval,
-		spinner.WithColor("green"),
+		spinner.WithColor("white"),
 		spinner.WithHiddenCursor(true),
 		spinner.WithSuffix(suffixColor.Sprintf(" %s", suffix)))
 }

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -78,26 +78,18 @@ type WorkloadHealthCondition = v1alpha2.WorkloadHealthCondition
 // ScopeHealthCondition holds health condition of a scope
 type ScopeHealthCondition = v1alpha2.ScopeHealthCondition
 
-// CompStatus represents the status of a component during "vela init"
-type CompStatus int
+// AppDeployStatus represents the status of application during "vela init" and "vela up --wait"
+type AppDeployStatus int
 
-// Enums of CompStatus
+// Enums of ApplicationStatus
 const (
-	compStatusDeploying CompStatus = iota
-	compStatusDeployFail
-	compStatusDeployed
-	compStatusUnknown
-)
-
-// Error msg used in `status` command
-const (
-	// ErrNotLoadAppConfig display the error message load
-	ErrNotLoadAppConfig = "cannot load the application"
+	appDeployFail AppDeployStatus = iota
+	appDeployedHealthy
+	appDeployError
 )
 
 const (
-	trackingInterval time.Duration = 1 * time.Second
-	deployTimeout    time.Duration = 10 * time.Second
+	trackingInterval = 1 * time.Second
 )
 
 // NewAppStatusCommand creates `status` command for showing status
@@ -402,59 +394,47 @@ func loopCheckStatus(c client.Client, ioStreams cmdutil.IOStreams, appName strin
 	return nil
 }
 
-func printTrackingDeployStatus(c common.Args, ioStreams cmdutil.IOStreams, appName string, namespace string) (CompStatus, error) {
-	sDeploy := newTrackingSpinnerWithDelay("Checking Status ...", trackingInterval)
+func printTrackingDeployStatus(c common.Args, ioStreams cmdutil.IOStreams, appName, namespace string, timeout time.Duration) (AppDeployStatus, error) {
+	sDeploy := newTrackingSpinnerWithDelay("Waiting app to be healthy ...", trackingInterval)
 	sDeploy.Start()
 	defer sDeploy.Stop()
+	startTime := time.Now()
 TrackDeployLoop:
 	for {
 		time.Sleep(trackingInterval)
-		deployStatus, failMsg, err := TrackDeployStatus(c, appName, namespace)
+		deployStatus, err := TrackDeployStatus(c, appName, namespace)
 		if err != nil {
-			return compStatusUnknown, err
+			return appDeployError, err
 		}
 		switch deployStatus {
-		case compStatusDeploying:
+		case commontypes.ApplicationStarting, commontypes.ApplicationRendering, commontypes.ApplicationPolicyGenerating, commontypes.ApplicationRunningWorkflow, commontypes.ApplicationUnhealthy:
+			if time.Now().After(startTime.Add(timeout)) {
+				ioStreams.Info(red.Sprintf("\n%s Timeout waiting Application to be healthy!", emojiFail))
+				return appDeployFail, nil
+			}
 			continue
-		case compStatusDeployed:
+		case commontypes.ApplicationWorkflowSuspending, commontypes.ApplicationRunning:
 			ioStreams.Info(green.Sprintf("\n%sApplication Deployed Successfully!", emojiSucceed))
 			break TrackDeployLoop
-		case compStatusDeployFail:
-			ioStreams.Info(red.Sprintf("\n%sApplication Failed to Deploy!", emojiFail))
-			ioStreams.Info(red.Sprintf("Reason: %s", failMsg))
-			return compStatusDeployFail, nil
-		default:
-			continue
+		case commontypes.ApplicationWorkflowTerminated, commontypes.ApplicationWorkflowFailed:
+			ioStreams.Info(red.Sprintf("\n%sApplication Deployment Failed!", emojiFail))
+			ioStreams.Info(red.Sprintf("Please run the following command to check details: \n   vela status %s -n %s\n", appName, namespace))
+			return appDeployFail, nil
+		case commontypes.ApplicationDeleting:
+			ioStreams.Info(red.Sprintf("\n%sApplication is in the deleting process!", emojiFail))
+			return appDeployFail, nil
 		}
 	}
-	return compStatusDeployed, nil
+	return appDeployedHealthy, nil
 }
 
 // TrackDeployStatus will only check AppConfig is deployed successfully,
-func TrackDeployStatus(c common.Args, appName string, namespace string) (CompStatus, string, error) {
+func TrackDeployStatus(c common.Args, appName string, namespace string) (commontypes.ApplicationPhase, error) {
 	appObj, err := appfile.LoadApplication(namespace, appName, c)
 	if err != nil {
-		return compStatusUnknown, "", err
+		return "", err
 	}
-	if appObj == nil {
-		return compStatusUnknown, "", errors.New(ErrNotLoadAppConfig)
-	}
-	condition := appObj.Status.Conditions
-	if len(condition) < 1 {
-		return compStatusDeploying, "", nil
-	}
-
-	// If condition is true, we can regard appConfig is deployed successfully
-	if appObj.Status.Phase == commontypes.ApplicationRunning {
-		return compStatusDeployed, "", nil
-	}
-
-	// if not found workload status in AppConfig
-	// then use age to check whether the workload controller is running
-	if time.Since(appObj.GetCreationTimestamp().Time) > deployTimeout {
-		return compStatusDeployFail, condition[0].Message, nil
-	}
-	return compStatusDeploying, "", nil
+	return appObj.Status.Phase, nil
 }
 
 func getHealthStatusColor(s bool) *color.Color {

--- a/references/common/application.go
+++ b/references/common/application.go
@@ -61,6 +61,7 @@ type AppfileOptions struct {
 	Kubecli   client.Client
 	IO        cmdutil.IOStreams
 	Namespace string
+	Name      string
 }
 
 // BuildResult is the export struct from AppFile yaml or AppFile object
@@ -380,7 +381,7 @@ func (o *AppfileOptions) BaseAppFileRun(result *BuildResult, args common.Args) e
 		return err
 	}
 	result.application.Spec.Components = kubernetesComponent
-
+	o.Name = result.application.Name
 	o.IO.Infof("\nApplying application ...\n")
 	return o.ApplyApp(result.application, result.scopes)
 }


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5072

#### Timeout Case

```
$ vela up -f vela.yaml -w --timeout=10s
Applying an application in vela K8s object format...
I1115 19:50:23.918135   10372 apply.go:119] "updating object" name="first-vela-app" resource="core.oam.dev/v1beta1, Kind=Application"
✅ App has been deployed 🚀🚀🚀
    Port forward: vela port-forward first-vela-app
             SSH: vela exec first-vela-app
         Logging: vela logs first-vela-app
      App status: vela status first-vela-app
        Endpoint: vela status first-vela-app --endpoint
Application /first-vela-app applied.
⠋ Waiting app to be healthy ...
❌  Timeout waiting Application to be healthy!
```

#### Success Case

```
$ vela up -f vela.yaml -w
Applying an application in vela K8s object format...
I1115 19:51:40.543135   10447 apply.go:119] "updating object" name="first-vela-app" resource="core.oam.dev/v1beta1, Kind=Application"
✅ App has been deployed 🚀🚀🚀
    Port forward: vela port-forward first-vela-app
             SSH: vela exec first-vela-app
         Logging: vela logs first-vela-app
      App status: vela status first-vela-app
        Endpoint: vela status first-vela-app --endpoint
Application /first-vela-app applied.
⠙ Waiting app to be healthy ...
✅ Application Deployed Successfully!
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->