### PR TITLE
Fix: the addon management APIs support the user impersonation

### DIFF
--- a/pkg/addon/cache.go
+++ b/pkg/addon/cache.go
@@ -67,13 +67,18 @@ func NewCache(ds RegistryDataStore) *Cache {
 }
 
 // DiscoverAndRefreshLoop will run a loop to automatically discovery and refresh addons from registry
-func (u *Cache) DiscoverAndRefreshLoop(cacheTime time.Duration) {
+func (u *Cache) DiscoverAndRefreshLoop(ctx context.Context, cacheTime time.Duration) {
 	ticker := time.NewTicker(cacheTime)
 	defer ticker.Stop()
 
 	// This is infinite loop, we can receive a channel for close
-	for ; true; <-ticker.C {
-		u.discoverAndRefreshRegistry()
+	for {
+		select {
+		case <-ticker.C:
+			u.discoverAndRefreshRegistry()
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/pkg/apiserver/domain/service/application.go
+++ b/pkg/apiserver/domain/service/application.go
@@ -539,7 +539,9 @@ func (c *applicationServiceImpl) ListRecords(ctx context.Context, appName string
 		AppPrimaryKey: appName,
 		Finished:      model.UnFinished,
 	}
-	records, err := c.Store.List(ctx, &record, &datastore.ListOptions{})
+	records, err := c.Store.List(ctx, &record, &datastore.ListOptions{SortBy: []datastore.SortOption{
+		{Key: "createTime", Order: datastore.SortOrderDescending},
+	}})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/domain/service/service.go
+++ b/pkg/apiserver/domain/service/service.go
@@ -49,7 +49,7 @@ func InitServiceBean(c config.Config) []interface{} {
 	pipelineService := NewPipelineService(c.WorkflowVersion)
 	pipelineRunService := NewPipelineRunService()
 	contextService := NewContextService()
-	needInitData = []DataInit{clusterService, userService, rbacService, projectService, targetService, systemInfoService}
+	needInitData = []DataInit{clusterService, userService, rbacService, projectService, targetService, systemInfoService, addonService}
 	return []interface{}{
 		clusterService, rbacService, projectService, envService, targetService, workflowService, oamApplicationService,
 		velaQLService, definitionService, addonService, envBindingService, systemInfoService, helmService, userService,

--- a/pkg/apiserver/event/sync/cache_test.go
+++ b/pkg/apiserver/event/sync/cache_test.go
@@ -68,20 +68,20 @@ var _ = Describe("Test Cache", func() {
 		app1 := &v1beta1.Application{}
 		app1.Name = "app1"
 		app1.Namespace = "app1-ns"
-		app1.Generation = 1
+		app1.ResourceVersion = "1"
 		Expect(cr2ux.shouldSync(ctx, app1, false)).Should(BeEquivalentTo(true))
 
 		app2 := &v1beta1.Application{}
 		app2.Name = "app2"
 		app2.Namespace = "app2-ns"
-		app2.Generation = 1
+		app2.ResourceVersion = "1"
 
 		Expect(cr2ux.shouldSync(ctx, app2, false)).Should(BeEquivalentTo(false))
 
 		app3 := &v1beta1.Application{}
 		app3.Name = "app3"
 		app3.Namespace = "app3-ns"
-		app3.Generation = 3
+		app3.ResourceVersion = "3"
 		app3.Labels = map[string]string{
 			model.LabelSyncGeneration: "1",
 			model.LabelSyncNamespace:  "app3-ns",

--- a/pkg/apiserver/event/sync/cache_test.go
+++ b/pkg/apiserver/event/sync/cache_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test Cache", func() {
 			model.LabelSyncGeneration: "1",
 			model.LabelSyncNamespace:  "app1-ns",
 		}})).Should(BeNil())
-		cr2ux.syncCache(formatAppComposedName(app1.Name, app1.Namespace), 1, 0)
+		cr2ux.syncCache(formatAppComposedName(app1.Name, app1.Namespace), "1", 0)
 		Expect(cr2ux.shouldSync(ctx, app1, false)).Should(BeEquivalentTo(false))
 		Expect(cr2ux.shouldSync(ctx, app1, true)).Should(BeEquivalentTo(true))
 		Expect(ds.Delete(ctx, &model.Application{Name: "app1"})).Should(BeNil())

--- a/pkg/apiserver/event/sync/convert.go
+++ b/pkg/apiserver/event/sync/convert.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	apitypes "github.com/oam-dev/kubevela/apis/types"
@@ -86,6 +87,7 @@ func (c *CR2UX) ConvertApp2DatastoreApp(ctx context.Context, targetApp *v1beta1.
 	if err != nil {
 		return nil, err
 	}
+	klog.Infof("generate the environment %s for the application %s", env.Name, targetApp.Name)
 	dsApp.Env = env
 	if newProject != "" {
 		project = v1.CreateProjectRequest{

--- a/pkg/apiserver/event/sync/convert/convert.go
+++ b/pkg/apiserver/event/sync/convert/convert.go
@@ -263,9 +263,9 @@ func FromCRApplicationRevision(ctx context.Context, cli client.Client, app *v1be
 	if err := cli.List(ctx, &appRevisionList,
 		client.HasLabels{fmt.Sprintf("%s=%s", oam.LabelAppName, app.Name)},
 		client.InNamespace(app.Namespace)); err == nil && len(appRevisionList.Items) > 0 {
-		for _, rev := range appRevisionList.Items {
+		for i, rev := range appRevisionList.Items {
 			if rev.Annotations[oam.AnnotationPublishVersion] == publishVersion {
-				appRevision = &rev
+				appRevision = &appRevisionList.Items[i]
 				break
 			}
 		}

--- a/pkg/apiserver/event/sync/cr2ux.go
+++ b/pkg/apiserver/event/sync/cr2ux.go
@@ -133,7 +133,7 @@ func (c *CR2UX) AddOrUpdate(ctx context.Context, targetApp *v1beta1.Application)
 	}
 
 	// update cache
-	c.syncCache(dsApp.AppMeta.PrimaryKey(), targetApp.Generation, int64(len(dsApp.Targets)))
+	c.syncCache(dsApp.AppMeta.PrimaryKey(), targetApp.ResourceVersion, int64(len(dsApp.Targets)))
 	return nil
 }
 

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/oam-dev/kubevela/apis/types"
+	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 	"github.com/oam-dev/kubevela/pkg/apiserver/config"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/service"
 	"github.com/oam-dev/kubevela/pkg/apiserver/event"
@@ -121,6 +122,10 @@ func (s *restServer) buildIoCContainer() error {
 		return fmt.Errorf("fail to provides the config factory bean to the container: %w", err)
 	}
 
+	addonStore := pkgaddon.NewRegistryDataStore(kubeClient)
+	if err := s.beanContainer.ProvideWithName("registryDatastore", addonStore); err != nil {
+		return fmt.Errorf("fail to provides the registry datastore bean to the container: %w", err)
+	}
 	// domain
 	if err := s.beanContainer.Provides(service.InitServiceBean(s.cfg)...); err != nil {
 		return fmt.Errorf("fail to provides the service bean to the container: %w", err)

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -59,7 +59,7 @@ func ContextWithUserInfo(ctx context.Context) context.Context {
 		userInfo.Groups = []string{UXDefaultGroup}
 	}
 	if userInfo.Name == model.DefaultAdminUserName && features.APIServerFeatureGate.Enabled(features.APIServerEnableAdminImpersonation) {
-		return ctx
+		userInfo.Groups = []string{UXDefaultGroup}
 	}
 	return request.WithUser(ctx, userInfo)
 }
@@ -107,6 +107,7 @@ func (c *authClient) Delete(ctx context.Context, obj client.Object, opts ...clie
 // Update .
 func (c *authClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 	ctx = ContextWithUserInfo(ctx)
+
 	return c.Client.Update(ctx, obj, opts...)
 }
 


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

This PR includes some related changes:

1. The Addon service shares the auth Kube client to support the user impersonation.
2. Add the `publish-version` for the addon application. Users could retry to deploy the Addon.
3. The sync cache key change from the application generation to resource version. This is useful to sync the workflow record.
4. The `APIServerEnableAdminImpersonation` feature implementation change to always bind `kubevela:ux` group. This allows the administrator to have maximum permissions.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->