### PR TITLE
Fix: make the synced workflow name normative

### DIFF
--- a/pkg/apiserver/domain/repository/envbinding.go
+++ b/pkg/apiserver/domain/repository/envbinding.go
@@ -120,10 +120,10 @@ func pickEnv(envs []*model.Env, name string) (*model.Env, error) {
 	return nil, bcode.ErrEnvNotExisted
 }
 
-func pickEnvWorkflow(envs []*model.Workflow, name string) (*model.Workflow, error) {
-	for _, e := range envs {
-		if e.EnvName == name {
-			return e, nil
+func pickEnvWorkflow(workflows []*model.Workflow, name string) (*model.Workflow, error) {
+	for _, w := range workflows {
+		if w.EnvName == name {
+			return w, nil
 		}
 	}
 	return nil, bcode.ErrWorkflowNotExist

--- a/pkg/apiserver/domain/repository/workflow.go
+++ b/pkg/apiserver/domain/repository/workflow.go
@@ -660,7 +660,7 @@ func ListWorkflowForApp(ctx context.Context, ds datastore.DataStore, appPrimaryK
 	var workflow = model.Workflow{
 		AppPrimaryKey: appPrimaryKey,
 	}
-	workflows, err := ds.List(ctx, &workflow, nil)
+	workflows, err := ds.List(ctx, &workflow, &datastore.ListOptions{SortBy: []datastore.SortOption{{Key: "createTime", Order: datastore.SortOrderDescending}}})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -1707,7 +1707,7 @@ func (c *applicationServiceImpl) RollbackWithRevision(ctx context.Context, appli
 		rollbackApplication = rollBackApp
 	}
 
-	work, _, err := convert.FromCRWorkflow(ctx, c.KubeClient, application.PrimaryKey(), rollbackApplication)
+	work, _, err := convert.FromCRWorkflow(ctx, c.KubeClient, application.PrimaryKey(), rollbackApplication, revision.EnvName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/domain/service/workflow.go
+++ b/pkg/apiserver/domain/service/workflow.go
@@ -290,7 +290,9 @@ func (w *workflowServiceImpl) ListWorkflowRecords(ctx context.Context, workflow 
 		AppPrimaryKey: workflow.AppPrimaryKey,
 		WorkflowName:  workflow.Name,
 	}
-	records, err := w.Store.List(ctx, &record, &datastore.ListOptions{Page: page, PageSize: pageSize})
+	records, err := w.Store.List(ctx, &record, &datastore.ListOptions{Page: page, PageSize: pageSize, SortBy: []datastore.SortOption{
+		{Key: "createTime", Order: datastore.SortOrderAscending},
+	}})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/event/sync/convert.go
+++ b/pkg/apiserver/event/sync/convert.go
@@ -117,11 +117,10 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 	}
 
 	// 5. convert workflow
-	wf, steps, err := convert.FromCRWorkflow(ctx, cli, appMeta.PrimaryKey(), targetApp)
+	wf, steps, err := convert.FromCRWorkflow(ctx, cli, appMeta.PrimaryKey(), targetApp, dsApp.Env.Name)
 	if err != nil {
 		return nil, err
 	}
-	wf.EnvName = dsApp.Env.Name
 	dsApp.Workflow = &wf
 
 	// 6. convert policy, some policies are references in workflow step, we need to sync all the outside policy to make that work

--- a/pkg/apiserver/event/sync/convert/convert.go
+++ b/pkg/apiserver/event/sync/convert/convert.go
@@ -32,6 +32,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
+	"github.com/oam-dev/kubevela/pkg/apiserver/utils"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/policy"
@@ -86,21 +87,19 @@ func FromCRPolicy(appPrimaryKey string, policyCR v1beta1.AppPolicy, creator stri
 }
 
 // FromCRWorkflow converts Application CR Workflow section into velaux data store workflow
-func FromCRWorkflow(ctx context.Context, cli client.Client, appPrimaryKey string, app *v1beta1.Application) (model.Workflow, []workflowv1alpha1.WorkflowStep, error) {
+func FromCRWorkflow(ctx context.Context, cli client.Client, appPrimaryKey string, app *v1beta1.Application, envName string) (model.Workflow, []workflowv1alpha1.WorkflowStep, error) {
 	var defaultWorkflow = true
 	name := app.Annotations[oam.AnnotationWorkflowName]
 	if name == "" {
-		name = model.AutoGenWorkflowNamePrefix + appPrimaryKey
+		name = fmt.Sprintf("workflow-%s", envName)
 	}
 	dataWf := model.Workflow{
 		AppPrimaryKey: appPrimaryKey,
-		// every namespace has a synced env
-		EnvName: model.AutoGenEnvNamePrefix + app.Namespace,
-		// every application has a synced workflow
-		Name:        name,
-		Alias:       model.AutoGenWorkflowNamePrefix + app.Name,
-		Description: model.AutoGenDesc,
-		Default:     &defaultWorkflow,
+		EnvName:       envName,
+		Name:          name,
+		Alias:         fmt.Sprintf("%s Workflow", utils.FirstUpper(envName)),
+		Description:   model.AutoGenDesc,
+		Default:       &defaultWorkflow,
 	}
 	if app.Spec.Workflow == nil {
 		return dataWf, nil, nil

--- a/pkg/apiserver/event/sync/cr2ux_test.go
+++ b/pkg/apiserver/event/sync/cr2ux_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Test CR convert to ux", func() {
 		app1 := &v1beta1.Application{}
 		Expect(common2.ReadYamlToObject("testdata/test-app1.yaml", app1)).Should(BeNil())
 		app1.Namespace = appNS1
+		envName := "sync-" + app1.Namespace
 		Expect(cr2ux.AddOrUpdate(context.Background(), app1)).Should(BeNil())
 		comp1 := model.ApplicationComponent{AppPrimaryKey: apName1, Name: "nginx"}
 		Expect(ds.Get(context.Background(), &comp1)).Should(BeNil())
@@ -128,7 +129,7 @@ var _ = Describe("Test CR convert to ux", func() {
 		Expect(ds.Get(ctx, &appPlc1)).Should(BeNil())
 		appPlc2 := model.ApplicationPolicy{AppPrimaryKey: app1.Name, Name: "topology-local"}
 		Expect(ds.Get(ctx, &appPlc2)).Should(BeNil())
-		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: model.AutoGenWorkflowNamePrefix + app1.Name}
+		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: "workflow-" + envName}
 		Expect(ds.Get(ctx, &appwf1)).Should(BeNil())
 		Expect(len(appwf1.Steps)).Should(BeEquivalentTo(1))
 

--- a/pkg/apiserver/event/sync/cr2ux_test.go
+++ b/pkg/apiserver/event/sync/cr2ux_test.go
@@ -115,7 +115,8 @@ var _ = Describe("Test CR convert to ux", func() {
 		app1 := &v1beta1.Application{}
 		Expect(common2.ReadYamlToObject("testdata/test-app1.yaml", app1)).Should(BeNil())
 		app1.Namespace = appNS1
-		envName := "sync-" + app1.Namespace
+		envName := model.AutoGenEnvNamePrefix + app1.Namespace
+
 		Expect(cr2ux.AddOrUpdate(context.Background(), app1)).Should(BeNil())
 		comp1 := model.ApplicationComponent{AppPrimaryKey: apName1, Name: "nginx"}
 		Expect(ds.Get(context.Background(), &comp1)).Should(BeNil())
@@ -129,6 +130,7 @@ var _ = Describe("Test CR convert to ux", func() {
 		Expect(ds.Get(ctx, &appPlc1)).Should(BeNil())
 		appPlc2 := model.ApplicationPolicy{AppPrimaryKey: app1.Name, Name: "topology-local"}
 		Expect(ds.Get(ctx, &appPlc2)).Should(BeNil())
+
 		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: "workflow-" + envName}
 		Expect(ds.Get(ctx, &appwf1)).Should(BeNil())
 		Expect(len(appwf1.Steps)).Should(BeEquivalentTo(1))

--- a/pkg/apiserver/event/sync/worker_test.go
+++ b/pkg/apiserver/event/sync/worker_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
+	"github.com/oam-dev/kubevela/pkg/apiserver/domain/repository"
 	"github.com/oam-dev/kubevela/pkg/apiserver/infrastructure/datastore"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
@@ -105,7 +106,7 @@ var _ = Describe("Test Worker CR sync to datastore", func() {
 		Expect(appPlc1.CreateTime.IsZero()).Should(BeFalse())
 		appPlc2 := model.ApplicationPolicy{AppPrimaryKey: app1.Name, Name: "topology-local"}
 		Expect(ds.Get(ctx, &appPlc2)).Should(BeNil())
-		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: model.AutoGenWorkflowNamePrefix + app1.Name}
+		appwf1 := model.Workflow{AppPrimaryKey: app1.Name, Name: repository.ConvertWorkflowName(env.Name)}
 		Expect(ds.Get(ctx, &appwf1)).Should(BeNil())
 
 		By("create test app2 and check the syncing results")


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

The workflow name format with `workflow-<envName>`.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->