### PR TITLE
Fix: bug of filter registry func will modify origin data

### DIFF
--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -505,10 +505,14 @@ func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Applicatio
 
 // FilterDependencyRegistries will return all registries besides the target registry itself
 func FilterDependencyRegistries(i int, rs []Registry) []Registry {
-	registries := make([]Registry, len(rs))
-	copy(registries, rs)
-	if i < len(registries) {
-		return append(registries[:i], registries[i+1:]...)
+	if i >= len(rs) {
+		return rs
 	}
-	return registries
+	if i < 0 {
+		return rs
+	}
+	ret := make([]Registry, len(rs)-1)
+	copy(ret, rs[:i])
+	copy(ret[i:], rs[i+1:])
+	return ret
 }

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -504,7 +504,9 @@ func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Applicatio
 }
 
 // FilterDependencyRegistries will return all registries besides the target registry itself
-func FilterDependencyRegistries(i int, registries []Registry) []Registry {
+func FilterDependencyRegistries(i int, rs []Registry) []Registry {
+	registries := make([]Registry, len(rs))
+	copy(registries, rs)
 	if i < len(registries) {
 		return append(registries[:i], registries[i+1:]...)
 	}

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -334,36 +334,43 @@ func TestFilterDependencyRegistries(t *testing.T) {
 		registries []Registry
 		index      int
 		res        []Registry
+		origin     []Registry
 	}{
 		{
 			registries: []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 			index:      0,
 			res:        []Registry{{Name: "r2"}, {Name: "r3"}},
+			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 		},
 		{
 			registries: []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 			index:      1,
 			res:        []Registry{{Name: "r1"}, {Name: "r3"}},
+			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 		},
 		{
 			registries: []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 			index:      2,
 			res:        []Registry{{Name: "r1"}, {Name: "r2"}},
+			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 		},
 		{
 			registries: []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 			index:      3,
 			res:        []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
+			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 		},
 		{
 			registries: []Registry{},
 			index:      0,
 			res:        []Registry{},
+			origin:     []Registry{},
 		},
 	}
 	for _, testCase := range testCases {
 		res := FilterDependencyRegistries(testCase.index, testCase.registries)
 		assert.Equal(t, res, testCase.res)
+		assert.Equal(t, testCase.registries, testCase.origin)
 	}
 }
 

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -361,6 +361,12 @@ func TestFilterDependencyRegistries(t *testing.T) {
 			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
 		},
 		{
+			registries: []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
+			index:      -1,
+			res:        []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
+			origin:     []Registry{{Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
+		},
+		{
 			registries: []Registry{},
 			index:      0,
 			res:        []Registry{},


### PR DESCRIPTION
filter registry func flaky which will cause flaky tests.

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->