### PR TITLE
Feat: add the API that rollbacks the application

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -1938,6 +1938,53 @@
 				}
 			}
 		},
+		"/api/v1/applications/{appName}/revisions/{revision}/rollback": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"application"
+				],
+				"summary": "detail revision for application",
+				"operationId": "rollbackApplicationWithRevision",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the application",
+						"name": "appName",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "identifier of the application revision",
+						"name": "revision",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ApplicationRollbackResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/applications/{appName}/statistics": {
 			"get": {
 				"consumes": [
@@ -6540,7 +6587,7 @@
 				"tags": [
 					"project"
 				],
-				"summary": "add a user to a project",
+				"summary": "update a user from a project",
 				"operationId": "updateProjectUser",
 				"parameters": [
 					{
@@ -9301,11 +9348,11 @@
 		"model.WorkflowStep": {
 			"required": [
 				"alias",
-				"type",
-				"orderIndex",
-				"name",
 				"description",
-				"dependsOn"
+				"orderIndex",
+				"dependsOn",
+				"name",
+				"type"
 			],
 			"properties": {
 				"alias": {
@@ -9422,8 +9469,8 @@
 		},
 		"model.WorkflowStepStatus": {
 			"required": [
-				"name",
 				"id",
+				"name",
 				"alias"
 			],
 			"properties": {
@@ -10007,12 +10054,12 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"triggerType",
 				"version",
 				"status",
-				"envName",
+				"triggerType",
 				"createTime",
 				"note",
+				"envName",
 				"record"
 			],
 			"properties": {
@@ -10147,6 +10194,16 @@
 				},
 				"version": {
 					"type": "string"
+				}
+			}
+		},
+		"v1.ApplicationRollbackResponse": {
+			"required": [
+				"record"
+			],
+			"properties": {
+				"record": {
+					"$ref": "#/definitions/v1.WorkflowRecordBase"
 				}
 			}
 		},
@@ -10776,13 +10833,13 @@
 		},
 		"v1.ConfigTemplateDetail": {
 			"required": [
-				"alias",
 				"name",
 				"namespace",
 				"description",
 				"scope",
 				"sensitive",
 				"createTime",
+				"alias",
 				"schema",
 				"uiSchema"
 			],
@@ -11612,11 +11669,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"name",
-				"icon",
 				"invisible",
+				"name",
 				"version",
 				"description",
+				"icon",
 				"schema",
 				"uiSchema",
 				"definitions",
@@ -11696,12 +11753,12 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
+				"project",
 				"createTime",
+				"updateTime",
 				"name",
 				"alias",
-				"project",
 				"description",
-				"updateTime",
 				"icon",
 				"policies",
 				"envBindings",
@@ -11759,20 +11816,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
+				"kubeConfigSecret",
 				"alias",
-				"description",
 				"status",
+				"dashboardURL",
+				"icon",
+				"description",
+				"reason",
+				"createTime",
+				"updateTime",
+				"name",
+				"kubeConfig",
+				"labels",
 				"provider",
 				"apiServerURL",
-				"updateTime",
-				"createTime",
-				"name",
-				"icon",
-				"labels",
-				"dashboardURL",
-				"kubeConfig",
-				"reason",
-				"kubeConfigSecret",
 				"resourceInfo"
 			],
 			"properties": {
@@ -11830,14 +11887,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
+				"name",
+				"main",
+				"alias",
 				"createTime",
 				"updateTime",
-				"alias",
-				"creator",
-				"name",
 				"appPrimaryKey",
+				"creator",
 				"type",
-				"main",
 				"definition"
 			],
 			"properties": {
@@ -11925,13 +11982,13 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
-				"status",
-				"name",
-				"description",
-				"icon",
-				"alias",
-				"labels",
 				"ownerAddon",
+				"name",
+				"alias",
+				"icon",
+				"labels",
+				"description",
+				"status",
 				"schema",
 				"uiSchema"
 			],
@@ -11988,15 +12045,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"alias",
-				"createTime",
+				"description",
 				"creator",
-				"properties",
-				"updateTime",
 				"envName",
 				"name",
+				"alias",
+				"createTime",
+				"updateTime",
 				"type",
-				"description"
+				"properties"
 			],
 			"properties": {
 				"alias": {
@@ -12038,18 +12095,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
-				"envName",
+				"appPrimaryKey",
+				"revisionCRName",
+				"triggerType",
+				"workflowName",
 				"version",
+				"status",
 				"deployUser",
 				"note",
-				"workflowName",
-				"appPrimaryKey",
-				"status",
-				"triggerType",
-				"revisionCRName",
-				"reason"
+				"createTime",
+				"updateTime",
+				"reason",
+				"envName"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12106,10 +12163,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"updateTime",
 				"name",
 				"project",
-				"createTime"
+				"createTime",
+				"updateTime"
 			],
 			"properties": {
 				"alias": {
@@ -12149,11 +12206,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
+				"email",
+				"disabled",
 				"createTime",
 				"lastLoginTime",
 				"name",
-				"email",
-				"disabled",
 				"projects",
 				"roles"
 			],
@@ -12194,13 +12251,13 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"workflowAlias",
 				"status",
+				"mode",
+				"workflowAlias",
 				"applicationRevision",
+				"namespace",
 				"message",
 				"name",
-				"namespace",
-				"mode",
 				"workflowName",
 				"deployTime",
 				"deployUser",
@@ -12264,15 +12321,15 @@
 		"v1.DetailWorkflowResponse": {
 			"required": [
 				"name",
-				"envName",
-				"updateTime",
-				"mode",
+				"description",
 				"createTime",
+				"updateTime",
 				"subMode",
 				"alias",
-				"description",
 				"enable",
-				"default"
+				"default",
+				"envName",
+				"mode"
 			],
 			"properties": {
 				"alias": {
@@ -12507,12 +12564,12 @@
 		},
 		"v1.GetPipelineResponse": {
 			"required": [
+				"spec",
+				"createTime",
 				"name",
 				"alias",
 				"project",
 				"description",
-				"createTime",
-				"spec",
 				"info"
 			],
 			"properties": {
@@ -12555,10 +12612,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
+				"phase",
 				"id",
 				"name",
 				"type",
-				"phase",
 				"source",
 				"log"
 			],
@@ -13212,11 +13269,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
 				"createTime",
+				"lastLoginTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13418,11 +13475,11 @@
 		},
 		"v1.PipelineBase": {
 			"required": [
+				"createTime",
 				"name",
 				"alias",
 				"project",
 				"description",
-				"createTime",
 				"spec"
 			],
 			"properties": {
@@ -13463,11 +13520,11 @@
 		},
 		"v1.PipelineListItem": {
 			"required": [
+				"name",
 				"alias",
 				"project",
 				"description",
 				"createTime",
-				"name",
 				"info"
 			],
 			"properties": {
@@ -13521,11 +13578,11 @@
 		},
 		"v1.PipelineMetaResponse": {
 			"required": [
-				"name",
-				"alias",
 				"project",
 				"description",
-				"createTime"
+				"createTime",
+				"name",
+				"alias"
 			],
 			"properties": {
 				"alias": {
@@ -13550,11 +13607,11 @@
 			"required": [
 				"pipelineName",
 				"project",
+				"pipelineRunName",
 				"record",
 				"contextName",
 				"contextValues",
 				"spec",
-				"pipelineRunName",
 				"status"
 			],
 			"properties": {
@@ -13590,9 +13647,9 @@
 		},
 		"v1.PipelineRunBase": {
 			"required": [
-				"pipelineRunName",
 				"pipelineName",
 				"project",
+				"pipelineRunName",
 				"record",
 				"contextName",
 				"contextValues",
@@ -14036,10 +14093,10 @@
 		},
 		"v1.StepInputBase": {
 			"required": [
+				"id",
 				"name",
 				"type",
 				"phase",
-				"id",
 				"values"
 			],
 			"properties": {
@@ -14065,10 +14122,10 @@
 		},
 		"v1.StepOutputBase": {
 			"required": [
+				"id",
 				"name",
 				"type",
 				"phase",
-				"id",
 				"values"
 			],
 			"properties": {
@@ -14151,9 +14208,9 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
-				"loginType",
 				"platformID",
 				"enableCollection",
+				"loginType",
 				"systemVersion"
 			],
 			"properties": {
@@ -14677,14 +14734,14 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"name",
 				"namespace",
+				"message",
+				"status",
 				"mode",
+				"name",
 				"workflowName",
 				"workflowAlias",
-				"applicationRevision",
-				"status",
-				"message"
+				"applicationRevision"
 			],
 			"properties": {
 				"applicationRevision": {
@@ -14775,8 +14832,8 @@
 		},
 		"v1.WorkflowStep": {
 			"required": [
-				"name",
-				"type"
+				"type",
+				"name"
 			],
 			"properties": {
 				"alias": {

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -41,7 +41,7 @@ import (
 	velatypes "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/repository"
-	syncconvert "github.com/oam-dev/kubevela/pkg/apiserver/event/sync/convert"
+	"github.com/oam-dev/kubevela/pkg/apiserver/event/sync/convert"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
 	assembler "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/assembler/v1"
 	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/dto/v1"
@@ -51,6 +51,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	pkgUtils "github.com/oam-dev/kubevela/pkg/utils"
+	"github.com/oam-dev/kubevela/pkg/utils/app"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 	commonutil "github.com/oam-dev/kubevela/pkg/utils/common"
 )
@@ -89,6 +90,7 @@ type ApplicationService interface {
 	UpdateApplicationTrait(ctx context.Context, app *model.Application, component *model.ApplicationComponent, traitType string, req apisv1.UpdateApplicationTraitRequest) (*apisv1.ApplicationTrait, error)
 	ListRevisions(ctx context.Context, appName, envName, status string, page, pageSize int) (*apisv1.ListRevisionsResponse, error)
 	DetailRevision(ctx context.Context, appName, revisionName string) (*apisv1.DetailRevisionResponse, error)
+	RollbackWithRevision(ctx context.Context, app *model.Application, revisionName string) (*apisv1.ApplicationRollbackResponse, error)
 	Statistics(ctx context.Context, app *model.Application) (*apisv1.ApplicationStatisticsResponse, error)
 	ListRecords(ctx context.Context, appName string) (*apisv1.ListWorkflowRecordsResponse, error)
 	CompareApp(ctx context.Context, app *model.Application, compareReq apisv1.AppCompareReq) (*apisv1.AppCompareResponse, error)
@@ -705,9 +707,10 @@ func (c *applicationServiceImpl) Deploy(ctx context.Context, app *model.Applicat
 	}
 
 	var appRevision = &model.ApplicationRevision{
-		AppPrimaryKey:  app.PrimaryKey(),
-		Version:        version,
-		RevisionCRName: version,
+		AppPrimaryKey: app.PrimaryKey(),
+		Version:       version,
+		// Setting it when syncing the workflow status
+		RevisionCRName: "",
 		ApplyAppConfig: string(configByte),
 		Status:         model.RevisionStatusInit,
 		DeployUser:     userName,
@@ -1425,13 +1428,29 @@ func (c *applicationServiceImpl) CompareApp(ctx context.Context, appModel *model
 	var base, compareTarget *v1beta1.Application
 	var err error
 	var envNameByRevision string
+
+	getRunningApp := func() *v1beta1.Application {
+		var envName string
+		if compareReq.CompareLatestWithRunning != nil {
+			envName = compareReq.CompareLatestWithRunning.Env
+		}
+		if compareReq.CompareRevisionWithRunning != nil {
+			envName = envNameByRevision
+		}
+		if envName == "" {
+			return nil
+		}
+		app, err := c.GetApplicationCRInEnv(ctx, appModel, envName)
+		if err != nil {
+			klog.Errorf("failed to query the application CR %s", err.Error())
+			return nil
+		}
+		return app
+	}
 	switch {
 	case compareReq.CompareLatestWithRunning != nil:
-		base, err = c.renderOAMApplication(ctx, appModel, "", compareReq.CompareLatestWithRunning.Env, "")
-		if err != nil {
-			klog.Errorf("failed to build the latest application %s", err.Error())
-			break
-		}
+		base = getRunningApp()
+
 	case compareReq.CompareRevisionWithRunning != nil || compareReq.CompareRevisionWithLatest != nil:
 		var revision = ""
 		if compareReq.CompareRevisionWithRunning != nil {
@@ -1448,23 +1467,9 @@ func (c *applicationServiceImpl) CompareApp(ctx context.Context, appModel *model
 	}
 
 	switch {
-	case compareReq.CompareLatestWithRunning != nil || compareReq.CompareRevisionWithRunning != nil:
-		var envName string
-		if compareReq.CompareLatestWithRunning != nil {
-			envName = compareReq.CompareLatestWithRunning.Env
-		}
-		if compareReq.CompareRevisionWithRunning != nil {
-			envName = envNameByRevision
-		}
-		if envName == "" {
-			break
-		}
-		compareTarget, err = c.GetApplicationCRInEnv(ctx, appModel, envName)
-		if err != nil {
-			klog.Errorf("failed to query the application CR %s", err.Error())
-			break
-		}
-	case compareReq.CompareRevisionWithLatest != nil:
+	case compareReq.CompareRevisionWithRunning != nil:
+		compareTarget = getRunningApp()
+	case compareReq.CompareRevisionWithLatest != nil || compareReq.CompareLatestWithRunning != nil:
 		compareTarget, err = c.renderOAMApplication(ctx, appModel, "", envNameByRevision, "")
 		if err != nil {
 			klog.Errorf("failed to build the latest application %s", err.Error())
@@ -1625,7 +1630,7 @@ func (c *applicationServiceImpl) resetApp(ctx context.Context, targetApp *v1beta
 	for _, comp := range targetComps {
 		// add or update new app's components from old app
 		if utils.StringsContain(readyToAdd, comp.Name) || utils.StringsContain(readyToUpdate, comp.Name) {
-			compModel, err := syncconvert.FromCRComponent(appPrimaryKey, comp)
+			compModel, err := convert.FromCRComponent(appPrimaryKey, comp)
 			if err != nil {
 				return &apisv1.AppResetResponse{}, bcode.ErrInvalidProperties
 			}
@@ -1648,6 +1653,69 @@ func (c *applicationServiceImpl) resetApp(ctx context.Context, targetApp *v1beta
 		}
 	}
 	return &apisv1.AppResetResponse{IsReset: true}, nil
+}
+
+func (c *applicationServiceImpl) RollbackWithRevision(ctx context.Context, application *model.Application, revisionVersion string) (*apisv1.ApplicationRollbackResponse, error) {
+	revision, err := c.DetailRevision(ctx, application.Name, revisionVersion)
+	if err != nil {
+		return nil, err
+	}
+	appCR, err := c.GetApplicationCRInEnv(ctx, application, revision.EnvName)
+	if err != nil {
+		return nil, err
+	}
+	var publishVersion = utils.GenerateVersion(revision.WorkflowName)
+	noRevision := false
+	var rollbackApplication *v1beta1.Application
+	if appCR != nil {
+		// The RevisionCRName is incorrect in the old version, ignore it.
+		if revision.RevisionCRName == revision.Version || revision.RevisionCRName == "" {
+			noRevision = true
+		} else {
+			_, appCR, err := app.RollbackApplicationWithRevision(ctx, c.KubeClient, appCR.Name, appCR.Namespace, revision.RevisionCRName, publishVersion)
+			if err != nil {
+				switch {
+				case errors.Is(err, app.ErrNotMatchRevision):
+					noRevision = true
+				case errors.Is(err, app.ErrRevisionNotChange):
+					return nil, bcode.ErrApplicationRevisionConflict
+				default:
+					return nil, err
+				}
+			}
+			rollbackApplication = appCR
+		}
+	}
+
+	// Rollback by the local revision
+	if appCR == nil || noRevision {
+		rollBackApp := &v1beta1.Application{}
+		if err := yaml.Unmarshal([]byte(revision.ApplyAppConfig), rollBackApp); err != nil {
+			return nil, err
+		}
+		oam.SetPublishVersion(rollBackApp, publishVersion)
+		if appCR != nil {
+			rollBackApp.ResourceVersion = appCR.ResourceVersion
+		}
+		err = c.Apply.Apply(ctx, rollBackApp)
+		if err != nil {
+			klog.Errorf("rollback the app %s failure %s", application.PrimaryKey(), err.Error())
+			return nil, err
+		}
+		rollbackApplication = rollBackApp
+	}
+
+	work, _, err := convert.FromCRWorkflow(ctx, c.KubeClient, application.PrimaryKey(), rollbackApplication)
+	if err != nil {
+		return nil, err
+	}
+	record, err := c.WorkflowService.CreateWorkflowRecord(ctx, application, rollbackApplication, &work)
+	if err != nil {
+		return nil, fmt.Errorf("create workflow record failure %w", err)
+	}
+	return &apisv1.ApplicationRollbackResponse{
+		WorkflowRecord: assembler.ConvertFromRecordModel(record).WorkflowRecordBase,
+	}, nil
 }
 
 func dryRunApplication(ctx context.Context, c commonutil.Args, app *v1beta1.Application) (bytes.Buffer, error) {
@@ -1693,9 +1761,7 @@ func dryRunApplication(ctx context.Context, c commonutil.Args, app *v1beta1.Appl
 // ignore the workflow spec
 func ignoreSomeParams(o *v1beta1.Application) {
 	var defaultApplication = v1beta1.Application{}
-	// only compare the spec without the workflow
 	defaultApplication.Spec = o.Spec
-	defaultApplication.Spec.Workflow = nil
 	defaultApplication.Name = o.Name
 	defaultApplication.Namespace = o.Namespace
 

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -700,7 +700,7 @@ func (c *applicationServiceImpl) Deploy(ctx context.Context, app *model.Applicat
 				status = revision.Status
 			}
 			if status != model.RevisionStatusComplete && status != model.RevisionStatusTerminated && status != model.RevisionStatusFail {
-				klog.Warningf("last app revision can not complete %s/%s", list[0].(*model.ApplicationRevision).AppPrimaryKey, list[0].(*model.ApplicationRevision).Version)
+				klog.Warningf("last app revision can not complete %s/%s,the current status is %s", list[0].(*model.ApplicationRevision).AppPrimaryKey, list[0].(*model.ApplicationRevision).Version, status)
 				return nil, bcode.ErrDeployConflict
 			}
 		}
@@ -1696,6 +1696,8 @@ func (c *applicationServiceImpl) RollbackWithRevision(ctx context.Context, appli
 		oam.SetPublishVersion(rollBackApp, publishVersion)
 		if appCR != nil {
 			rollBackApp.ResourceVersion = appCR.ResourceVersion
+		} else {
+			rollBackApp.ResourceVersion = ""
 		}
 		err = c.Apply.Apply(ctx, rollBackApp)
 		if err != nil {

--- a/pkg/apiserver/domain/service/application_test.go
+++ b/pkg/apiserver/domain/service/application_test.go
@@ -532,8 +532,10 @@ var _ = Describe("Test application service function", func() {
 		})
 		Expect(err).Should(BeNil())
 		Expect(cmp.Diff(compareResponse.IsDiff, true)).Should(BeEmpty())
-		Expect(cmp.Diff(compareResponse.TargetAppYAML, "")).Should(BeEmpty())
-		Expect(cmp.Diff(compareResponse.BaseAppYAML, "")).ShouldNot(BeEmpty())
+		// The target represents the latest config
+		Expect(cmp.Diff(compareResponse.TargetAppYAML, "")).ShouldNot(BeEmpty())
+		// The base represents the running config
+		Expect(cmp.Diff(compareResponse.BaseAppYAML, "")).Should(BeEmpty())
 
 		By("compare when app's env add target, should return false")
 		_, err = targetService.CreateTarget(context.TODO(), v1.CreateTargetRequest{Name: "dev-target1", Project: appModel.Project, Cluster: &v1.ClusterTarget{ClusterName: "local", Namespace: "dev-target1"}})

--- a/pkg/apiserver/domain/service/rbac.go
+++ b/pkg/apiserver/domain/service/rbac.go
@@ -101,7 +101,7 @@ var defaultProjectPermissionTemplate = []*model.PermissionTemplate{
 		Name:  "pipeline-management",
 		Alias: "Pipeline Management",
 		Resources: []string{
-			"project:{projectName}/pipeline:*",
+			"project:{projectName}/pipeline:*/*",
 		},
 		Actions: []string{"*"},
 		Effect:  "Allow",

--- a/pkg/apiserver/domain/service/workflow_test.go
+++ b/pkg/apiserver/domain/service/workflow_test.go
@@ -259,6 +259,7 @@ var _ = Describe("Test workflow service functions", func() {
 		app.Status.Workflow.Finished = true
 		err = workflowService.KubeClient.Create(ctx, app.DeepCopy())
 		Expect(err).Should(BeNil())
+		app.Status.ObservedGeneration = 1
 		err = workflowService.KubeClient.Status().Patch(ctx, app, client.Merge)
 		Expect(err).Should(BeNil())
 		err = workflowService.SyncWorkflowRecord(ctx)

--- a/pkg/apiserver/event/sync/convert/convert.go
+++ b/pkg/apiserver/event/sync/convert/convert.go
@@ -33,6 +33,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/policy"
 )
 
@@ -87,12 +88,16 @@ func FromCRPolicy(appPrimaryKey string, policyCR v1beta1.AppPolicy, creator stri
 // FromCRWorkflow converts Application CR Workflow section into velaux data store workflow
 func FromCRWorkflow(ctx context.Context, cli client.Client, appPrimaryKey string, app *v1beta1.Application) (model.Workflow, []workflowv1alpha1.WorkflowStep, error) {
 	var defaultWorkflow = true
+	name := app.Annotations[oam.AnnotationWorkflowName]
+	if name == "" {
+		name = model.AutoGenWorkflowNamePrefix + appPrimaryKey
+	}
 	dataWf := model.Workflow{
 		AppPrimaryKey: appPrimaryKey,
 		// every namespace has a synced env
 		EnvName: model.AutoGenEnvNamePrefix + app.Namespace,
 		// every application has a synced workflow
-		Name:        model.AutoGenWorkflowNamePrefix + appPrimaryKey,
+		Name:        name,
 		Alias:       model.AutoGenWorkflowNamePrefix + app.Name,
 		Description: model.AutoGenDesc,
 		Default:     &defaultWorkflow,

--- a/pkg/apiserver/interfaces/api/dto/v1/types.go
+++ b/pkg/apiserver/interfaces/api/dto/v1/types.go
@@ -1152,6 +1152,11 @@ type ApplicationDeployResponse struct {
 	WorkflowRecord          WorkflowRecordBase `json:"record"`
 }
 
+// ApplicationRollbackResponse the response body that rollback with the revision
+type ApplicationRollbackResponse struct {
+	WorkflowRecord WorkflowRecordBase `json:"record"`
+}
+
 // ApplicationDockerhubWebhookResponse dockerhub webhook response body
 type ApplicationDockerhubWebhookResponse struct {
 	State       string `json:"state,omitempty"`

--- a/pkg/apiserver/interfaces/api/pipeline.go
+++ b/pkg/apiserver/interfaces/api/pipeline.go
@@ -154,7 +154,7 @@ func initPipelineRoutes(ws *restful.WebService, n *project) {
 		Doc("get pipeline run").
 		Returns(200, "OK", apis.PipelineRunBase{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Filter(n.RBACService.CheckPerm("project/pipeline/pipelineRun", "get")).
+		Filter(n.RBACService.CheckPerm("project/pipeline/pipelineRun", "detail")).
 		Writes(apis.PipelineRunBase{}).Do(meta, projParam, pipelineParam, runParam))
 
 	ws.Route(ws.DELETE("/{projectName}/pipelines/{pipelineName}/runs/{runName}").To(n.deletePipelineRun).

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -105,7 +105,7 @@ func (s *restServer) buildIoCContainer() error {
 		return fmt.Errorf("fail to provides the datastore bean to the container: %w", err)
 	}
 
-	kubeClient = utils.NewAuthApplicationClient(kubeClient)
+	kubeClient = utils.NewAuthClient(kubeClient)
 	if err := s.beanContainer.ProvideWithName("kubeClient", kubeClient); err != nil {
 		return fmt.Errorf("fail to provides the kubeClient bean to the container: %w", err)
 	}

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -72,42 +72,54 @@ func SetUsernameAndProjectInRequestContext(req *restful.Request, userName string
 	req.Request = req.Request.WithContext(ctx)
 }
 
-// NewAuthApplicationClient will carry UserInfo for mutating requests related to application automatically
-func NewAuthApplicationClient(cli client.Client) client.Client {
-	return &authAppClient{Client: cli}
+// NewAuthClient will carry UserInfo for mutating requests automatically
+func NewAuthClient(cli client.Client) client.Client {
+	return &authClient{Client: cli}
 }
 
-type authAppClient struct {
+type authClient struct {
 	client.Client
 }
 
 // Status .
-func (c *authAppClient) Status() client.StatusWriter {
+func (c *authClient) Status() client.StatusWriter {
 	return &authAppStatusClient{StatusWriter: c.Client.Status()}
 }
 
+// List .
+func (c *authClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	ctx = ContextWithUserInfo(ctx)
+	return c.Client.List(ctx, obj, opts...)
+}
+
 // Create .
-func (c *authAppClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (c *authClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	ctx = ContextWithUserInfo(ctx)
 	return c.Client.Create(ctx, obj, opts...)
 }
 
 // Delete .
-func (c *authAppClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func (c *authClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	ctx = ContextWithUserInfo(ctx)
 	return c.Client.Delete(ctx, obj, opts...)
 }
 
 // Update .
-func (c *authAppClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func (c *authClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 	ctx = ContextWithUserInfo(ctx)
 	return c.Client.Update(ctx, obj, opts...)
 }
 
 // Patch .
-func (c *authAppClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+func (c *authClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	ctx = ContextWithUserInfo(ctx)
 	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+// DeleteAllOf .
+func (c *authClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	ctx = ContextWithUserInfo(ctx)
+	return c.Client.DeleteAllOf(ctx, obj, opts...)
 }
 
 type authAppStatusClient struct {

--- a/pkg/apiserver/utils/bcode/001_application.go
+++ b/pkg/apiserver/utils/bcode/001_application.go
@@ -99,3 +99,6 @@ var ErrApplicationPolicyIsBeingUsed = NewBcode(400, 10026, "the policy is being 
 
 // ErrApplicationDryRunFailed means the application configuration does not dry run successfully
 var ErrApplicationDryRunFailed = NewBcode(400, 10027, "The application dry run failed")
+
+// ErrApplicationRevisionConflict -
+var ErrApplicationRevisionConflict = NewBcode(400, 10028, "The current revision of the application is equal to the requested revision")

--- a/pkg/auth/privileges.go
+++ b/pkg/auth/privileges.go
@@ -338,7 +338,12 @@ func (a *ApplicationPrivilege) GetRoles() []client.Object {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"core.oam.dev"},
-					Resources: []string{"applications", "policies", "workflows", "workflowruns"},
+					Resources: []string{"applications", "applications/status", "policies", "workflows", "workflowruns", "workflowruns/status"},
+					Verbs:     verbs,
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"secrets", "configmaps"},
 					Verbs:     verbs,
 				},
 			},

--- a/pkg/utils/app/app.go
+++ b/pkg/utils/app/app.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	apiutils "github.com/oam-dev/kubevela/pkg/apiserver/utils"
+	"github.com/oam-dev/kubevela/pkg/component"
+	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application"
+	"github.com/oam-dev/kubevela/pkg/controller/utils"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+// ErrNotMatchRevision -
+var ErrNotMatchRevision = errors.Errorf("failed to find revision matching the application")
+
+// ErrPublishVersionNotChange -
+var ErrPublishVersionNotChange = errors.Errorf("the PublishVersion is not changed")
+
+// ErrRevisionNotChange -
+var ErrRevisionNotChange = errors.Errorf("the revision is not changed")
+
+// RollbackApplicationWithRevision make the exist application rollback to specified revision.
+func RollbackApplicationWithRevision(ctx context.Context, cli client.Client, appName, appNamespace, revisionName, publishVersion string) (*v1beta1.ApplicationRevision, *v1beta1.Application, error) {
+
+	revisionCtx := apiutils.WithProject(ctx, "")
+	// check revision
+	revs, err := application.GetSortedAppRevisions(revisionCtx, cli, appName, appNamespace)
+	if err != nil {
+		return nil, nil, err
+	}
+	var matchedRev *v1beta1.ApplicationRevision
+	for _, rev := range revs {
+		if rev.Name == revisionName {
+			matchedRev = rev.DeepCopy()
+		}
+	}
+	if matchedRev == nil {
+		return nil, nil, ErrNotMatchRevision
+	}
+
+	app := &v1beta1.Application{}
+	if err := cli.Get(ctx, k8stypes.NamespacedName{Name: appName, Namespace: appNamespace}, app); err != nil {
+		return nil, nil, err
+	}
+
+	if appPV := oam.GetPublishVersion(app); appPV == publishVersion {
+		return nil, nil, ErrPublishVersionNotChange
+	}
+
+	if app != nil && app.Status.LatestRevision != nil && app.Status.LatestRevision.Name == revisionName {
+		return nil, nil, ErrRevisionNotChange
+	}
+
+	// freeze the application
+	appKey := client.ObjectKeyFromObject(app)
+	controllerRequirement, err := utils.FreezeApplication(ctx, cli, app, func() {
+		app.Spec = matchedRev.Spec.Application.Spec
+		oam.SetPublishVersion(app, publishVersion)
+	})
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to freeze application %s before update", appKey)
+	}
+
+	defer func() {
+		// unfreeze application
+		if err = utils.UnfreezeApplication(ctx, cli, app, nil, controllerRequirement); err != nil {
+			klog.Errorf("failed to unfreeze application %s after update:%s", appKey, err.Error())
+		}
+	}()
+
+	// create new revision based on the matched revision
+	revName, revisionNum := utils.GetAppNextRevision(app)
+	matchedRev.Name = revName
+	oam.SetPublishVersion(matchedRev, publishVersion)
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(matchedRev)
+	if err != nil {
+		return nil, nil, err
+	}
+	un := &unstructured.Unstructured{Object: obj}
+	component.ClearRefObjectForDispatch(un)
+	if err = cli.Create(revisionCtx, un); err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to update application %s to create new revision %s", appKey, revName)
+	}
+
+	// update application status to point to the new revision
+	if err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err = cli.Get(ctx, appKey, app); err != nil {
+			return err
+		}
+		app.Status = apicommon.AppStatus{
+			LatestRevision: &apicommon.Revision{Name: revName, Revision: revisionNum, RevisionHash: matchedRev.GetLabels()[oam.LabelAppRevisionHash]},
+		}
+		return cli.Status().Update(ctx, app)
+	}); err != nil {
+		if delErr := cli.Delete(revisionCtx, un); delErr != nil {
+			klog.Warningf("failed to clear the new revision after failed to rollback application:%s:%s", appName, delErr.Error())
+		}
+		return nil, nil, errors.Wrapf(err, "failed to update application %s to use new revision %s", appKey, revName)
+	}
+	return matchedRev, app, nil
+}

--- a/pkg/utils/app/app.go
+++ b/pkg/utils/app/app.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"

--- a/test/e2e-apiserver-test/application_rollback_test.go
+++ b/test/e2e-apiserver-test/application_rollback_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_apiserver_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
+	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/interfaces/api/dto/v1"
+)
+
+var _ = Describe("Test the rest api that rollback the application", func() {
+	var appName = "test-rollback"
+	var envName = "rollback"
+	var revision = ""
+	var waitAppReady = func() apisv1.ApplicationStatusResponse {
+		var sr apisv1.ApplicationStatusResponse
+		Eventually(func() error {
+			res := get("/applications/" + appName + "/envs/" + envName + "/status")
+			if err := decodeResponseBody(res, &sr); err != nil {
+				return err
+			}
+			if sr.Status == nil {
+				return errors.New("the application is not running")
+			}
+			if sr.Status.Phase != common.ApplicationRunning {
+				return fmt.Errorf("the application status is %s, not running", sr.Status.Phase)
+			}
+			return nil
+		}).WithTimeout(time.Minute * 1).WithPolling(3 * time.Second).Should(BeNil())
+		return sr
+	}
+
+	var deployApp = func() string {
+		var req = apisv1.ApplicationDeployRequest{
+			Note:         "test apply",
+			TriggerType:  "web",
+			WorkflowName: "workflow-" + envName,
+			Force:        false,
+		}
+		res := post("/applications/"+appName+"/deploy", req)
+		var response apisv1.ApplicationDeployResponse
+		Expect(decodeResponseBody(res, &response)).Should(Succeed())
+		Expect(cmp.Diff(response.Status, model.RevisionStatusRunning)).Should(BeEmpty())
+		return response.ApplicationRevisionBase.Version
+	}
+	It("Prepare the environment", func() {
+		ct := apisv1.CreateTargetRequest{
+			Name:    "rollback",
+			Project: appProject,
+			Cluster: &apisv1.ClusterTarget{
+				ClusterName: "local",
+				Namespace:   "rollback",
+			},
+		}
+		res := post("/targets", ct)
+		var targetBase apisv1.TargetBase
+		Expect(decodeResponseBody(res, &targetBase)).Should(Succeed())
+
+		ce := apisv1.CreateEnvRequest{
+			Name:      envName,
+			Project:   appProject,
+			Namespace: "rollback",
+			Targets:   []string{targetBase.Name},
+		}
+
+		env := post("/envs", ce)
+		var envRes apisv1.Env
+		Expect(decodeResponseBody(env, &envRes)).Should(Succeed())
+	})
+	It("Prepare the test application", func() {
+		var req = apisv1.CreateApplicationRequest{
+			Name:        appName,
+			Project:     appProject,
+			Description: "this is an application to testing the rollback",
+			Icon:        "",
+			Labels:      map[string]string{"test": "true"},
+			EnvBinding:  []*apisv1.EnvBinding{{Name: envName}},
+			Component: &apisv1.CreateComponentRequest{
+				Name:          "webservice",
+				ComponentType: "webservice",
+				Properties:    "{\"image\":\"nginx\"}",
+			},
+		}
+		res := post("/applications", req)
+		var appBase apisv1.ApplicationBase
+		Expect(decodeResponseBody(res, &appBase)).Should(Succeed())
+	})
+	It("Test rollback by the cluster revision", func() {
+		// first deploy
+		firstRevision := deployApp()
+		status := waitAppReady()
+		Expect(len(status.Status.Services)).Should(Equal(1))
+		var createComponent = apisv1.CreateComponentRequest{
+			Name:          "component2",
+			ComponentType: "webservice",
+			Properties:    `{"image": "nginx","ports": [{"port": 80, "expose": true}]}`,
+		}
+		res := post("/applications/"+appName+"/components", createComponent)
+		var cb apisv1.ComponentBase
+		Expect(decodeResponseBody(res, &cb)).Should(Succeed())
+		Expect(cmp.Diff(cb.Name, "component2")).Should(BeEmpty())
+		// second deploy
+		revision = deployApp()
+		status = waitAppReady()
+		Expect(len(status.Status.Services)).Should(Equal(2))
+
+		// rollback to first revision
+		res = post("/applications/"+appName+"/revisions/"+firstRevision+"/rollback", nil)
+		var rollback apisv1.ApplicationRollbackResponse
+		Expect(decodeResponseBody(res, &rollback)).Should(Succeed())
+		Expect(rollback.WorkflowRecord.Name).ShouldNot(BeEmpty())
+		status = waitAppReady()
+		Expect(len(status.Status.Services)).Should(Equal(1))
+	})
+	It("Test rollback by the local revision", func() {
+		res := post("/applications/"+appName+"/envs/"+envName+"/recycle", nil)
+		Expect(decodeResponseBody(res, nil)).Should(Succeed())
+		var sr apisv1.ApplicationStatusResponse
+		Eventually(func() error {
+			res := get("/applications/" + appName + "/envs/" + envName + "/status")
+			if err := decodeResponseBody(res, &sr); err != nil {
+				return err
+			}
+			if sr.Status == nil {
+				return nil
+			}
+			return fmt.Errorf("the application status is %s", sr.Status.Phase)
+		}).WithTimeout(time.Minute * 1).WithPolling(3 * time.Second).Should(BeNil())
+
+		res = post("/applications/"+appName+"/revisions/"+revision+"/rollback", nil)
+		var rollback apisv1.ApplicationRollbackResponse
+		Expect(decodeResponseBody(res, &rollback)).Should(Succeed())
+		Expect(rollback.WorkflowRecord.Name).ShouldNot(BeEmpty())
+		status := waitAppReady()
+		Expect(len(status.Status.Services)).Should(Equal(2))
+	})
+})

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -47,8 +47,8 @@ var k8sClient client.Client
 var token string
 
 const (
-	baseDomain   = "http://127.0.0.1:8000"
-	baseURL      = "http://127.0.0.1:8000/api/v1"
+	baseDomain   = "http://127.0.0.1:8001"
+	baseURL      = "http://127.0.0.1:8001/api/v1"
 	testNSprefix = "api-e2e-test-"
 )
 
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	ctx := context.Background()
 
 	cfg := config.Config{
-		BindAddr: "127.0.0.1:8000",
+		BindAddr: "127.0.0.1:8001",
 		Datastore: datastore.Config{
 			Type:     "kubeapi",
 			Database: "kubevela",
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 			}
 			bodyByte, err := json.Marshal(req)
 			Expect(err).Should(BeNil())
-			resp, err := http.Post("http://127.0.0.1:8000/api/v1/auth/login", "application/json", bytes.NewBuffer(bodyByte))
+			resp, err := http.Post(baseURL+"/auth/login", "application/json", bytes.NewBuffer(bodyByte))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Rollback rules:

1. If the application revision in the hub cluster exits, rollbacking based on them.
2. If not exist, rollbacking based on the revision save in the database. It will use the latest definition to render.
3. Rollbacking will execute the workflow in revision, not the latest workflow.

Fixes: #4222

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->