### PR TITLE
Fix: dependency makefile variable error

### DIFF
--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -1,13 +1,13 @@
 
 GOLANGCILINT_VERSION ?= 1.49.0
-GOLANGCILINT := $(shell which golangci-lint)
+GLOBAL_GOLANGCILINT := $(shell which golangci-lint)
 GOBIN_GOLANGCILINT:= $(shell which $(GOBIN)/golangci-lint)
 
 .PHONY: golangci
 golangci:
-ifeq ($(shell $(GOLANGCILINT) version --format short), $(GOLANGCILINT_VERSION))
+ifeq ($(shell $(GLOBAL_GOLANGCILINT) version --format short), $(GOLANGCILINT_VERSION))
 	@$(OK) golangci-lint is already installed
-GOLANGCILINT=$(GOLANGCILINT)
+GOLANGCILINT=$(GLOBAL_GOLANGCILINT)
 else ifeq ($(shell $(GOBIN_GOLANGCILINT) version --format short), $(GOLANGCILINT_VERSION))
 	@$(OK) golangci-lint is already installed
 GOLANGCILINT=$(GOBIN_GOLANGCILINT)


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

Fix var error in makefile 
```
makefiles/dependency.mk:10: *** Recursive variable `GOLANGCILINT' references itself (eventually).  Stop.
```

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/47812250/209623322-5c8af75a-6651-4c90-9bb4-0e1e72bae7d9.png">

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->