### PR TITLE
Feat: support data-passing in deploy step

### DIFF
--- a/apis/types/componentmanifest.go
+++ b/apis/types/componentmanifest.go
@@ -28,9 +28,11 @@ type ComponentManifest struct {
 	RevisionName     string
 	RevisionHash     string
 	ExternalRevision string
+	// StandardWorkload contains K8s resource generated from "output" block of ComponentDefinition
 	StandardWorkload *unstructured.Unstructured
-	Traits           []*unstructured.Unstructured
-	Scopes           []*corev1.ObjectReference
+	// Traits contains both resources generated from "outputs" block of ComponentDefinition and resources generated from TraitDefinition
+	Traits []*unstructured.Unstructured
+	Scopes []*corev1.ObjectReference
 
 	// PackagedWorkloadResources contain all the workload related resources. It could be a Helm
 	// Release, Git Repo or anything that can package and run a workload.

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -99,22 +99,26 @@ func (wl *Workload) EvalContext(ctx process.Context) error {
 	return wl.engine.Complete(ctx, wl.FullTemplate.TemplateStr, wl.Params)
 }
 
+func (wl *Workload) GetTemplateContext(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (map[string]interface{}, error) {
+	return wl.engine.GetTemplateContext(ctx, client, accessor)
+}
+
 // EvalStatus eval workload status
-func (wl *Workload) EvalStatus(ctx process.Context, cli client.Client, accessor util.NamespaceAccessor) (string, error) {
+func (wl *Workload) EvalStatus(templateContext map[string]interface{}) (string, error) {
 	// if the  standard workload is managed by trait always return empty message
 	if wl.SkipApplyWorkload {
 		return "", nil
 	}
-	return wl.engine.Status(ctx, cli, accessor, wl.FullTemplate.CustomStatus, wl.Params)
+	return wl.engine.Status(templateContext, wl.FullTemplate.CustomStatus, wl.Params)
 }
 
 // EvalHealth eval workload health check
-func (wl *Workload) EvalHealth(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (bool, error) {
+func (wl *Workload) EvalHealth(templateContext map[string]interface{}) (bool, error) {
 	// if health of template is not set or standard workload is managed by trait always return true
 	if wl.SkipApplyWorkload {
 		return true, nil
 	}
-	return wl.engine.HealthCheck(ctx, client, accessor, wl.FullTemplate.Health, wl.Params)
+	return wl.engine.HealthCheck(templateContext, wl.FullTemplate.Health, wl.Params)
 }
 
 // Scope defines the scope of workload
@@ -147,14 +151,18 @@ func (trait *Trait) EvalContext(ctx process.Context) error {
 	return trait.engine.Complete(ctx, trait.Template, trait.Params)
 }
 
+func (trait *Trait) GetTemplateContext(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (map[string]interface{}, error) {
+	return trait.engine.GetTemplateContext(ctx, client, accessor)
+}
+
 // EvalStatus eval trait status
-func (trait *Trait) EvalStatus(ctx process.Context, cli client.Client, accessor util.NamespaceAccessor) (string, error) {
-	return trait.engine.Status(ctx, cli, accessor, trait.CustomStatusFormat, trait.Params)
+func (trait *Trait) EvalStatus(templateContext map[string]interface{}) (string, error) {
+	return trait.engine.Status(templateContext, trait.CustomStatusFormat, trait.Params)
 }
 
 // EvalHealth eval trait health check
-func (trait *Trait) EvalHealth(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (bool, error) {
-	return trait.engine.HealthCheck(ctx, client, accessor, trait.HealthCheckPolicy, trait.Params)
+func (trait *Trait) EvalHealth(templateContext map[string]interface{}) (bool, error) {
+	return trait.engine.HealthCheck(templateContext, trait.HealthCheckPolicy, trait.Params)
 }
 
 // Appfile describes application

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -99,6 +99,7 @@ func (wl *Workload) EvalContext(ctx process.Context) error {
 	return wl.engine.Complete(ctx, wl.FullTemplate.TemplateStr, wl.Params)
 }
 
+// GetTemplateContext get workload template context, it will be used to eval status and health
 func (wl *Workload) GetTemplateContext(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (map[string]interface{}, error) {
 	return wl.engine.GetTemplateContext(ctx, client, accessor)
 }
@@ -151,6 +152,7 @@ func (trait *Trait) EvalContext(ctx process.Context) error {
 	return trait.engine.Complete(ctx, trait.Template, trait.Params)
 }
 
+// GetTemplateContext get trait template context, it will be used to eval status and health
 func (trait *Trait) GetTemplateContext(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (map[string]interface{}, error) {
 	return trait.engine.GetTemplateContext(ctx, client, accessor)
 }

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -101,12 +101,16 @@ func (wl *Workload) EvalContext(ctx process.Context) error {
 
 // GetTemplateContext get workload template context, it will be used to eval status and health
 func (wl *Workload) GetTemplateContext(ctx process.Context, client client.Client, accessor util.NamespaceAccessor) (map[string]interface{}, error) {
+	// if the standard workload is managed by trait, just return empty context
+	if wl.SkipApplyWorkload {
+		return nil, nil
+	}
 	return wl.engine.GetTemplateContext(ctx, client, accessor)
 }
 
 // EvalStatus eval workload status
 func (wl *Workload) EvalStatus(templateContext map[string]interface{}) (string, error) {
-	// if the  standard workload is managed by trait always return empty message
+	// if the standard workload is managed by trait always return empty message
 	if wl.SkipApplyWorkload {
 		return "", nil
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -63,11 +63,6 @@ type AppHandler struct {
 	mu sync.Mutex
 }
 
-type cluster struct {
-	cluster string
-	output  *unstructured.Unstructured
-}
-
 // NewAppHandler create new app handler
 func NewAppHandler(ctx context.Context, r *Reconciler, app *v1beta1.Application, parser *appfile.Parser) (*AppHandler, error) {
 	if ctx, ok := ctx.(monitorContext.Context); ok {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -63,6 +63,11 @@ type AppHandler struct {
 	mu sync.Mutex
 }
 
+type cluster struct {
+	cluster string
+	output  *unstructured.Unstructured
+}
+
 // NewAppHandler create new app handler
 func NewAppHandler(ctx context.Context, r *Reconciler, app *v1beta1.Application, parser *appfile.Parser) (*AppHandler, error) {
 	if ctx, ok := ctx.(monitorContext.Context); ok {
@@ -228,7 +233,7 @@ func (h *AppHandler) ProduceArtifacts(ctx context.Context, comps []*types.Compon
 }
 
 // collectTraitHealthStatus collect trait health status
-func (h *AppHandler) collectTraitHealthStatus(wl *appfile.Workload, tr *appfile.Trait, appRev *v1beta1.ApplicationRevision, overrideNamespace string) (common.ApplicationTraitStatus, error) {
+func (h *AppHandler) collectTraitHealthStatus(wl *appfile.Workload, tr *appfile.Trait, appRev *v1beta1.ApplicationRevision, overrideNamespace string) (common.ApplicationTraitStatus, []*unstructured.Unstructured, error) {
 	defer func(clusterName string) {
 		wl.Ctx.SetCtx(pkgmulticluster.WithCluster(wl.Ctx.GetCtx(), clusterName))
 	}(multicluster.ClusterNameInContext(wl.Ctx.GetCtx()))
@@ -248,22 +253,27 @@ func (h *AppHandler) collectTraitHealthStatus(wl *appfile.Workload, tr *appfile.
 		pCtx.SetCtx(pkgmulticluster.WithCluster(pCtx.GetCtx(), pkgmulticluster.Local))
 	}
 	_accessor := util.NewApplicationResourceNamespaceAccessor(h.app.Namespace, traitOverrideNamespace)
-	if ok, err := tr.EvalHealth(pCtx, h.r.Client, _accessor); !ok || err != nil {
+	templateContext, err := tr.GetTemplateContext(pCtx, h.r.Client, _accessor)
+	if err != nil {
+		return common.ApplicationTraitStatus{}, nil, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, get template context error", appName, wl.Name, tr.Name)
+	}
+	if ok, err := tr.EvalHealth(templateContext); !ok || err != nil {
 		traitStatus.Healthy = false
 	}
-	traitStatus.Message, err = tr.EvalStatus(pCtx, h.r.Client, _accessor)
+	traitStatus.Message, err = tr.EvalStatus(templateContext)
 	if err != nil {
-		return common.ApplicationTraitStatus{}, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, evaluate status message error", appName, wl.Name, tr.Name)
+		return common.ApplicationTraitStatus{}, nil, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, evaluate status message error", appName, wl.Name, tr.Name)
 	}
-	return traitStatus, nil
+	return traitStatus, extractOutputs(templateContext), nil
 }
 
 // collectWorkloadHealthStatus collect workload health status
-func (h *AppHandler) collectWorkloadHealthStatus(ctx context.Context, wl *appfile.Workload, appRev *v1beta1.ApplicationRevision, status *common.ApplicationComponentStatus, accessor util.NamespaceAccessor) (bool, error) {
+func (h *AppHandler) collectWorkloadHealthStatus(ctx context.Context, wl *appfile.Workload, appRev *v1beta1.ApplicationRevision, status *common.ApplicationComponentStatus, accessor util.NamespaceAccessor) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	var output *unstructured.Unstructured
+	var outputs []*unstructured.Unstructured
 	var (
 		appName  = appRev.Spec.Application.Name
 		isHealth = true
-		err      error
 	)
 	if wl.CapabilityCategory == types.TerraformCategory {
 		var configuration terraforv1beta2.Configuration
@@ -271,32 +281,40 @@ func (h *AppHandler) collectWorkloadHealthStatus(ctx context.Context, wl *appfil
 			if kerrors.IsNotFound(err) {
 				var legacyConfiguration terraforv1beta1.Configuration
 				if err := h.r.Client.Get(ctx, client.ObjectKey{Name: wl.Name, Namespace: accessor.Namespace()}, &legacyConfiguration); err != nil {
-					return false, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appName, wl.Name)
+					return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appName, wl.Name)
 				}
 				isHealth = setStatus(status, legacyConfiguration.Status.ObservedGeneration, legacyConfiguration.Generation,
 					legacyConfiguration.GetLabels(), appRev.Name, legacyConfiguration.Status.Apply.State, legacyConfiguration.Status.Apply.Message)
 			} else {
-				return false, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appName, wl.Name)
+				return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appName, wl.Name)
 			}
 		} else {
 			isHealth = setStatus(status, configuration.Status.ObservedGeneration, configuration.Generation, configuration.GetLabels(),
 				appRev.Name, configuration.Status.Apply.State, configuration.Status.Apply.Message)
 		}
 	} else {
-		if ok, err := wl.EvalHealth(wl.Ctx, h.r.Client, accessor); !ok || err != nil {
+		templateContext, err := wl.GetTemplateContext(wl.Ctx, h.r.Client, accessor)
+		if err != nil {
+			return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, get template context error", appName, wl.Name)
+		}
+		if ok, err := wl.EvalHealth(templateContext); !ok || err != nil {
 			isHealth = false
 		}
 		status.Healthy = isHealth
-		status.Message, err = wl.EvalStatus(wl.Ctx, h.r.Client, accessor)
+		status.Message, err = wl.EvalStatus(templateContext)
 		if err != nil {
-			return false, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, wl.Name)
+			return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, wl.Name)
 		}
+		output, outputs = extractOutputAndOutputs(templateContext)
 	}
-	return isHealth, nil
+	return isHealth, output, outputs, nil
 }
 
 // nolint
-func (h *AppHandler) collectHealthStatus(ctx context.Context, wl *appfile.Workload, appRev *v1beta1.ApplicationRevision, overrideNamespace string, skipWorkload bool, traitFilters ...TraitFilter) (*common.ApplicationComponentStatus, bool, error) {
+// collectHealthStatus will collect health status of component, including component itself and traits.
+func (h *AppHandler) collectHealthStatus(ctx context.Context, wl *appfile.Workload, appRev *v1beta1.ApplicationRevision, overrideNamespace string, skipWorkload bool, traitFilters ...TraitFilter) (*common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+	output := new(unstructured.Unstructured)
+	outputs := make([]*unstructured.Unstructured, 0)
 	accessor := util.NewApplicationResourceNamespaceAccessor(h.app.Namespace, overrideNamespace)
 	var (
 		status = common.ApplicationComponentStatus{
@@ -312,9 +330,9 @@ func (h *AppHandler) collectHealthStatus(ctx context.Context, wl *appfile.Worklo
 
 	status = h.getServiceStatus(status)
 	if !skipWorkload {
-		isHealth, err = h.collectWorkloadHealthStatus(ctx, wl, appRev, &status, accessor)
+		isHealth, output, outputs, err = h.collectWorkloadHealthStatus(ctx, wl, appRev, &status, accessor)
 		if err != nil {
-			return nil, false, err
+			return nil, nil, nil, false, err
 		}
 	}
 
@@ -328,10 +346,11 @@ collectNext:
 			}
 		}
 
-		traitStatus, err := h.collectTraitHealthStatus(wl, tr, appRev, overrideNamespace)
+		traitStatus, _outputs, err := h.collectTraitHealthStatus(wl, tr, appRev, overrideNamespace)
 		if err != nil {
-			return nil, false, err
+			return nil, nil, nil, false, err
 		}
+		outputs = append(outputs, _outputs...)
 
 		isHealth = isHealth && traitStatus.Healthy
 		if status.Message == "" && traitStatus.Message != "" {
@@ -350,7 +369,7 @@ collectNext:
 	status.Traits = append(status.Traits, traitStatusList...)
 	status.Scopes = generateScopeReference(wl.Scopes)
 	h.addServiceStatus(true, status)
-	return &status, isHealth, nil
+	return &status, output, outputs, isHealth, nil
 }
 
 func setStatus(status *common.ApplicationComponentStatus, observedGeneration, generation int64, labels map[string]string,
@@ -433,4 +452,23 @@ func (h *AppHandler) ApplyPolicies(ctx context.Context, af *appfile.Appfile) err
 		}
 	}
 	return nil
+}
+
+func extractOutputAndOutputs(templateContext map[string]interface{}) (*unstructured.Unstructured, []*unstructured.Unstructured) {
+	output := new(unstructured.Unstructured)
+	if templateContext["output"] != nil {
+		output = &unstructured.Unstructured{Object: templateContext["output"].(map[string]interface{})}
+	}
+	outputs := extractOutputs(templateContext)
+	return output, outputs
+}
+
+func extractOutputs(templateContext map[string]interface{}) []*unstructured.Unstructured {
+	outputs := make([]*unstructured.Unstructured, 0)
+	if templateContext["outputs"] != nil {
+		for _, v := range templateContext["outputs"].(map[string]interface{}) {
+			outputs = append(outputs, &unstructured.Unstructured{Object: v.(map[string]interface{})})
+		}
+	}
+	return outputs
 }

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatcher.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatcher.go
@@ -127,7 +127,7 @@ func (h *AppHandler) generateDispatcher(appRev *v1beta1.ApplicationRevision, rea
 			if !h.resourceKeeper.ContainsResources(manifests) {
 				return false, nil
 			}
-			_, isHealth, err := h.collectHealthStatus(ctx, wl, appRev, options.OverrideNamespace, skipWorkload,
+			_, _, _, isHealth, err := h.collectHealthStatus(ctx, wl, appRev, options.OverrideNamespace, skipWorkload,
 				ByTraitType(readyTraits, options.Traits))
 			if err != nil {
 				return false, err
@@ -140,7 +140,7 @@ func (h *AppHandler) generateDispatcher(appRev *v1beta1.ApplicationRevision, rea
 				if err := h.Dispatch(ctx, clusterName, common.WorkflowResourceCreator, dispatchManifests...); err != nil {
 					return false, errors.WithMessage(err, "Dispatch")
 				}
-				status, isHealth, err := h.collectHealthStatus(ctx, wl, appRev, options.OverrideNamespace, skipWorkload,
+				status, _, _, isHealth, err := h.collectHealthStatus(ctx, wl, appRev, options.OverrideNamespace, skipWorkload,
 					ByTraitType(readyTraits, options.Traits))
 				if err != nil {
 					return false, errors.WithMessage(err, "CollectHealthStatus")

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -332,13 +332,12 @@ func (h *AppHandler) checkComponentHealth(appParser *appfile.Parser, appRev *v1b
 			return false, nil, nil, err
 		}
 
-		_, isHealth, err := h.collectHealthStatus(auth.ContextWithUserInfo(ctx, h.app), wl, appRev, overrideNamespace, false)
+		_, output, outputs, isHealth, err := h.collectHealthStatus(auth.ContextWithUserInfo(ctx, h.app), wl, appRev, overrideNamespace, false)
 		if err != nil {
 			return false, nil, nil, err
 		}
 
-		workload, traits, err := getComponentResources(auth.ContextWithUserInfo(ctx, h.app), manifest, wl.SkipApplyWorkload, h.r.Client)
-		return isHealth, workload, traits, err
+		return isHealth, output, outputs, err
 	}
 }
 
@@ -390,7 +389,7 @@ func (h *AppHandler) applyComponentFunc(appParser *appfile.Parser, appRev *v1bet
 			if err := h.Dispatch(ctx, clusterName, common.WorkflowResourceCreator, dispatchResources...); err != nil {
 				return nil, nil, false, errors.WithMessage(err, "Dispatch")
 			}
-			_, isHealth, err = h.collectHealthStatus(ctx, wl, appRev, overrideNamespace, false)
+			_, _, _, isHealth, err = h.collectHealthStatus(ctx, wl, appRev, overrideNamespace, false)
 			if err != nil {
 				return nil, nil, false, errors.WithMessage(err, "CollectHealthStatus")
 			}

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -333,6 +333,10 @@ func (h *AppHandler) checkComponentHealth(appParser *appfile.Parser, appRev *v1b
 		}
 
 		_, isHealth, err := h.collectHealthStatus(auth.ContextWithUserInfo(ctx, h.app), wl, appRev, overrideNamespace, false)
+		if err != nil {
+			return false, nil, nil, err
+		}
+
 		workload, traits, err := getComponentResources(auth.ContextWithUserInfo(ctx, h.app), manifest, wl.SkipApplyWorkload, h.r.Client)
 		return isHealth, workload, traits, err
 	}

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -19,12 +19,12 @@ package multicluster
 import (
 	"context"
 	"fmt"
-	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"strings"
 	"sync"
 
 	pkgsync "github.com/kubevela/pkg/util/sync"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
+	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -24,7 +24,6 @@ import (
 
 	pkgsync "github.com/kubevela/pkg/util/sync"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
-	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -40,6 +39,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
 	"github.com/oam-dev/kubevela/pkg/utils"
+	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"github.com/oam-dev/kubevela/pkg/utils/parallel"
 	oamProvider "github.com/oam-dev/kubevela/pkg/workflow/providers/oam"
 )

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -119,9 +119,9 @@ func TestApplyComponentsDepends(t *testing.T) {
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
 		return nil, nil, true, nil
 	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, error) {
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
-		return found, nil
+		return found, nil, nil, nil
 	}
 	parallelism := 10
 
@@ -161,7 +161,11 @@ func TestApplyComponentsIO(t *testing.T) {
 	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
-		return &unstructured.Unstructured{Object: map[string]interface{}{
+		return nil, nil, true, nil
+	}
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
+		return found, &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"path": fmt.Sprintf("%s/%s", clusterName, comp.Name),
 				},
@@ -178,11 +182,7 @@ func TestApplyComponentsIO(t *testing.T) {
 						},
 					},
 				},
-			}, true, nil
-	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, error) {
-		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
-		return found, nil
+			}, nil
 	}
 
 	resetStore := func() {

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -28,11 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
 
 	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 func TestOverrideConfiguration(t *testing.T) {
@@ -91,7 +94,7 @@ func TestOverrideConfiguration(t *testing.T) {
 	}
 }
 
-func TestApplyComponents(t *testing.T) {
+func TestApplyComponentsDepends(t *testing.T) {
 	r := require.New(t)
 	const n, m = 50, 5
 	var components []apicommon.ApplicationComponent
@@ -145,4 +148,139 @@ func TestApplyComponents(t *testing.T) {
 	r.NoError(err)
 	r.True(healthy)
 	r.Equal(3*n*m, countMap())
+}
+
+func TestApplyComponentsIO(t *testing.T) {
+	r := require.New(t)
+
+	var (
+		parallelism = 10
+		applyMap    = new(sync.Map)
+		ctx         = context.Background()
+	)
+	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
+		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"path": fmt.Sprintf("%s/%s", clusterName, comp.Name),
+				},
+			}}, []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								oam.TraitResource: "obj",
+							},
+						},
+						"spec": map[string]interface{}{
+							"path": fmt.Sprintf("%s/%s", clusterName, comp.Name),
+						},
+					},
+				},
+			}, true, nil
+	}
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, error) {
+		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
+		return found, nil
+	}
+
+	resetStore := func() {
+		applyMap = &sync.Map{}
+	}
+	countMap := func() int {
+		cnt := 0
+		applyMap.Range(func(key, value interface{}) bool {
+			cnt++
+			return true
+		})
+		return cnt
+	}
+
+	t.Run("apply components with io successfully", func(t *testing.T) {
+		resetStore()
+		const n, m = 10, 5
+		var components []apicommon.ApplicationComponent
+		var placements []v1alpha1.PlacementDecision
+		for i := 0; i < n; i++ {
+			comp := apicommon.ApplicationComponent{
+				Name:       fmt.Sprintf("comp-%d", i),
+				Properties: &runtime.RawExtension{Raw: []byte(fmt.Sprintf(`{"placeholder":%d}`, i))},
+			}
+			if i != 0 {
+				comp.Inputs = workflowv1alpha1.StepInputs{
+					{
+						ParameterKey: "input_slot_1",
+						From:         fmt.Sprintf("var-output-%d", i-1),
+					},
+					{
+						ParameterKey: "input_slot_2",
+						From:         fmt.Sprintf("var-outputs-%d", i-1),
+					},
+				}
+			}
+			if i != n-1 {
+				comp.Outputs = workflowv1alpha1.StepOutputs{
+					{
+						ValueFrom: "output.spec.path",
+						Name:      fmt.Sprintf("var-output-%d", i),
+					},
+					{
+						ValueFrom: "outputs.obj.spec.path",
+						Name:      fmt.Sprintf("var-outputs-%d", i),
+					},
+				}
+			}
+			components = append(components, comp)
+		}
+		for i := 0; i < m; i++ {
+			placements = append(placements, v1alpha1.PlacementDecision{Cluster: fmt.Sprintf("cluster-%d", i)})
+		}
+
+		for i := 0; i < n; i++ {
+			healthy, _, err := applyComponents(ctx, apply, healthCheck, components, placements, parallelism)
+			r.NoError(err)
+			r.Equal((i+1)*m, countMap())
+			if i == n-1 {
+				r.True(healthy)
+			} else {
+				r.False(healthy)
+			}
+		}
+	})
+
+	t.Run("apply components with io failed", func(t *testing.T) {
+		resetStore()
+		components := []apicommon.ApplicationComponent{
+			{
+				Name: "comp-0",
+				Outputs: workflowv1alpha1.StepOutputs{
+					{
+						ValueFrom: "output.spec.error_path",
+						Name:      "var1",
+					},
+				},
+			},
+
+			{
+				Name: "comp-1",
+				Inputs: workflowv1alpha1.StepInputs{
+					{
+						ParameterKey: "input_slot_1",
+						From:         "var1",
+					},
+				},
+			},
+		}
+		placements := []v1alpha1.PlacementDecision{
+			{Cluster: "cluster-0"},
+		}
+		healthy, _, err := applyComponents(ctx, apply, healthCheck, components, placements, parallelism)
+		r.NoError(err)
+		r.False(healthy)
+		healthy, _, err = applyComponents(ctx, apply, healthCheck, components, placements, parallelism)
+		r.ErrorContains(err, "error getting output from")
+		r.False(healthy)
+
+	})
 }

--- a/pkg/workflow/providers/multicluster/multicluster.go
+++ b/pkg/workflow/providers/multicluster/multicluster.go
@@ -171,7 +171,7 @@ func (p *provider) ListClusters(ctx monitorContext.Context, wfCtx wfContext.Cont
 	return v.FillObject(clusters, "outputs", "clusters")
 }
 
-func (p *provider) Deploy(ctx monitorContext.Context, wfCtx wfContext.Context, v *value.Value, act wfTypes.Action) error {
+func (p *provider) Deploy(ctx monitorContext.Context, _ wfContext.Context, v *value.Value, act wfTypes.Action) error {
 	policyNames, err := v.GetStringSlice("policies")
 	if err != nil {
 		return err
@@ -187,8 +187,13 @@ func (p *provider) Deploy(ctx monitorContext.Context, wfCtx wfContext.Context, v
 	if err != nil {
 		return err
 	}
-	executor := NewDeployWorkflowStepExecutor(p.Client, p.af, p.apply, p.healthCheck, p.renderer, ignoreTerraformComponent)
-	healthy, reason, err := executor.Deploy(ctx, policyNames, int(parallelism))
+	param := DeployParameter{
+		Policies:                 policyNames,
+		Parallelism:              parallelism,
+		IgnoreTerraformComponent: ignoreTerraformComponent,
+	}
+	executor := NewDeployWorkflowStepExecutor(p.Client, p.af, p.apply, p.healthCheck, p.renderer, param)
+	healthy, reason, err := executor.Deploy(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflow/providers/oam/apply.go
+++ b/pkg/workflow/providers/oam/apply.go
@@ -50,7 +50,7 @@ type ComponentApply func(ctx context.Context, comp common.ApplicationComponent, 
 type ComponentRender func(ctx context.Context, comp common.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, error)
 
 // ComponentHealthCheck health check oam component.
-type ComponentHealthCheck func(ctx context.Context, comp common.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, error)
+type ComponentHealthCheck func(ctx context.Context, comp common.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error)
 
 // WorkloadRenderer renderer to render application component into workload
 type WorkloadRenderer func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Workload, error)

--- a/test/e2e-multicluster-test/testdata/app/app-deploy-io.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-deploy-io.yaml
@@ -1,0 +1,49 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-deploy-io
+spec:
+  components:
+    - name: podinfo
+      outputs:
+        - name: message
+          valueFrom: output.status.conditions[0].message
+        - name: ip
+          valueFrom: outputs.service.spec.clusterIP
+
+      properties:
+        image: stefanprodan/podinfo:4.0.3
+      type: webservice
+      traits:
+        - type: expose
+          properties:
+            port: [ 80 ]
+    - name: configmap
+      properties:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: deployment-msg
+      type: raw
+      inputs:
+        - from: message
+          parameterKey: data.msg
+        - from: ip
+          parameterKey: data.ip
+  policies:
+    - name: topo
+      properties:
+        clusters: [ "local","cluster-worker" ]
+      type: topology
+    - name: override
+      properties:
+        selector:
+          - configmap
+          - podinfo
+      type: override
+  workflow:
+    steps:
+      - name: deploy
+        properties:
+          policies: [ "topo", "override" ]
+        type: deploy


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


## Description of your changes

### Intro

This PR add component level input/output capability for `deploy` step. Now `deploy` can correctly deal with components like:

```YAML
  components:
    - name: podinfo
      outputs:
        - name: message
          valueFrom: output.status.conditions[0].message
      properties:
        image: stefanprodan/podinfo:4.0.3
      type: webservice
    - name: configmap
      properties:
        apiVersion: v1
        kind: ConfigMap
        metadata:
          name: deployment-msg
      type: raw
      inputs:
        - from: message
          parameterKey: data.msg
```

### Variable matching mechanism

There are two possible variable matching ways:
1. First try to match the var strictly. Find var with key `<cluster>/<namespace>/<replication>/<var>`.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/47812250/209041789-51dc2ad2-f0de-464e-be20-96ee2d6779af.png">

2. As fallback, if no matching in the first step, restriction on <replication> can be given up. Try to match var with `<cluster>/<namespace>//<var>`. Namely the <replication> is empty.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/47812250/209041872-41497930-cd5e-4960-a833-b7dcc2138e7c.png">



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->