### PR TITLE
Feat: support dry-run with cue format definition

### DIFF
--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -74,6 +74,20 @@ var _ = Describe("Test dry run with policy", func() {
 		Expect(buff.String()).Should(ContainSubstring("- image: oamdev/hello-world:v2\n        name: server-v2"))
 	})
 
+	It("Test dry run with cue component format", func() {
+
+		c := common2.Args{}
+		c.SetConfig(cfg)
+		c.SetClient(k8sClient)
+
+		opt := DryRunCmdOptions{ApplicationFile: "test-data/dry-run/app.yaml", DefinitionFile: "test-data/dry-run/my-comp.cue", OfflineMode: true}
+		buff, err := DryRunApplication(&opt, c, "")
+		Expect(err).Should(BeNil())
+		Expect(buff.String()).Should(ContainSubstring("name: hello-world"))
+		Expect(buff.String()).Should(ContainSubstring("kind: Deployment"))
+		Expect(buff.String()).Should(ContainSubstring("name: hello-world-service"))
+		Expect(buff.String()).Should(ContainSubstring("kind: Service"))
+	})
 })
 
 var plcapp = `apiVersion: core.oam.dev/v1beta1

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -104,7 +104,7 @@ func LiveDiffApplication(cmdOption *LiveDiffCmdOptions, c common.Args) (bytes.Bu
 	}
 	objs := []oam.Object{}
 	if cmdOption.DefinitionFile != "" {
-		objs, err = ReadObjectsFromFile(cmdOption.DefinitionFile)
+		objs, err = ReadDefinitionsFromFile(cmdOption.DefinitionFile)
 		if err != nil {
 			return buff, err
 		}

--- a/references/cli/test-data/dry-run/app.yaml
+++ b/references/cli/test-data/dry-run/app.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: vela-app
+spec:
+  components:
+    - name: express-server
+      type: my-comp

--- a/references/cli/test-data/dry-run/my-comp.cue
+++ b/references/cli/test-data/dry-run/my-comp.cue
@@ -1,0 +1,50 @@
+"my-comp": {
+	annotations: {}
+	attributes: workload: definition: {
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+	}
+	description: "My component."
+	labels: {}
+	type: "component"
+}
+template: {
+	output: {
+		metadata: name: "hello-world"
+		spec: {
+			replicas: 1
+			selector: matchLabels: "app.kubernetes.io/name": "hello-world"
+			template: {
+				metadata: labels: "app.kubernetes.io/name": "hello-world"
+				spec: containers: [{
+					name:  "hello-world"
+					image: "somefive/hello-world"
+					ports: [{
+						name:          "http"
+						containerPort: 80
+						protocol:      "TCP"
+					}]
+				}]
+			}
+		}
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+	}
+	outputs: "hello-world-service": {
+		metadata: name: "hello-world-service"
+		spec: {
+			ports: [{
+				name:       "http"
+				protocol:   "TCP"
+				port:       80
+				targetPort: 8080
+			}]
+			selector: app: "hello-world"
+			type: "LoadBalancer"
+		}
+		apiVersion: "v1"
+		kind:       "Service"
+	}
+	parameter: {}
+
+}


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

```
vela dry-run -f app.yaml -d my-comp.cue
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->