### PR TITLE
Feat: add step definitions to support deploying static site on OSS

### DIFF
--- a/references/docgen/def-doc/workflowstep/build-source-code.eg.md
+++ b/references/docgen/def-doc/workflowstep/build-source-code.eg.md
@@ -1,0 +1,23 @@
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: build-source-code
+  namespace: default
+spec:
+  components: []
+  workflow:
+    steps:
+      - name: build
+        type: build-source-code
+        properties:
+          image: node:14.17
+          cmd: "yarn install && yarn build"
+          repo:
+            url: https://github.com/open-gitops/website.git
+            branch: main
+          pvc:
+            name: my-pvc
+            storageClassName: my-storage
+            mountPath: /generated
+```

--- a/references/docgen/def-doc/workflowstep/upload-to-bucket.eg.md
+++ b/references/docgen/def-doc/workflowstep/upload-to-bucket.eg.md
@@ -1,0 +1,28 @@
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: upload-to-bucket
+  namespace: default
+spec:
+  components: []
+  workflow:
+    steps:
+      - name: upload
+        type: upload-to-bucket
+        properties:
+          oss:
+            accessKey:
+              # User can either use plaintext as input parameters `id` and `secret` or `secretRef` to specify the credentials.
+              id: <your_alibaba_accesskey_id>
+              secret: <your_alibaba_accesskey_secret>
+              # secretRef:
+              #   name: my-secret
+              #   keyId: ALICLOUD_ACCESS_KEY
+              #   keySecret: ALICLOUD_SECRET_KEY
+            bucket: example-doc
+            endpoint: oss-cn-hangzhou.aliyuncs.com
+          pvc:
+            name: my-pvc
+            mountPath: /generated
+```

--- a/vela-templates/definitions/internal/workflowstep/build-source-code.cue
+++ b/vela-templates/definitions/internal/workflowstep/build-source-code.cue
@@ -1,0 +1,153 @@
+import (
+	"vela/op"
+)
+
+"build-source-code": {
+	alias: ""
+	annotations: {}
+	attributes: {}
+	description: "Init storage, clone git repo, build source code and persist generated folder in pvc"
+	labels: {}
+	type: "workflow-step"
+}
+
+template: {
+	storageclass: op.#Apply & {
+		value: {
+			apiVersion: "storage.k8s.io/v1"
+			kind:       "StorageClass"
+			metadata: {
+				name:      "\(context.name)-local-storage"
+				namespace: context.namespace
+			}
+			provisioner:       "kubernetes.io/no-provisioner"
+			volumeBindingMode: "WaitForFirstConsumer"
+		}
+	}
+
+	pv: op.#Apply & {
+		value: {
+			apiVersion: "v1"
+			kind:       "PersistentVolume"
+			metadata: {
+				name:      "\(context.name)-local-pv"
+				namespace: context.namespace
+			}
+			spec: {
+				storageClassName: storageclass.value.metadata.name
+				capacity: storage: "1Gi"
+				accessModes: ["ReadWriteOnce"]
+				hostPath: path: "/mnt/data"
+			}
+		}
+	}
+
+	pvc: op.#Apply & {
+		value: {
+			apiVersion: "v1"
+			kind:       "PersistentVolumeClaim"
+			metadata: {
+				name:      parameter.pvc.name
+				namespace: context.namespace
+			}
+			spec: {
+				storageClassName: storageclass.value.metadata.name
+				accessModes: ["ReadWriteOnce"]
+				resources: requests: storage: "1Gi"
+				volumeName: pv.value.metadata.name
+			}
+		}
+	}
+
+	wait: op.#ConditionalWait & {
+		continue: pvc.value.status != _|_ && pvc.value.status.phase == "Bound"
+	}
+
+	job: op.#Apply & {
+		value: {
+			apiVersion: "batch/v1"
+			kind:       "Job"
+			metadata: {
+				name:      "\(context.name)-\(context.stepName)-\(context.stepSessionID)-job"
+				namespace: context.namespace
+			}
+			spec: {
+				template: {
+					metadata: {
+						labels: {
+							"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+						}
+					}
+					spec: {
+						containers: [
+							{
+								name:  "\(context.name)-\(context.stepName)-\(context.stepSessionID)-container"
+								image: parameter.image
+								volumeMounts: [
+									{
+										name:      "\(context.name)-\(context.stepName)-\(context.stepSessionID)-volume"
+										mountPath: parameter.pvc.mountPath
+									},
+								]
+								command: [
+									"sh",
+									"-c",
+									"""
+									git clone -b \(parameter.branch) \(parameter.url) repo/
+									cd repo/
+									\(parameter.cmd)
+									generated_dir=`ls -t .|head -n1|awk '{print $0}'`
+									cp -r $generated_dir/* \(parameter.pvc.mountPath)
+									""",
+								]
+							},
+						]
+						volumes: [
+							{
+								name: "\(context.name)-\(context.stepName)-\(context.stepSessionID)-volume"
+								persistentVolumeClaim: claimName: parameter.pvc.name
+							},
+						]
+						restartPolicy: "OnFailure"
+					}
+				}
+			}
+		}
+	}
+
+	log: op.#Log & {
+		source: {
+			resources: [{labelSelector: {
+				"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+			}}]
+		}
+	}
+
+	wait: op.#ConditionalWait & {
+		continue: job.value.status != _|_ && job.value.status.phase == "Succeeded"
+	}
+
+	parameter: {
+		// +usage=Specify the base image where source code to be built
+		image: string
+
+		// +usage=Specify the commands to build source code
+		cmd: string
+
+		// +usage=Specify the git repo for your source code
+		repo: {
+			// +usage=Specify the url
+			url: string
+			// +usage=Specify the branch, default to master
+			branch: *"master" | string
+		}
+
+		// +usage=Specify the pvc to store the generated files
+		pvc: {
+			// +usage=Specify the pvc name
+			name: string
+			// +usage=Specify the pvc mountPath
+			mountPath: string
+		}
+	}
+}

--- a/vela-templates/definitions/internal/workflowstep/upload-to-bucket.cue
+++ b/vela-templates/definitions/internal/workflowstep/upload-to-bucket.cue
@@ -1,0 +1,101 @@
+import (
+	"vela/op"
+)
+
+"upload-to-bucket": {
+	alias: ""
+	annotations: {}
+	attributes: {}
+	description: "Get folder from pvc, upload it to object storage bucket"
+	labels: {}
+	type: "workflow-step"
+}
+
+template: {
+	job: op.#Apply & {
+		value: {
+			apiVersion: "batch/v1"
+			kind:       "Job"
+			metadata: {
+				name:      "\(context.name)-\(context.stepName)-\(context.stepSessionID)-job"
+				namespace: context.namespace
+			}
+			spec: {
+				template: {
+					metadata: {
+						labels: {
+							"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+						}
+					}
+					spec: {
+						containers: [
+							{
+								name:  "\(context.name)-\(context.stepName)-\(context.stepSessionID)-container"
+								image: "alpine:latest"
+								volumeMounts: [
+									{
+										name:      "\(context.name)-\(context.stepName)-\(context.stepSessionID)-volume"
+										mountPath: parameter.pvc.mountPath
+									},
+								]
+								command: [
+									"sh",
+									"-c",
+									"""
+									apk update && apk add sudo curl unzip bash
+									sudo -v ; curl https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash
+									ossutil config -e \(parameter.oss.endpoint) -i \(parameter.oss.accessKey.id) -k \(parameter.oss.accessKey.secret)
+									ossutil rm oss://\(parameter.oss.bucket) -rf
+									ossutil cp -r \(parameter.pvc.mountPath) oss://\(parameter.oss.bucket) -f
+									""",
+								]
+							},
+						]
+						volumes: [
+							{
+								name: "\(context.name)-\(context.stepName)-\(context.stepSessionID)-volume"
+								persistentVolumeClaim: claimName: parameter.pvc.name
+							},
+						]
+						restartPolicy: "OnFailure"
+					}
+				}
+			}
+		}
+	}
+
+	log: op.#Log & {
+		source: {
+			resources: [{labelSelector: {
+				"workflow.oam.dev/step-name": "\(context.name)-\(context.stepName)"
+			}}]
+		}
+	}
+
+	wait: op.#ConditionalWait & {
+		continue: job.value.status != _|_ && job.value.status.phase == "Succeeded"
+	}
+
+	parameter: {
+		// +usage=Specify the pvc to get generated files
+		pvc: {
+			// +usage=Specify the pvc name
+			name: string
+			// +usage=Specify the pvc mountPath
+			mountPath: string
+		}
+
+		// +usage=Specify the alibaba oss bucket as backend
+		oss: {
+			// +usage=Specify the credentials to access alibaba oss
+			accessKey: {
+				id:     string
+				secret: string
+			}
+			// +usage=Specify the target oss bucket
+			bucket: string
+			// +usage=Specify the target oss endpoint
+			endpoint: string
+		}
+	}
+}


### PR DESCRIPTION
### Description of your changes

Fixes #3898

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Design of WorkflowStep

We design two workflow steps, mainly using cue actions to operate Kubernetes objects. 

##### 1 build-source-code.cue

1. Init storage
    1. `op.#Apply` a PersistentVolumeClaim for a Job to mount
        - Specify PVC's `name` and `storageClassName` by the input parameter
        - `storageClassName` will specify which StorageClass that PVC will use
2. Clone git repo, build source code, and persist generated files
    1. `op.#Apply` a Job
        - Mount the PVC and specify the `claimName` and `mountPath`
        - Using user-specified container image, execute user-specified commands to build
        - Get the recently generated folder and persist its files in `mountPath`
    2. `op.#Log` to collect Job's log using `labelSelector`
    3. `op.#ConditionalWait` for Job successfully created and executed
    
##### 2 upload-to-bucket.cue

1. Get the required credentials
    1. `op.#Steps` to combine a set of operations to get the accessKey(`id` and `secret`).
1. Get files from PVC, and upload them to the object storage bucket
    1. `op.#Apply` a Job
        - Mount the PVC and specify the `claimName` and `mountPath`
        - In the container, it will prepare ossutils env first
        - And then config cloud provider with input parameters to get access
        - Clean the bucket first, then copy the static site files up to it 
    3. `op.#Log` to collect Job's log using `labelSelector`
    4. `op.#ConditionalWait` for Job successfully created and executed

### How has this code been tested

From the user's perspective, you can use these two workflow steps without any Components if you already have an OSS bucket ready to host a static site.

<details>
<summary>YAML example</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application # or you can use WorkflowRun
metadata:
  name: test-build-and-upload
spec:
  components: []
  workflow:
    steps:
      - name: build
        type: build-source-code
        properties:
          image: node:14.17 # the base image where the source code is to be built
          cmd: "yarn install && yarn build" # the commands to build source code
          repo:
            url: https://github.com/open-gitops/website.git # repo's git URL
            branch: main # repo's branch, default to "master"
          pvc:
            name: my-pvc # the PVC name user want to apply
            storageClassName: my-storage # the StorageClass user want to use
            mountPath: /generated # the PVC mountPath user wants to persist in
      - name: upload
        type: upload-to-bucket
        properties:
          oss: # specify the Alibaba OSS bucket as backend storage
            accessKey: # the credentials to access Alibaba oss
              # User can either use `secretRef` to access the credentials or just use plaintext as input parameters `id` and `secret`.
              # id: <your_id>
              # secret: <your_secret>
              secretRef:
                name: my-secret
                keyId: ALICLOUD_ACCESS_KEY
                keySecret: ALICLOUD_SECRET_KEY
            bucket: opengitops-doc # the target OSS bucket
            endpoint: oss-cn-hangzhou.aliyuncs.com # the target OSS endpoint
          pvc: # the PVC to get generated files
            name: my-pvc
            mountPath: /generated
```

</details>

Or you can use them with the Component `alibaba-oss-website` to create an OSS bucket for you and config the static site setting. Don't forget to use `inputs` and `outputs` to pass data between workflow steps for simplification.

<details>
<summary>YAML example</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: beta
spec:
  components:
    - name: object-storage-service
      type: Alibaba-oss-website
      properties:
        bucket: opengitops-doc
        acl: public-read
        index_document: index.html
        error_document: 404.html
  workflow:
    steps:
      - name: create-bucket
        type: apply-component
        properties:
          component: oss-website
        outputs: # pass data between workflow steps
        - name: bucket
          valueFrom: output.status.apply.outputs.BUCKET_NAME.value
        - name: endpoint
          valueFrom: output.status.apply.outputs.EXTRANET_ENDPOINT.value
      - name: build
        type: build-source-code
        properties:
          image: node:14.17
          cmd: "yarn install && yarn build"
          repo:
            url: https://github.com/open-gitops/website.git
            branch: main
          pvc:
            name: my-pvc
            storageClassName: my-storage
            mountPath: /generated
      - name: upload
        type: upload-to-bucket
        inputs: # pass data between workflow steps
        - from: bucket 
          parameterKey: properties.oss.bucket
        - from: endpoint
          parameterKey: properties.oss.endpoint
        properties:
          oss:
            accessKey:
              # id: <your_id>
              # secret: <your_secret>
              secretRef:
                name: my-secret
                keyId: ALICLOUD_ACCESS_KEY
                keySecret: ALICLOUD_SECRET_KEY
          pvc:
            name: my-pvc
            mountPath: /generated
```

</details>

### Special notes for your reviewer

_Still WIP, I'll mark it ready to review if ready._

#### Followup works

- [x] Support Secrets mount
- [x] Add sufficient documents
- [ ] Add `annotations`, `labels` field. like [this](https://github.com/kubevela/kubevela/blob/master/vela-templates/definitions/internal/workflowstep/apply-component.cue#L3-L8)
- [ ] Optimize performance and resource
- [ ] Generally stable and robust

#### Known issues

For security reasons, the policy for "accessing OSS static web page" had changed. When accessing the default domain name(`https://{bucket_name}.oss-cn-hangzhou.aliyuncs.com`) via browser, files will be downloaded as attachments, rather than previewed directly.

[Source link](https://help.aliyun.com/document_detail/31872.html#section-suf-0nf-b9n)


In this situation, the user should have a custom domain name in advance and bind it with the bucket. And it seems that the process needs the user to operate manually on the portal website. 

In our original design(https://github.com/kubevela/kubevela/issues/3898#issue-1236589430), "the endpoint should be printed after the whole process is finished". Now, the accessible endpoint is the user's domain name, it seems like the user doesn't need the default endpoint anymore.


#### Improvements outlook

- Deprecate previous implementation: [kubevela-contrib/terraform-modules/pull/12](https://github.com/kubevela-contrib/terraform-modules/pull/12), or leave it as an alternative.
- Support other object storage services, like aws s3. (Maybe need to extend components)
