### PR TITLE
Feat: velaql support indexing into exported array field

### DIFF
--- a/pkg/velaql/parse.go
+++ b/pkg/velaql/parse.go
@@ -37,7 +37,7 @@ type QueryView struct {
 
 const (
 	// PatternQL is the pattern string of velaQL, velaQL's query syntax is `ViewName{key1=value1 ,key2="value2",}.Export`
-	PatternQL = `(?P<view>[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)(?P<parameter>{.*?})?\.?(?P<export>[_a-zA-Z][\._a-zA-Z0-9]*)?`
+	PatternQL = `(?P<view>[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)(?P<parameter>{.*?})?\.?(?P<export>[_a-zA-Z][\._a-zA-Z0-9\[\]]*)?`
 	// PatternKV is the pattern string of parameter
 	PatternKV = `(?P<key>[^=]+)=(?P<value>[^=]*?)(?:,|$)`
 	// KeyWordView represent view keyword

--- a/pkg/velaql/parse_test.go
+++ b/pkg/velaql/parse_test.go
@@ -58,6 +58,13 @@ func TestParseVelaQL(t *testing.T) {
 			Export: "output.value.spec",
 		},
 		err: nil,
+	}, {
+		ql: `view{test=true}.output.value[0].spec`,
+		query: QueryView{
+			View:   "view",
+			Export: "output.value[0].spec",
+		},
+		err: nil,
 	}}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
Signed-off-by: hnd4r7 <307365651@qq.com>


### Description of your changes
Support indexing array field in the exported value of the velaql query result to satisfy certain needs such as getting the cluster name of the first pod in component-pod-view.

Before, 
![image](https://user-images.githubusercontent.com/10682438/211798505-b5571b33-4239-4780-aefd-fc34145a267b.png)
After,
![image](https://user-images.githubusercontent.com/10682438/211798524-01cb9858-3e52-4869-a682-69e24a1b3c8c.png)

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->