### PR TITLE
Chore: cleanup ioutil for newer go version

### DIFF
--- a/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
@@ -19,7 +19,7 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -211,7 +211,7 @@ func TestResourceTrackerCompression(t *testing.T) {
 		"../../../legacy/charts/vela-core-legacy/crds/standard.oam.dev_podspecworkloads.yaml",
 	}
 	for _, p := range paths {
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		r.NoError(err)
 		data = append(data, string(b))
 	}

--- a/hack/docgen/cli/gen.go
+++ b/hack/docgen/cli/gen.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -117,7 +116,7 @@ func main() {
 		if info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -163,7 +162,7 @@ func main() {
 
 		newlines = append(newlines, lines...)
 		newcontent := strings.Join(newlines, "\n")
-		return ioutil.WriteFile(path, []byte(newcontent), info.Mode())
+		return os.WriteFile(path, []byte(newcontent), info.Mode())
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/hack/docgen/def/collect-translation/collect.go
+++ b/hack/docgen/def/collect-translation/collect.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 )
 
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 
 	if *path != "" {
-		data, err := ioutil.ReadFile(*path)
+		data, err := os.ReadFile(*path)
 		if err == nil {
 			err = json.Unmarshal(data, &i18nDoc)
 			if err != nil {
@@ -63,7 +63,7 @@ func main() {
 		if strings.TrimSpace(v) == "" {
 			continue
 		}
-		data, err := ioutil.ReadFile(v)
+		data, err := os.ReadFile(v)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -76,7 +76,7 @@ func main() {
 		if strings.TrimSpace(v) == "" {
 			continue
 		}
-		data, err := ioutil.ReadFile(v)
+		data, err := os.ReadFile(v)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -122,19 +121,19 @@ var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request
 var helmHandler http.HandlerFunc = func(writer http.ResponseWriter, request *http.Request) {
 	switch {
 	case strings.Contains(request.URL.Path, "index.yaml"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/index.yaml")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/index.yaml")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-1.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/fluxcd-1.0.0.tgz")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/fluxcd-1.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-2.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/fluxcd-2.0.0.tgz")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/fluxcd-2.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}

--- a/pkg/addon/push_test.go
+++ b/pkg/addon/push_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -77,7 +76,7 @@ var _ = Describe("Addon push command", func() {
 			}))
 
 			// Create new Helm home w/ test repo
-			tmp, err = ioutil.TempDir("", "helm-push-test")
+			tmp, err = os.MkdirTemp("", "helm-push-test")
 			Expect(err).To(Succeed())
 
 			// Add our helm repo to addon registry
@@ -164,7 +163,7 @@ var _ = Describe("Addon push command", func() {
 			ts.StartTLS()
 
 			// Create new Helm home w/ test repo
-			tmp, err = ioutil.TempDir("", "helm-push-test")
+			tmp, err = os.MkdirTemp("", "helm-push-test")
 			Expect(err).To(Succeed())
 
 			// Add our helm repo to addon registry

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -152,31 +152,31 @@ func TestMerge2Map(t *testing.T) {
 
 func TestUsingAddonInfo(t *testing.T) {
 	apps := []v1beta1.Application{
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-3", Name: "app-3"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-3", Name: "app-3"}},
 	}
 	res := appsDependsOnAddonErrInfo(apps)
 	assert.Contains(t, res, "and other 1 more applications. Please delete all of them before removing.")
 
 	apps = []v1beta1.Application{
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
 	}
 	res = appsDependsOnAddonErrInfo(apps)
 	assert.Contains(t, res, "Please delete all of them before removing.")
 
 	apps = []v1beta1.Application{
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
 	}
 	res = appsDependsOnAddonErrInfo(apps)
 	assert.Contains(t, res, "this addon is being used by: namespace-1/app-1 applications. Please delete all of them before removing.")
 
 	apps = []v1beta1.Application{
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
-		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
 	}
 	res = appsDependsOnAddonErrInfo(apps)
 	assert.Contains(t, res, ". Please delete all of them before removing.")

--- a/pkg/addon/versioned_registry_test.go
+++ b/pkg/addon/versioned_registry_test.go
@@ -18,9 +18,9 @@ package addon
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -62,13 +62,13 @@ func TestChooseAddonVersion(t *testing.T) {
 var versionedHandler http.HandlerFunc = func(writer http.ResponseWriter, request *http.Request) {
 	switch {
 	case strings.Contains(request.URL.Path, "index.yaml"):
-		files, err := ioutil.ReadFile("./testdata/helm-repo/index.yaml")
+		files, err := os.ReadFile("./testdata/helm-repo/index.yaml")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-1.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/helm-repo/fluxcd-1.0.0.tgz")
+		files, err := os.ReadFile("./testdata/helm-repo/fluxcd-1.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
@@ -90,13 +90,13 @@ var basicAuthVersionedHandler http.HandlerFunc = func(writer http.ResponseWriter
 	}
 	switch {
 	case strings.Contains(request.URL.Path, "index.yaml"):
-		files, err := ioutil.ReadFile("./testdata/basicauth-helm-repo/index.yaml")
+		files, err := os.ReadFile("./testdata/basicauth-helm-repo/index.yaml")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-1.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/basicauth-helm-repo/fluxcd-1.0.0.tgz")
+		files, err := os.ReadFile("./testdata/basicauth-helm-repo/fluxcd-1.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
@@ -107,19 +107,19 @@ var basicAuthVersionedHandler http.HandlerFunc = func(writer http.ResponseWriter
 var multiVersionHandler http.HandlerFunc = func(writer http.ResponseWriter, request *http.Request) {
 	switch {
 	case strings.Contains(request.URL.Path, "index.yaml"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/index.yaml")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/index.yaml")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-1.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/fluxcd-1.0.0.tgz")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/fluxcd-1.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}
 		writer.Write(files)
 	case strings.Contains(request.URL.Path, "fluxcd-2.0.0.tgz"):
-		files, err := ioutil.ReadFile("./testdata/multiversion-helm-repo/fluxcd-2.0.0.tgz")
+		files, err := os.ReadFile("./testdata/multiversion-helm-repo/fluxcd-2.0.0.tgz")
 		if err != nil {
 			_, _ = writer.Write([]byte(err.Error()))
 		}

--- a/pkg/apiserver/domain/service/addon_test.go
+++ b/pkg/apiserver/domain/service/addon_test.go
@@ -19,7 +19,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 
@@ -42,7 +42,7 @@ var _ = Describe("addon service test", func() {
 	})
 
 	It("Test render customize ui-schema", func() {
-		schemaData, err := ioutil.ReadFile("testdata/addon-uischema-test.yaml")
+		schemaData, err := os.ReadFile("testdata/addon-uischema-test.yaml")
 
 		addonName := "test"
 		Expect(err).Should(BeNil())

--- a/pkg/apiserver/domain/service/authentication_test.go
+++ b/pkg/apiserver/domain/service/authentication_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -177,7 +177,7 @@ var _ = Describe("Test authentication service functions", func() {
 			},
 		})
 		Expect(err).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-		webserver, err := ioutil.ReadFile("./testdata/dex-config-def.yaml")
+		webserver, err := os.ReadFile("./testdata/dex-config-def.yaml")
 		Expect(err).Should(Succeed())
 		var cd v1beta1.ComponentDefinition
 		err = yaml.Unmarshal(webserver, &cd)

--- a/pkg/apiserver/domain/service/cloudshell_test.go
+++ b/pkg/apiserver/domain/service/cloudshell_test.go
@@ -19,7 +19,7 @@ package service
 import (
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"time"
 
 	v1alpha1 "github.com/cloudtty/cloudtty/pkg/apis/cloudshell/v1alpha1"
@@ -211,7 +211,7 @@ var _ = Describe("Test cloudshell service function", func() {
 		Expect(err.Error()).Should(Equal(bcode.ErrCloudShellAddonNotEnabled.Error()))
 
 		By("Test with CRD")
-		cloudshellCRDBytes, err := ioutil.ReadFile("./testdata/cloudshell-crd.yaml")
+		cloudshellCRDBytes, err := os.ReadFile("./testdata/cloudshell-crd.yaml")
 		Expect(err).Should(BeNil())
 
 		crd := apiextensionsv1.CustomResourceDefinition{}

--- a/pkg/apiserver/domain/service/definition_test.go
+++ b/pkg/apiserver/domain/service/definition_test.go
@@ -19,7 +19,7 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -54,7 +54,7 @@ var _ = Describe("Test namespace service functions", func() {
 	})
 	It("Test ListDefinitions function", func() {
 		By("List component definitions")
-		webserver, err := ioutil.ReadFile("./testdata/webserver-cd.yaml")
+		webserver, err := os.ReadFile("./testdata/webserver-cd.yaml")
 		Expect(err).Should(Succeed())
 		var cd v1beta1.ComponentDefinition
 		err = yaml.Unmarshal(webserver, &cd)
@@ -76,7 +76,7 @@ var _ = Describe("Test namespace service functions", func() {
 		Expect(selectDefinition.Alias).Should(Equal("test-alias"))
 
 		By("List trait definitions")
-		myingress, err := ioutil.ReadFile("./testdata/myingress-td.yaml")
+		myingress, err := os.ReadFile("./testdata/myingress-td.yaml")
 		Expect(err).Should(Succeed())
 		var td v1beta1.TraitDefinition
 		err = yaml.Unmarshal(myingress, &td)
@@ -95,7 +95,7 @@ var _ = Describe("Test namespace service functions", func() {
 		Expect(traits[0].Alias).Should(Equal("test-alias"))
 
 		By("List workflow step definitions")
-		step, err := ioutil.ReadFile("./testdata/applyapplication-sd.yaml")
+		step, err := os.ReadFile("./testdata/applyapplication-sd.yaml")
 		Expect(err).Should(Succeed())
 		var sd v1beta1.WorkflowStepDefinition
 		err = yaml.Unmarshal(step, &sd)
@@ -117,7 +117,7 @@ var _ = Describe("Test namespace service functions", func() {
 		// the definition should be filtered
 		Expect(cmp.Diff(len(wfstep), 1)).Should(BeEmpty())
 
-		step, err = ioutil.ReadFile("./testdata/apply-application-hide.yaml")
+		step, err = os.ReadFile("./testdata/apply-application-hide.yaml")
 		Expect(err).Should(Succeed())
 		var sd2 v1beta1.WorkflowStepDefinition
 		err = yaml.Unmarshal(step, &sd2)
@@ -168,7 +168,7 @@ var _ = Describe("Test namespace service functions", func() {
 
 	It("Test DetailDefinition function", func() {
 
-		webserver, err := ioutil.ReadFile("./testdata/apply-object.yaml")
+		webserver, err := os.ReadFile("./testdata/apply-object.yaml")
 		Expect(err).Should(Succeed())
 		var cd v1beta1.WorkflowStepDefinition
 		err = yaml.Unmarshal(webserver, &cd)
@@ -199,7 +199,7 @@ var _ = Describe("Test namespace service functions", func() {
 
 	It("Test renderDefaultUISchema", func() {
 		schema := &v1.DetailDefinitionResponse{}
-		data, err := ioutil.ReadFile("./testdata/api-schema.json")
+		data, err := os.ReadFile("./testdata/api-schema.json")
 		Expect(err).Should(Succeed())
 		err = json.Unmarshal(data, schema)
 		Expect(err).Should(Succeed())
@@ -210,7 +210,7 @@ var _ = Describe("Test namespace service functions", func() {
 
 	It("Test patchSchema", func() {
 		ddr := &v1.DetailDefinitionResponse{}
-		data, err := ioutil.ReadFile("./testdata/api-schema.json")
+		data, err := os.ReadFile("./testdata/api-schema.json")
 		Expect(err).Should(Succeed())
 		err = json.Unmarshal(data, ddr)
 		Expect(err).Should(Succeed())
@@ -218,7 +218,7 @@ var _ = Describe("Test namespace service functions", func() {
 		defaultschema := renderDefaultUISchema(ddr.APISchema)
 
 		customschema := []*utils.UIParameter{}
-		cdata, err := ioutil.ReadFile("./testdata/ui-custom-schema.yaml")
+		cdata, err := os.ReadFile("./testdata/ui-custom-schema.yaml")
 		Expect(err).Should(Succeed())
 		err = yaml.Unmarshal(cdata, &customschema)
 		Expect(err).Should(Succeed())
@@ -235,7 +235,7 @@ var _ = Describe("Test namespace service functions", func() {
 		du := &definitionServiceImpl{
 			KubeClient: k8sClient,
 		}
-		cdata, err := ioutil.ReadFile("./testdata/workflowstep-apply-object.yaml")
+		cdata, err := os.ReadFile("./testdata/workflowstep-apply-object.yaml")
 		Expect(err).Should(Succeed())
 		var schema utils.UISchema
 		yaml.Unmarshal(cdata, &schema)

--- a/pkg/apiserver/domain/service/helm_test.go
+++ b/pkg/apiserver/domain/service/helm_test.go
@@ -19,9 +19,9 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -174,7 +174,7 @@ var _ = Describe("test helm usecasae", func() {
 			}
 			switch {
 			case request.URL.Path == "/index.yaml":
-				index, err := ioutil.ReadFile("./testdata/helm/index.yaml")
+				index, err := os.ReadFile("./testdata/helm/index.yaml")
 				indexFile := string(index)
 				indexFile = strings.ReplaceAll(indexFile, "server-url", mockServer.URL)
 				if err != nil {
@@ -185,7 +185,7 @@ var _ = Describe("test helm usecasae", func() {
 
 				return
 			case strings.Contains(request.URL.Path, "mysql-8.8.23.tgz"):
-				pkg, err := ioutil.ReadFile("./testdata/helm/mysql-8.8.23.tgz")
+				pkg, err := os.ReadFile("./testdata/helm/mysql-8.8.23.tgz")
 				if err != nil {
 					writer.Write([]byte(err.Error()))
 					return

--- a/pkg/appfile/dryrun/diff_test.go
+++ b/pkg/appfile/dryrun/diff_test.go
@@ -19,7 +19,7 @@ package dryrun
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -159,7 +159,7 @@ var _ = Describe("Test Live-Diff", func() {
 			Parser: appfile.NewApplicationParser(k8sClient, dm, pd),
 		}
 		applyFile := func(filename string, ns string) {
-			bs, err := ioutil.ReadFile("./testdata/" + filename)
+			bs, err := os.ReadFile("./testdata/" + filename)
 			Expect(err).Should(Succeed())
 			un := &unstructured.Unstructured{}
 			Expect(yaml.Unmarshal(bs, un)).Should(Succeed())

--- a/pkg/config/factory_test.go
+++ b/pkg/config/factory_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,7 +31,7 @@ import (
 
 func TestParseConfigTemplate(t *testing.T) {
 	r := require.New(t)
-	content, err := ioutil.ReadFile("testdata/helm-repo.cue")
+	content, err := os.ReadFile("testdata/helm-repo.cue")
 	r.Equal(err, nil)
 	var inf = &kubeConfigFactory{}
 	template, err := inf.ParseTemplate("default", content)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/assemble/assemble_suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/assemble/assemble_suite_test.go
@@ -193,12 +193,12 @@ var _ = Describe("Test Assemble Options", func() {
 var _ = Describe("Test handleCheckManageWorkloadTrait func", func() {
 	It("Test every situation", func() {
 		traitDefs := map[string]v1beta1.TraitDefinition{
-			"rollout": v1beta1.TraitDefinition{
+			"rollout": {
 				Spec: v1beta1.TraitDefinitionSpec{
 					ManageWorkload: true,
 				},
 			},
-			"normal": v1beta1.TraitDefinition{
+			"normal": {
 				Spec: v1beta1.TraitDefinitionSpec{},
 			},
 		}

--- a/pkg/controller/utils/capability_config_test.go
+++ b/pkg/controller/utils/capability_config_test.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,7 +108,7 @@ variable "aaa" {
 			if len(tc.args.data) > 0 {
 				err := os.MkdirAll(tmpPath, os.ModePerm)
 				assert.NilError(t, err)
-				err = ioutil.WriteFile(filepath.Clean(filepath.Join(tmpPath, tc.args.variableFile)), tc.args.data, 0644)
+				err = os.WriteFile(filepath.Clean(filepath.Join(tmpPath, tc.args.variableFile)), tc.args.data, 0644)
 				assert.NilError(t, err)
 			}
 			defer os.RemoveAll(tmpPath)

--- a/pkg/definition/definition_test.go
+++ b/pkg/definition/definition_test.go
@@ -19,7 +19,7 @@ package definition
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -153,13 +153,13 @@ func TestDefinitionRevisionSearch(t *testing.T) {
 	var err error
 
 	// Load test DefinitionRevisions files into client
-	testFiles, err := ioutil.ReadDir("testdata")
+	testFiles, err := os.ReadDir("testdata")
 	assert.NoError(t, err, "read testdata failed")
 	for _, file := range testFiles {
 		if !strings.HasSuffix(file.Name(), ".yaml") {
 			continue
 		}
-		content, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
+		content, err := os.ReadFile(filepath.Join("testdata", file.Name()))
 		assert.NoError(t, err)
 		def := &v1beta1.DefinitionRevision{}
 		err = yaml.Unmarshal(content, def)

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package definition
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -333,7 +333,7 @@ func TestGenAllDef(t *testing.T) {
 	for _, f := range glob {
 		if !stringInSlice(filepath.Base(f), skipDefs) {
 			t.Run(filepath.Base(f), func(t *testing.T) {
-				file, err := ioutil.ReadFile(f)
+				file, err := os.ReadFile(f)
 				assert.NoError(t, err)
 				def := Definition{Unstructured: unstructured.Unstructured{}}
 				err = def.FromCUEString(string(file), nil)

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -195,7 +194,7 @@ func TestHttpGetCaFile(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond)
-	caFile, err := ioutil.ReadFile("./testdata/server.crt")
+	caFile, err := os.ReadFile("./testdata/server.crt")
 	assert.NoError(t, err)
 
 	cases := map[string]struct {

--- a/pkg/utils/filters/filter_test.go
+++ b/pkg/utils/filters/filter_test.go
@@ -44,8 +44,8 @@ func TestApply(t *testing.T) {
 
 func TestApplyToList(t *testing.T) {
 	list := unstructured.UnstructuredList{Items: []unstructured.Unstructured{
-		unstructured.Unstructured{},
-		unstructured.Unstructured{},
+		{},
+		{},
 	}}
 
 	list.Items[0].SetName("name")

--- a/pkg/velaql/view_test.go
+++ b/pkg/velaql/view_test.go
@@ -19,7 +19,6 @@ package velaql
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -174,7 +173,7 @@ var _ = Describe("test StoreViewFromFile", func() {
 		It("from local file", func() {
 			cueStr := "something: {}\nstatus: something"
 			filename := "norm-create.cue"
-			err := ioutil.WriteFile(filename, []byte(cueStr), 0600)
+			err := os.WriteFile(filename, []byte(cueStr), 0600)
 			Expect(err).Should(Succeed())
 			defer os.RemoveAll(filename)
 			viewName := "test-view-" + strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -188,7 +187,7 @@ var _ = Describe("test StoreViewFromFile", func() {
 		It("update a previously updated view", func() {
 			cueStr := "something: {}\nstatus: something"
 			filename := "norm-create.cue"
-			err := ioutil.WriteFile(filename, []byte(cueStr), 0600)
+			err := os.WriteFile(filename, []byte(cueStr), 0600)
 			Expect(err).Should(Succeed())
 			defer os.RemoveAll(filename)
 			viewName := "test-view-" + strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -196,7 +195,7 @@ var _ = Describe("test StoreViewFromFile", func() {
 			Expect(err).Should(Succeed())
 			// Update it
 			newCueStr := "something: {a: \"123\"}\nstatus: something"
-			err = ioutil.WriteFile(filename, []byte(newCueStr), 0600)
+			err = os.WriteFile(filename, []byte(newCueStr), 0600)
 			Expect(err).Should(Succeed())
 			err = StoreViewFromFile(context.TODO(), k8sClient, filename, viewName)
 			Expect(err).Should(Succeed())
@@ -217,7 +216,7 @@ var _ = Describe("test StoreViewFromFile", func() {
 		It("invalid cue", func() {
 			cueStr := "status: what-is-this"
 			filename := "failed-create-invalid.cue"
-			err := ioutil.WriteFile(filename, []byte(cueStr), 0600)
+			err := os.WriteFile(filename, []byte(cueStr), 0600)
 			Expect(err).Should(Succeed())
 			defer os.RemoveAll(filename)
 			err = StoreViewFromFile(context.TODO(), k8sClient, filename, "5678")

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -398,7 +397,7 @@ var _ = Describe("Addon push command", func() {
 			}))
 
 			// Create new Helm home w/ test repo
-			tmp, err = ioutil.TempDir("", "helm-push-test")
+			tmp, err = os.MkdirTemp("", "helm-push-test")
 			Expect(err).To(Succeed())
 
 			// Add our helm repo to addon registry
@@ -502,7 +501,7 @@ var _ = Describe("Addon push command", func() {
 			ts.StartTLS()
 
 			// Create new Helm home w/ test repo
-			tmp, err = ioutil.TempDir("", "helm-push-test")
+			tmp, err = os.MkdirTemp("", "helm-push-test")
 			Expect(err).To(Succeed())
 
 			// Add our helm repo to addon registry

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -420,13 +419,13 @@ func TestNewDefinitionGetCommand(t *testing.T) {
 
 	// Load test DefinitionRevisions files into client
 	dir := filepath.Join("..", "..", "pkg", "definition", "testdata")
-	testFiles, err := ioutil.ReadDir(dir)
+	testFiles, err := os.ReadDir(dir)
 	assert.NoError(t, err, "read testdata failed")
 	for _, file := range testFiles {
 		if !strings.HasSuffix(file.Name(), ".yaml") {
 			continue
 		}
-		content, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+		content, err := os.ReadFile(filepath.Join(dir, file.Name()))
 		assert.NoError(t, err)
 		def := &v1beta1.DefinitionRevision{}
 		err = yaml.Unmarshal(content, def)

--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -19,7 +19,7 @@ package cli
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("Test dry run with policy", func() {
 	It("Test dry run with normal policy", func() {
-		webservice, err := ioutil.ReadFile("../../charts/vela-core/templates/defwithtemplate/webservice.yaml")
+		webservice, err := os.ReadFile("../../charts/vela-core/templates/defwithtemplate/webservice.yaml")
 		Expect(err).Should(BeNil())
 		webserviceYAML := strings.Replace(string(webservice), "{{ include \"systemDefinitionNamespace\" . }}", types.DefaultKubeVelaNS, 1)
 		wwd := v1beta1.ComponentDefinition{}

--- a/references/cli/revision_test.go
+++ b/references/cli/revision_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -760,7 +760,7 @@ func tableOut(name, pv, s, hash, bt, status string) string {
 }
 
 func setupView() {
-	viewContent, err := ioutil.ReadFile("../../charts/vela-core/templates/velaql/application-revision.yaml")
+	viewContent, err := os.ReadFile("../../charts/vela-core/templates/velaql/application-revision.yaml")
 	Expect(err).Should(BeNil())
 	viewContent = bytes.ReplaceAll(viewContent, []byte("{{ include \"systemDefinitionNamespace\" . }}"), []byte(types.DefaultKubeVelaNS))
 	cm := &v1.ConfigMap{}

--- a/references/cli/velaql_test.go
+++ b/references/cli/velaql_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -440,7 +439,7 @@ var _ = Describe("Test velaQL", func() {
 				}
 			}
 		}
-		velaQL, err := ioutil.ReadFile("../../charts/vela-core/templates/velaql/endpoints.yaml")
+		velaQL, err := os.ReadFile("../../charts/vela-core/templates/velaql/endpoints.yaml")
 		Expect(err).Should(BeNil())
 		velaQLYaml := strings.Replace(string(velaQL), "{{ include \"systemDefinitionNamespace\" . }}", types.DefaultKubeVelaNS, 1)
 		var cm corev1.ConfigMap
@@ -524,7 +523,7 @@ var _ = Describe("test NewQLApplyCommand", func() {
 		It("no view name specified, inferred from filename", func() {
 			cueStr := "something: {}\nstatus: something"
 			filename := "test-view" + strconv.FormatInt(time.Now().UnixNano(), 10) + ".cue"
-			err := ioutil.WriteFile(filename, []byte(cueStr), 0600)
+			err := os.WriteFile(filename, []byte(cueStr), 0600)
 			Expect(err).Should(Succeed())
 			defer os.RemoveAll(filename)
 			cmd.SetArgs([]string{"-f", filename})

--- a/references/docgen/cluster_test.go
+++ b/references/docgen/cluster_test.go
@@ -19,7 +19,6 @@ package docgen
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -374,13 +373,13 @@ var _ = Describe("test GetCapabilityFromDefinitionRevision", func() {
 
 		// Load test DefinitionRevisions files into client
 		dir := filepath.Join("..", "..", "pkg", "definition", "testdata")
-		testFiles, err := ioutil.ReadDir(dir)
+		testFiles, err := os.ReadDir(dir)
 		Expect(err).Should(Succeed())
 		for _, file := range testFiles {
 			if !strings.HasSuffix(file.Name(), ".yaml") {
 				continue
 			}
-			content, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+			content, err := os.ReadFile(filepath.Join(dir, file.Name()))
 			Expect(err).Should(Succeed())
 			def := &corev1beta1.DefinitionRevision{}
 			err = yaml.Unmarshal(content, def)

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -19,7 +19,7 @@ package e2e_apiserver_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -205,7 +205,7 @@ var _ = Describe("Test addon rest api", func() {
 				Message      string `json:"Message"`
 			}
 			var errResponse errResp
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			Expect(err).Should(BeNil())
 			err = json.Unmarshal(body, &errResponse)
 			Expect(err).Should(BeNil())

--- a/test/e2e-apiserver-test/cluster_test.go
+++ b/test/e2e-apiserver-test/cluster_test.go
@@ -18,7 +18,6 @@ package e2e_apiserver_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -44,7 +43,7 @@ var _ = Describe("Test cluster rest api", func() {
 
 		BeforeEach(func() {
 			clusterName = WorkerClusterName + "-" + rand.RandomString(8)
-			kubeconfigBytes, err := ioutil.ReadFile(WorkerClusterKubeConfigPath)
+			kubeconfigBytes, err := os.ReadFile(WorkerClusterKubeConfigPath)
 			Expect(err).Should(Succeed())
 			resp := post("/clusters", v1.CreateClusterRequest{
 				Name:       clusterName,
@@ -82,7 +81,7 @@ var _ = Describe("Test cluster rest api", func() {
 		})
 
 		It("Test modify cluster", func() {
-			kubeconfigBytes, err := ioutil.ReadFile(WorkerClusterKubeConfigPath)
+			kubeconfigBytes, err := os.ReadFile(WorkerClusterKubeConfigPath)
 			Expect(err).Should(Succeed())
 			resp := put("/clusters/"+clusterName, v1.CreateClusterRequest{
 				Name:        clusterName,

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -211,7 +211,7 @@ func decodeResponseBody(resp *http.Response, dst interface{}) error {
 		return fmt.Errorf("response body is nil")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/test/e2e-multicluster-test/multicluster_rollout_test.go
+++ b/test/e2e-multicluster-test/multicluster_rollout_test.go
@@ -16,7 +16,7 @@ package e2e_multicluster_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -93,7 +93,7 @@ var _ = Describe("Test MultiCluster Rollout", func() {
 
 		It("Test Rollout whole feature in runtime cluster ", func() {
 			app := &v1beta1.Application{}
-			appYaml, err := ioutil.ReadFile("./testdata/app/app-rollout-envbinding.yaml")
+			appYaml, err := os.ReadFile("./testdata/app/app-rollout-envbinding.yaml")
 			Expect(err).Should(Succeed())
 			Expect(yaml.Unmarshal([]byte(appYaml), app)).Should(Succeed())
 			app.SetNamespace(namespace)
@@ -116,7 +116,7 @@ var _ = Describe("Test MultiCluster Rollout", func() {
 			verifySucceed(componentName + "-v2")
 
 			By("revert to v1, should guarantee compRev v1 still exist")
-			appYaml, err = ioutil.ReadFile("./testdata/app/revert-app-envbinding.yaml")
+			appYaml, err = os.ReadFile("./testdata/app/revert-app-envbinding.yaml")
 			Expect(err).Should(Succeed())
 
 			Expect(k8sClient.Get(hubCtx, types.NamespacedName{Namespace: namespace, Name: app.Name}, checkApp)).Should(BeNil())
@@ -137,7 +137,7 @@ var _ = Describe("Test MultiCluster Rollout", func() {
 		// HealthScopeController will not work properly with authentication module now
 		PIt("Test Rollout with health check policy, guarantee health scope controller work ", func() {
 			app := &v1beta1.Application{}
-			appYaml, err := ioutil.ReadFile("./testdata/app/multi-cluster-health-policy.yaml")
+			appYaml, err := os.ReadFile("./testdata/app/multi-cluster-health-policy.yaml")
 			Expect(err).Should(Succeed())
 			Expect(yaml.Unmarshal([]byte(appYaml), app)).Should(Succeed())
 			app.SetNamespace(namespace)

--- a/test/e2e-multicluster-test/multicluster_standalone_test.go
+++ b/test/e2e-multicluster-test/multicluster_standalone_test.go
@@ -19,7 +19,7 @@ package e2e_multicluster_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -55,7 +55,7 @@ var _ = Describe("Test multicluster standalone scenario", func() {
 	var workerCtx context.Context
 
 	readFile := func(filename string) *unstructured.Unstructured {
-		bs, err := ioutil.ReadFile("./testdata/app/standalone/" + filename)
+		bs, err := os.ReadFile("./testdata/app/standalone/" + filename)
 		Expect(err).Should(Succeed())
 		un := &unstructured.Unstructured{}
 		Expect(yaml.Unmarshal(bs, un)).Should(Succeed())

--- a/test/e2e-test/trait_test.go
+++ b/test/e2e-test/trait_test.go
@@ -18,7 +18,7 @@ package controllers_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -34,7 +34,7 @@ import (
 )
 
 func readAppFromFile(filename string) (*v1beta1.Application, error) {
-	bs, err := ioutil.ReadFile(filename)
+	bs, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
/kind cleanup

The package io/ioutil should be cleanup from go 1.16: https://go.dev/doc/go1.16#ioutil