### PR TITLE
Fix: apiVersion of CronJob for 1.25+ clusters

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -12,8 +12,13 @@ spec:
     cue:
       template: |
         output: {
-        	apiVersion: "batch/v1beta1"
-        	kind:       "CronJob"
+        	if context.clusterVersion.minor < 25 {
+        		apiVersion: "batch/v1beta1"
+        	}
+        	if context.clusterVersion.minor >= 25 {
+        		apiVersion: "batch/v1"
+        	}
+        	kind: "CronJob"
         	spec: {
         		schedule:                   parameter.schedule
         		concurrencyPolicy:          parameter.concurrencyPolicy

--- a/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
@@ -12,8 +12,13 @@ spec:
     cue:
       template: |
         output: {
-        	apiVersion: "batch/v1beta1"
-        	kind:       "CronJob"
+        	if context.clusterVersion.minor < 25 {
+        		apiVersion: "batch/v1beta1"
+        	}
+        	if context.clusterVersion.minor >= 25 {
+        		apiVersion: "batch/v1"
+        	}
+        	kind: "CronJob"
         	spec: {
         		schedule:                   parameter.schedule
         		concurrencyPolicy:          parameter.concurrencyPolicy

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -13,8 +13,13 @@
 }
 template: {
 	output: {
-		apiVersion: "batch/v1beta1"
-		kind:       "CronJob"
+		if context.clusterVersion.minor < 25 {
+			apiVersion: "batch/v1beta1"
+		}
+		if context.clusterVersion.minor >= 25 {
+			apiVersion: "batch/v1"
+		}
+		kind: "CronJob"
 		spec: {
 			schedule:                   parameter.schedule
 			concurrencyPolicy:          parameter.concurrencyPolicy


### PR DESCRIPTION
Signed-off-by: Vasco Lameiras <lameiras@gmail.com>

### Description of your changes

Fixes #5476 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested it locally with k3s `v1.25.5+k3s2`

### Special notes for your reviewer

