### PR TITLE
Fix: delete appplication fails if status.workflow.endTime not specified.

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -336,7 +336,8 @@ type WorkflowStatus struct {
 	Steps          []workflowv1alpha1.WorkflowStepStatus `json:"steps,omitempty"`
 
 	StartTime metav1.Time `json:"startTime,omitempty"`
-	EndTime   metav1.Time `json:"endTime,omitempty"`
+	// +nullable
+	EndTime metav1.Time `json:"endTime,omitempty"`
 }
 
 // DefinitionType describes the type of DefinitionRevision.

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -848,6 +848,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -2806,6 +2807,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -4942,6 +4944,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -774,6 +774,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean
@@ -1535,6 +1536,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -848,6 +848,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -2806,6 +2807,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -4942,6 +4944,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -774,6 +774,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean
@@ -1535,6 +1536,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -848,6 +848,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -2806,6 +2807,7 @@ spec:
                             x-kubernetes-map-type: atomic
                           endTime:
                             format: date-time
+                            nullable: true
                             type: string
                           finished:
                             type: boolean
@@ -4942,6 +4944,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -774,6 +774,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean
@@ -1535,6 +1536,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   endTime:
                     format: date-time
+                    nullable: true
                     type: string
                   finished:
                     type: boolean


### PR DESCRIPTION
Signed-off-by: old.prince <di7zhang@gmail.com>


### Description of your changes

If the workflow is not completed, the endtime should be null, and the deletion of the application will fail.

#### Error log

```shell
E0106 08:12:02.807341       1 controller.go:317] controller/application "msg"="Reconciler error" "error"="Application.core.oam.dev \"test\" is invalid: status.workflow.endTime: Invalid value: \"null\": status.workflow.endTime in body must be of type string: \"null\"" "name"="test" "namespace"="test" "reconciler group"="core.oam.dev" "reconciler kind"="Application"
```

#### solution

+nullable tag for status.workflow.endTime fields

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


### Special notes for your reviewer

