### PR TITLE
Feat: The vela-apiserver supports displaying chart values stored in the OCI registry

### DIFF
--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -45,7 +45,7 @@ func NewHelmService() HelmService {
 type HelmService interface {
 	ListChartNames(ctx context.Context, url string, secretName string, skipCache bool) ([]string, error)
 	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error)
-	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, skipCache bool) (map[string]interface{}, error)
+	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
 	ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error)
 }
 
@@ -99,7 +99,7 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	return chartVersions, nil
 }
 
-func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, skipCache bool) (map[string]interface{}, error) {
+func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
@@ -111,7 +111,7 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 			return nil, bcode.ErrRepoBasicAuth
 		}
 	}
-	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, opts)
+	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {
 		klog.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
 		return nil, bcode.ErrGetChartValues

--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -45,9 +45,9 @@ func NewHelmService() HelmService {
 type HelmService interface {
 	ListChartNames(ctx context.Context, url string, secretName string, skipCache bool) ([]string, error)
 	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error)
-	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error)
+	ListChartValuesFiles(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error)
 	ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error)
-	DeprecatedGetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
+	GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
 }
 
 type defaultHelmImpl struct {
@@ -100,7 +100,7 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	return chartVersions, nil
 }
 
-func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error) {
+func (d defaultHelmImpl) ListChartValuesFiles(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
@@ -120,7 +120,7 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 	return v.Data, nil
 }
 
-func (d defaultHelmImpl) DeprecatedGetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
+func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}

--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -47,6 +47,7 @@ type HelmService interface {
 	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error)
 	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error)
 	ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error)
+	DeprecatedGetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
 }
 
 type defaultHelmImpl struct {
@@ -116,7 +117,29 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 		klog.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
 		return nil, bcode.ErrGetChartValues
 	}
-	return v, nil
+	return v.Data, nil
+}
+
+func (d defaultHelmImpl) DeprecatedGetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
+	if !utils.IsValidURL(repoURL) {
+		return nil, bcode.ErrRepoInvalidURL
+	}
+	var opts *common.HTTPOption
+	var err error
+	if len(secretName) != 0 {
+		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
+		if err != nil {
+			return nil, bcode.ErrRepoBasicAuth
+		}
+	}
+	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
+	if err != nil {
+		klog.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
+		return nil, bcode.ErrGetChartValues
+	}
+	res := make(map[string]interface{}, len(v.Values))
+	flattenKey("", v.Values, res)
+	return res, nil
 }
 
 func (d defaultHelmImpl) ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error) {

--- a/pkg/apiserver/domain/service/helm.go
+++ b/pkg/apiserver/domain/service/helm.go
@@ -45,7 +45,7 @@ func NewHelmService() HelmService {
 type HelmService interface {
 	ListChartNames(ctx context.Context, url string, secretName string, skipCache bool) ([]string, error)
 	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error)
-	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
+	GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (string, error)
 	ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error)
 }
 
@@ -99,26 +99,24 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	return chartVersions, nil
 }
 
-func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
+func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (string, error) {
 	if !utils.IsValidURL(repoURL) {
-		return nil, bcode.ErrRepoInvalidURL
+		return "", bcode.ErrRepoInvalidURL
 	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
 		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
 		if err != nil {
-			return nil, bcode.ErrRepoBasicAuth
+			return "", bcode.ErrRepoBasicAuth
 		}
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {
 		klog.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
-		return nil, bcode.ErrGetChartValues
+		return "", bcode.ErrGetChartValues
 	}
-	res := make(map[string]interface{}, len(v))
-	flattenKey("", v, res)
-	return res, nil
+	return v, nil
 }
 
 func (d defaultHelmImpl) ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error) {

--- a/pkg/apiserver/domain/service/helm_test.go
+++ b/pkg/apiserver/domain/service/helm_test.go
@@ -213,7 +213,7 @@ var _ = Describe("test helm usecasae", func() {
 		Expect(len(versions)).Should(BeEquivalentTo(1))
 		Expect(versions[0].Version).Should(BeEquivalentTo("8.8.23"))
 
-		values, err := u.GetChartValues(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", "helm", false)
+		values, err := u.ListChartValuesFiles(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", "helm", false)
 		Expect(err).Should(BeNil())
 		Expect(values).ShouldNot(BeNil())
 		Expect(len(values)).ShouldNot(BeEquivalentTo(0))
@@ -228,7 +228,7 @@ var _ = Describe("test helm usecasae", func() {
 		_, err = u.ListChartVersions(ctx, "http://127.0.0.1:8080", "mysql", "repo-secret-notExist", false)
 		Expect(err).ShouldNot(BeNil())
 
-		_, err = u.GetChartValues(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", "helm", false)
+		_, err = u.ListChartValuesFiles(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", "helm", false)
 		Expect(err).ShouldNot(BeNil())
 	})
 })

--- a/pkg/apiserver/domain/service/helm_test.go
+++ b/pkg/apiserver/domain/service/helm_test.go
@@ -213,7 +213,7 @@ var _ = Describe("test helm usecasae", func() {
 		Expect(len(versions)).Should(BeEquivalentTo(1))
 		Expect(versions[0].Version).Should(BeEquivalentTo("8.8.23"))
 
-		values, err := u.GetChartValues(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", false)
+		values, err := u.GetChartValues(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", "helm", false)
 		Expect(err).Should(BeNil())
 		Expect(values).ShouldNot(BeNil())
 		Expect(len(values)).ShouldNot(BeEquivalentTo(0))
@@ -228,7 +228,7 @@ var _ = Describe("test helm usecasae", func() {
 		_, err = u.ListChartVersions(ctx, "http://127.0.0.1:8080", "mysql", "repo-secret-notExist", false)
 		Expect(err).ShouldNot(BeNil())
 
-		_, err = u.GetChartValues(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", false)
+		_, err = u.GetChartValues(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", "helm", false)
 		Expect(err).ShouldNot(BeNil())
 	})
 })

--- a/pkg/apiserver/interfaces/api/repository.go
+++ b/pkg/apiserver/interfaces/api/repository.go
@@ -99,7 +99,7 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
 		Returns(200, "OK", "").
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes([]string{}))
+		Writes(map[string]string{}))
 
 	ws.Route(ws.GET("/charts/{chart}/versions/{version}/values").To(h.chartValues).
 		Doc("get chart value").Deprecate().
@@ -108,7 +108,7 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
 		Returns(200, "OK", map[string]interface{}{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes([]string{}))
+		Writes(map[string]string{}))
 
 	ws.Route(ws.GET("/image/repos").To(h.getImageRepos).
 		Doc("get the oci repos").

--- a/pkg/apiserver/interfaces/api/repository.go
+++ b/pkg/apiserver/interfaces/api/repository.go
@@ -97,7 +97,7 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string").Required(true)).
 		Param(ws.QueryParameter("repoType", "helm repository type").DataType("string").Required(true)).
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
-		Returns(200, "OK", map[string]interface{}{}).
+		Returns(200, "OK", "").
 		Returns(400, "Bad Request", bcode.Bcode{}).
 		Writes([]string{}))
 
@@ -188,12 +188,12 @@ func (h repository) chartValues(req *restful.Request, res *restful.Response) {
 		return
 	}
 
-	versions, err := h.HelmService.GetChartValues(req.Request.Context(), url, chartName, version, secName, repoType, skipCache)
+	values, err := h.HelmService.GetChartValues(req.Request.Context(), url, chartName, version, secName, repoType, skipCache)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return
 	}
-	err = res.WriteEntity(versions)
+	err = res.WriteEntity(values)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/pkg/utils/helm/helm_helper.go
+++ b/pkg/utils/helm/helm_helper.go
@@ -60,6 +60,7 @@ const (
 	valuesPatten = "repoUrl: %s, chart: %s, version: %s"
 )
 
+// ChartValues contain all values files in chart and default chart values
 type ChartValues struct {
 	Data   map[string]string
 	Values map[string]interface{}

--- a/pkg/utils/helm/helm_helper.go
+++ b/pkg/utils/helm/helm_helper.go
@@ -364,7 +364,7 @@ func fetchChartValuesFromOciRepo(repoURL string, chartName string, version strin
 		Verify:  downloader.VerifyNever,
 		Getters: getter.All(cli.New()),
 	}
-	
+
 	if opts != nil {
 		d.Options = append(d.Options, getter.WithInsecureSkipVerifyTLS(opts.InsecureSkipTLS),
 			getter.WithTLSClientConfig(opts.CertFile, opts.KeyFile, opts.CaFile),

--- a/pkg/utils/helm/helm_helper.go
+++ b/pkg/utils/helm/helm_helper.go
@@ -404,9 +404,9 @@ func fetchChartValuesFromOciRepo(repoURL string, chartName string, version strin
 
 func loadValuesYamlFile(chart *chart.Chart) map[string]string {
 	result := map[string]string{}
-	re := regexp.MustCompile(`.*values.yaml$`)
+	re := regexp.MustCompile(`.*yaml$`)
 	for _, f := range chart.Raw {
-		if re.MatchString(f.Name) {
+		if re.MatchString(f.Name) && !strings.Contains(f.Name, "/") && f.Name != "Chart.yaml" {
 			result[f.Name] = string(f.Data)
 		}
 	}

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Test helm helper", func() {
 
 	It("Test getValues from chart", func() {
 		helper := NewHelper()
-		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0", true, nil)
+		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0", true, "helm", nil)
 		Expect(err).Should(BeNil())
 		Expect(values).ShouldNot(BeEmpty())
 	})

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Test helm helper", func() {
 		helper := NewHelper()
 		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0", true, "helm", nil)
 		Expect(err).Should(BeNil())
-		Expect(values).ShouldNot(BeEmpty())
+		Expect(values).ShouldNot(BeNil())
 	})
 })
 

--- a/test/e2e-apiserver-test/repository_test.go
+++ b/test/e2e-apiserver-test/repository_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package e2e_apiserver_test
 
 import (
+	"io"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -32,8 +34,8 @@ var _ = Describe("Helm rest api test", func() {
 				"version":  "6.1.0",
 			})
 			defer resp.Body.Close()
-			values := map[string]interface{}{}
-			Expect(decodeResponseBody(resp, &values)).Should(Succeed())
+			values, err := io.ReadAll(resp.Body)
+			Expect(err).Should(BeNil())
 			Expect(len(values)).ShouldNot(BeEquivalentTo(0))
 		})
 	})

--- a/test/e2e-apiserver-test/repository_test.go
+++ b/test/e2e-apiserver-test/repository_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_apiserver_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Helm rest api test", func() {
+
+	Describe("helm repo api test", func() {
+		It("test fetching chart values in OCI registry", func() {
+			resp := getWithQuery("/repository/chart/values", map[string]string{
+				"repoUrl":  "oci://ghcr.io",
+				"chart":    "stefanprodan/charts/podinfo",
+				"repoType": "oci",
+				"version":  "6.1.0",
+			})
+			defer resp.Body.Close()
+			values := map[string]interface{}{}
+			Expect(decodeResponseBody(resp, &values)).Should(Succeed())
+			Expect(len(values)).ShouldNot(BeEquivalentTo(0))
+		})
+	})
+})

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -191,6 +191,26 @@ func get(path string) *http.Response {
 	return response
 }
 
+func getWithQuery(path string, params map[string]string) *http.Response {
+	client := &http.Client{}
+	if !strings.HasPrefix(path, "/v1") {
+		path = baseURL + path
+	} else {
+		path = baseDomain + path
+	}
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	Expect(err).Should(BeNil())
+	req.Header.Add("Authorization", token)
+	query := req.URL.Query()
+	for k, v := range params {
+		query.Set(k, v)
+	}
+	req.URL.RawQuery = query.Encode()
+	response, err := client.Do(req)
+	Expect(err).Should(BeNil())
+	return response
+}
+
 func delete(path string) *http.Response {
 	client := &http.Client{}
 	if !strings.HasPrefix(path, "/v1") {


### PR DESCRIPTION
vela-apiserver support helm chart values

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>

rebase

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->