### PR TITLE
Feat: enhance the application synchronizer

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1076,6 +1076,8 @@ func (h *Installer) checkDependency(addon *InstallPackage) ([]string, error) {
 
 // createOrUpdate will return true if updated
 func (h *Installer) createOrUpdate(app *v1beta1.Application) (bool, error) {
+	// Set the publish version for the addon application
+	oam.SetPublishVersion(app, apiutils.GenerateVersion("addon"))
 	var existApp v1beta1.Application
 	err := h.cli.Get(h.ctx, client.ObjectKey{Name: app.Name, Namespace: app.Namespace}, &existApp)
 	if apierrors.IsNotFound(err) {
@@ -1087,8 +1089,6 @@ func (h *Installer) createOrUpdate(app *v1beta1.Application) (bool, error) {
 	existApp.Spec = app.Spec
 	existApp.Labels = app.Labels
 	existApp.Annotations = app.Annotations
-	// Set the publish version for the addon application
-	oam.SetPublishVersion(&existApp, apiutils.GenerateVersion("addon"))
 	err = h.cli.Update(h.ctx, &existApp)
 	if err != nil {
 		klog.Errorf("fail to create application: %v", err)

--- a/pkg/apiserver/domain/model/whole.go
+++ b/pkg/apiserver/domain/model/whole.go
@@ -38,6 +38,8 @@ const (
 
 	// LabelSyncGeneration describes the generation synced from
 	LabelSyncGeneration = "ux.oam.dev/synced-generation"
+	// LabelSyncRevision describes the revision name synced from
+	LabelSyncRevision = "ux.oam.dev/synced-revision"
 	// LabelSyncNamespace describes the namespace synced from
 	LabelSyncNamespace = "ux.oam.dev/from-namespace"
 )

--- a/pkg/apiserver/domain/repository/suite_test.go
+++ b/pkg/apiserver/domain/repository/suite_test.go
@@ -106,7 +106,7 @@ func NewDatastore(cfg datastore.Config) (ds datastore.DataStore, err error) {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}
 	case "kubeapi":
-		ds, err = kubeapi.New(context.Background(), cfg)
+		ds, err = kubeapi.New(context.Background(), cfg, k8sClient)
 		if err != nil {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}

--- a/pkg/apiserver/domain/service/suite_test.go
+++ b/pkg/apiserver/domain/service/suite_test.go
@@ -104,7 +104,7 @@ func NewDatastore(cfg datastore.Config) (ds datastore.DataStore, err error) {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}
 	case "kubeapi":
-		ds, err = kubeapi.New(context.Background(), cfg)
+		ds, err = kubeapi.New(context.Background(), cfg, k8sClient)
 		if err != nil {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}

--- a/pkg/apiserver/event/collect/suit_test.go
+++ b/pkg/apiserver/event/collect/suit_test.go
@@ -89,7 +89,7 @@ func NewDatastore(cfg datastore.Config) (ds datastore.DataStore, err error) {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}
 	case "kubeapi":
-		ds, err = kubeapi.New(context.Background(), cfg)
+		ds, err = kubeapi.New(context.Background(), cfg, k8sClient)
 		if err != nil {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}

--- a/pkg/apiserver/event/collect/system_info_collect_test.go
+++ b/pkg/apiserver/event/collect/system_info_collect_test.go
@@ -83,7 +83,8 @@ var _ = Describe("Test calculate cronJob", func() {
 		testProject = "test-cronjob-project"
 		mockDataInDs()
 		i = InfoCalculateCronJob{
-			Store: ds,
+			Store:      ds,
+			KubeClient: k8sClient,
 		}
 		systemInfo := model.SystemInfo{InstallID: "test-id", EnableCollection: true}
 		Expect(ds.Add(ctx, &systemInfo)).Should(SatisfyAny(BeNil(), DataExistMatcher{}))

--- a/pkg/apiserver/event/sync/cache.go
+++ b/pkg/apiserver/event/sync/cache.go
@@ -91,11 +91,9 @@ func (c *CR2UX) shouldSync(ctx context.Context, targetApp *v1beta1.Application, 
 		_, _, err := c.getApp(ctx, targetApp.Name, targetApp.Namespace)
 		if del || err != nil {
 			c.cache.Delete(key)
-		} else {
-			if cd.revision == getRevision(*targetApp) {
-				klog.V(5).Infof("app %s/%s with resource revision(%v) hasn't updated, ignore the sync event..", targetApp.Name, targetApp.Namespace, targetApp.ResourceVersion)
-				return false
-			}
+		} else if cd.revision == getRevision(*targetApp) {
+			klog.V(5).Infof("app %s/%s with resource revision(%v) hasn't updated, ignore the sync event..", targetApp.Name, targetApp.Namespace, targetApp.ResourceVersion)
+			return false
 		}
 	}
 	return true

--- a/pkg/apiserver/event/sync/cache_test.go
+++ b/pkg/apiserver/event/sync/cache_test.go
@@ -68,14 +68,18 @@ var _ = Describe("Test Cache", func() {
 		app1 := &v1beta1.Application{}
 		app1.Name = "app1"
 		app1.Namespace = "app1-ns"
-		app1.ResourceVersion = "1"
 		Expect(cr2ux.shouldSync(ctx, app1, false)).Should(BeEquivalentTo(true))
 
 		app2 := &v1beta1.Application{}
 		app2.Name = "app2"
 		app2.Namespace = "app2-ns"
-		app2.ResourceVersion = "1"
+		app2.Generation = 1
+		app2.Status.LatestRevision = &common.Revision{Name: "v1"}
 
+		Expect(cr2ux.shouldSync(ctx, app2, false)).Should(BeEquivalentTo(true))
+
+		// Only need to sync once.
+		cr2ux.syncCache(formatAppComposedName(app2.Name, app2.Namespace), "v1", 1)
 		Expect(cr2ux.shouldSync(ctx, app2, false)).Should(BeEquivalentTo(false))
 
 		app3 := &v1beta1.Application{}
@@ -83,18 +87,17 @@ var _ = Describe("Test Cache", func() {
 		app3.Namespace = "app3-ns"
 		app3.ResourceVersion = "3"
 		app3.Labels = map[string]string{
-			model.LabelSyncGeneration: "1",
-			model.LabelSyncNamespace:  "app3-ns",
-			model.LabelSourceOfTruth:  model.FromUX,
+			model.LabelSourceOfTruth: model.FromUX,
 		}
 
 		Expect(cr2ux.shouldSync(ctx, app3, false)).Should(BeEquivalentTo(false))
 
 		Expect(ds.Put(ctx, &model.Application{Name: "app1", Labels: map[string]string{
-			model.LabelSyncGeneration: "1",
-			model.LabelSyncNamespace:  "app1-ns",
+			model.LabelSyncRevision:  "v1",
+			model.LabelSyncNamespace: "app1-ns",
 		}})).Should(BeNil())
-		cr2ux.syncCache(formatAppComposedName(app1.Name, app1.Namespace), "1", 0)
+		cr2ux.syncCache(formatAppComposedName(app1.Name, app1.Namespace), "v1", 0)
+
 		Expect(cr2ux.shouldSync(ctx, app1, false)).Should(BeEquivalentTo(false))
 		Expect(cr2ux.shouldSync(ctx, app1, true)).Should(BeEquivalentTo(true))
 		Expect(ds.Delete(ctx, &model.Application{Name: "app1"})).Should(BeNil())

--- a/pkg/apiserver/event/sync/cache_test.go
+++ b/pkg/apiserver/event/sync/cache_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Test Cache", func() {
 			model.LabelSyncNamespace: "app1-ns",
 		}})).Should(BeNil())
 		cr2ux.syncCache(formatAppComposedName(app1.Name, app1.Namespace), "v1", 0)
-
+		app1.Status.LatestRevision = &common.Revision{Name: "v1"}
 		Expect(cr2ux.shouldSync(ctx, app1, false)).Should(BeEquivalentTo(false))
 		Expect(cr2ux.shouldSync(ctx, app1, true)).Should(BeEquivalentTo(true))
 		Expect(ds.Delete(ctx, &model.Application{Name: "app1"})).Should(BeNil())

--- a/pkg/apiserver/event/sync/cr2ux.go
+++ b/pkg/apiserver/event/sync/cr2ux.go
@@ -133,7 +133,10 @@ func (c *CR2UX) AddOrUpdate(ctx context.Context, targetApp *v1beta1.Application)
 	}
 
 	// update cache
-	c.syncCache(dsApp.AppMeta.PrimaryKey(), targetApp.ResourceVersion, int64(len(dsApp.Targets)))
+	key := formatAppComposedName(targetApp.Name, targetApp.Namespace)
+	syncedVersion := getSyncedRevision(dsApp.Revision)
+	c.syncCache(key, syncedVersion, int64(len(dsApp.Targets)))
+	klog.Infof("application %s/%s revision %s synced successful", targetApp.Name, targetApp.Namespace, syncedVersion)
 	return nil
 }
 

--- a/pkg/apiserver/event/sync/cr2ux_test.go
+++ b/pkg/apiserver/event/sync/cr2ux_test.go
@@ -26,6 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/service"
@@ -138,7 +139,7 @@ var _ = Describe("Test CR convert to ux", func() {
 		app2 := &v1beta1.Application{}
 		Expect(common2.ReadYamlToObject("testdata/test-app2.yaml", app2)).Should(BeNil())
 		app1.Namespace = appNS1
-		app1.Generation = 2
+		app1.Status.LatestRevision = &common.Revision{Name: "v2"}
 		app1.Spec = app2.Spec
 		Expect(cr2ux.AddOrUpdate(context.Background(), app1)).Should(BeNil())
 		comp3 := model.ApplicationComponent{AppPrimaryKey: apName1, Name: "blog"}

--- a/pkg/apiserver/event/sync/suit_test.go
+++ b/pkg/apiserver/event/sync/suit_test.go
@@ -87,7 +87,7 @@ func NewDatastore(cfg datastore.Config) (ds datastore.DataStore, err error) {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}
 	case "kubeapi":
-		ds, err = kubeapi.New(context.Background(), cfg)
+		ds, err = kubeapi.New(context.Background(), cfg, k8sClient)
 		if err != nil {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}

--- a/pkg/apiserver/event/sync/worker.go
+++ b/pkg/apiserver/event/sync/worker.go
@@ -101,7 +101,7 @@ func (a *ApplicationSync) Start(ctx context.Context, errorChan chan error) {
 		app := getApp(obj)
 		if app.DeletionTimestamp == nil {
 			a.Queue.Add(app)
-			klog.Infof("watched update/add app event, namespace: %s, name: %s", app.Namespace, app.Name)
+			klog.V(4).Infof("watched update/add app event, namespace: %s, name: %s", app.Namespace, app.Name)
 		}
 	}
 
@@ -114,7 +114,7 @@ func (a *ApplicationSync) Start(ctx context.Context, errorChan chan error) {
 		},
 		DeleteFunc: func(obj interface{}) {
 			app := getApp(obj)
-			klog.Infof("watched delete app event, namespace: %s, name: %s", app.Namespace, app.Name)
+			klog.V(4).Infof("watched delete app event, namespace: %s, name: %s", app.Namespace, app.Name)
 			a.Queue.Forget(app)
 			a.Queue.Done(app)
 			err = cu.DeleteApp(ctx, app)

--- a/pkg/apiserver/event/sync/worker_test.go
+++ b/pkg/apiserver/event/sync/worker_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/model"
 	"github.com/oam-dev/kubevela/pkg/apiserver/domain/repository"
@@ -132,6 +133,9 @@ var _ = Describe("Test Worker CR sync to datastore", func() {
 		Expect(common2.ReadYamlToObject("testdata/test-app3.yaml", newapp2)).Should(BeNil())
 		app2.Spec = newapp2.Spec
 		Expect(k8sClient.Update(context.TODO(), app2)).Should(BeNil())
+
+		app2.Status.LatestRevision = &common.Revision{Name: "v3"}
+		Expect(k8sClient.Status().Update(context.TODO(), app2)).Should(BeNil())
 
 		Eventually(func() error {
 			appm := model.ApplicationComponent{AppPrimaryKey: formatAppComposedName(app2.Name, app2.Namespace), Name: "nginx2"}

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_suite_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/kubeapi_suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func(done Done) {
 	By("new kube client success")
 
 	clients.SetKubeClient(k8sClient)
-	kubeStore, err = New(context.TODO(), datastore.Config{Database: "test"})
+	kubeStore, err = New(context.TODO(), datastore.Config{Database: "test"}, k8sClient)
 	Expect(err).Should(BeNil())
 	Expect(kubeStore).ToNot(BeNil())
 	close(done)

--- a/pkg/apiserver/infrastructure/datastore/kubeapi/migrate_test.go
+++ b/pkg/apiserver/infrastructure/datastore/kubeapi/migrate_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Test Migrate", func() {
 		cm.Namespace = nsName
 		Expect(ds.kubeClient.Create(context.Background(), cm)).Should(BeNil())
 
-		migrate(nsName)
+		migrate(nsName, k8sClient)
 		cmList := v1.ConfigMapList{}
 		Expect(k8sClient.List(context.Background(), &cmList, client.InNamespace(nsName))).Should(BeNil())
 		Expect(len(cmList.Items)).Should(BeEquivalentTo(2))

--- a/pkg/apiserver/interfaces/api/api_suite_test.go
+++ b/pkg/apiserver/interfaces/api/api_suite_test.go
@@ -90,7 +90,7 @@ func NewDatastore(cfg datastore.Config) (ds datastore.DataStore, err error) {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}
 	case "kubeapi":
-		ds, err = kubeapi.New(context.Background(), cfg)
+		ds, err = kubeapi.New(context.Background(), cfg, k8sClient)
 		if err != nil {
 			return nil, fmt.Errorf("create mongodb datastore instance failure %w", err)
 		}

--- a/pkg/apiserver/interfaces/api/target.go
+++ b/pkg/apiserver/interfaces/api/target.go
@@ -121,7 +121,7 @@ func (dt *Target) createTarget(req *restful.Request, res *restful.Response) {
 	// Call the domain layer code
 	TargetDetail, err := dt.TargetService.CreateTarget(req.Request.Context(), createReq)
 	if err != nil {
-		klog.Errorf("create -target failure %s", err.Error())
+		klog.Errorf("create target failure %s", err.Error())
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -86,6 +86,12 @@ func (c *authClient) Status() client.StatusWriter {
 	return &authAppStatusClient{StatusWriter: c.Client.Status()}
 }
 
+// Get .
+func (c *authClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	ctx = ContextWithUserInfo(ctx)
+	return c.Client.Get(ctx, key, obj)
+}
+
 // List .
 func (c *authClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 	ctx = ContextWithUserInfo(ctx)

--- a/pkg/auth/round_trippers.go
+++ b/pkg/auth/round_trippers.go
@@ -24,6 +24,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
 
 	"github.com/oam-dev/kubevela/pkg/utils"
 )
@@ -50,6 +51,7 @@ func (rt *impersonatingRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	ctx := req.Context()
 	req = req.Clone(ctx)
 	userInfo, exists := request.UserFrom(ctx)
+	klog.V(7).Infof("impersonation request log. path: %s method: %s user info: %+v", req.URL.String(), req.Method, userInfo)
 	if exists && userInfo != nil {
 		if name := userInfo.GetName(); name != "" {
 			req.Header.Set(transport.ImpersonateUserHeader, name)

--- a/test/e2e-apiserver-test/application_sync_test.go
+++ b/test/e2e-apiserver-test/application_sync_test.go
@@ -108,12 +108,13 @@ var _ = Describe("Test the application synchronizing", func() {
 			}
 			recordRes := get(fmt.Sprintf("/applications/%s/workflows/%s/records", appName, repository.ConvertWorkflowName(list.Revisions[0].EnvName)))
 			var lrr apisv1.ListWorkflowRecordsResponse
-			Expect(decodeResponseBody(res, &recordRes)).Should(Succeed())
+			Expect(decodeResponseBody(recordRes, &lrr)).Should(Succeed())
 			Expect(lrr.Total).Should(Equal(int64(2)))
 			Expect(lrr.Records[1].Name).Should(Equal("test-v2"))
 
-			if list.Revisions[0].Status != "complete" {
-				return fmt.Errorf("the new revision status is %s, record status is %s, not complete", list.Revisions[0].Status, lrr.Records[1].Status)
+			// The workflow includes a suspend step.
+			if lrr.Records[1].Status != "suspending" {
+				return fmt.Errorf("the record status is %s, not suspending", lrr.Records[1].Status)
 			}
 			return nil
 		}).WithTimeout(time.Minute * 1).WithPolling(3 * time.Second).Should(BeNil())


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes


Before, we use the generation number as the cache key. If users only change the publish version to rerun the workflow, the application spec does not change, the generation does not change, so the revision and the workflow record can not be synced.

In PR #5282 try to use the resource version as the cache key. The resource version changes constantly When the application workflow running. We did not need to sync the record status in the application synchronizer, so, this resulted in excessive database requests.

Now, we use the revision as the cache key. When the new revision is generated the app synchronizer should resync the application.

This PR makes the API server use the unitive auth client to request the kube API.


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->