### PR TITLE
Fix: fix error info when there is no note.cue and optimize addon init command

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1210,6 +1210,9 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 }
 
 func (h *Installer) renderNotes(addon *InstallPackage) (string, error) {
+	if len(addon.Notes.Data) == 0 {
+		return "", nil
+	}
 	r := addonCueTemplateRender{
 		addon:     addon,
 		inputArgs: h.args,

--- a/pkg/addon/init.go
+++ b/pkg/addon/init.go
@@ -196,9 +196,13 @@ func (cmd *InitCmd) createHelmComponent() error {
 	tmpl := helmComponentTmpl{}
 	tmpl.Type = "helm"
 	tmpl.Properties.RepoType = "helm"
+	if strings.HasPrefix(cmd.HelmRepoURL, "oci") {
+		tmpl.Properties.RepoType = "oci"
+	}
 	tmpl.Properties.URL = cmd.HelmRepoURL
 	tmpl.Properties.Chart = cmd.HelmChartName
 	tmpl.Properties.Version = cmd.HelmChartVersion
+	tmpl.Name = "addon-" + cmd.AddonName
 
 	str, err := toCUEResourceString(tmpl)
 	if err != nil {
@@ -383,6 +387,7 @@ func (cmd *InitCmd) writeFiles() error {
 
 // helmComponentTmpl is a template for a helm component .cue in an addon
 type helmComponentTmpl struct {
+	Name       string `json:"name"`
 	Type       string `json:"type"`
 	Properties struct {
 		RepoType string `json:"repoType"`

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -50,19 +50,6 @@ import (
 )
 
 const (
-	// DescAnnotation records the description of addon
-	DescAnnotation = "addons.oam.dev/description"
-
-	// DependsOnWorkFlowStepName is workflow step name which is used to check dependsOn app
-	DependsOnWorkFlowStepName = "depends-on-app"
-
-	// AddonTerraformProviderNamespace is the namespace of addon terraform provider
-	AddonTerraformProviderNamespace = "default"
-	// AddonTerraformProviderNameArgument is the argument name of addon terraform provider
-	AddonTerraformProviderNameArgument = "providerName"
-)
-
-const (
 	statusEnabled  = "enabled"
 	statusDisabled = "disabled"
 	statusSuspend  = "suspend"


### PR DESCRIPTION
1. fix error info when there is no note.cue of addon 
![image](https://user-images.githubusercontent.com/77846369/211739923-25e8c6df-5349-4d90-9b7d-7ff29348ecfd.png)
3. optimize addon init command, set the component name and add oci helm repo  for helm 

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>

name the compoennt

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->