### PR TITLE
Fix: gc failure cause workflow restart not working properly

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -303,6 +303,11 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 	}))
 	defer subCtx.Commit("finish gc resourceTrackers")
 
+	statusUpdater := r.patchStatus
+	if isUpdate {
+		statusUpdater = r.updateStatus
+	}
+
 	var options []resourcekeeper.GCOption
 	if !gcOutdated {
 		options = append(options, resourcekeeper.DisableMarkStageGCOption{}, resourcekeeper.DisableGCComponentRevisionOption{}, resourcekeeper.DisableLegacyGCOption{})
@@ -310,8 +315,10 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 	finished, waiting, err := handler.resourceKeeper.GarbageCollect(logCtx, options...)
 	if err != nil {
 		logCtx.Error(err, "Failed to gc resourcetrackers")
-		r.Recorder.Event(handler.app, event.Warning(velatypes.ReasonFailedGC, err))
-		return r.endWithNegativeCondition(logCtx, handler.app, condition.ReconcileError(err), phase)
+		cond := condition.Deleting()
+		cond.Message = fmt.Sprintf("error encountered during garbage collection: %s", err.Error())
+		handler.app.Status.SetConditions(cond)
+		return r.result(statusUpdater(logCtx, handler.app, phase)).ret()
 	}
 	if !finished {
 		logCtx.Info("GarbageCollecting resourcetrackers unfinished")
@@ -320,13 +327,10 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 			cond.Message = fmt.Sprintf("Waiting for %s to delete. (At least %d resources are deleting.)", waiting[0].DisplayName(), len(waiting))
 		}
 		handler.app.Status.SetConditions(cond)
-		return r.result(r.patchStatus(logCtx, handler.app, phase)).requeue(baseGCBackoffWaitTime).ret()
+		return r.result(statusUpdater(logCtx, handler.app, phase)).requeue(baseGCBackoffWaitTime).ret()
 	}
 	logCtx.Info("GarbageCollected resourcetrackers")
-	if isUpdate {
-		return r.result(r.updateStatus(logCtx, handler.app, phase)).ret()
-	}
-	return r.result(r.patchStatus(logCtx, handler.app, phase)).ret()
+	return r.result(statusUpdater(logCtx, handler.app, phase)).ret()
 }
 
 type reconcileResult struct {

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -826,5 +826,87 @@ var _ = Describe("Test multicluster scenario", func() {
 				g.Expect(kerrors.IsNotFound(k8sClient.Get(hubCtx, appKey, app))).Should(BeTrue())
 			}, 20*time.Second).Should(Succeed())
 		})
+
+		It("Test application with failed gc and restart workflow", func() {
+			By("duplicate cluster")
+			secret := &corev1.Secret{}
+			const secretName = "disconnection-test"
+			Expect(k8sClient.Get(hubCtx, types.NamespacedName{Namespace: kubevelatypes.DefaultKubeVelaNS, Name: WorkerClusterName}, secret)).Should(Succeed())
+			secret.SetName(secretName)
+			secret.SetResourceVersion("")
+			Expect(k8sClient.Create(hubCtx, secret)).Should(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(hubCtx, secret)
+			}()
+
+			By("create cluster normally")
+			bs, err := os.ReadFile("./testdata/app/app-disconnection-test.yaml")
+			Expect(err).Should(Succeed())
+			app := &v1beta1.Application{}
+			Expect(yaml.Unmarshal(bs, app)).Should(Succeed())
+			app.SetNamespace(namespace)
+			Expect(k8sClient.Create(hubCtx, app)).Should(Succeed())
+			key := client.ObjectKeyFromObject(app)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(hubCtx, key, app)).Should(Succeed())
+				g.Expect(app.Status.Phase).Should(Equal(common.ApplicationRunning))
+			}).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+			By("disconnect cluster")
+			Expect(k8sClient.Get(hubCtx, types.NamespacedName{Namespace: kubevelatypes.DefaultKubeVelaNS, Name: secretName}, secret)).Should(Succeed())
+			secret.Data["endpoint"] = []byte("https://1.2.3.4:9999")
+			Expect(k8sClient.Update(hubCtx, secret)).Should(Succeed())
+
+			By("update application")
+			Expect(k8sClient.Get(hubCtx, key, app)).Should(Succeed())
+			app.Spec.Policies = nil
+			Expect(k8sClient.Update(hubCtx, app)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(hubCtx, key, app)).Should(Succeed())
+				g.Expect(app.Status.ObservedGeneration).Should(Equal(app.Generation))
+				g.Expect(app.Status.Phase).Should(Equal(common.ApplicationRunning))
+				rts := &v1beta1.ResourceTrackerList{}
+				g.Expect(k8sClient.List(hubCtx, rts, client.MatchingLabels{oam.LabelAppName: key.Name, oam.LabelAppNamespace: key.Namespace})).Should(Succeed())
+				cnt := 0
+				for _, item := range rts.Items {
+					if item.Spec.Type == v1beta1.ResourceTrackerTypeVersioned {
+						cnt++
+					}
+				}
+				g.Expect(cnt).Should(Equal(2))
+			}).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+			By("try update application again")
+			Expect(k8sClient.Get(hubCtx, key, app)).Should(Succeed())
+			if app.Annotations == nil {
+				app.Annotations = map[string]string{}
+			}
+			app.Annotations[oam.AnnotationPublishVersion] = "test"
+			Expect(k8sClient.Update(hubCtx, app)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(hubCtx, key, app)).Should(Succeed())
+				g.Expect(app.Status.LatestRevision).ShouldNot(BeNil())
+				g.Expect(app.Status.LatestRevision.Revision).Should(Equal(int64(3)))
+				g.Expect(app.Status.ObservedGeneration).Should(Equal(app.Generation))
+				g.Expect(app.Status.Phase).Should(Equal(common.ApplicationRunning))
+			}).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+			By("clear disconnection cluster secret")
+			Expect(k8sClient.Get(hubCtx, types.NamespacedName{Namespace: kubevelatypes.DefaultKubeVelaNS, Name: secretName}, secret)).Should(Succeed())
+			Expect(k8sClient.Delete(hubCtx, secret)).Should(Succeed())
+
+			By("wait gc application completed")
+			Eventually(func(g Gomega) {
+				rts := &v1beta1.ResourceTrackerList{}
+				g.Expect(k8sClient.List(hubCtx, rts, client.MatchingLabels{oam.LabelAppName: key.Name, oam.LabelAppNamespace: key.Namespace})).Should(Succeed())
+				cnt := 0
+				for _, item := range rts.Items {
+					if item.Spec.Type == v1beta1.ResourceTrackerTypeVersioned {
+						cnt++
+					}
+				}
+				g.Expect(cnt).Should(Equal(1))
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+		})
 	})
 })

--- a/test/e2e-multicluster-test/testdata/app/app-disconnection-test.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-disconnection-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-disconnection-test
+spec:
+  components:
+    - type: k8s-objects
+      name: app-dis-cm
+      properties:
+        objects:
+          - apiVersion: v1
+            kind: ConfigMap
+  policies:
+    - type: topology
+      name: disconnection-test
+      properties:
+        clusters: ["disconnection-test"]


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In the past, when application needs to rerun workflow, it will clear the steps status first. However, since steps are array attribute, it cannot be updated through patch request, so it needs update request.

In the case when garbage collection could fail due to the potential problems like cluster disconnection or other things, it will redirect the steps clear to use the patch request, which will cause workflow restart but with outdated step status. This will let the workflow directly finished without any step executed. Then it will further lead to all resources under the application being recycled.

This PR enforces using update request for clear workflow step status, even if the garbage collection fails. I also recommend to add additional check for step finish in workflow. /cc @FogDong 

The test added in this PR reproduce this issue and would fail in v1.4.11 if no controller fix is used.
1. First create an application deploying a resource to cluster X.
2. Let X down.
3. Update the application to deploy a resource to cluster Y. This update will succeed but the following gc will fail.
4. Update the application again and now in old versions, the application update will not succeed due to the improper status update for workflow steps.
5. Delete cluster X and all gc should go back to normal.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->