### PR TITLE
Feat: vela cluster export config

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -108,7 +108,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 
 		// Workflows
 		NewWorkflowCommand(commandArgs, ioStream),
-		ClusterCommandGroup(commandArgs, ioStream),
+		ClusterCommandGroup(f, commandArgs, ioStream),
 
 		// Debug
 		NewDebugCommand(commandArgs, ioStream),

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -202,6 +202,12 @@ var _ = Describe("Test multicluster scenario", func() {
 			Expect(err).Should(Succeed())
 		})
 
+		It("Test vela cluster export-config", func() {
+			out, err := execCommand("cluster", "export-config")
+			Expect(err).Should(Succeed())
+			Expect(out).Should(ContainSubstring("name: " + WorkerClusterName))
+		})
+
 	})
 
 	Context("Test multi-cluster Application", func() {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support export multi-cluster kubeconfig.

```
Export multi-cluster kubeconfig

 Load existing cluster kubeconfig and list clusters registered in KubeVela. Export the proxy access of these clusters to
KubeConfig and print it out.

Usage:
  vela cluster export-config [flags]

Examples:
  # Export all clusters to kubeconfig
  vela cluster export-config
  
  # Export clusters with specified kubeconfig
  KUBECONFIG=./my-hub-cluster.kubeconfig vela cluster export-config
  
  # Export clusters with specified labels
  vela cluster export-config -l gpu-cluster=true
  
  # Export clusters to kubeconfig and save in file
  vela cluster export-config > my-vela.kubeconfig
  
  # Use the exported kubeconfig in kubectl
  KUBECONFIG=my-vela.kubeconfig kubectl get namespaces --cluster c2

Flags:
  -h, --help              help for export-config
  -l, --selector string   LabelSelector for select clusters to export.

Global Flags:
  -y, --yes   Assume yes for all user prompts
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->