### PR TITLE
Fix: Index structure map[string]string,Mongo resulting in inconsistent results obtained by filtering non-string type by index. 

### DIFF
--- a/pkg/apiserver/domain/model/application.go
+++ b/pkg/apiserver/domain/model/application.go
@@ -59,8 +59,8 @@ func (a *Application) PrimaryKey() string {
 }
 
 // Index return custom index
-func (a *Application) Index() map[string]string {
-	index := make(map[string]string)
+func (a *Application) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if a.Name != "" {
 		index["name"] = a.Name
 	}
@@ -154,8 +154,8 @@ func (a *ApplicationComponent) PrimaryKey() string {
 }
 
 // Index return custom index
-func (a *ApplicationComponent) Index() map[string]string {
-	index := make(map[string]string)
+func (a *ApplicationComponent) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if a.Name != "" {
 		index["name"] = a.Name
 	}
@@ -202,8 +202,8 @@ func (a *ApplicationPolicy) PrimaryKey() string {
 }
 
 // Index return custom index
-func (a *ApplicationPolicy) Index() map[string]string {
-	index := make(map[string]string)
+func (a *ApplicationPolicy) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if a.Name != "" {
 		index["name"] = a.Name
 	}
@@ -348,8 +348,8 @@ func (a *ApplicationRevision) PrimaryKey() string {
 }
 
 // Index return custom index
-func (a *ApplicationRevision) Index() map[string]string {
-	index := make(map[string]string)
+func (a *ApplicationRevision) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if a.Version != "" {
 		index["version"] = a.Version
 	}
@@ -434,8 +434,8 @@ func (w *ApplicationTrigger) PrimaryKey() string {
 }
 
 // Index return custom index
-func (w *ApplicationTrigger) Index() map[string]string {
-	index := make(map[string]string)
+func (w *ApplicationTrigger) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if w.AppPrimaryKey != "" {
 		index["appPrimaryKey"] = w.AppPrimaryKey
 	}

--- a/pkg/apiserver/domain/model/cluster.go
+++ b/pkg/apiserver/domain/model/cluster.go
@@ -93,8 +93,8 @@ func (c *Cluster) PrimaryKey() string {
 }
 
 // Index set to nil for list
-func (c *Cluster) Index() map[string]string {
-	index := make(map[string]string)
+func (c *Cluster) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if c.Name != "" {
 		index["name"] = c.Name
 	}

--- a/pkg/apiserver/domain/model/env.go
+++ b/pkg/apiserver/domain/model/env.go
@@ -53,8 +53,8 @@ func (p *Env) PrimaryKey() string {
 }
 
 // Index return custom index
-func (p *Env) Index() map[string]string {
-	index := make(map[string]string)
+func (p *Env) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if p.Name != "" {
 		index["name"] = p.Name
 	}

--- a/pkg/apiserver/domain/model/envbinding.go
+++ b/pkg/apiserver/domain/model/envbinding.go
@@ -62,8 +62,8 @@ func (e *EnvBinding) PrimaryKey() string {
 }
 
 // Index return custom index
-func (e *EnvBinding) Index() map[string]string {
-	index := make(map[string]string)
+func (e *EnvBinding) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if e.Name != "" {
 		index["name"] = e.Name
 	}

--- a/pkg/apiserver/domain/model/pipeline.go
+++ b/pkg/apiserver/domain/model/pipeline.go
@@ -61,8 +61,8 @@ func (p Pipeline) ShortTableName() string {
 }
 
 // Index return custom index
-func (p Pipeline) Index() map[string]string {
-	var index = make(map[string]string)
+func (p Pipeline) Index() map[string]interface{} {
+	var index = make(map[string]interface{})
 	if p.Project != "" {
 		index["project"] = p.Project
 	}
@@ -102,8 +102,8 @@ func (c *PipelineContext) PrimaryKey() string {
 }
 
 // Index return custom index
-func (c *PipelineContext) Index() map[string]string {
-	index := make(map[string]string)
+func (c *PipelineContext) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if c.ProjectName != "" {
 		index["project_name"] = c.ProjectName
 	}

--- a/pkg/apiserver/domain/model/project.go
+++ b/pkg/apiserver/domain/model/project.go
@@ -54,8 +54,8 @@ func (p *Project) PrimaryKey() string {
 }
 
 // Index return custom index
-func (p *Project) Index() map[string]string {
-	index := make(map[string]string)
+func (p *Project) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if p.Name != "" {
 		index["name"] = p.Name
 	}

--- a/pkg/apiserver/domain/model/system_info.go
+++ b/pkg/apiserver/domain/model/system_info.go
@@ -146,8 +146,8 @@ func (u *SystemInfo) PrimaryKey() string {
 }
 
 // Index return custom index
-func (u *SystemInfo) Index() map[string]string {
-	index := make(map[string]string)
+func (u *SystemInfo) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if u.InstallID != "" {
 		index["installID"] = u.InstallID
 	}

--- a/pkg/apiserver/domain/model/target.go
+++ b/pkg/apiserver/domain/model/target.go
@@ -48,8 +48,8 @@ func (d *Target) PrimaryKey() string {
 }
 
 // Index return custom index
-func (d *Target) Index() map[string]string {
-	index := make(map[string]string)
+func (d *Target) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if d.Name != "" {
 		index["name"] = d.Name
 	}

--- a/pkg/apiserver/domain/model/user.go
+++ b/pkg/apiserver/domain/model/user.go
@@ -67,8 +67,8 @@ func (u *User) PrimaryKey() string {
 }
 
 // Index return custom index
-func (u *User) Index() map[string]string {
-	index := make(map[string]string)
+func (u *User) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if u.Name != "" {
 		index["name"] = u.Name
 	}
@@ -106,8 +106,8 @@ func (u *ProjectUser) PrimaryKey() string {
 }
 
 // Index return custom index
-func (u *ProjectUser) Index() map[string]string {
-	index := make(map[string]string)
+func (u *ProjectUser) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if u.Username != "" {
 		index["username"] = u.Username
 	}
@@ -177,8 +177,8 @@ func (r *Role) PrimaryKey() string {
 }
 
 // Index return custom index
-func (r *Role) Index() map[string]string {
-	index := make(map[string]string)
+func (r *Role) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if r.Name != "" {
 		index["name"] = r.Name
 	}
@@ -207,8 +207,8 @@ func (p *Permission) PrimaryKey() string {
 }
 
 // Index return custom index
-func (p *Permission) Index() map[string]string {
-	index := make(map[string]string)
+func (p *Permission) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if p.Name != "" {
 		index["name"] = p.Name
 	}
@@ -250,8 +250,8 @@ func (p *PermissionTemplate) PrimaryKey() string {
 }
 
 // Index return custom index
-func (p *PermissionTemplate) Index() map[string]string {
-	index := make(map[string]string)
+func (p *PermissionTemplate) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if p.Name != "" {
 		index["name"] = p.Name
 	}

--- a/pkg/apiserver/domain/model/workflow.go
+++ b/pkg/apiserver/domain/model/workflow.go
@@ -18,7 +18,6 @@ package model
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
@@ -88,8 +87,8 @@ func (w *Workflow) PrimaryKey() string {
 }
 
 // Index return custom primary key
-func (w *Workflow) Index() map[string]string {
-	index := make(map[string]string)
+func (w *Workflow) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if w.Name != "" {
 		index["name"] = w.Name
 	}
@@ -100,7 +99,7 @@ func (w *Workflow) Index() map[string]string {
 		index["envName"] = w.EnvName
 	}
 	if w.Default != nil {
-		index["default"] = strconv.FormatBool(*w.Default)
+		index["default"] = *w.Default
 	}
 
 	return index
@@ -161,8 +160,8 @@ func (w *WorkflowRecord) PrimaryKey() string {
 }
 
 // Index return custom primary key
-func (w *WorkflowRecord) Index() map[string]string {
-	index := make(map[string]string)
+func (w *WorkflowRecord) Index() map[string]interface{} {
+	index := make(map[string]interface{})
 	if w.Name != "" {
 		index["name"] = w.Name
 	}

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -851,8 +851,8 @@ func (w *workflowServiceImpl) RollbackRecord(ctx context.Context, appModel *mode
 		if len(revisions) == 0 {
 			return nil, bcode.ErrApplicationNoReadyRevision
 		}
-		revisionVersion = revisions[0].Index()["version"]
-		klog.Infof("select lastest complete revision %s", revisions[0].Index()["version"])
+		revisionVersion = pkgUtils.ToString(revisions[0].Index()["version"])
+		klog.Infof("select lastest complete revision %s", revisionVersion)
 	}
 
 	var record = &model.WorkflowRecord{

--- a/pkg/apiserver/infrastructure/datastore/datastore.go
+++ b/pkg/apiserver/infrastructure/datastore/datastore.go
@@ -74,7 +74,7 @@ type Entity interface {
 	PrimaryKey() string
 	TableName() string
 	ShortTableName() string
-	Index() map[string]string
+	Index() map[string]interface{}
 }
 
 // NewEntity Create a new object based on the input type

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_test.go
@@ -19,6 +19,7 @@ package kubeapi
 import (
 	"context"
 	"fmt"
+	"github.com/oam-dev/kubevela/pkg/utils"
 	"strings"
 	"time"
 
@@ -80,7 +81,7 @@ var _ = Describe("Test kubeapi datastore driver", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cmp.Diff(app.Index()["name"], "test")).Should(BeEmpty())
 		for k, v := range app.Index() {
-			rq, err := labels.NewRequirement(k, selection.Equals, []string{v})
+			rq, err := labels.NewRequirement(k, selection.Equals, []string{utils.ToString(v)})
 			Expect(err).ToNot(HaveOccurred())
 			selector = selector.Add(*rq)
 		}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -81,7 +81,7 @@ func SliceIncludeSlice(a, b []string) bool {
 	return true
 }
 
-// ToStringE casts an interface to a string type.
+// ToString convery an interface to a string type.
 func ToString(i interface{}) string {
 	if i == nil {
 		return ""

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -78,6 +79,54 @@ func SliceIncludeSlice(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// ToStringE casts an interface to a string type.
+func ToString(i interface{}) string {
+	if i == nil {
+		return ""
+	}
+	v := reflect.ValueOf(i)
+	if v.Kind() == reflect.Ptr && !v.IsNil() {
+		v = v.Elem()
+	}
+	i = v.Interface()
+	switch s := i.(type) {
+	case string:
+		return s
+	case bool:
+		return strconv.FormatBool(s)
+	case float64:
+		return strconv.FormatFloat(s, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(s), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(s)
+	case int64:
+		return strconv.FormatInt(s, 10)
+	case int32:
+		return strconv.Itoa(int(s))
+	case int16:
+		return strconv.FormatInt(int64(s), 10)
+	case int8:
+		return strconv.FormatInt(int64(s), 10)
+	case uint:
+		return strconv.FormatUint(uint64(s), 10)
+	case uint64:
+		return strconv.FormatUint(uint64(s), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(s), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(s), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(s), 10)
+	case []byte:
+		return string(s)
+	case nil:
+		return ""
+	default:
+		return ""
+	}
 }
 
 // MapKey2Array convery map keys to array

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -137,3 +137,16 @@ func TestJoinURL(t *testing.T) {
 	}
 
 }
+
+func TestToString(t *testing.T) {
+	boolPtr := true
+	caseA := []interface{}{"true", true, []byte("true"), &boolPtr}
+	for _, value := range caseA {
+		assert.Equal(t, "true", ToString(value))
+	}
+	intPtr := 123
+	caseB := []interface{}{"123", 123, []byte("123"), &intPtr}
+	for _, value := range caseB {
+		assert.Equal(t, "123", ToString(value))
+	}
+}


### PR DESCRIPTION
Signed-off-by: old.prince <di7zhang@gmail.com>


### Description of your changes
[5263](https://github.com/kubevela/kubevela/issues/5263)
Value of non-string type stored in mongo is not string.Resulting in inconsistent results obtained by filtering non-string type by index.The reason is that when mongo stores the index is still filtered by string value but the actual value is not a string.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->