### PR TITLE
Fix: ignore validation webhook for ref-objects typed component

### DIFF
--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubevela/workflow/pkg/cue/process"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/types"
 	velaprocess "github.com/oam-dev/kubevela/pkg/cue/process"
 )
@@ -32,7 +33,7 @@ func (p *Parser) ValidateCUESchematicAppfile(a *Appfile) error {
 	for _, wl := range a.Workloads {
 		// because helm & kube schematic has no CUE template
 		// it only validates CUE schematic workload
-		if wl.CapabilityCategory != types.CUECategory {
+		if wl.CapabilityCategory != types.CUECategory || wl.Type == v1alpha1.RefObjectsComponentType {
 			continue
 		}
 		ctxData := GenerateContextDataFromAppFile(a, wl.Name)


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Ref-objects typed component has a load operation on apply component. So for the validation webhook, it will not properly recognize the content of referred objects and therefore cause trait patch error due to the lack of proper workload data.

This PR skip the validation check for ref-objects typed component.

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->