### PR TITLE
Fix: swagger DateType

### DIFF
--- a/pkg/apiserver/interfaces/api/pipeline.go
+++ b/pkg/apiserver/interfaces/api/pipeline.go
@@ -235,7 +235,7 @@ func (n *pipeline) GetWebServiceRoute() *restful.WebService {
 		Doc("list pipelines").
 		Param(ws.QueryParameter("query", "Fuzzy search based on name or description").DataType("string")).
 		Param(ws.QueryParameter("projectName", "query pipelines within a project").DataType("string")).
-		Param(ws.QueryParameter("detailed", "query pipelines with detail").DataType("bool").DefaultValue("true")).
+		Param(ws.QueryParameter("detailed", "query pipelines with detail").DataType("boolean").DefaultValue("true")).
 		Returns(200, "OK", apis.ListPipelineResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
 		Writes(apis.ListPipelineResponse{}).Do(meta))


### PR DESCRIPTION
### Description of your changes
Swagger body should be one of [string number boolean integer array] 

Fixes #

paths./api/v1/pipelines.get.parameters.type in body should be one of [string number boolean integer array]

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


### Special notes for your reviewer

@wonderflow