### PR TITLE
Fix: vela top can not show Containers and Pod metrics, when the Compo…

### DIFF
--- a/references/cli/top/model/pod.go
+++ b/references/cli/top/model/pod.go
@@ -102,7 +102,7 @@ func LoadPodDetail(cfg *rest.Config, pod *v1.Pod, componentCluster string) Pod {
 		IP:        pod.Status.PodIP,
 		NodeName:  pod.Spec.NodeName,
 	}
-	metric, err := utils.PodMetric(cfg, pod.Name, pod.Namespace)
+	metric, err := utils.PodMetric(cfg, pod.Name, pod.Namespace, componentCluster)
 	if err != nil {
 		podInfo.CPU, podInfo.Mem, podInfo.CPUL, podInfo.MemL, podInfo.CPUR, podInfo.MemR = utils.NA, utils.NA, utils.NA, utils.NA, utils.NA, utils.NA
 	} else {

--- a/references/cli/top/utils/metrics.go
+++ b/references/cli/top/utils/metrics.go
@@ -21,12 +21,15 @@ import (
 	"math"
 	"strconv"
 
+	pkgmulticluster "github.com/kubevela/pkg/multicluster"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metrics "k8s.io/metrics/pkg/client/clientset/versioned"
+
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 )
 
 const (
@@ -106,8 +109,9 @@ func podRequests(spec v1.PodSpec) (*resource.Quantity, *resource.Quantity) {
 }
 
 // PodMetric return the pod metric
-func PodMetric(cfg *rest.Config, name, namespace string) (*v1beta1.PodMetrics, error) {
-	ctx := context.Background()
+func PodMetric(cfg *rest.Config, name, namespace, cluster string) (*v1beta1.PodMetrics, error) {
+	ctx := multicluster.ContextWithClusterName(context.Background(), cluster)
+	cfg.Wrap(pkgmulticluster.NewTransportWrapper())
 	c, err := metrics.NewForConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/references/cli/top/view/container_view_test.go
+++ b/references/cli/top/view/container_view_test.go
@@ -52,6 +52,7 @@ func TestContainerView(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, &model.CtxKeyPod, "pod1")
 	ctx = context.WithValue(ctx, &model.CtxKeyNamespace, "default")
+	ctx = context.WithValue(ctx, &model.CtxKeyCluster, "local")
 
 	containerView := new(ContainerView)
 


### PR DESCRIPTION
…nent is deployed to member cluster


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5533 
Make vela top's Pod and Container views works for multi-cluster scenario

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->