### PR TITLE
Fix: Add confirmation prompt for vela adopt --apply with existing app name

### DIFF
--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -190,9 +191,9 @@ func (opt *AdoptOptions) Complete(f velacmd.Factory, cmd *cobra.Command, args []
 		opt.AdoptTemplate = defaultAdoptTemplate
 	}
 	if opt.AppName != "" {
-		config := client.Client(client.Options{})
-		c := config.GetClient()
-		app, err := loadRemoteApplication(c, opt.AppNamespace, opt.AppName)
+		var ctx = context.Background()
+		app := &v1beta1.Application{}
+		err := f.Client().Get(ctx, apitypes.NamespacedName{Namespace: opt.AppNamespace, Name: opt.AppName}, app)
 		if err == nil && app != nil {
 			if !opt.Yes {
 				userInput := NewUserInput()

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -197,7 +197,7 @@ func (opt *AdoptOptions) Complete(f velacmd.Factory, cmd *cobra.Command, args []
 		if err == nil && app != nil {
 			if !opt.Yes {
 				userInput := NewUserInput()
-				confirm := userInput.AskBool("Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: "+opt.AppName, &UserInputOptions{AssumeYes: true})
+				confirm := userInput.AskBool("Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: "+opt.AppName, &UserInputOptions{AssumeYes: false})
 				if !confirm {
 					return nil
 				}

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -190,14 +190,14 @@ func (opt *AdoptOptions) Complete(f velacmd.Factory, cmd *cobra.Command, args []
 		opt.AdoptTemplate = defaultAdoptTemplate
 	}
 	if opt.AppName != "" {
-		app, err := f.AppGetter().Get(opt.AppName, opt.AppNamespace)
+		config := client.Client(client.Options{})
+		c := config.GetClient()
+		app, err := loadRemoteApplication(c, opt.AppNamespace, opt.AppName)
 		if err == nil && app != nil {
 			if !opt.Yes {
-				confirm, err := util.UserInput("Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: ", o.AppName)
-				if err != nil {
-					return err
-				}
-				if confirm != "Y" {
+				userInput := NewUserInput()
+				confirm := userInput.AskBool("Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: "+opt.AppName, &UserInputOptions{AssumeYes: true})
+				if !confirm {
 					return nil
 				}
 			}

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -189,6 +189,20 @@ func (opt *AdoptOptions) Complete(f velacmd.Factory, cmd *cobra.Command, args []
 	} else {
 		opt.AdoptTemplate = defaultAdoptTemplate
 	}
+	if opt.AppName != "" {
+		app, err := f.AppGetter().Get(opt.AppName, opt.AppNamespace)
+		if err == nil && app != nil {
+			if !opt.Yes {
+				confirm, err := util.UserInput("Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: ", o.AppName)
+				if err != nil {
+					return err
+				}
+				if confirm != "Y" {
+					return nil
+				}
+			}
+		}
+	}
 	opt.AdoptTemplateCUEValue = cuecontext.New().CompileString(fmt.Sprintf("%s\n\n%s: %s", opt.AdoptTemplate, adoptCUETempVal, adoptCUETempFunc))
 	return nil
 }
@@ -441,19 +455,6 @@ func NewAdoptCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
-			if o.AppName != "" {
-				app, err := f.AppGetter().Get(o.AppName)
-				if err == nil && app != nil {
-					if !o.Yes {
-						var confirm string
-						fmt.Fprintf(o.IOStreams.Out, "Application '%s' already exists, apply will override the existing app with the adopted one, please confirm [Y/n]: ", o.AppName)
-						fmt.Fscanf(o.IOStreams.In, "%s", &confirm)
-						if confirm != "Y" {
-							return
-						}
-					}
-				}
-			}
 			cmdutil.CheckErr(o.Run(f, cmd))
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Karanjot Singh <drquark@duck.com>


### Description of your changes
This pull request adds the ability for the vela adopt command to override an existing application when the adopted resource has the same name. When the --yes flag is used and an application with the same name already exists, the user will be prompted to confirm the override. If confirmed, the existing application will be replaced with the adopted one.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5369

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->