### PR TITLE
Fix: skip last-applied-configuration error for threewaymergepatch

### DIFF
--- a/pkg/utils/apply/patch.go
+++ b/pkg/utils/apply/patch.go
@@ -164,7 +164,7 @@ func getOriginalConfiguration(obj runtime.Object) ([]byte, error) {
 		return nil, nil
 	}
 	original, ok := annots[oam.AnnotationLastAppliedConfig]
-	if !ok {
+	if !ok || original == "-" || original == "skip" {
 		return nil, nil
 	}
 	return []byte(original), nil


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When annotation `app.oam.dev/last-applied-configuration` is set to `-` or `skip`, the threewaymergepatch cannot properly recognize it and report error. This PR fixes it.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->