### PR TITLE
Fix: optimize skip reconcile and expose error if the traits patch an invalid workload like terraform

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -254,7 +254,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		}
 	case workflowv1alpha1.WorkflowStateSkipped:
-		return ctrl.Result{}, nil
+		return r.result(nil).requeue(executor.GetBackoffWaitTime()).ret()
 	default:
 	}
 

--- a/pkg/cue/definition/template.go
+++ b/pkg/cue/definition/template.go
@@ -351,13 +351,16 @@ func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, param
 
 	patcher := val.LookupPath(value.FieldPath(PatchFieldName))
 	base, auxiliaries := ctx.Output()
-	if base != nil && patcher.Exists() {
+	if patcher.Exists() {
+		if base == nil {
+			return fmt.Errorf("patch trait %s into an invalid workload", td.name)
+		}
 		if err := base.Unify(patcher, sets.CreateUnifyOptionsForPatcher(patcher)...); err != nil {
 			return errors.WithMessagef(err, "invalid patch trait %s into workload", td.name)
 		}
 	}
 	outputsPatcher := val.LookupPath(value.FieldPath(PatchOutputsFieldName))
-	if base != nil && outputsPatcher.Exists() {
+	if outputsPatcher.Exists() {
 		for _, auxiliary := range auxiliaries {
 			target := outputsPatcher.LookupPath(value.FieldPath(auxiliary.Name))
 			if !target.Exists() {


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix: optimize skip reconcile and expose error if the traits patch an invalid workload like terraform

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->