### PR TITLE
Feat: Introduce timeout mechanism into cache and update network request mechanism in `vela top`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/alibabacloud-go/tea v1.1.19
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
 	github.com/barnettZQG/inject v0.0.1
+	github.com/bluele/gcache v0.0.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/briandowns/spinner v1.11.1
 	github.com/chartmuseum/helm-push v0.10.2
@@ -50,7 +51,6 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl/v2 v2.9.1
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/imdario/mergo v0.3.12

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
+github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
+github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
@@ -1180,7 +1182,6 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/references/cli/top/view/application_topology_view.go
+++ b/references/cli/top/view/application_topology_view.go
@@ -38,9 +38,10 @@ type TopologyView struct {
 	actions                  model.KeyActions
 	ctx                      context.Context
 	focusTopology            bool
-	cache                    gcache.Cache
+	cache                    gcache.Cache // lru cache with expired time
 	appTopologyInstance      *TopologyTree
 	resourceTopologyInstance *TopologyTree
+	cancelFunc               func() // auto refresh cancel function
 }
 
 type cacheView struct {
@@ -55,7 +56,10 @@ type TopologyTree struct {
 
 const (
 	numberOfCacheView = 10
-	expireTime        = 10
+	// cache expire time
+	expireTime = 10
+	// request timeout time
+	topologyReqTimeout = 5
 )
 
 var (
@@ -85,49 +89,22 @@ func (v *TopologyView) Init() {
 	v.SetRows(0).SetColumns(-1, -1)
 	v.SetBorder(true)
 	v.SetBorderAttributes(tcell.AttrItalic)
-	v.SetTitle(title).SetTitleColor(config.ResourceTableTitleColor)
+	v.SetTitle(title)
+	v.SetTitleColor(config.ResourceTableTitleColor)
 	v.bindKeys()
 	v.SetInputCapture(v.keyboard)
 }
 
 // Start the topology view
 func (v *TopologyView) Start() {
-	appName := v.ctx.Value(&model.CtxKeyAppName).(string)
-	namespace := v.ctx.Value(&model.CtxKeyNamespace).(string)
-	key := fmt.Sprintf("%s-%s", appName, namespace)
-
-	value, err := v.cache.Get(key)
-	if err != nil {
-		v.resourceTopologyInstance = v.NewResourceTopologyView()
-		v.appTopologyInstance = v.NewAppTopologyView()
-		_ = v.cache.Set(key, &cacheView{
-			resourceTopologyInstance: v.resourceTopologyInstance,
-			appTopologyInstance:      v.appTopologyInstance,
-		})
-	} else {
-		view, ok := value.(*cacheView)
-		if ok {
-			v.appTopologyInstance = view.appTopologyInstance
-			v.resourceTopologyInstance = view.resourceTopologyInstance
-		} else {
-			v.resourceTopologyInstance = v.NewResourceTopologyView()
-			v.appTopologyInstance = v.NewAppTopologyView()
-			_ = v.cache.Set(key, &cacheView{
-				resourceTopologyInstance: v.resourceTopologyInstance,
-				appTopologyInstance:      v.appTopologyInstance,
-			})
-		}
-	}
-
-	v.Grid.AddItem(v.appTopologyInstance, 0, 0, 1, 1, 0, 0, true)
-	v.Grid.AddItem(v.resourceTopologyInstance, 0, 1, 1, 1, 0, 0, true)
-
-	v.app.SetFocus(v.appTopologyInstance)
+	v.Update(func() {})
+	v.AutoRefresh(v.Update)
 }
 
 // Stop the topology view
 func (v *TopologyView) Stop() {
 	v.Grid.Clear()
+	v.cancelFunc()
 }
 
 // Hint return the menu hints of topology view
@@ -138,6 +115,49 @@ func (v *TopologyView) Hint() []model.MenuHint {
 // Name return the name of topology view
 func (v *TopologyView) Name() string {
 	return "Topology"
+}
+
+// Update the topology view
+func (v *TopologyView) Update(timeoutCancel func()) {
+	appName := v.ctx.Value(&model.CtxKeyAppName).(string)
+	namespace := v.ctx.Value(&model.CtxKeyNamespace).(string)
+	key := fmt.Sprintf("%s-%s", appName, namespace)
+
+	value, err := v.cache.Get(key)
+
+	generateTopology := func() {
+		v.resourceTopologyInstance = v.NewResourceTopologyView()
+		v.appTopologyInstance = v.NewAppTopologyView()
+		// add new topology view to cache
+		_ = v.cache.Set(key, &cacheView{
+			resourceTopologyInstance: v.resourceTopologyInstance,
+			appTopologyInstance:      v.appTopologyInstance,
+		})
+	}
+
+	if err != nil {
+		generateTopology()
+	} else {
+		view, ok := value.(*cacheView)
+		if ok {
+			v.appTopologyInstance = view.appTopologyInstance
+			v.resourceTopologyInstance = view.resourceTopologyInstance
+		} else {
+			generateTopology()
+		}
+	}
+
+	v.Grid.AddItem(v.appTopologyInstance, 0, 0, 1, 1, 0, 0, true)
+	v.Grid.AddItem(v.resourceTopologyInstance, 0, 1, 1, 1, 0, 0, true)
+
+	// reset focus
+	if v.focusTopology {
+		v.app.SetFocus(v.resourceTopologyInstance)
+	} else {
+		v.app.SetFocus(v.appTopologyInstance)
+	}
+	// ctx done
+	timeoutCancel()
 }
 
 func (v *TopologyView) keyboard(event *tcell.EventKey) *tcell.EventKey {
@@ -280,4 +300,41 @@ func buildTopology(node *types.ResourceTreeNode) *tview.TreeNode {
 	}
 
 	return rootNode
+}
+
+// Refresh the topology  view
+func (v *TopologyView) Refresh(clear bool, update func(timeoutCancel func())) {
+	if clear {
+		v.Grid.Clear()
+	}
+
+	updateWithTimeout := func() {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*topologyReqTimeout)
+		defer cancelFunc()
+		go update(cancelFunc)
+
+		select {
+		case <-time.After(time.Second * topologyReqTimeout): // timeout
+		case <-ctx.Done(): // success
+		}
+	}
+
+	v.app.QueueUpdateDraw(updateWithTimeout)
+}
+
+// AutoRefresh will refresh the view in every RefreshDelay delay
+func (v *TopologyView) AutoRefresh(update func(timeoutCancel func())) {
+	var ctx context.Context
+	ctx, v.cancelFunc = context.WithCancel(context.Background())
+	go func() {
+		for {
+			time.Sleep(RefreshDelay * time.Second)
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				v.Refresh(true, update)
+			}
+		}
+	}()
 }

--- a/references/cli/top/view/application_view.go
+++ b/references/cli/top/view/application_view.go
@@ -49,7 +49,7 @@ func (v *ApplicationView) Init() {
 // Start the application view
 func (v *ApplicationView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
@@ -78,9 +78,10 @@ func (v *ApplicationView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *ApplicationView) Update() {
+func (v *ApplicationView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/cluster_namespace_view.go
+++ b/references/cli/top/view/cluster_namespace_view.go
@@ -49,7 +49,7 @@ func (v *ClusterNamespaceView) Init() {
 // Start the cluster namespace view
 func (v *ClusterNamespaceView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.AutoRefresh(v.Update)
 }
 
@@ -78,9 +78,10 @@ func (v *ClusterNamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *ClusterNamespaceView) Update() {
+func (v *ClusterNamespaceView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/cluster_view.go
+++ b/references/cli/top/view/cluster_view.go
@@ -48,7 +48,7 @@ func (v *ClusterView) Name() string {
 // Start the cluster view
 func (v *ClusterView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
@@ -77,9 +77,10 @@ func (v *ClusterView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *ClusterView) Update() {
+func (v *ClusterView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/container_view.go
+++ b/references/cli/top/view/container_view.go
@@ -49,7 +49,7 @@ func (v *ContainerView) Name() string {
 // Start the container view
 func (v *ContainerView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
@@ -78,9 +78,10 @@ func (v *ContainerView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *ContainerView) Update() {
+func (v *ContainerView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/managed_resource_view.go
+++ b/references/cli/top/view/managed_resource_view.go
@@ -50,7 +50,7 @@ func (v *ManagedResourceView) Init() {
 // Start the managed resource view
 func (v *ManagedResourceView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
@@ -92,9 +92,10 @@ func (v *ManagedResourceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *ManagedResourceView) Update() {
+func (v *ManagedResourceView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/namespace_view.go
+++ b/references/cli/top/view/namespace_view.go
@@ -49,7 +49,7 @@ func (v *NamespaceView) Name() string {
 // Start the managed namespace view
 func (v *NamespaceView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.CommonResourceView.AutoRefresh(v.Update)
 }
 
@@ -78,9 +78,10 @@ func (v *NamespaceView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *NamespaceView) Update() {
+func (v *NamespaceView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/pod_view.go
+++ b/references/cli/top/view/pod_view.go
@@ -42,7 +42,7 @@ func (v *PodView) Name() string {
 // Start the pod view
 func (v *PodView) Start() {
 	v.Clear()
-	v.Update()
+	v.Update(func() {})
 	v.AutoRefresh(v.Update)
 }
 
@@ -78,9 +78,10 @@ func (v *PodView) Refresh(_ *tcell.EventKey) *tcell.EventKey {
 }
 
 // Update refresh the content of body of view
-func (v *PodView) Update() {
+func (v *PodView) Update(timeoutCancel func()) {
 	v.BuildHeader()
 	v.BuildBody()
+	timeoutCancel()
 }
 
 // BuildHeader render the header of table

--- a/references/cli/top/view/resource_view_test.go
+++ b/references/cli/top/view/resource_view_test.go
@@ -39,11 +39,11 @@ func TestResourceView(t *testing.T) {
 	assert.Equal(t, view.GetCell(1, 0).Text, "Name1")
 	assert.Equal(t, view.GetCell(1, 1).Text, "Data1")
 
-	view.Refresh(true, func() {})
+	view.Refresh(true, func(func()) {})
 	assert.Equal(t, view.GetCell(0, 0).Text, "")
 
 	view.BuildHeader([]string{"Name", "Data"})
-	view.Refresh(false, func() {})
+	view.Refresh(false, func(func()) {})
 	assert.Equal(t, view.GetCell(0, 0).Text, "Name")
 
 	view.BuildHeader([]string{"Name", "Data"})


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In #5151, due to the lack of timeout mechanism, the data in the cache will not be clear, so we update the LRU cache to LRU cache with expired time to ensure the data in cache will be clear after some time.

But only clearing the cached data will not make the topology refresh immediately. Therefore, we introduce an automatic refresh mechanism in the topology view.
In addition, we found that the view refresh requires network requests, and the blocking of network IO will further affect the loading speed of the interface. Therefore, we optimized the network IO, added a timeout abandonment mechanism to the network request, and terminated the timeout request in time to prevent blocking.

Fixes #5151  
Fixes #5152

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->