### PR TITLE
Fix: update actions to solve 「 deprecated 」warnings

### DIFF
--- a/.github/workflows/apiserver-test.yml
+++ b/.github/workflows/apiserver-test.yml
@@ -29,12 +29,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v4.0.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
+          continue-on-error: true
 
   apiserver-unit-tests:
     runs-on: ubuntu-20.04
@@ -43,18 +43,18 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -80,7 +80,7 @@ jobs:
         run: make unit-test-apiserver
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
@@ -100,13 +100,13 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -178,7 +178,7 @@ jobs:
         run: make end-e2e-core
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/e2e_apiserver_test.out

--- a/.github/workflows/back-port.yml
+++ b/.github/workflows/back-port.yml
@@ -11,12 +11,13 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      # TODO need update action version to resolve node 12 deprecated.
       - name: Open Backport PR
-        uses: zeebe-io/backport-action@v0.0.6
+        uses: zeebe-io/backport-action@v0.0.8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -28,18 +28,18 @@ jobs:
       VELA_ROLLOUT_HELM_CHART_NAME: vela-rollout
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Get git revision
         id: vars
         shell: bash
         run: |
           echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Generate helm doc

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@v1.3.1
+      - uses: thehanimo/pr-title-checker@v1.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: true

--- a/.github/workflows/core-api-test.yml
+++ b/.github/workflows/core-api-test.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - name: Set up Go 1.19
-              uses: actions/setup-go@v1
+              uses: actions/setup-go@v3
               env:
                   GO_VERSION: '1.19'
                   GOLANGCI_VERSION: 'v1.49'
@@ -23,11 +23,11 @@ jobs:
               id: go
 
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Get the version
               id: get_version
-              run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+              run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
             - name: Test build kubevela-core-api
               env:

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -27,12 +27,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v4.0.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
+          continue-on-error: true
 
   e2e-multi-cluster-tests:
     runs-on: aliyun
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -113,7 +113,7 @@ jobs:
         run: make end-e2e-core
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/e2e-profile.out,/tmp/e2e_multicluster_test.out

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -27,12 +27,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v4.0.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
+          continue-on-error: true
 
   e2e-rollout-tests:
     runs-on: aliyun
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -97,7 +97,7 @@ jobs:
         run: make end-e2e
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/e2e-profile.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v4.0.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
+          continue-on-error: true
 
   staticcheck:
     runs-on: ubuntu-20.04
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -71,17 +71,17 @@ jobs:
 
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -103,17 +103,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -121,7 +121,7 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@2022.1
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -149,17 +149,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: "oam-dev/kubevela-github-actions"
           path: ./actions
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Extract Command
         id: command
-        uses: xt0rted/slash-command-action@v1
+        uses: xt0rted/slash-command-action@v2
         with:
           repo-token: ${{ secrets.VELA_BOT_TOKEN }}
           command: backport
@@ -44,7 +44,7 @@ jobs:
           allow-edits: "false"
           permission-level: read
       - name: Handle Command
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         env:
           VERSION: ${{ steps.command.outputs.command-arguments }}
         with:
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      # TODO need update action version to resolve node 12 deprecated.
       - name: Open Backport PR
         uses: zeebe-io/backport-action@v0.0.8
         with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for unapproved licenses
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -15,7 +15,7 @@ jobs:
   publish-core-images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: |
@@ -30,29 +30,29 @@ jobs:
         run: |
           echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login docker.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login Alibaba Cloud ACR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ secrets.ACR_DOMAIN }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
           driver-opts: image=moby/buildkit:master
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         name: Build & Pushing vela-core for Dockerhub, GHCR and ACR
         with:
           context: .
@@ -71,7 +71,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}
             ${{ secrets.ACR_DOMAIN }}/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         name: Build & Pushing CLI for Dockerhub, GHCR and ACR
         with:
           context: .
@@ -93,7 +93,7 @@ jobs:
   publish-addon-images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: |
@@ -108,29 +108,29 @@ jobs:
         run: |
           echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login docker.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login Alibaba Cloud ACR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ secrets.ACR_DOMAIN }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
           driver-opts: image=moby/buildkit:master
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         name: Build & Pushing vela-apiserver for Dockerhub, GHCR and ACR
         with:
           context: .
@@ -149,7 +149,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/oamdev/vela-apiserver:${{ steps.get_version.outputs.VERSION }}
             ${{ secrets.ACR_DOMAIN }}/oamdev/vela-apiserver:${{ steps.get_version.outputs.VERSION }}
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         name: Build & Pushing runtime rollout Dockerhub, GHCR and ACR
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,14 @@ jobs:
       DIST_DIRS: find * -type d -exec
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.2.2
+        uses: bruceadams/get-release@v1.3.2
       - name: Get version
         run: echo "VELA_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Get matrix
@@ -43,7 +43,6 @@ jobs:
           TARGETS=${{matrix.TARGETS}}
           echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
           echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
-
       - name: Get ldflags
         id: get_ldflags
         run: |
@@ -76,30 +75,30 @@ jobs:
           cd .. && \
           sha256sum vela/vela-* kubectl-vela/kubectl-vela-* >> sha256-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.txt \
       - name: Upload Vela tar.gz
-        uses: actions/upload-release-asset@v1.0.2
+        uses: basefas/upload-release-asset-action@v1
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/vela/vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_name: vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_content_type: binary/octet-stream
       - name: Upload Vela zip
-        uses: actions/upload-release-asset@v1.0.2
+        uses: basefas/upload-release-asset-action@v1
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/vela/vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_name: vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_content_type: binary/octet-stream
       - name: Upload Kubectl-Vela tar.gz
-        uses: actions/upload-release-asset@v1.0.2
+        uses: basefas/upload-release-asset-action@v1
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/kubectl-vela/kubectl-vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_name: kubectl-vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_content_type: binary/octet-stream
       - name: Upload Kubectl-Vela zip
-        uses: actions/upload-release-asset@v1.0.2
+        uses: basefas/upload-release-asset-action@v1
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/kubectl-vela/kubectl-vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_name: kubectl-vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_content_type: binary/octet-stream
@@ -120,7 +119,6 @@ jobs:
         run: ./ossutil --config-file .ossutilconfig config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
       - name: sync local to cloud
         run: ./ossutil --config-file .ossutilconfig sync ./_bin/vela oss://$BUCKET/binary/vela/${{ env.VELA_VERSION }}
-      
       - name: sync the latest version file
         if: ${{ !contains(env.VELA_VERSION,'alpha') && !contains(env.VELA_VERSION,'beta') }}
         run: |
@@ -132,19 +130,18 @@ jobs:
           echo ${{ env.VELA_VERSION }} > ./latest_version
           ./ossutil --config-file .ossutilconfig cp -u ./latest_version oss://$BUCKET/binary/vela/latest_version
 
-
   upload-plugin-homebrew:
     needs: build
     runs-on: ubuntu-latest
     name: upload-sha256sums
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.2.2
+        uses: bruceadams/get-release@v1.3.2
       - name: Download sha256sums
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: sha256sums
           path: cli-artifacts
@@ -163,9 +160,9 @@ jobs:
             cat ${file} >> sha256sums.txt
           done
       - name: Upload Checksums
-        uses: actions/upload-release-asset@v1.0.2
+        uses: basefas/upload-release-asset-action@v1
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          release_id: ${{ steps.get_release.outputs.id }}
           asset_path: cli-artifacts/sha256sums.txt
           asset_name: sha256sums.txt
           asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,33 +75,29 @@ jobs:
           cd .. && \
           sha256sum vela/vela-* kubectl-vela/kubectl-vela-* >> sha256-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.txt \
       - name: Upload Vela tar.gz
-        uses: basefas/upload-release-asset-action@v1
+        uses: kubevela/vela-upload-release-asset@v1
         with:
           release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/vela/vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_name: vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
-          asset_content_type: binary/octet-stream
       - name: Upload Vela zip
-        uses: basefas/upload-release-asset-action@v1
+        uses: kubevela/vela-upload-release-asset@v1
         with:
           release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/vela/vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_name: vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
-          asset_content_type: binary/octet-stream
       - name: Upload Kubectl-Vela tar.gz
-        uses: basefas/upload-release-asset-action@v1
+        uses: kubevela/vela-upload-release-asset@v1
         with:
           release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/kubectl-vela/kubectl-vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
           asset_name: kubectl-vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.tar.gz
-          asset_content_type: binary/octet-stream
       - name: Upload Kubectl-Vela zip
-        uses: basefas/upload-release-asset-action@v1
+        uses: kubevela/vela-upload-release-asset@v1
         with:
           release_id: ${{ steps.get_release.outputs.id }}
           asset_path: ./_bin/kubectl-vela/kubectl-vela-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
           asset_name: kubectl-vela-${{ env.VELA_VERSION }}-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.zip
-          asset_content_type: binary/octet-stream
       - name: Post sha256
         uses: actions/upload-artifact@v2
         with:
@@ -160,12 +156,11 @@ jobs:
             cat ${file} >> sha256sums.txt
           done
       - name: Upload Checksums
-        uses: basefas/upload-release-asset-action@v1
+        uses: kubevela/vela-upload-release-asset@v1
         with:
           release_id: ${{ steps.get_release.outputs.id }}
           asset_path: cli-artifacts/sha256sums.txt
           asset_name: sha256sums.txt
-          asset_content_type: text/plain
       - name: Update kubectl plugin version in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.38
       - name: Update Homebrew formula

--- a/.github/workflows/sync-api.yml
+++ b/.github/workflows/sync-api.yml
@@ -7,26 +7,24 @@ on:
     tags:
       - "v*"
 
+env:
+  GO_VERSION: '1.19'
+
 jobs:
   sync-core-api:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v1
-        env:
-          GO_VERSION: '1.19'
-          GOLANGCI_VERSION: 'v1.49'
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-        id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get the version
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
 
       - name: Sync to kubevela-core-api Repo
         env:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build Vela Core image from Dockerfile
         run: |
@@ -24,7 +24,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v4.0.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-          concurrent_skipping: false
+          continue-on-error: true
 
   unit-tests:
     runs-on: ubuntu-20.04
@@ -39,18 +39,17 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-        id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -77,7 +76,7 @@ jobs:
         run: make test
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt


### PR DESCRIPTION
Signed-off-by: basefas <basefas@hotmail.com>

### Description of your changes

## 1.  Node.js 12 actions are deprecated.

For more information see: 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

directly change: 

1. actions/checkout@v2 to actions/checkout@v3
2. actions/setup-go@v2 to actions/setup-go@v3
3. bruceadams/get-release@v1.2.2 to bruceadams/get-release@v1.3.2
4. actions/upload-artifact@v2 to actions/upload-artifact@v3
5. actions/download-artifact@v2 to actions/download-artifact@v3
6. actions/cache@v2 to actions/cache@v3
7. thehanimo/pr-title-checker@v1.3.1 to thehanimo/pr-title-checker@v1.3.5
8. actions/setup-node@v2 to actions/setup-node@v3
9. docker/setup-qemu-action@v1 to docker/setup-qemu-action@v2
10. docker/setup-buildx-action@v1 to docker/setup-buildx-action@v2
11. docker/build-push-action@v2 to docker/build-push-action@v3
12. github/codeql-action/upload-sarif@v1 to github/codeql-action/upload-sarif@v2
13. xt0rted/slash-command-action@v1 to xt0rted/slash-command-action@v2
14. actions/github-script@v4 to actions/github-script@v6
15. docker/login-action@v1 todocker/login-action@v2


other change: 

1. actions/upload-release-asset@v1.0.2  **repository archived** . Because the official repo archived, I create a new action [upload-release-asset-action](https://github.com/basefas/upload-release-asset-action)to fix it with the same logic.
2. fkirc/skip-duplicate-actions@v4.0.0 to fkirc/skip-duplicate-actions@v5  concurrent_skipping should be ‘never’, it's default value, so it can be delete, see [Inputs-concurrent_skipping](https://github.com/fkirc/skip-duplicate-actions#concurrent_skipping). Add `continue-on-error: true` for official recommend. see https://github.com/fkirc/skip-duplicate-actions/releases/tag/v5.0.0.
3. codecov/codecov-action@v1 to codecov/codecov-action@v3 need verify
4. azure/setup-helm@v1 to azure/setup-helm@v3 need verify
5. RyanSiu1995/kubebuilder-action@v1.2 no dist, not sure


waiting for update:

1. zeebe-io/backport-action  waiting for merge pr zeebe-io/backport-action#295


## 2. CodeQL Action v1 will be deprecated.

For more information, see https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

## 3. `set-output` command is deprecated

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## 4. The `save-state` command is deprecated and will be disabled soon.

 For more information see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)