### PR TITLE
[Backport release-1.6] Fix: conflict while using gc policy and shared-resource policy concurrently (#5330)

### DIFF
--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Install ginkgo
         run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo apt-get update
           sudo apt-get install -y golang-ginkgo-dev
 
       - name: Start MongoDB

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Install ginkgo
         run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo apt-get update
           sudo apt-get install -y golang-ginkgo-dev
 
       - name: Setup K3d

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -364,6 +364,7 @@ func (h *gcHandler) deleteManagedResource(ctx context.Context, mr v1beta1.Manage
 				return nil
 			}
 		}
+		util.RemoveAnnotations(entry.obj, []string{oam.AnnotationAppSharedBy})
 		if mr.SkipGC {
 			if labels := entry.obj.GetLabels(); labels != nil {
 				delete(labels, oam.LabelAppName)

--- a/test/e2e-multicluster-test/testdata/app/app-gc-shared.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-gc-shared.yaml
@@ -1,0 +1,26 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-gc-shared
+spec:
+  components:
+    - type: k8s-objects
+      name: app-gc-shared
+      properties:
+        objects:
+          - apiVersion: v1
+            kind: ConfigMap
+  policies:
+    - name: gc-policy
+      type: garbage-collect
+      properties:
+        rules:
+          - selector:
+              resourceTypes: ["ConfigMap"]
+            strategy: never
+    - name: shared-policy
+      type: shared-resource
+      properties:
+        rules:
+          - selector:
+              resourceTypes: ["ConfigMap"]


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Backport #5330 into release-1.6

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->