### PR TITLE
Fix: correct typo in the long cli description of vela system command

### DIFF
--- a/references/cli/system.go
+++ b/references/cli/system.go
@@ -58,7 +58,7 @@ func NewSystemCommand(c common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "system",
 		Short: "Manage system.",
-		Long:  "Manage system, incluing printing the system deployment information in vela-system namespace and diagnosing the system's health.",
+		Long:  "Manage system, including printing the system deployment information in vela-system namespace and diagnosing the system's health.",
 		Example: "# Check all deployments information in all namespaces with label app.kubernetes.io/name=vela-core :\n" +
 			"> vela system info\n" +
 			"# Specify a deployment name with a namespace to check detail information:\n" +


### PR DESCRIPTION
### Description of your changes

Fix typo in the long cli description of vela system command

Ad hoc

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [X] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

just run `vela system`


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->