### PR TITLE
Feat: return notFound error when deleting app

### DIFF
--- a/references/common/application.go
+++ b/references/common/application.go
@@ -187,7 +187,7 @@ func (o *DeleteOptions) DeleteAppWithoutDoubleCheck(io cmdutil.IOStreams) error 
 	err := o.Client.Get(ctx, client.ObjectKey{Name: o.AppName, Namespace: o.Namespace}, app)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil
+			return fmt.Errorf("app %s not exist or deleted in namespace %s", o.AppName, o.Namespace)
 		}
 		return fmt.Errorf("delete application err: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: suwanliang_yewu <suwanliang_yewu@cmss.chinamobile.com>


### Description of your changes

When deleting an app from a namespace,if there is not the app in the namespace, it should return the error of "notFound".

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->



I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->