### PR TITLE
Fix: apply label to pod for vela-cli workflow step definition. Fixes #5247

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
@@ -69,7 +69,7 @@ spec:
         		spec: {
         			backoffLimit: 3
         			template: {
-        				labels: "workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+        				metadata: labels: "workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
         				spec: {
         					containers: [
         						{

--- a/charts/vela-minimal/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/vela-cli.yaml
@@ -69,7 +69,7 @@ spec:
         		spec: {
         			backoffLimit: 3
         			template: {
-        				labels: "workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+        				metadata: labels: "workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
         				spec: {
         					containers: [
         						{

--- a/vela-templates/definitions/internal/workflowstep/vela-cli.cue
+++ b/vela-templates/definitions/internal/workflowstep/vela-cli.cue
@@ -66,8 +66,10 @@ template: {
 			spec: {
 				backoffLimit: 3
 				template: {
-					labels: {
-						"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+					metadata: {
+						labels: {
+							"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+						}
 					}
 					spec: {
 						containers: [


### PR DESCRIPTION
### Description of your changes
Puts the `label` under `metadata` so it applies properly. Allows the output of the pod to be available in `vela workflow logs`. Fixes #5247.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary. (Seems not necessary)

### How has this code been tested
I'm unsure how to write an automated test for this, but I have tested by running a workflow with a `vela-cli` step and saw the output in VelaUX UI and also with `vela workflow logs`. (I re-ran the workflow from #5247).

To ensure it doesn't cause a regression, I ran `make test` and `make e2e-test`. The unit tests passed. The E2E tests failed with the same errors they fail with when I make no code change, so I don't think I broke them.


### Special notes for your reviewer
Nothing.