### PR TITLE
Test: use mock server in addon tests

### DIFF
--- a/pkg/addon/helper_test.go
+++ b/pkg/addon/helper_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package addon
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +31,38 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func setupMockServer() *httptest.Server {
+	var listenURL string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fileList := []string{
+			"index.yaml",
+			"fluxcd-test-version-1.0.0.tgz",
+			"fluxcd-test-version-2.0.0.tgz",
+			"vela-workflow-v0.3.5.tgz",
+			"foo-v1.0.0.tgz",
+			"bar-v1.0.0.tgz",
+			"bar-v2.0.0.tgz",
+			"mock-be-dep-addon-v1.0.0.tgz",
+		}
+		for _, f := range fileList {
+			if strings.Contains(req.URL.Path, f) {
+				file, err := os.ReadFile("../../e2e/addon/mock/testrepo/helm-repo/" + f)
+				if err != nil {
+					_, _ = w.Write([]byte(err.Error()))
+				}
+				if f == "index.yaml" {
+					// in index.yaml, url is hardcoded to 127.0.0.1:9098,
+					// so we need to replace it with the real random listen url
+					file = bytes.ReplaceAll(file, []byte("http://127.0.0.1:9098"), []byte(listenURL))
+				}
+				_, _ = w.Write(file)
+			}
+		}
+	}))
+	listenURL = s.URL
+	return s
+}
 
 var _ = Describe("test FindAddonPackagesDetailFromRegistry", func() {
 	Describe("when no registry is added, no matter what you do, it will just return error", func() {
@@ -50,12 +85,15 @@ var _ = Describe("test FindAddonPackagesDetailFromRegistry", func() {
 	})
 
 	Describe("one versioned registry is added", func() {
+		var s *httptest.Server
+
 		BeforeEach(func() {
-			// Prepare KubeVela registry
+			s = setupMockServer()
+			// Prepare registry
 			reg := &Registry{
-				Name: "KubeVela",
+				Name: "addon_helper_test",
 				Helm: &HelmSource{
-					URL: "https://addons.kubevela.net",
+					URL: s.URL,
 				},
 			}
 			ds := NewRegistryDataStore(k8sClient)
@@ -63,38 +101,36 @@ var _ = Describe("test FindAddonPackagesDetailFromRegistry", func() {
 		})
 
 		AfterEach(func() {
-			// Clean up KubeVela registry
+			// Clean up registry
 			ds := NewRegistryDataStore(k8sClient)
-			Expect(ds.DeleteRegistry(context.Background(), "KubeVela")).To(Succeed())
+			Expect(ds.DeleteRegistry(context.Background(), "addon_helper_test")).To(Succeed())
+			s.Close()
 		})
 
 		Context("when empty addonNames and registryNames is supplied", func() {
 			It("should return error, empty addonNames are not allowed", func() {
-				_, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{}, []string{"KubeVela"})
+				_, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{}, []string{"addon_helper_test"})
 				Expect(err).To(HaveOccurred())
 			})
 			It("should return error, empty addonNames are not allowed", func() {
-				_, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, nil, []string{"KubeVela"})
+				_, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, nil, []string{"addon_helper_test"})
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("one existing addon name provided", func() {
 			It("should return one valid result, matching all registries", func() {
-				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"velaux"}, nil)
+				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"foo"}, nil)
+
 				Expect(err).To(Succeed())
 				Expect(res).To(HaveLen(1))
-				Expect(res[0].Name).To(Equal("velaux"))
-				Expect(res[0].InstallPackage).ToNot(BeNil())
-				Expect(res[0].APISchema).ToNot(BeNil())
+				Expect(res[0].Name).To(Equal("foo"))
 			})
 			It("should return one valid result, matching one registry", func() {
-				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"velaux"}, []string{"KubeVela"})
+				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"foo"}, []string{"addon_helper_test"})
 				Expect(err).To(Succeed())
 				Expect(res).To(HaveLen(1))
-				Expect(res[0].Name).To(Equal("velaux"))
-				Expect(res[0].InstallPackage).ToNot(BeNil())
-				Expect(res[0].APISchema).ToNot(BeNil())
+				Expect(res[0].Name).To(Equal("foo"))
 			})
 		})
 
@@ -108,26 +144,20 @@ var _ = Describe("test FindAddonPackagesDetailFromRegistry", func() {
 
 		Context("two existing addon names provided", func() {
 			It("should return two valid result", func() {
-				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"velaux", "traefik"}, nil)
+				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"foo", "bar"}, nil)
 				Expect(err).To(Succeed())
 				Expect(res).To(HaveLen(2))
-				Expect(res[0].Name).To(Equal("velaux"))
-				Expect(res[0].InstallPackage).ToNot(BeNil())
-				Expect(res[0].APISchema).ToNot(BeNil())
-				Expect(res[1].Name).To(Equal("traefik"))
-				Expect(res[1].InstallPackage).ToNot(BeNil())
-				Expect(res[1].APISchema).ToNot(BeNil())
+				Expect(res[0].Name).To(Equal("foo"))
+				Expect(res[1].Name).To(Equal("bar"))
 			})
 		})
 
 		Context("one existing addon name and one non-existent addon name provided", func() {
 			It("should return only one valid result", func() {
-				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"velaux", "non-existent-addon"}, nil)
+				res, err := FindAddonPackagesDetailFromRegistry(context.Background(), k8sClient, []string{"foo", "non-existent-addon"}, nil)
 				Expect(err).To(Succeed())
 				Expect(res).To(HaveLen(1))
-				Expect(res[0].Name).To(Equal("velaux"))
-				Expect(res[0].InstallPackage).ToNot(BeNil())
-				Expect(res[0].APISchema).ToNot(BeNil())
+				Expect(res[0].Name).To(Equal("foo"))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>


### Description of your changes

The addon helper tests previously used real upstream KubeVela repository, which will sometimes change and make this test flacky.

This PR sets up a local mock server instead, in an effort to make this test more stable.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->