### PR TITLE
Feat: support fallback to kubeconfig namespace when env not set

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -46,6 +46,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/condition"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	types2 "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 )
@@ -297,7 +298,7 @@ func GetDefinitionNamespaceWithCtx(ctx context.Context) string {
 func SetNamespaceInCtx(ctx context.Context, namespace string) context.Context {
 	if namespace == "" {
 		// compatible with some webhook handlers that maybe receive empty string as app namespace which means `default` namespace
-		namespace = "default"
+		namespace = types2.DefaultAppNamespace
 	}
 	ctx = context.WithValue(ctx, AppDefinitionNamespace, namespace)
 	return ctx

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -589,3 +589,10 @@ func TestHTTPGetKubernetesObjects(t *testing.T) {
 	assert.Equal(t, "busybox", uns[1].GetName())
 	assert.Equal(t, "ConfigMap", uns[1].GetKind())
 }
+
+func TestGetRawConfig(t *testing.T) {
+	assert.NoError(t, os.Setenv("KUBECONFIG", filepath.Join("testdata", "testkube.conf")))
+	ag := Args{}
+	ns := ag.GetNamespaceFromConfig()
+	assert.Equal(t, "prod", ns)
+}

--- a/pkg/utils/common/testdata/testkube.conf
+++ b/pkg/utils/common/testdata/testkube.conf
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+    certificate-authority-data: YWJjMQ==
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: "kubernetes-admin"
+    namespace: "prod"
+  name: kubernetes-admin
+current-context: kubernetes-admin
+kind: Config
+preferences: {}
+users:
+- name: "kubernetes-admin"
+  user:
+    client-certificate-data: S1N6
+    client-key-data: S1N6

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -76,7 +76,7 @@ You can also specify a remote url for app:
 				}
 
 				// Set the namespace to default to match behavior of `GetFlagNamespaceOrEnv`
-				namespace = "default"
+				namespace = types.DefaultAppNamespace
 			}
 
 			buff, err := DryRunApplication(o, c, namespace)

--- a/references/cli/env.go
+++ b/references/cli/env.go
@@ -251,7 +251,11 @@ func GetFlagEnvOrCurrent(cmd *cobra.Command, args common.Args) (*types.EnvMeta, 
 	if err != nil {
 		// ignore this error and return a default value
 		// nolint:nilerr
-		return &types.EnvMeta{Name: "", Namespace: "default"}, nil
+		ns := args.GetNamespaceFromConfig()
+		if ns == "" {
+			ns = types.DefaultAppNamespace
+		}
+		return &types.EnvMeta{Name: "", Namespace: ns}, nil
 	}
 	return cur, nil
 }


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5121

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->