### PR TITLE
Fix: length of name should be less than 32

### DIFF
--- a/pkg/apiserver/interfaces/api/validate.go
+++ b/pkg/apiserver/interfaces/api/validate.go
@@ -69,7 +69,7 @@ func ValidatePayloadType(fl validator.FieldLevel) bool {
 // ValidateName custom check name field
 func ValidateName(fl validator.FieldLevel) bool {
 	value := fl.Field().String()
-	if len(value) > 32 || len(value) < 2 {
+	if len(value) > 31 || len(value) < 2 {
 		return false
 	}
 	return nameRegexp.MatchString(value)

--- a/test/e2e-apiserver-test/suite_test.go
+++ b/test/e2e-apiserver-test/suite_test.go
@@ -49,7 +49,7 @@ var token string
 const (
 	baseDomain   = "http://127.0.0.1:8001"
 	baseURL      = "http://127.0.0.1:8001/api/v1"
-	testNSprefix = "api-e2e-test-"
+	testNSprefix = "api-test-"
 )
 
 func TestE2eApiserverTest(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

Name can not be more than 31. When app name is `ab012345678901234567890123456789 `, I create it failed. 

![im](https://user-images.githubusercontent.com/107997570/220278088-6c206149-6770-4f7e-bee6-2348f350395a.png)

![im](https://user-images.githubusercontent.com/107997570/220278100-cb0f2b85-2d44-4697-8673-e82b4f698370.png)

Fixes #5548 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->