### PR TITLE
Feat: add more information about resource in vela top's topology view

### DIFF
--- a/references/cli/top/view/application_topology_view_test.go
+++ b/references/cli/top/view/application_topology_view_test.go
@@ -57,6 +57,7 @@ func TestTopologyView(t *testing.T) {
 
 	t.Run("init", func(t *testing.T) {
 		topologyView.Init()
+		assert.NotEmpty(t, topologyView.metricsInstance)
 		assert.Equal(t, topologyView.GetTitle(), "[ Topology ]")
 		assert.Equal(t, topologyView.GetBorderColor(), topologyView.app.config.Theme.Border.Table.Color())
 	})
@@ -67,6 +68,7 @@ func TestTopologyView(t *testing.T) {
 
 	t.Run("start", func(t *testing.T) {
 		topologyView.Start()
+		assert.Equal(t, topologyView.metricsInstance.HasFocus(), false)
 		assert.Equal(t, topologyView.appTopologyInstance.HasFocus(), true)
 		assert.Equal(t, topologyView.resourceTopologyInstance.HasFocus(), false)
 		topologyView.switchTopology(nil)


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Based on the fact that KubeVela can already provide the ability to collect the number of resources in an application and metrics status, I introduced the obtained information into vela top, and now I can provide more resource information in the topology view.

![image](https://user-images.githubusercontent.com/30918851/221525430-abf7a584-36d4-4310-8f9c-c0e2315d4cd4.png)


Fixes #5375

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->