### PR TITLE
Feat: support direct connection mode for cluster gateway

### DIFF
--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -105,20 +105,21 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 ### MultiCluster parameters
 
-| Name                                                        | Description                                     | Value                            |
-| ----------------------------------------------------------- | ----------------------------------------------- | -------------------------------- |
-| `multicluster.enabled`                                      | Whether to enable multi-cluster                 | `true`                           |
-| `multicluster.metrics.enabled`                              | Whether to enable multi-cluster metrics collect | `false`                          |
-| `multicluster.clusterGateway.replicaCount`                  | ClusterGateway replica count                    | `1`                              |
-| `multicluster.clusterGateway.port`                          | ClusterGateway port                             | `9443`                           |
-| `multicluster.clusterGateway.image.repository`              | ClusterGateway image repository                 | `oamdev/cluster-gateway`         |
-| `multicluster.clusterGateway.image.tag`                     | ClusterGateway image tag                        | `v1.8.0-alpha.3`                 |
-| `multicluster.clusterGateway.image.pullPolicy`              | ClusterGateway image pull policy                | `IfNotPresent`                   |
-| `multicluster.clusterGateway.resources.limits.cpu`          | ClusterGateway cpu limit                        | `100m`                           |
-| `multicluster.clusterGateway.resources.limits.memory`       | ClusterGateway memory limit                     | `200Mi`                          |
-| `multicluster.clusterGateway.secureTLS.enabled`             | Whether to enable secure TLS                    | `true`                           |
-| `multicluster.clusterGateway.secureTLS.certPath`            | Path to the certificate file                    | `/etc/k8s-cluster-gateway-certs` |
-| `multicluster.clusterGateway.secureTLS.certManager.enabled` | Whether to enable cert-manager                  | `false`                          |
+| Name                                                        | Description                                                                                 | Value                            |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------- |
+| `multicluster.enabled`                                      | Whether to enable multi-cluster                                                             | `true`                           |
+| `multicluster.metrics.enabled`                              | Whether to enable multi-cluster metrics collect                                             | `false`                          |
+| `multicluster.clusterGateway.direct`                        | controller will connect to ClusterGateway directly instead of going to Kubernetes APIServer | `false`                          |
+| `multicluster.clusterGateway.replicaCount`                  | ClusterGateway replica count                                                                | `1`                              |
+| `multicluster.clusterGateway.port`                          | ClusterGateway port                                                                         | `9443`                           |
+| `multicluster.clusterGateway.image.repository`              | ClusterGateway image repository                                                             | `oamdev/cluster-gateway`         |
+| `multicluster.clusterGateway.image.tag`                     | ClusterGateway image tag                                                                    | `v1.8.0-alpha.3`                 |
+| `multicluster.clusterGateway.image.pullPolicy`              | ClusterGateway image pull policy                                                            | `IfNotPresent`                   |
+| `multicluster.clusterGateway.resources.limits.cpu`          | ClusterGateway cpu limit                                                                    | `100m`                           |
+| `multicluster.clusterGateway.resources.limits.memory`       | ClusterGateway memory limit                                                                 | `200Mi`                          |
+| `multicluster.clusterGateway.secureTLS.enabled`             | Whether to enable secure TLS                                                                | `true`                           |
+| `multicluster.clusterGateway.secureTLS.certPath`            | Path to the certificate file                                                                | `/etc/k8s-cluster-gateway-certs` |
+| `multicluster.clusterGateway.secureTLS.certManager.enabled` | Whether to enable cert-manager                                                              | `false`                          |
 
 
 ### Test parameters

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -281,6 +281,9 @@ spec:
             - "--oam-spec-ver={{ .Values.OAMSpecVer }}"
             {{ if .Values.multicluster.enabled }}
             - "--enable-cluster-gateway"
+            {{ if .Values.multicluster.clusterGateway.direct }}
+            - "--cluster-gateway-url={{ .Release.Name }}-cluster-gateway-service:9443"
+            {{ end }}
             {{ end }}
             {{ if .Values.multicluster.metrics.enabled }}
             - "--enable-cluster-metrics"

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -131,6 +131,7 @@ featureGates:
 
 ## @param multicluster.enabled Whether to enable multi-cluster
 ## @param multicluster.metrics.enabled Whether to enable multi-cluster metrics collect
+## @param multicluster.clusterGateway.direct controller will connect to ClusterGateway directly instead of going to Kubernetes APIServer
 ## @param multicluster.clusterGateway.replicaCount ClusterGateway replica count
 ## @param multicluster.clusterGateway.port ClusterGateway port
 ## @param multicluster.clusterGateway.image.repository ClusterGateway image repository
@@ -146,6 +147,7 @@ multicluster:
   metrics:
     enabled: false
   clusterGateway:
+    direct: false
     replicaCount: 1
     port: 9443
     image:

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -50,6 +50,7 @@ e2e-setup-core-w-auth:
 	    --set featureGates.zstdResourceTracker=true     \
 	    --set featureGates.zstdApplicationRevision=true \
 	    --set featureGates.validateComponentWhenSharding=true \
+	    --set multicluster.clusterGateway.enabled=true \
 	    --set sharding.enabled=true
 	kubectl get deploy kubevela-vela-core -oyaml -n vela-system | \
 		sed 's/schedulable-shards=/shard-id=shard-0/g' | \


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

  
![image](https://user-images.githubusercontent.com/14019297/222394943-2c072cf2-0c7a-4e76-a8e8-53320ff9cfee.png)


If `--set multicluster.clusterGateway.direct=true` is set, core controller will connect to cluster-gateway directly instead of go to Kubernetes APIServer for delegation.

This has two advantages:
1. The latency of multi-cluster request can be reduced as shown above, 11ms to 6ms. The burden of managed cluster apiserver can be reduced.
2. It does not require hub cluster apiserver and cluster-gateway are mutually connectable. Only require cluster-gateway to be able to connect to hub cluster apiserver.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->