### PR TITLE
Fix: end test environments

### DIFF
--- a/pkg/utils/env/env_test.go
+++ b/pkg/utils/env/env_test.go
@@ -51,6 +51,9 @@ func TestCreateEnv(t *testing.T) {
 	var err error
 	cfg, err = testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
 	assert.NoError(t, clientgoscheme.AddToScheme(testScheme))
 
 	rawClient, err = client.New(cfg, client.Options{Scheme: testScheme})
@@ -95,4 +98,5 @@ func TestCreateEnv(t *testing.T) {
 			}
 		})
 	}
+
 }

--- a/references/cli/top/component/info_test.go
+++ b/references/cli/top/component/info_test.go
@@ -41,4 +41,5 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, info.GetCell(1, 0).Text, "K8S Version:")
 	assert.Equal(t, info.GetCell(2, 0).Text, "VelaCLI Version:")
 	assert.Equal(t, info.GetCell(3, 0).Text, "VelaCore Version:")
+	testEnv.Stop()
 }

--- a/references/cli/top/view/app_test.go
+++ b/references/cli/top/view/app_test.go
@@ -38,6 +38,9 @@ func TestApp(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/application_topology_view_test.go
+++ b/references/cli/top/view/application_topology_view_test.go
@@ -38,6 +38,10 @@ func TestTopologyView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/application_view_test.go
+++ b/references/cli/top/view/application_view_test.go
@@ -39,6 +39,10 @@ func TestApplicationView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/cluster_namespace_view_test.go
+++ b/references/cli/top/view/cluster_namespace_view_test.go
@@ -38,6 +38,10 @@ func TestClusterNamespaceView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")
@@ -83,4 +87,5 @@ func TestClusterNamespaceView(t *testing.T) {
 		cnsView.Table.Table = cnsView.Table.Select(1, 1)
 		assert.Empty(t, cnsView.managedResourceView(nil))
 	})
+
 }

--- a/references/cli/top/view/cluster_view_test.go
+++ b/references/cli/top/view/cluster_view_test.go
@@ -39,6 +39,10 @@ func TestClusterView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/container_view_test.go
+++ b/references/cli/top/view/container_view_test.go
@@ -39,6 +39,10 @@ func TestContainerView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/help_view_test.go
+++ b/references/cli/top/view/help_view_test.go
@@ -36,6 +36,10 @@ func TestHelpView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/log_view_test.go
+++ b/references/cli/top/view/log_view_test.go
@@ -39,6 +39,10 @@ func TestLogView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/managed_resource_view_test.go
+++ b/references/cli/top/view/managed_resource_view_test.go
@@ -39,6 +39,10 @@ func TestManagedResourceView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/namespace_view_test.go
+++ b/references/cli/top/view/namespace_view_test.go
@@ -39,6 +39,10 @@ func TestNamespaceView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/page_stack_test.go
+++ b/references/cli/top/view/page_stack_test.go
@@ -36,6 +36,10 @@ func TestPageStack(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/pod_view_test.go
+++ b/references/cli/top/view/pod_view_test.go
@@ -39,6 +39,10 @@ func TestPodView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")

--- a/references/cli/top/view/yaml_view_test.go
+++ b/references/cli/top/view/yaml_view_test.go
@@ -38,6 +38,13 @@ func TestYamlView(t *testing.T) {
 	}
 	cfg, err := testEnv.Start()
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
 	testClient, err := client.New(cfg, client.Options{Scheme: common.Scheme})
 	assert.NoError(t, err)
 	app := NewApp(testClient, cfg, "")


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

There are some testEnv isn't stopped after test. There will be lot's of apiserver/etcd processes aren't get killed.

<img width="659" alt="image" src="https://user-images.githubusercontent.com/47812250/203269716-ceeba1d6-bc24-40f8-888b-3ad7d342e8fa.png">

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->