### PR TITLE
Fix: render addon application checkDeployClusters invalid

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -599,10 +599,20 @@ func getClusters(args map[string]interface{}) []string {
 		return nil
 	}
 	cc, ok := ccr.([]string)
+	if ok {
+		return cc
+	}
+	ccrslice, ok := ccr.([]interface{})
 	if !ok {
 		return nil
 	}
-	return cc
+	var ccstring []string
+	for _, c := range ccrslice {
+		if cstring, ok := c.(string); ok {
+			ccstring = append(ccstring, cstring)
+		}
+	}
+	return ccstring
 }
 
 // renderNeededNamespaceAsComps will convert namespace as app components to create namespace for managed clusters

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -298,6 +298,41 @@ func TestRenderK8sObjects(t *testing.T) {
 	assert.Equal(t, comp.Type, "k8s-objects")
 }
 
+func TestGetClusters(t *testing.T) {
+	// string array test
+	args := map[string]interface{}{
+		types.ClustersArg: []string{
+			"cluster1", "cluster2",
+		},
+	}
+	clusters := getClusters(args)
+	assert.Equal(t, clusters, []string{
+		"cluster1", "cluster2",
+	})
+	// interface array test
+	args1 := map[string]interface{}{
+		types.ClustersArg: []interface{}{
+			"cluster3", "cluster4",
+		},
+	}
+	clusters1 := getClusters(args1)
+	assert.Equal(t, clusters1, []string{
+		"cluster3", "cluster4",
+	})
+	// no cluster arg test
+	args2 := map[string]interface{}{
+		"anyargkey": "anyargvalue",
+	}
+	clusters2 := getClusters(args2)
+	assert.Nil(t, clusters2)
+	// other type test
+	args3 := map[string]interface{}{
+		types.ClustersArg: "cluster5",
+	}
+	clusters3 := getClusters(args3)
+	assert.Nil(t, clusters3)
+}
+
 func TestGetAddonStatus(t *testing.T) {
 	getFunc := test.MockGetFn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 		switch key.Name {


### PR DESCRIPTION
### Description of your changes


Fixes #5554 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

vela addon enable rollout --clusters={b,a}

### Special notes for your reviewer

@wangyikewxgm 