### PR TITLE
Fix: rework on apisrever e2e test covergae

### DIFF
--- a/.github/workflows/apiserver-test.yml
+++ b/.github/workflows/apiserver-test.yml
@@ -186,7 +186,7 @@ jobs:
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: /tmp/e2e_apiserver_test.out
+          files: /tmp/e2e-profile.out, /tmp/e2e_apiserver_test.out
           flags: apiserver-e2etests
           name: codecov-umbrella
 


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>


### Description of your changes

We missed server side coverage report. Send it to codecov. Check the `apiserver-e2etests` below to see the effect.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->