### PR TITLE
Fix:Terraform typed ComponentDefinition generation issues

### DIFF
--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -282,6 +282,7 @@ variable "intVar" {
 			configuration: `
 variable "name" {
   default = "abc"
+  type = string 
 }`,
 			want: want{
 				subStr: "abc",
@@ -292,6 +293,7 @@ variable "name" {
 			configuration: `
 variable "name" {
   default = [123]
+  type = string
 }`,
 			want: want{
 				subStr: "123",
@@ -302,6 +304,7 @@ variable "name" {
 			configuration: `
 variable "name" {
   default = {a = 1}
+  type = string
 }`,
 			want: want{
 				subStr: "a",
@@ -312,6 +315,7 @@ variable "name" {
 			configuration: `
 variable "name" {
   default = 123
+  type = string
 }`,
 			want: want{
 				subStr: "123",


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #3179 ":
 When a variable's type isn't specified, set it to string
-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->