### PR TITLE
Fix: pod view invalid cue for special pod output

### DIFF
--- a/charts/vela-core/templates/velaql/component-pod.yaml
+++ b/charts/vela-core/templates/velaql/component-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   template: |
       import (
-      "vela/ql"
+        "vela/ql"
       )
 
       parameter: {
@@ -55,9 +55,15 @@ data:
               phase: pod.object.status.phase
               // refer to https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
               if phase != "Pending" && phase != "Unknown" {
-                podIP:    pod.object.status.podIP
-                hostIP:   pod.object.status.hostIP
-                nodeName: pod.object.spec.nodeName
+                if pod.object.podIP != _|_ {
+                  podIP: pod.object.status.podIP
+                }
+                if pod.object.hostIP != _|_ {
+                  hostIP: pod.object.status.hostIP
+                }
+                if pod.object.nodeName != _|_ {
+                  nodeName: pod.object.spec.nodeName
+                }
               }
             }
           }]


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When returned pod does not have podIP/hostIP/nodeName, it could lead to the incomplete value for VelaQL pod-view to run.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->