### PR TITLE
Fix: remove useless field when loading pod in top

### DIFF
--- a/references/cli/top/model/pod.go
+++ b/references/cli/top/model/pod.go
@@ -95,7 +95,6 @@ func LoadPodDetail(cfg *rest.Config, pod *v1.Pod) Pod {
 	podInfo := Pod{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,
-		Cluster:   pod.ClusterName,
 		Ready:     readyContainerNum(pod),
 		Status:    string(pod.Status.Phase),
 		Age:       utils.TimeFormat(time.Since(pod.CreationTimestamp.Time)),


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

remove `clusterName` when load pod details. This field is not actually returned by anyone. And it will be remove in the next version of `k8s.io/api` and cause compatibility problem. This PR removes it.

Code in k8s.io/api

```go
	// The name of the cluster which the object belongs to.
	// This is used to distinguish resources with same name and namespace in different clusters.
	// This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
	// +optional
	ClusterName string `json:"clusterName,omitempty" protobuf:"bytes,15,opt,name=clusterName"`
```

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->