### PR TITLE
Fix: recover application watcher when sharding disabled

### DIFF
--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -201,6 +201,13 @@ func run(ctx context.Context, s *options.CoreOptions) error {
 		}
 	}
 
+	klog.Info("Start the vela application monitor")
+	informer, err := mgr.GetCache().GetInformer(ctx, &v1beta1.Application{})
+	if err != nil {
+		klog.ErrorS(err, "Unable to get informer for application")
+	}
+	watcher.StartApplicationMetricsWatcher(informer)
+
 	if err := mgr.Start(ctx); err != nil {
 		klog.ErrorS(err, "Failed to run manager")
 		return err
@@ -227,13 +234,6 @@ func prepareRunInShardingMode(ctx context.Context, mgr manager.Manager, s *optio
 			return err
 		}
 	}
-
-	klog.Info("Start the vela application monitor")
-	informer, err := mgr.GetCache().GetInformer(ctx, &v1beta1.Application{})
-	if err != nil {
-		klog.ErrorS(err, "Unable to get informer for application")
-	}
-	watcher.StartApplicationMetricsWatcher(informer)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->