### PR TITLE
Feat: add feature gate to allow disable cluster watch at the start of vela-core

### DIFF
--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -100,6 +100,7 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 | `featureGates.preDispatchDryRun`                  | enable dryrun before dispatching resources. Enable this flag can help prevent unsuccessful dispatch resources entering resourcetracker and improve the user experiences of gc but at the cost of increasing network requests.    | `true`  |
 | `featureGates.validateComponentWhenSharding`      | enable component validation in webhook when sharding mode enabled                                                                                                                                                                | `false` |
 | `featureGates.disableWebhookAutoSchedule`         | disable auto schedule for application mutating webhook when sharding enabled                                                                                                                                                     | `false` |
+| `featureGates.disableBootstrapClusterInfo`        | disable the cluster info bootstrap at the starting of the controller                                                                                                                                                             | `false` |
 
 
 ### MultiCluster parameters

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -302,6 +302,7 @@ spec:
             - "--feature-gates=GzipApplicationRevision={{- .Values.featureGates.gzipApplicationRevision | toString -}}"
             - "--feature-gates=ZstdApplicationRevision={{- .Values.featureGates.zstdApplicationRevision | toString -}}"
             - "--feature-gates=PreDispatchDryRun={{- .Values.featureGates.preDispatchDryRun | toString -}}"
+            - "--feature-gates=DisableBootstrapClusterInfo={{- .Values.featureGates.disableBootstrapClusterInfo | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}
             - "--authentication-with-user"

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -112,6 +112,7 @@ optimize:
 ##@param featureGates.preDispatchDryRun enable dryrun before dispatching resources. Enable this flag can help prevent unsuccessful dispatch resources entering resourcetracker and improve the user experiences of gc but at the cost of increasing network requests.
 ##@param featureGates.validateComponentWhenSharding enable component validation in webhook when sharding mode enabled
 ##@param featureGates.disableWebhookAutoSchedule disable auto schedule for application mutating webhook when sharding enabled
+##@param featureGates.disableBootstrapClusterInfo disable the cluster info bootstrap at the starting of the controller
 ##@param
 featureGates:
   enableLegacyComponentRevision: false
@@ -124,6 +125,7 @@ featureGates:
   preDispatchDryRun: true
   validateComponentWhenSharding: false
   disableWebhookAutoSchedule: false
+  disableBootstrapClusterInfo: false
 
 ## @section MultiCluster parameters
 

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -100,6 +100,9 @@ const (
 	// If set to true, the webhook will not make auto schedule for applications and users can make customized
 	// scheduler for assigning shards to applications
 	DisableWebhookAutoSchedule = "DisableWebhookAutoSchedule"
+
+	// DisableBootstrapClusterInfo disable the cluster info bootstrap at the starting of the controller
+	DisableBootstrapClusterInfo = "DisableBootstrapClusterInfo"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -121,6 +124,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PreDispatchDryRun:             {Default: true, PreRelease: featuregate.Alpha},
 	ValidateComponentWhenSharding: {Default: false, PreRelease: featuregate.Alpha},
 	DisableWebhookAutoSchedule:    {Default: false, PreRelease: featuregate.Alpha},
+	DisableBootstrapClusterInfo:   {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {


### PR DESCRIPTION
… vela-core


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add featuregate `DisableBootstrapClusterInfo` to prevent the scanning of all joined clusters at the beginning of running vela-core.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->