### PR TITLE
Feat: parallelize state-keep

### DIFF
--- a/pkg/resourcekeeper/cache_test.go
+++ b/pkg/resourcekeeper/cache_test.go
@@ -84,7 +84,9 @@ func TestResourceCache(t *testing.T) {
 	}
 	rts := []*v1beta1.ResourceTracker{nil, rt1, rt2, rt3}
 	cache.registerResourceTrackers(rts...)
-	r.False(cache.m[createMR("resource-1").ResourceKey()].loaded)
+	o, ok := cache.m.Get(createMR("resource-1").ResourceKey())
+	r.True(ok)
+	r.False(o.loaded)
 	for _, check := range []struct {
 		name           string
 		usedBy         []*v1beta1.ResourceTracker

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -434,7 +434,7 @@ func (h *gcHandler) GarbageCollectComponentRevisionResourceTracker(ctx context.C
 		return nil
 	}
 	inUseComponents := map[string]bool{}
-	for _, entry := range h.cache.m {
+	for _, entry := range h.cache.m.Data() {
 		for _, rt := range entry.usedBy {
 			if rt.GetDeletionTimestamp() == nil || len(rt.GetFinalizers()) != 0 {
 				inUseComponents[entry.mr.ComponentKey()] = true


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Parallelize state-keep to enhance the state-keep efficiency.

Effect: In the load-testing with 3k applications, the average reconcile time could be reduced by 30%~40% while using state-keep. (Each application contains 1 deployment, 1 secret, 1 configmap)

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->