### PR TITLE
Fix: removes `default` parameter name for terraform provider

### DIFF
--- a/pkg/apiserver/domain/service/config_test.go
+++ b/pkg/apiserver/domain/service/config_test.go
@@ -91,7 +91,7 @@ template: {
 
 	parameter: {
 		//+usage=The name of Terraform Provider for Alibaba Cloud
-		name: *"default" | string
+		name: string
 		//+usage=Get ALICLOUD_ACCESS_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html
 		ALICLOUD_ACCESS_KEY: string
 		//+usage=Get ALICLOUD_SECRET_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html

--- a/pkg/apiserver/domain/service/config_test.go
+++ b/pkg/apiserver/domain/service/config_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Test config service", func() {
 		Expect(err).ToNot(BeNil())
 		var paramErr = &script.ParameterError{}
 		Expect(errors.As(err, &paramErr)).To(Equal(true))
-		Expect(paramErr.Name).To(Equal("ALICLOUD_ACCESS_KEY"))
+		Expect(paramErr.Name).To(Equal("name"))
 		Expect(paramErr.Message).To(Equal("This parameter is required"))
 
 		config, err := configService.CreateConfig(context.TODO(), "", v1.CreateConfigRequest{

--- a/pkg/apiserver/utils/bcode/016_config.go
+++ b/pkg/apiserver/utils/bcode/016_config.go
@@ -23,21 +23,21 @@ var (
 	// ErrNoConfigOrTarget means there is no target or config when creating the distribution.
 	ErrNoConfigOrTarget = NewBcode(400, 16002, "you must specify the config name and destination to distribute")
 
-	// ErrConfigExist means the config is exist
-	ErrConfigExist = NewBcode(400, 16003, "the config name is exist")
+	// ErrConfigExist means the config does exist
+	ErrConfigExist = NewBcode(400, 16003, "the config name does exist")
 
-	// ErrChangeTemplate the template of the config can not be change
-	ErrChangeTemplate = NewBcode(400, 16004, "the template of the config can not be change")
+	// ErrChangeTemplate the template of the config can not be changed
+	ErrChangeTemplate = NewBcode(400, 16004, "the template of the config can not be changed")
 
-	// ErrTemplateNotFound means the template is not exist
-	ErrTemplateNotFound = NewBcode(404, 16005, "the template is not exist")
+	// ErrTemplateNotFound means the template does not exist
+	ErrTemplateNotFound = NewBcode(404, 16005, "the template does not exist")
 
-	// ErrConfigNotFound means the config is not exist
-	ErrConfigNotFound = NewBcode(404, 16006, "the config is not exist")
+	// ErrConfigNotFound means the config does not exist
+	ErrConfigNotFound = NewBcode(404, 16006, "the config does not exist")
 
-	// ErrNotFoundDistribution means the distribution is not exist
-	ErrNotFoundDistribution = NewBcode(404, 16007, "the distribution is not exist")
+	// ErrNotFoundDistribution means the distribution does not exist
+	ErrNotFoundDistribution = NewBcode(404, 16007, "the distribution does not exist")
 
-	// ErrChangeSecretType the secret type of the config can not be change
-	ErrChangeSecretType = NewBcode(400, 16008, "the secret type of the config can not be change")
+	// ErrChangeSecretType the secret type of the config can not be changed
+	ErrChangeSecretType = NewBcode(400, 16008, "the secret type of the config can not be changed")
 )

--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -76,23 +76,23 @@ var ErrSensitiveConfig = errors.New("the config is sensitive")
 // ErrNoConfigOrTarget means the config or the target is empty.
 var ErrNoConfigOrTarget = errors.New("you must specify the config name and destination to distribute")
 
-// ErrNotFoundDistribution means the app of the distribution is not exist.
-var ErrNotFoundDistribution = errors.New("the distribution is not found")
+// ErrNotFoundDistribution means the app of the distribution does not exist.
+var ErrNotFoundDistribution = errors.New("the distribution does not found")
 
-// ErrConfigExist means the config is exist.
-var ErrConfigExist = errors.New("the config is exist")
+// ErrConfigExist means the config does exist.
+var ErrConfigExist = errors.New("the config does exist")
 
-// ErrConfigNotFound means the config is not exist
-var ErrConfigNotFound = errors.New("the config is not exist")
+// ErrConfigNotFound means the config does not exist
+var ErrConfigNotFound = errors.New("the config does not exist")
 
-// ErrTemplateNotFound means the template is not exist
-var ErrTemplateNotFound = errors.New("the template is not exist")
+// ErrTemplateNotFound means the template does not exist
+var ErrTemplateNotFound = errors.New("the template does not exist")
 
-// ErrChangeTemplate means the template of the config can not be change
-var ErrChangeTemplate = errors.New("the template of the config can not be change")
+// ErrChangeTemplate means the template of the config can not be changed
+var ErrChangeTemplate = errors.New("the template of the config can not be changed")
 
-// ErrChangeSecretType means the secret type of the config can not be change
-var ErrChangeSecretType = errors.New("the secret type of the config can not be change")
+// ErrChangeSecretType means the secret type of the config can not be changed
+var ErrChangeSecretType = errors.New("the secret type of the config can not be changed")
 
 // NamespacedName the namespace and name model
 type NamespacedName struct {

--- a/pkg/config/provider/provider_test.go
+++ b/pkg/config/provider/provider_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test the config provider", func() {
 		`, nil, "")
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Create(mCtx, new(wfContext.WorkflowContext), v, nil)
-		Expect(strings.Contains(err.Error(), "the template is not exist")).Should(BeTrue())
+		Expect(strings.Contains(err.Error(), "the template does not exist")).Should(BeTrue())
 
 		template, err := p.factory.ParseTemplate("test-image-registry", []byte(templateContent))
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e-apiserver-test/config_test.go
+++ b/test/e2e-apiserver-test/config_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Test the rest api about the config", func() {
 		Expect(config.Secret).Should(BeNil())
 		Expect(config.Properties["registry"]).Should(Equal("kubevela.test.com"))
 
-		By("the config name is exist")
+		By("the config name does exist")
 		req = v1.CreateConfigRequest{
 			Name:        "test-registry",
 			Alias:       "Test Registry",
@@ -164,7 +164,7 @@ var _ = Describe("Test the rest api about the config", func() {
 		res = post("/configs", req)
 		Expect(res.StatusCode).Should(Equal(400))
 
-		By("the template is not exist")
+		By("the template does not exist")
 		req = v1.CreateConfigRequest{
 			Name:        "test-registry2",
 			Alias:       "Test Registry",


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5427 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->