### PR TITLE
Fix: use get before create or update

### DIFF
--- a/pkg/apiserver/domain/service/target.go
+++ b/pkg/apiserver/domain/service/target.go
@@ -259,7 +259,9 @@ func managePrivilegesForTarget(ctx context.Context, cli client.Client, target *m
 		f, msg = auth.RevokePrivileges, "RevokePrivileges"
 	}
 	if err := f(ctx, cli, []auth.PrivilegeDescription{p}, identity, writer); err != nil {
-		return err
+		klog.Warningf("error encountered for %s: %s", msg, err.Error())
+		// for some cluster, authn/authz is not supported, ignore errors
+		return client.IgnoreNotFound(err)
 	}
 	klog.Infof("%s: %s", msg, writer.String())
 	return nil


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Sometimes, the namespace cannot be created (only update and get are allowed). At this time, CreateOrUpdateNamespace will fail. This PR fixes it.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->