### PR TITLE
Fix: delete example url in definitions that refer to workflowrun example

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Apply terraform configuration in the step
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: apply-terraform-config
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Apply terraform provider config
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: apply-terraform-provider
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/build-push-image.yaml
+++ b/charts/vela-core/templates/defwithtemplate/build-push-image.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Build and push image from git url
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/built-push-image.yaml
   name: build-push-image
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/request.yaml
+++ b/charts/vela-core/templates/defwithtemplate/request.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Send request to the url
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/request.yaml
   name: request
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
@@ -5,7 +5,6 @@ kind: WorkflowStepDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Run a vela command
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: vela-cli
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/apply-terraform-config.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/apply-terraform-config.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Apply terraform configuration in the step
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: apply-terraform-config
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/apply-terraform-provider.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/apply-terraform-provider.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Apply terraform provider config
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: apply-terraform-provider
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/build-push-image.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/build-push-image.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Build and push image from git url
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/built-push-image.yaml
   name: build-push-image
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/request.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/request.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     definition.oam.dev/alias: ""
     definition.oam.dev/description: Send request to the url
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/request.yaml
   name: request
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/charts/vela-minimal/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/vela-cli.yaml
@@ -5,7 +5,6 @@ kind: WorkflowStepDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Run a vela command
-    definition.oam.dev/example-url: https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml
   name: vela-cli
   namespace: {{ include "systemDefinitionNamespace" . }}
 spec:

--- a/vela-templates/definitions/internal/workflowstep/apply-terraform-config.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-terraform-config.cue
@@ -4,9 +4,6 @@ import (
 
 "apply-terraform-config": {
 	alias: ""
-	annotations: {
-		"definition.oam.dev/example-url": "https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml"
-	}
 	attributes: {}
 	description: "Apply terraform configuration in the step"
 	labels: {}

--- a/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
@@ -5,9 +5,6 @@ import (
 
 "apply-terraform-provider": {
 	alias: ""
-	annotations: {
-		"definition.oam.dev/example-url": "https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml"
-	}
 	attributes: {}
 	description: "Apply terraform provider config"
 	labels: {}

--- a/vela-templates/definitions/internal/workflowstep/build-push-image.cue
+++ b/vela-templates/definitions/internal/workflowstep/build-push-image.cue
@@ -6,9 +6,6 @@ import (
 
 "build-push-image": {
 	alias: ""
-	annotations: {
-		"definition.oam.dev/example-url": "https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/built-push-image.yaml"
-	}
 	attributes: {}
 	description: "Build and push image from git url"
 	labels: {}

--- a/vela-templates/definitions/internal/workflowstep/request.cue
+++ b/vela-templates/definitions/internal/workflowstep/request.cue
@@ -5,9 +5,6 @@ import (
 
 request: {
 	alias: ""
-	annotations: {
-		"definition.oam.dev/example-url": "https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/request.yaml"
-	}
 	attributes: {}
 	description: "Send request to the url"
 	labels: {}

--- a/vela-templates/definitions/internal/workflowstep/vela-cli.cue
+++ b/vela-templates/definitions/internal/workflowstep/vela-cli.cue
@@ -3,10 +3,7 @@ import (
 )
 
 "vela-cli": {
-	type: "workflow-step"
-	annotations: {
-		"definition.oam.dev/example-url": "https://raw.githubusercontent.com/kubevela/workflow/main/examples/workflow-run/apply-terraform-resource.yaml"
-	}
+	type:        "workflow-step"
 	description: "Run a vela command"
 }
 template: {


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix: delete example url in definitions that refer to workflowrun example

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->