### PR TITLE
Feat: refactor prom metrics for app reconcile

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -94,7 +94,7 @@ func NewDryRunApplicationParser(cli client.Client, dm discoverymapper.DiscoveryM
 func (p *Parser) GenerateAppFile(ctx context.Context, app *v1beta1.Application) (*Appfile, error) {
 	if ctx, ok := ctx.(monitorContext.Context); ok {
 		subCtx := ctx.Fork("generate-app-file", monitorContext.DurationMetric(func(v float64) {
-			metrics.ParseAppFileDurationHistogram.WithLabelValues("application").Observe(v)
+			metrics.AppReconcileStageDurationHistogram.WithLabelValues("generate-appfile").Observe(v)
 		}))
 		defer subCtx.Commit("finish generate appFile")
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -88,6 +88,9 @@ func (h *AppHandler) GenerateApplicationSteps(ctx monitorContext.Context,
 	af *appfile.Appfile,
 	appRev *v1beta1.ApplicationRevision) (*wfTypes.WorkflowInstance, []wfTypes.TaskRunner, error) {
 
+	t := time.Now()
+	defer metrics.AppReconcileStageDurationHistogram.WithLabelValues("generate-app-steps").Observe(time.Since(t).Seconds())
+
 	appLabels := map[string]string{
 		oam.LabelAppName:      app.Name,
 		oam.LabelAppNamespace: app.Namespace,

--- a/pkg/monitor/metrics/application.go
+++ b/pkg/monitor/metrics/application.go
@@ -23,58 +23,10 @@ import (
 )
 
 var (
-	// CreateAppHandlerDurationHistogram report the create appHandler execution duration.
-	CreateAppHandlerDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "create_app_handler_time_seconds",
-		Help:        "create appHandler duration distributions, this operate will list ResourceTrackers.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller"})
-
-	// HandleFinalizersDurationHistogram report the handle finalizers execution duration.
-	HandleFinalizersDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "handle_finalizers_time_seconds",
-		Help:        "handle finalizers duration distributions.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller", "type"})
-
-	// ParseAppFileDurationHistogram report the parse appFile execution duration.
-	ParseAppFileDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "parse_appFile_time_seconds",
-		Help:        "parse appFile duration distributions.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller"})
-
-	// PrepareCurrentAppRevisionDurationHistogram report the parse current appRevision execution duration.
-	PrepareCurrentAppRevisionDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "prepare_current_appRevision_time_seconds",
-		Help:        "parse current appRevision duration distributions.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller"})
-
-	// ApplyAppRevisionDurationHistogram report the apply appRevision execution duration.
-	ApplyAppRevisionDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "apply_appRevision_time_seconds",
-		Help:        "apply appRevision duration distributions.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller"})
-
-	// ApplyPoliciesDurationHistogram report execution duration for applying policies
-	ApplyPoliciesDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "apply_policies",
-		Help:        "render and dispatch policy duration distributions.",
-		Buckets:     velametrics.FineGrainedBuckets,
-		ConstLabels: prometheus.Labels{},
-	}, []string{"controller"})
-
-	// GCResourceTrackersDurationHistogram report the gc resourceTrackers execution duration.
-	GCResourceTrackersDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "gc_resourceTrackers_time_seconds",
-		Help:        "gc resourceTrackers duration distributions.",
+	// AppReconcileStageDurationHistogram report staged reconcile time for application
+	AppReconcileStageDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "kubevela_app_reconcile_time_seconds",
+		Help:        "application reconcile time costs.",
 		Buckets:     velametrics.FineGrainedBuckets,
 		ConstLabels: prometheus.Labels{},
 	}, []string{"stage"})

--- a/pkg/monitor/metrics/workflow.go
+++ b/pkg/monitor/metrics/workflow.go
@@ -32,14 +32,8 @@ var (
 )
 
 var collectorGroup = []prometheus.Collector{
-	CreateAppHandlerDurationHistogram,
-	HandleFinalizersDurationHistogram,
-	ParseAppFileDurationHistogram,
-	PrepareCurrentAppRevisionDurationHistogram,
-	ApplyAppRevisionDurationHistogram,
-	ApplyPoliciesDurationHistogram,
+	AppReconcileStageDurationHistogram,
 	StepDurationHistogram,
-	GCResourceTrackersDurationHistogram,
 	ListResourceTrackerCounter,
 	ApplicationReconcileTimeHistogram,
 	ApplyComponentTimeHistogram,

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -164,7 +164,7 @@ func (h *gcHandler) monitor(stage string) func() {
 	begin := time.Now()
 	return func() {
 		v := time.Since(begin).Seconds()
-		metrics.GCResourceTrackersDurationHistogram.WithLabelValues(stage).Observe(v)
+		metrics.AppReconcileStageDurationHistogram.WithLabelValues("gc-rt." + stage).Observe(v)
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Align the time metrics for different stages of application reconcile into one unified metric with labels.

For example, previously, use `create_app_handler_time_seconds` to record time cost for creating AppHandler. Now use `kubevela_app_reconcile_time_seconds{stage="create-app-handler"}`.

Additionally add stage time recording for `execute-workflow`, `gc-rev`, `state-keep`, etc.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->