### PR TITLE
Fix: more explicit error when addon package hasn't a metadata.yaml

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -911,7 +911,6 @@ func NewAddonInstaller(ctx context.Context, cli client.Client, discoveryClient *
 func (h *Installer) enableAddon(addon *InstallPackage) (string, error) {
 	var err error
 	h.addon = addon
-
 	if !h.skipVersionValidate {
 		err = checkAddonVersionMeetRequired(h.ctx, addon.SystemRequirements, h.cli, h.dc)
 		if err != nil {

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -58,6 +58,9 @@ func EnableAddon(ctx context.Context, name string, version string, cli client.Cl
 	if err != nil {
 		return "", err
 	}
+	if err := checkAddonPackageValid(pkg); err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("failed to enable addon: %s", name))
+	}
 	return h.enableAddon(pkg)
 }
 
@@ -105,6 +108,9 @@ func EnableAddonByLocalDir(ctx context.Context, name string, dir string, cli cli
 	pkg, err := GetInstallPackageFromReader(r, &meta, UIData)
 	if err != nil {
 		return "", err
+	}
+	if err := checkAddonPackageValid(pkg); err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("failed to enable addon by local dir: %s", dir))
 	}
 	h := NewAddonInstaller(ctx, cli, dc, applicator, config, &Registry{Name: LocalAddonRegistryName}, args, nil, nil, opts...)
 	needEnableAddonNames, err := h.checkDependency(pkg)

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -58,7 +58,7 @@ func EnableAddon(ctx context.Context, name string, version string, cli client.Cl
 	if err != nil {
 		return "", err
 	}
-	if err := checkAddonPackageValid(pkg); err != nil {
+	if err := validateAddonPackage(pkg); err != nil {
 		return "", errors.Wrap(err, fmt.Sprintf("failed to enable addon: %s", name))
 	}
 	return h.enableAddon(pkg)
@@ -109,7 +109,7 @@ func EnableAddonByLocalDir(ctx context.Context, name string, dir string, cli cli
 	if err != nil {
 		return "", err
 	}
-	if err := checkAddonPackageValid(pkg); err != nil {
+	if err := validateAddonPackage(pkg); err != nil {
 		return "", errors.Wrap(err, fmt.Sprintf("failed to enable addon by local dir: %s", dir))
 	}
 	h := NewAddonInstaller(ctx, cli, dc, applicator, config, &Registry{Name: LocalAddonRegistryName}, args, nil, nil, opts...)

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -504,7 +504,7 @@ func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Applicatio
 	return false
 }
 
-func checkAddonPackageValid(addonPkg *InstallPackage) error {
+func validateAddonPackage(addonPkg *InstallPackage) error {
 	if reflect.DeepEqual(addonPkg.Meta, Meta{}) {
 		return fmt.Errorf("the addon package doesn't have `metadata.yaml`")
 	}

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -501,6 +502,19 @@ func checkBondComponentExist(u unstructured.Unstructured, app v1beta1.Applicatio
 		}
 	}
 	return false
+}
+
+func checkAddonPackageValid(addonPkg *InstallPackage) error {
+	if reflect.DeepEqual(addonPkg.Meta, Meta{}) {
+		return fmt.Errorf("the addon package doesn't have `metadata.yaml`")
+	}
+	if addonPkg.Name == "" {
+		return fmt.Errorf("`matadata.yaml` must define the name of addon")
+	}
+	if addonPkg.Version == "" {
+		return fmt.Errorf("`matadata.yaml` must define the version of addon")
+	}
+	return nil
 }
 
 // FilterDependencyRegistries will return all registries besides the target registry itself

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -423,7 +423,7 @@ func TestCheckAddonPackageValid(t *testing.T) {
 	},
 	}
 	for _, testCase := range testCases {
-		err := checkAddonPackageValid(&InstallPackage{Meta: testCase.testCase})
+		err := validateAddonPackage(&InstallPackage{Meta: testCase.testCase})
 		assert.Equal(t, reflect.DeepEqual(err, testCase.err), true)
 	}
 }

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -399,6 +401,30 @@ func TestFilterDependencyRegistries(t *testing.T) {
 		res := FilterDependencyRegistries(testCase.index, testCase.registries)
 		assert.Equal(t, res, testCase.res)
 		assert.Equal(t, testCase.registries, testCase.origin)
+	}
+}
+
+func TestCheckAddonPackageValid(t *testing.T) {
+	testCases := []struct {
+		testCase Meta
+		err      error
+	}{{
+		testCase: Meta{},
+		err:      fmt.Errorf("the addon pacakge doesn't have `metadata.yaml`"),
+	}, {
+		testCase: Meta{Version: "v1.4.0"},
+		err:      fmt.Errorf("`matadata.yaml` must define the name of addon"),
+	}, {
+		testCase: Meta{Name: "test-addon"},
+		err:      fmt.Errorf("`matadata.yaml` must define the version of addon"),
+	}, {
+		testCase: Meta{Name: "test-addon", Version: "1.4.5"},
+		err:      nil,
+	},
+	}
+	for _, testCase := range testCases {
+		err := checkAddonPackageValid(&InstallPackage{Meta: testCase.testCase})
+		assert.Equal(t, reflect.DeepEqual(err, testCase.err), true)
 	}
 }
 

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -410,7 +410,7 @@ func TestCheckAddonPackageValid(t *testing.T) {
 		err      error
 	}{{
 		testCase: Meta{},
-		err:      fmt.Errorf("the addon pacakge doesn't have `metadata.yaml`"),
+		err:      fmt.Errorf("the addon package doesn't have `metadata.yaml`"),
 	}, {
 		testCase: Meta{Version: "v1.4.0"},
 		err:      fmt.Errorf("`matadata.yaml` must define the name of addon"),

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -185,7 +185,7 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 				if !file.IsDir() {
 					return fmt.Errorf("%s is not addon dir", addonOrDir)
 				}
-				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
+				ioStream.Infof(color.New(color.FgYellow).Sprintf("enabling addon by local dir: %s \n", addonOrDir))
 				// args[0] is a local path install with local dir, use base dir name as addonName
 				abs, err := filepath.Abs(addonOrDir)
 				if err != nil {
@@ -314,7 +314,7 @@ non-empty new arg
 				if !file.IsDir() {
 					return fmt.Errorf("%s is not addon dir", addonOrDir)
 				}
-				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
+				ioStream.Infof(color.New(color.FgYellow).Sprintf("enabling addon by local dir: %s \n", addonOrDir))
 				// args[0] is a local path install with local dir
 				abs, err := filepath.Abs(addonOrDir)
 				if err != nil {


### PR DESCRIPTION
more explicit error when addon package hasn't a metadata.yaml

before:

![image](https://user-images.githubusercontent.com/77846369/211511926-c341ecb5-2e94-4e09-b828-bb370f5083ee.png)

after:

![image](https://user-images.githubusercontent.com/77846369/211512464-4e12d0f1-3928-4f13-91cc-799b985e531a.png)


Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->