### PR TITLE
Fix: addon ls command does not show the componentless application

### DIFF
--- a/references/cli/ls.go
+++ b/references/cli/ls.go
@@ -134,6 +134,15 @@ func buildApplicationListTable(ctx context.Context, c client.Reader, namespace s
 			service[s.Name] = s
 		}
 
+		if len(a.Spec.Components) == 0 {
+			if AllNamespace {
+				table.AddRow(a.Namespace, a.Name, "", "", "", a.Status.Phase, "", "", a.CreationTimestamp)
+			} else {
+				table.AddRow(a.Name, "", "", "", a.Status.Phase, "", "", a.CreationTimestamp)
+			}
+			continue
+		}
+
 		for idx, cmp := range a.Spec.Components {
 			var appName = a.Name
 			if idx > 0 {


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### Description of your changes

Fixes #5200 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
1. `vela addon enable vegeta`
2. `vela ls -n vela-system`


### Special notes for your reviewer
@joelhy 