### PR TITLE
Fix:  loading definitions if lack in the revision when calculate dispatch stage of trait.

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	velatypes "github.com/oam-dev/kubevela/apis/types"
+)
+
+var _ = Describe("Test dispatch stage", func() {
+	BeforeEach(func() {
+		traitDefinition := v1beta1.TraitDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "kruise-rollout",
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Spec: v1beta1.TraitDefinitionSpec{
+				Stage: v1beta1.PreDispatch,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), &traitDefinition)).Should(BeNil())
+	})
+
+	It("Test get dispatch stage from trait", func() {
+		appRev := v1beta1.ApplicationRevision{
+			Spec: v1beta1.ApplicationRevisionSpec{
+				ApplicationRevisionCompressibleFields: v1beta1.ApplicationRevisionCompressibleFields{
+					TraitDefinitions: map[string]v1beta1.TraitDefinition{
+						"gateway": {
+							Spec: v1beta1.TraitDefinitionSpec{
+								Stage: v1beta1.PostDispatch,
+							},
+						},
+						"hpa": {
+							Spec: v1beta1.TraitDefinitionSpec{},
+						},
+					},
+				},
+			},
+		}
+
+		stage, err := getTraitDispatchStage(k8sClient, "kruise-rollout", &appRev)
+		Expect(err).Should(BeNil())
+		Expect(stage).Should(BeEquivalentTo(PreDispatch))
+		stage, err = getTraitDispatchStage(k8sClient, "gateway", &appRev)
+		Expect(err).Should(BeNil())
+		Expect(stage).Should(BeEquivalentTo(PostDispatch))
+		stage, err = getTraitDispatchStage(k8sClient, "hpa", &appRev)
+		Expect(err).Should(BeNil())
+		Expect(stage).Should(BeEquivalentTo(DefaultDispatch))
+	})
+})

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch_test.go
@@ -68,5 +68,8 @@ var _ = Describe("Test dispatch stage", func() {
 		stage, err = getTraitDispatchStage(k8sClient, "hpa", &appRev)
 		Expect(err).Should(BeNil())
 		Expect(stage).Should(BeEquivalentTo(DefaultDispatch))
+		stage, err = getTraitDispatchStage(k8sClient, "not-exist", &appRev)
+		Expect(err).ShouldNot(BeNil())
+		Expect(stage).Should(BeEquivalentTo(DefaultDispatch))
 	})
 })

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatcher.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatcher.go
@@ -21,12 +21,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/oam"
-
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/appfile"
@@ -177,15 +179,9 @@ func (h *AppHandler) generateDispatcher(appRev *v1beta1.ApplicationRevision, rea
 					traitType = splitName
 				}
 			}
-			if trait, ok := appRev.Spec.TraitDefinitions[traitType]; ok {
-				_stageType := trait.Spec.Stage
-				if len(_stageType) == 0 {
-					_stageType = v1beta1.DefaultDispatch
-				}
-				stageType, err = ParseStageType(string(_stageType))
-				if err != nil {
-					return nil, err
-				}
+			stageType, err = getTraitDispatchStage(h.r.Client, traitType, appRev)
+			if err != nil {
+				return nil, err
 			}
 		}
 		traitStageMap[stageType] = append(traitStageMap[stageType], readyTrait)
@@ -212,4 +208,24 @@ func (h *AppHandler) generateDispatcher(appRev *v1beta1.ApplicationRevision, rea
 		manifestDispatchers = append(manifestDispatchers, dispatcherGenerator(option))
 	}
 	return manifestDispatchers, nil
+}
+
+func getTraitDispatchStage(client client.Client, traitType string, appRev *v1beta1.ApplicationRevision) (StageType, error) {
+	trait, ok := appRev.Spec.TraitDefinitions[traitType]
+	if !ok {
+		trait = v1beta1.TraitDefinition{}
+		err := oamutil.GetCapabilityDefinition(context.Background(), client, &trait, traitType)
+		if err != nil {
+			return DefaultDispatch, err
+		}
+	}
+	_stageType := trait.Spec.Stage
+	if len(_stageType) == 0 {
+		_stageType = v1beta1.DefaultDispatch
+	}
+	stageType, err := ParseStageType(string(_stageType))
+	if err != nil {
+		return DefaultDispatch, err
+	}
+	return stageType, nil
 }


### PR DESCRIPTION
### Description of your changes

When we add a trait to a component with an inline policy, the trait's definition isn't stored in the application revision. As a result, to determine if the traitDefinition's stage is predispatch or postdispatch, we must retrieve it from the cluster.

This pr is a fix for https://github.com/kubevela/kubevela/pull/5416

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->