### PR TITLE
Fix: can't find the component pod view

### DIFF
--- a/charts/vela-core/templates/velaql/component-pod.yaml
+++ b/charts/vela-core/templates/velaql/component-pod.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "ConfigMap" (include "systemDefinitionNamespace" .) "component-pod-view") }}
 apiVersion: v1
 data:
   template: |
@@ -74,4 +73,3 @@ kind: ConfigMap
 metadata:
   name: component-pod-view
   namespace: {{ include "systemDefinitionNamespace" . }}
-{{- end }}

--- a/charts/vela-core/templates/velaql/component-service.yaml
+++ b/charts/vela-core/templates/velaql/component-service.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "ConfigMap" (include "systemDefinitionNamespace" .) "component-service-view") }}
 apiVersion: v1
 data:
   template: |
@@ -47,4 +46,3 @@ kind: ConfigMap
 metadata:
   name: component-service-view
   namespace: {{ include "systemDefinitionNamespace" . }}
-{{- end}}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Managing resources at the same time for helm and addon causes the resource to be deleted when the chart is upgraded. Now, we only manage the common velaQL view in the chart.

If users encounter the ConfigMap resource conflict when upgrading the vela-core, they only need to delete the ConfigMap and retry.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->