### PR TITLE
Fix: The resource topology fails to display the pods under the job #5566

### DIFF
--- a/pkg/velaql/providers/query/tree.go
+++ b/pkg/velaql/providers/query/tree.go
@@ -109,6 +109,15 @@ func init() {
 			GroupResourceType: GroupResourceType{Group: "apps", Kind: "DaemonSet"},
 		},
 		ChildrenResourcesRule{
+			GroupResourceType: GroupResourceType{Group: "batch", Kind: "Job"},
+			SubResources: buildSubResources([]*SubResourceSelector{
+				{
+					ResourceType: ResourceType{APIVersion: "v1", Kind: "Pod"},
+					listOptions:  defaultWorkloadLabelListOption,
+				},
+			}),
+		},
+		ChildrenResourcesRule{
 			GroupResourceType: GroupResourceType{Group: "", Kind: "Service"},
 			SubResources: buildSubResources([]*SubResourceSelector{
 				{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5566

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have carried out local debugging to verify this function, and it can normally solve the display problem of the job-associated pod under the resource topology

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->