### PR TITLE
Feat: add sub-module to Golang SDK

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -42,10 +42,10 @@ jobs:
         run: make vela-cli
 
       - name: Build SDK
-        run: bin/vela def gen-api -f vela-templates/definitions/internal/ -o ./kubevela-go-sdk --package=github.com/kubevela-contrib/kubevela-go-sdk
+        run: bin/vela def gen-api -f vela-templates/definitions/internal/ -o ./kubevela-go-sdk --package=github.com/kubevela-contrib/kubevela-go-sdk --init
 
       - name: Validate SDK
         run: |
           cd kubevela-go-sdk
           go mod tidy
-          golangci-lint run --timeout 5m ./...
+          golangci-lint run --timeout 5m -e "exported:" -e "dot-imports" ./...

--- a/design/vela-cli/sdk_generating.md
+++ b/design/vela-cli/sdk_generating.md
@@ -96,10 +96,10 @@ This command requires `docker` in PATH as we'll run openapi-generator in docker.
 
 ```shell
 # Initialize the SDK, generate API from all definitions, 
-vela def gen-api --init -f /path/to/def/dir -o /path/to/sdk --lang go
+vela def gen-api --init -f /path/to/def/dir -o /path/to/sdk --language go
 
 # Incrementally generate API from definitions
-vela def gen-api -f /path/to/def/dir -o /path/to/sdk --lang go
+vela def gen-api -f /path/to/def/dir -o /path/to/sdk --language go
 ```
 
 ## Future work

--- a/hack/sdk/sync.sh
+++ b/hack/sdk/sync.sh
@@ -33,7 +33,7 @@ config() {
   git config --global user.name "kubevela-bot"
 }
 
-cloneAndClearRepo() {
+cloneAndClearCoreAPI() {
   echo "git clone"
 
   if [[ -n "$SSH_DEPLOY_KEY" ]]; then
@@ -42,8 +42,13 @@ cloneAndClearRepo() {
     git clone --single-branch --depth 1 https://github.com/$VELA_GO_SDK.git kubevela-go-sdk
   fi
 
-  echo "Clear kubevela-go-sdk pkg/*"
-  rm -r kubevela-go-sdk/pkg/*
+  echo "Clear kubevela-go-sdk pkg/apis/common, pkg/apis/component, pkg/apis/policy, pkg/apis/trait, pkg/apis/workflow-step, pkg/apis/utils, pkg/apis/types.go "
+  rm -rf kubevela-go-sdk/pkg/apis/common
+  rm -rf kubevela-go-sdk/pkg/apis/component
+  rm -rf kubevela-go-sdk/pkg/apis/policy
+  rm -rf kubevela-go-sdk/pkg/apis/trait
+  rm -rf kubevela-go-sdk/pkg/apis/workflow-step
+  rm -rf kubevela-go-sdk/pkg/apis/utils
 }
 
 updateRepo() {
@@ -79,7 +84,7 @@ syncRepo() {
 
 main() {
   config
-  cloneAndClearRepo
+  cloneAndClearCoreAPI
   updateRepo
   syncRepo
 }

--- a/pkg/definition/gen_sdk/_scaffold/go/go.mod_
+++ b/pkg/definition/gen_sdk/_scaffold/go/go.mod_
@@ -13,7 +13,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 
     // for sub-module
-	github.com/kubevela/vela-go-sdk v0.0.0-20230310062146-e5d4070da6b4
+	github.com/kubevela/vela-go-sdk v0.0.0-20230309022604-cd431bb25a9a
 )
 
 require (

--- a/pkg/definition/gen_sdk/_scaffold/go/go.mod_
+++ b/pkg/definition/gen_sdk/_scaffold/go/go.mod_
@@ -4,11 +4,16 @@ go 1.19
 
 require (
 	github.com/oam-dev/kubevela-core-api v1.5.8
+
+	// for main module
 	github.com/pkg/errors v0.9.1
 	k8s.io/apimachinery v0.23.6
 	k8s.io/client-go v0.23.6
 	sigs.k8s.io/controller-runtime v0.11.2
 	sigs.k8s.io/yaml v1.3.0
+
+    // for sub-module
+	github.com/kubevela/vela-go-sdk v0.0.0-20230310062146-e5d4070da6b4
 )
 
 require (

--- a/pkg/definition/gen_sdk/_scaffold/go/go.mod_
+++ b/pkg/definition/gen_sdk/_scaffold/go/go.mod_
@@ -11,10 +11,10 @@ require (
 	k8s.io/client-go v0.23.6
 	sigs.k8s.io/controller-runtime v0.11.2
 	sigs.k8s.io/yaml v1.3.0
-
-    // for sub-module
-	github.com/kubevela/vela-go-sdk v0.0.0-20230309022604-cd431bb25a9a
 )
+
+// for sub-module
+// require github.com/kubevela/vela-go-sdk v0.0.0-20230309022604-cd431bb25a9a
 
 require (
 	cuelang.org/go v0.5.0-alpha.1 // indirect

--- a/pkg/definition/gen_sdk/_scaffold/go/pkg/apis/common/application.go
+++ b/pkg/definition/gen_sdk/_scaffold/go/pkg/apis/common/application.go
@@ -285,14 +285,14 @@ func (a *ApplicationBuilder) Validate() error {
 	return nil
 }
 
-func FromK8sObject(app *v1beta1.Application) (TypedApplication, error) {
+func FromK8sObject(app v1beta1.Application) (TypedApplication, error) {
 	a := &ApplicationBuilder{}
 	a.Name(app.Name)
 	a.Namespace(app.Namespace)
 	a.resourceVersion = app.ResourceVersion
 
 	for _, comp := range app.Spec.Components {
-		c, err := FromComponent(&comp)
+		c, err := FromComponent(comp)
 		if err != nil {
 			return nil, errors.Wrap(err, "convert component from k8s object")
 		}
@@ -300,7 +300,7 @@ func FromK8sObject(app *v1beta1.Application) (TypedApplication, error) {
 	}
 	if app.Spec.Workflow != nil {
 		for _, step := range app.Spec.Workflow.Steps {
-			s, err := FromWorkflowStep(&step)
+			s, err := FromWorkflowStep(step)
 			if err != nil {
 				return nil, errors.Wrap(err, "convert workflow step from k8s object")
 			}
@@ -308,7 +308,7 @@ func FromK8sObject(app *v1beta1.Application) (TypedApplication, error) {
 		}
 	}
 	for _, policy := range app.Spec.Policies {
-		p, err := FromPolicy(&policy)
+		p, err := FromPolicy(policy)
 		if err != nil {
 			return nil, errors.Wrap(err, "convert policy from k8s object")
 		}
@@ -317,34 +317,34 @@ func FromK8sObject(app *v1beta1.Application) (TypedApplication, error) {
 	return a, nil
 }
 
-func FromComponent(component *common.ApplicationComponent) (Component, error) {
+func FromComponent(component common.ApplicationComponent) (Component, error) {
 	build, ok := ComponentsBuilders[component.Type]
 	if !ok {
 		return nil, errors.Errorf("no component type %s registered", component.Type)
 	}
-	return build(*component)
+	return build(component)
 }
 
-func FromWorkflowStep(step *v1beta1.WorkflowStep) (WorkflowStep, error) {
+func FromWorkflowStep(step v1beta1.WorkflowStep) (WorkflowStep, error) {
 	build, ok := WorkflowStepsBuilders[step.Type]
 	if !ok {
 		return nil, errors.Errorf("no workflow step type %s registered", step.Type)
 	}
-	return build(*step)
+	return build(step)
 }
 
-func FromPolicy(policy *v1beta1.AppPolicy) (Policy, error) {
+func FromPolicy(policy v1beta1.AppPolicy) (Policy, error) {
 	build, ok := PoliciesBuilders[policy.Type]
 	if !ok {
 		return nil, errors.Errorf("no policy type %s registered", policy.Type)
 	}
-	return build(*policy)
+	return build(policy)
 }
 
-func FromTrait(trait *common.ApplicationTrait) (Trait, error) {
+func FromTrait(trait common.ApplicationTrait) (Trait, error) {
 	build, ok := TraitBuilders[trait.Type]
 	if !ok {
 		return nil, errors.Errorf("no trait type %s registered", trait.Type)
 	}
-	return build(*trait)
+	return build(trait)
 }

--- a/pkg/definition/gen_sdk/_scaffold/go/pkg/client/client.go
+++ b/pkg/definition/gen_sdk/_scaffold/go/pkg/client/client.go
@@ -97,7 +97,7 @@ func (c clientImpl) Get(ctx context.Context, key client.ObjectKey) (apis.TypedAp
 	if err != nil {
 		return nil, err
 	}
-	return sdkcommon.FromK8sObject(&_app)
+	return sdkcommon.FromK8sObject(_app)
 }
 
 func (c clientImpl) List(ctx context.Context, opts client.ListOption) ([]apis.TypedApplication, error) {
@@ -108,7 +108,7 @@ func (c clientImpl) List(ctx context.Context, opts client.ListOption) ([]apis.Ty
 	}
 	var apps []apis.TypedApplication
 	for _, app := range _appList.Items {
-		_app, err := sdkcommon.FromK8sObject(&app)
+		_app, err := sdkcommon.FromK8sObject(app)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/definition/gen_sdk/gen_sdk.go
+++ b/pkg/definition/gen_sdk/gen_sdk.go
@@ -115,11 +115,11 @@ func (meta *GenMeta) Init(c common.Args, flags *pflag.FlagSet) (err error) {
 	if flags != nil {
 		switch meta.Lang {
 		case "go":
-			if goargs, err := flags.GetStringSlice("go-args"); err != nil {
+			goargs, err := flags.GetStringSlice("go-args")
+			if err != nil {
 				return err
-			} else {
-				meta.GoArgs.parse(goargs)
 			}
+			meta.GoArgs.parse(goargs)
 		}
 	}
 	packageFuncs := map[string]byteHandler{
@@ -302,6 +302,7 @@ func (meta *GenMeta) Run() error {
 	return nil
 }
 
+// SetDefinition sets definition name and kind
 func (meta *GenMeta) SetDefinition(defName, defKind string) {
 	meta.name = defName
 	meta.kind = defKind

--- a/pkg/definition/gen_sdk/gen_sdk.go
+++ b/pkg/definition/gen_sdk/gen_sdk.go
@@ -324,6 +324,7 @@ func (meta *GenMeta) Run() error {
 	if len(meta.cuePaths) == 0 {
 		return nil
 	}
+	APIGenerated := false
 	for _, cuePath := range meta.cuePaths {
 		klog.Infof("Generating API for %s", cuePath)
 		// nolint:gosec
@@ -351,6 +352,10 @@ func (meta *GenMeta) Run() error {
 		if err != nil {
 			return err
 		}
+		APIGenerated = true
+	}
+	if !APIGenerated {
+		return nil
 	}
 	for _, m := range g.moduleModifiers {
 		err := m.Modify()

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -302,7 +302,7 @@ var _ = Describe("getValueType", func() {
 	}
 })
 
-var _ = FDescribe("type fit", func() {
+var _ = Describe("type fit", func() {
 
 	var schema *openapi3.Schema
 

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Test Generating SDK", func() {
 		Expect(err).Should(BeNil())
 	}
 	genWithMeta := func(meta GenMeta) {
-		err = meta.Init(common.Args{})
+		err = meta.Init(common.Args{}, nil)
 		Expect(err).Should(BeNil())
 		err = meta.CreateScaffold()
 		Expect(err).Should(BeNil())

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -34,17 +34,22 @@ var _ = Describe("Test Generating SDK", func() {
 	meta := GenMeta{
 		Output:       outputDir,
 		Lang:         lang,
-		Package:      "github.com/kubevela/test-gen-sdk",
-		File:         []string{filepath.Join("testdata", "cron-task.cue")},
-		InitSDK:      true,
+		Package:      "github.com/kubevela-contrib/kubevela-go-sdk",
 		APIDirectory: defaultAPIDir[lang],
 	}
+	var langArgs []string
+
+	BeforeEach(func() {
+		meta.InitSDK = false
+		meta.File = []string{filepath.Join("testdata", "cron-task.cue")}
+	})
+
 	checkDirNotEmpty := func(dir string) {
 		_, err = os.Stat(dir)
 		Expect(err).Should(BeNil())
 	}
-	genWithMeta := func(meta GenMeta) {
-		err = meta.Init(common.Args{}, nil)
+	genWithMeta := func() {
+		err = meta.Init(common.Args{}, langArgs)
 		Expect(err).Should(BeNil())
 		err = meta.CreateScaffold()
 		Expect(err).Should(BeNil())
@@ -54,43 +59,40 @@ var _ = Describe("Test Generating SDK", func() {
 		Expect(err).Should(BeNil())
 	}
 	It("Test generating SDK and init the scaffold", func() {
-		genWithMeta(meta)
+		meta.InitSDK = true
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis"))
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "component", "cron-task"))
 	})
 
 	It("Test generating SDK, append apis", func() {
-		meta.InitSDK = false
 		meta.File = append(meta.File, "testdata/shared-resource.cue")
 
-		genWithMeta(meta)
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "policy", "shared-resource"))
 	})
 
 	It("Test free form parameter {...}", func() {
-		meta.InitSDK = false
 		meta.File = []string{"testdata/json-merge-patch.cue"}
 		meta.Verbose = true
 
-		genWithMeta(meta)
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "trait", "json-merge-patch"))
 	})
 
 	It("Test workflow step", func() {
-		meta.InitSDK = false
 		meta.File = []string{"testdata/deploy.cue"}
 		meta.Verbose = true
 
-		genWithMeta(meta)
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "workflow-step", "deploy"))
 	})
 
 	It("Test step-group", func() {
-		meta.InitSDK = false
 		meta.File = []string{"testdata/step-group.cue"}
 		meta.Verbose = true
 
-		genWithMeta(meta)
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "workflow-step", "step-group"))
 		By("check if AddSubStep is generated")
 		content, err := os.ReadFile(filepath.Join(outputDir, "pkg", "apis", "workflow-step", "step-group", "step_group.go"))
@@ -99,20 +101,30 @@ var _ = Describe("Test Generating SDK", func() {
 	})
 
 	It("Test oneOf", func() {
-		meta.InitSDK = false
 		meta.File = []string{"testdata/one_of.cue"}
 		meta.Verbose = true
 
-		genWithMeta(meta)
+		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "workflow-step", "one_of"))
 		By("check if ")
 	})
 
 	It("Test known issue: apply-terraform-provider", func() {
-		meta.InitSDK = false
 		meta.Verbose = true
 		meta.File = []string{"testdata/apply-terraform-provider.cue"}
-		genWithMeta(meta)
+		genWithMeta()
+	})
+
+	It("Test generate sub-module", func() {
+		meta.APIDirectory = "addons/test_addon"
+		langArgs = []string{
+			string(mainModuleVersionKey) + "=" + mainModuleVersion.Default,
+		}
+		meta.IsSubModule = true
+		genWithMeta()
+
+		Expect(err).Should(BeNil())
+		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "addons", "test_addon", "component", "cron-task"))
 	})
 
 	AfterSuite(func() {
@@ -207,5 +219,119 @@ var _ = Describe("FixSchemaWithOneAnyAllOf", func() {
 		Expect(schema.Value.OneOf).To(HaveLen(1))
 		Expect(schema.Value.OneOf[0].Value.Type).To(Equal("string"))
 		Expect(schema.Value.OneOf[0].Value.Enum).To(Equal([]interface{}{"go", "java", "python", "node", "ruby"}))
+	})
+})
+
+var _ = Describe("TestNewLanguageArgs", func() {
+	type args struct {
+		lang     string
+		langArgs []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "should create a languageArgs struct with the correct values",
+			args: args{
+				lang:     "go",
+				langArgs: []string{"flag1=value1", "flag2=value2"},
+			},
+			want:    map[string]string{"flag1": "value1", "flag2": "value2"},
+			wantErr: false,
+		},
+		{
+			name: "should not set a value for an unknown flag",
+			args: args{
+				lang:     "go",
+				langArgs: []string{"unknownFlag=value"},
+			},
+			want:    map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "should warn if an argument is not in the key=value format",
+			args: args{
+				lang:     "go",
+				langArgs: []string{"invalidArgument"},
+			},
+			want:    map[string]string{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		It(tt.name, func() {
+			got, err := NewLanguageArgs(tt.args.lang, tt.args.langArgs)
+			if tt.wantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			for k, v := range tt.want {
+				Expect(got.Get(langArgKey(k))).To(Equal(v))
+			}
+		})
+	}
+
+})
+
+var _ = Describe("getValueType", func() {
+
+	type valueTypeTest struct {
+		input    interface{}
+		expected CUEType
+	}
+
+	tests := []valueTypeTest{
+		{nil, ""},
+		{"hello", "string"},
+		{42, "integer"},
+		{float32(3.14), "number"},
+		{3.14159265358979323846, "number"},
+		{true, "boolean"},
+		{map[string]interface{}{"key": "value"}, "object"},
+		{[]interface{}{1, 2, 3}, "array"},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		It("should return the correct CUEType for the input", func() {
+			Expect(getValueType(tt.input)).To(Equal(tt.expected))
+		})
+	}
+})
+
+var _ = FDescribe("type fit", func() {
+
+	var schema *openapi3.Schema
+
+	BeforeEach(func() {
+		schema = &openapi3.Schema{Type: "string"}
+	})
+
+	var testCases = []struct {
+		name        string
+		cueType     CUEType
+		expectedFit bool
+		schemaType  string
+	}{
+		{"string can be oas string", CUEType("string"), true, "string"},
+		{"string not oas integer", CUEType("string"), false, "integer"},
+		{"integer can be oas integer", CUEType("integer"), true, "integer"},
+		{"integer can be oas number", CUEType("integer"), true, "number"},
+		{"number can be oas number", CUEType("number"), true, "number"},
+		{"number not oas integer", CUEType("number"), false, "integer"},
+		{"boolean can be oas boolean", CUEType("boolean"), true, "boolean"},
+		{"array can be oas array", CUEType("array"), true, "array"},
+		{"invalid type and any schema", CUEType(""), false, "anyschema"},
+	}
+
+	It("should return whether the CUEType fits the schema type or not", func() {
+		for _, tc := range testCases {
+			schema.Type = tc.schemaType
+			result := tc.cueType.fit(schema)
+			Expect(result).To(Equal(tc.expectedFit), tc.name)
+		}
 	})
 })

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -30,12 +30,14 @@ import (
 var _ = Describe("Test Generating SDK", func() {
 	var err error
 	outputDir := filepath.Join("testdata", "output")
+	lang := "go"
 	meta := GenMeta{
-		Output:  outputDir,
-		Lang:    "go",
-		Package: "github.com/kubevela/test-gen-sdk",
-		File:    []string{filepath.Join("testdata", "cron-task.cue")},
-		InitSDK: true,
+		Output:       outputDir,
+		Lang:         lang,
+		Package:      "github.com/kubevela/test-gen-sdk",
+		File:         []string{filepath.Join("testdata", "cron-task.cue")},
+		InitSDK:      true,
+		APIDirectory: defaultAPIDir[lang],
 	}
 	checkDirNotEmpty := func(dir string) {
 		_, err = os.Stat(dir)

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -36,12 +36,14 @@ var _ = Describe("Test Generating SDK", func() {
 		Lang:         lang,
 		Package:      "github.com/kubevela-contrib/kubevela-go-sdk",
 		APIDirectory: defaultAPIDir[lang],
+		Verbose:      true,
 	}
 	var langArgs []string
 
 	BeforeEach(func() {
 		meta.InitSDK = false
 		meta.File = []string{filepath.Join("testdata", "cron-task.cue")}
+		meta.cuePaths = []string{}
 	})
 
 	checkDirNotEmpty := func(dir string) {
@@ -106,7 +108,6 @@ var _ = Describe("Test Generating SDK", func() {
 
 		genWithMeta()
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "workflow-step", "one_of"))
-		By("check if ")
 	})
 
 	It("Test known issue: apply-terraform-provider", func() {
@@ -116,14 +117,12 @@ var _ = Describe("Test Generating SDK", func() {
 	})
 
 	It("Test generate sub-module", func() {
-		meta.APIDirectory = "addons/test_addon"
+		meta.APIDirectory = "pkg/apis/addons/test_addon"
 		langArgs = []string{
 			string(mainModuleVersionKey) + "=" + mainModuleVersion.Default,
 		}
 		meta.IsSubModule = true
 		genWithMeta()
-
-		Expect(err).Should(BeNil())
 		checkDirNotEmpty(filepath.Join(outputDir, "pkg", "apis", "addons", "test_addon", "component", "cron-task"))
 	})
 

--- a/pkg/definition/gen_sdk/go.go
+++ b/pkg/definition/gen_sdk/go.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -34,6 +35,20 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
+)
+
+type GoArgs struct {
+	// MainModuleVersion is version of main module, it will be used in go get command. For example, tag, commit id, branch name
+	// if set, vela will run a go get command in docker
+	MainModuleVersion string
+	// GoProxy is the proxy for go get/go mod tidy command
+	GoProxy string
+}
+
+const (
+	DefaultMainModuleHash = "cd431bb25a9a"
+	DefaultGoProxy        = "https://goproxy.cn,direct"
+	DefaultPackage        = "github.com/kubevela/vela-go-sdk"
 )
 
 var (
@@ -60,14 +75,20 @@ var (
 	}
 )
 
-// GoModifier is the Modifier for golang
-type GoModifier struct {
-	g *Generator
+// GoDefModifier is the Modifier for golang, modify code for each definition
+type GoDefModifier struct {
+	*GenMeta
+	*goArgs
 
-	defName string
-	defKind string
-	verbose bool
+	defStructPointer *j.Statement
+}
 
+type GoModuleModifier struct {
+	*GenMeta
+	*goArgs
+}
+
+type goArgs struct {
 	apiDir   string
 	defDir   string
 	utilsDir string
@@ -78,25 +99,29 @@ type GoModifier struct {
 	typeVarName          string
 	defStructName        string
 	defFuncReceiver      string
-	defStructPointer     *j.Statement
 }
 
-// Name the name of modifier
-func (m *GoModifier) Name() string {
-	return "GoModifier"
+func (a *goArgs) init(m *GenMeta) error {
+	var err error
+	a.apiDir, err = filepath.Abs(path.Join(m.Output, m.APIDirectory))
+	if err != nil {
+		return err
+	}
+	a.defDir = path.Join(a.apiDir, pkgdef.DefinitionKindToType[m.kind], m.name)
+	a.utilsDir = path.Join(m.Output, "pkg", "apis", "utils")
+	a.nameInSnakeCase = strcase.ToSnake(m.name)
+	a.nameInPascalCase = strcase.ToPascal(m.name)
+	a.typeVarName = a.nameInPascalCase + "Type"
+	a.specNameInPascalCase = a.nameInPascalCase + "Spec"
+	a.defStructName = strcase.ToGoPascal(m.name + "-" + pkgdef.DefinitionKindToType[m.kind])
+	a.defFuncReceiver = m.name[:1]
+	return nil
 }
 
-// Modify the modification of generated code
-func (m *GoModifier) Modify() error {
+func (m *GoModuleModifier) Modify() error {
 	for _, fn := range []func() error{
 		m.init,
-		m.clean,
 		m.addSubGoMod,
-		m.moveUtils,
-		m.modifyDefs,
-		m.addDefAPI,
-		m.addValidateTraits,
-		m.exportMethods,
 		m.format,
 	} {
 		if err := fn(); err != nil {
@@ -106,26 +131,56 @@ func (m *GoModifier) Modify() error {
 	return nil
 }
 
-func (m *GoModifier) init() error {
-	m.defName = m.g.name
-	m.defKind = m.g.kind
-	m.verbose = m.g.meta.Verbose
+func (m *GoModuleModifier) init() error {
+	m.goArgs = &goArgs{}
+	err := m.goArgs.init(m.GenMeta)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
-	m.apiDir = path.Join(m.g.meta.Output, m.g.meta.APIDirectory)
-	m.defDir = path.Join(m.apiDir, pkgdef.DefinitionKindToType[m.defKind], m.defName)
-	m.utilsDir = path.Join(m.g.meta.Output, "pkg", "apis", "utils")
-	m.nameInSnakeCase = strcase.ToSnake(m.defName)
-	m.nameInPascalCase = strcase.ToPascal(m.defName)
-	m.typeVarName = m.nameInPascalCase + "Type"
-	m.specNameInPascalCase = m.nameInPascalCase + "Spec"
-	m.defStructName = strcase.ToGoPascal(m.defName + "-" + pkgdef.DefinitionKindToType[m.defKind])
+func (m *GoModuleModifier) Name() string {
+	return "goModuleModifier"
+}
+
+// Name the name of modifier
+func (m *GoDefModifier) Name() string {
+	return "GoDefModifier"
+}
+
+// Modify the modification of generated code
+func (m *GoDefModifier) Modify() error {
+	for _, fn := range []func() error{
+		m.init,
+		m.clean,
+		m.moveUtils,
+		m.modifyDefs,
+		m.addDefAPI,
+		m.addValidateTraits,
+		m.exportMethods,
+	} {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *GoDefModifier) init() error {
+	m.goArgs = &goArgs{}
+	err := m.goArgs.init(m.GenMeta)
+	if err != nil {
+		return err
+	}
+
 	m.defStructPointer = j.Op("*").Id(m.defStructName)
-	m.defFuncReceiver = m.defName[:1]
-	err := os.MkdirAll(m.utilsDir, 0750)
+
+	err = os.MkdirAll(m.utilsDir, 0750)
 	return err
 }
 
-func (m *GoModifier) clean() error {
+func (m *GoDefModifier) clean() error {
 	err := os.RemoveAll(path.Join(m.defDir, ".openapi-generator"))
 	if err != nil {
 		return err
@@ -150,9 +205,9 @@ func (m *GoModifier) clean() error {
 
 }
 
-// addSubGoMod will add a go.mod and go.sum in the api directory if user mark that the api is a sub module
-func (m *GoModifier) addSubGoMod() error {
-	if !m.g.meta.IsSubModule {
+// addSubGoMod will add a go.mod and go.sum in the api directory if user mark that the api is a submodule
+func (m *GoModuleModifier) addSubGoMod() error {
+	if !m.IsSubModule {
 		return nil
 	}
 	copyFiles := map[string]string{
@@ -164,9 +219,43 @@ func (m *GoModifier) addSubGoMod() error {
 		if err != nil {
 			return errors.Wrap(err, "read "+src)
 		}
+		subModuleName := strings.TrimSuffix(fmt.Sprintf("%s/%s", m.Package, m.APIDirectory), "/")
+		srcContent = bytes.ReplaceAll(srcContent, []byte(DefaultPackage), []byte(subModuleName))
+
 		err = os.WriteFile(path.Join(m.apiDir, dst), srcContent, 0644)
 		if err != nil {
 			return errors.Wrap(err, "write "+dst)
+		}
+	}
+
+	cmds := make([]*exec.Cmd, 0)
+	if m.GoArgs.MainModuleVersion != DefaultMainModuleHash {
+		cmds = append(cmds, exec.Command("docker", "run",
+			"--rm",
+			"-v", m.apiDir+":/api",
+			"-w", "/api",
+			"golang:1.19-alpine",
+			"go", "get", fmt.Sprintf("%s@%s", m.Package, m.GoArgs.MainModuleVersion),
+		))
+	}
+	cmds = append(cmds, exec.Command("docker", "run",
+		"--rm",
+		"-v", m.apiDir+":/api",
+		"-w", "/api",
+		"golang:1.19-alpine",
+		"go", "mod", "tidy",
+	))
+	for _, cmd := range cmds {
+		if m.Verbose {
+			fmt.Println(cmd.String())
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
+
+		cmd.Env = append(cmd.Env, "GOPROXY="+m.GoArgs.GoProxy)
+		err := cmd.Run()
+		if err != nil {
+			return errors.Wrapf(err, "fail to run command %s", cmd.String())
 		}
 	}
 	return nil
@@ -175,14 +264,14 @@ func (m *GoModifier) addSubGoMod() error {
 // read all files in definition directory,
 // 1. replace the Nullable* Struct
 // 2. replace the package name
-func (m *GoModifier) modifyDefs() error {
+func (m *GoDefModifier) modifyDefs() error {
 	changeNullableType := func(b []byte) []byte {
 		return regexp.MustCompile("Nullable(String|(Float|Int)(32|64)|Bool)").ReplaceAll(b, []byte("utils.Nullable$1"))
 	}
 
 	files, err := os.ReadDir(m.defDir)
 	defHandleFunc := []byteHandler{
-		m.g.meta.packageFunc,
+		m.packageFunc,
 		changeNullableType,
 	}
 	if err != nil {
@@ -204,7 +293,7 @@ func (m *GoModifier) modifyDefs() error {
 	return nil
 }
 
-func (m *GoModifier) moveUtils() error {
+func (m *GoDefModifier) moveUtils() error {
 	// Adjust the generated files and code
 	err := os.Rename(path.Join(m.defDir, "utils.go"), path.Join(m.utilsDir, "utils.go"))
 	if err != nil {
@@ -217,7 +306,7 @@ func (m *GoModifier) moveUtils() error {
 	if err != nil {
 		return err
 	}
-	utilsBytes = bytes.Replace(utilsBytes, []byte(fmt.Sprintf("package %s", strcase.ToSnake(m.defName))), []byte("package utils"), 1)
+	utilsBytes = bytes.Replace(utilsBytes, []byte(fmt.Sprintf("package %s", strcase.ToSnake(m.name))), []byte("package utils"), 1)
 	utilsBytes = bytes.ReplaceAll(utilsBytes, []byte("isNil"), []byte("IsNil"))
 	err = os.WriteFile(utilsFile, utilsBytes, 0600)
 	if err != nil {
@@ -227,7 +316,7 @@ func (m *GoModifier) moveUtils() error {
 }
 
 // addDefAPI will add component/trait/workflowstep/policy Object to the api
-func (m *GoModifier) addDefAPI() error {
+func (m *GoDefModifier) addDefAPI() error {
 	file, err := os.OpenFile(path.Join(m.defDir, m.nameInSnakeCase+".go"), os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
@@ -260,11 +349,11 @@ func (m *GoModifier) addDefAPI() error {
 	return nil
 }
 
-func (m *GoModifier) genCommonFunc() []*j.Statement {
-	kind := m.defKind
+func (m *GoDefModifier) genCommonFunc() []*j.Statement {
+	kind := m.kind
 	typeName := j.Id(m.nameInPascalCase + "Type")
-	typeConst := j.Const().Add(typeName).Op("=").Lit(m.defName)
-	j.Op("=").Lit(m.defName)
+	typeConst := j.Const().Add(typeName).Op("=").Lit(m.name)
+	j.Op("=").Lit(m.name)
 	defStruct := j.Type().Id(m.defStructName).Struct(
 		j.Id("Base").Id("apis").Dot(DefinitionKindToBaseType[kind]),
 		j.Id("Properties").Id(m.specNameInPascalCase),
@@ -352,8 +441,8 @@ func (m *GoModifier) genCommonFunc() []*j.Statement {
 	return []*j.Statement{typeConst, initFunc, defStruct, defStructConstructor, buildFunc}
 }
 
-func (m *GoModifier) genFromFunc() []*j.Statement {
-	kind := m.g.kind
+func (m *GoDefModifier) genFromFunc() []*j.Statement {
+	kind := m.kind
 	kindBaseProperties := map[string][]string{
 		v1beta1.ComponentDefinitionKind:    {"Name", "DependsOn", "Inputs", "Outputs"},
 		v1beta1.WorkflowStepDefinitionKind: {"Name", "DependsOn", "Inputs", "Outputs", "If", "Timeout", "Meta"},
@@ -364,7 +453,7 @@ func (m *GoModifier) genFromFunc() []*j.Statement {
 	// fromFuncRsv means build from a part of K8s Object (e.g. v1beta1.Application.spec.component[*] to internal presentation (e.g. Component)
 	// fromFuncRsv will have a function receiver
 	getSubSteps := func(sub bool) func(g *j.Group) {
-		if m.defKind != v1beta1.WorkflowStepDefinitionKind || sub {
+		if m.kind != v1beta1.WorkflowStepDefinitionKind || sub {
 			return func(g *j.Group) {}
 		}
 		return func(g *j.Group) {
@@ -382,7 +471,7 @@ func (m *GoModifier) genFromFunc() []*j.Statement {
 		}
 	}
 	assignSubSteps := func(sub bool) func(g *j.Group) {
-		if m.defKind != v1beta1.WorkflowStepDefinitionKind || sub {
+		if m.kind != v1beta1.WorkflowStepDefinitionKind || sub {
 			return func(g *j.Group) {}
 		}
 		return func(g *j.Group) {
@@ -449,15 +538,15 @@ func (m *GoModifier) genFromFunc() []*j.Statement {
 		)
 
 	res := []*j.Statement{fromFuncRsv(false), fromFunc}
-	if m.defKind == v1beta1.WorkflowStepDefinitionKind {
+	if m.kind == v1beta1.WorkflowStepDefinitionKind {
 		res = append(res, fromFuncRsv(true), fromSubFunc)
 	}
 	return res
 }
 
 // genDedicatedFunc generate functions for definition kinds
-func (m *GoModifier) genDedicatedFunc() []*j.Statement {
-	switch m.defKind {
+func (m *GoDefModifier) genDedicatedFunc() []*j.Statement {
+	switch m.kind {
 	case v1beta1.ComponentDefinitionKind:
 		setTraitFunc := j.Func().
 			Params(j.Id(m.defFuncReceiver).Add(m.defStructPointer)).
@@ -508,14 +597,14 @@ func (m *GoModifier) genDedicatedFunc() []*j.Statement {
 	return nil
 }
 
-func (m *GoModifier) genNameTypeFunc() []*j.Statement {
-	nameFunc := j.Func().Params(j.Id(m.defFuncReceiver).Add(m.defStructPointer)).Id(DefinitionKindToPascal[m.defKind] + "Name").Params().String().Block(
+func (m *GoDefModifier) genNameTypeFunc() []*j.Statement {
+	nameFunc := j.Func().Params(j.Id(m.defFuncReceiver).Add(m.defStructPointer)).Id(DefinitionKindToPascal[m.kind] + "Name").Params().String().Block(
 		j.Return(j.Id(m.defFuncReceiver).Dot("Base").Dot("Name")),
 	)
 	typeFunc := j.Func().Params(j.Id(m.defFuncReceiver).Add(m.defStructPointer)).Id("DefType").Params().String().Block(
 		j.Return(j.Id(m.typeVarName)),
 	)
-	switch m.defKind {
+	switch m.kind {
 	case v1beta1.ComponentDefinitionKind, v1beta1.WorkflowStepDefinitionKind, v1beta1.PolicyDefinitionKind:
 		return []*j.Statement{nameFunc, typeFunc}
 	case v1beta1.TraitDefinitionKind:
@@ -524,11 +613,11 @@ func (m *GoModifier) genNameTypeFunc() []*j.Statement {
 	return nil
 }
 
-func (m *GoModifier) genUnmarshalFunc() []*j.Statement {
+func (m *GoDefModifier) genUnmarshalFunc() []*j.Statement {
 	return []*j.Statement{j.Null()}
 }
 
-func (m *GoModifier) genBaseSetterFunc() []*j.Statement {
+func (m *GoDefModifier) genBaseSetterFunc() []*j.Statement {
 	baseFuncArgs := map[string][]struct {
 		funcName string
 		argName  string
@@ -557,7 +646,7 @@ func (m *GoModifier) genBaseSetterFunc() []*j.Statement {
 		},
 	}
 	baseFuncs := make([]*j.Statement, 0)
-	for _, fn := range baseFuncArgs[m.defKind] {
+	for _, fn := range baseFuncArgs[m.kind] {
 		if fn.dst == nil {
 			fn.dst = j.Dot(fn.funcName)
 		}
@@ -580,8 +669,8 @@ func (m *GoModifier) genBaseSetterFunc() []*j.Statement {
 	return baseFuncs
 }
 
-func (m *GoModifier) genAddSubStepFunc() *j.Statement {
-	if m.defName != "step-group" || m.defKind != v1beta1.WorkflowStepDefinitionKind {
+func (m *GoDefModifier) genAddSubStepFunc() *j.Statement {
+	if m.name != "step-group" || m.kind != v1beta1.WorkflowStepDefinitionKind {
 		return j.Null()
 	}
 	subList := j.Id(m.defFuncReceiver).Dot("Base").Dot("SubSteps")
@@ -597,7 +686,7 @@ func (m *GoModifier) genAddSubStepFunc() *j.Statement {
 }
 
 // exportMethods will export methods from definition spec struct to definition struct
-func (m *GoModifier) exportMethods() error {
+func (m *GoDefModifier) exportMethods() error {
 	fileLoc := path.Join(m.defDir, m.nameInSnakeCase+".go")
 	// nolint:gosec
 	file, err := os.ReadFile(fileLoc)
@@ -628,8 +717,8 @@ func (m *GoModifier) exportMethods() error {
 	return os.WriteFile(fileLoc, []byte(fileStr), 0600)
 }
 
-func (m *GoModifier) addValidateTraits() error {
-	if m.defKind != v1beta1.ComponentDefinitionKind {
+func (m *GoDefModifier) addValidateTraits() error {
+	if m.kind != v1beta1.ComponentDefinitionKind {
 		return nil
 	}
 	fileLoc := path.Join(m.defDir, m.nameInSnakeCase+".go")
@@ -656,7 +745,7 @@ func (m *GoModifier) addValidateTraits() error {
 
 	return os.WriteFile(fileLoc, []byte(fileStr), 0600)
 }
-func (m *GoModifier) format() error {
+func (m *GoModuleModifier) format() error {
 	// check if gofmt is installed
 	// todo (chivalryq): support go mod tidy for sub-module
 
@@ -673,11 +762,11 @@ func (m *GoModifier) format() error {
 	}
 	if allFormattersInstalled {
 		for _, fmter := range formatterPaths {
-			if m.verbose {
+			if m.Verbose {
 				fmt.Printf("Use %s to format code\n", fmter)
 			}
 			// nolint:gosec
-			cmd := exec.Command(fmter, "-w", m.defDir)
+			cmd := exec.Command(fmter, "-w", m.apiDir)
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				return errors.Wrap(err, string(output))
@@ -686,31 +775,51 @@ func (m *GoModifier) format() error {
 		return nil
 	}
 	// fallback to use go lib
-	if m.verbose {
+	if m.Verbose {
 		fmt.Println("At least one of linters is not installed, use go/format lib to format code")
 	}
-	files, err := os.ReadDir(m.defDir)
-	if err != nil {
-		return errors.Wrap(err, "read dir")
-	}
-	for _, f := range files {
-		if !strings.HasSuffix(f.Name(), ".go") {
-			continue
+
+	// format all .go files
+	return filepath.Walk(m.apiDir, func(path string, info os.FileInfo, err error) error {
+		if !strings.HasSuffix(path, ".go") {
+			return nil
 		}
-		filePath := path.Join(m.defDir, f.Name())
 		// nolint:gosec
-		content, err := os.ReadFile(filePath)
+		content, err := os.ReadFile(path)
 		if err != nil {
-			return errors.Wrapf(err, "read file %s", filePath)
+			return errors.Wrapf(err, "read file %s", path)
 		}
 		formatted, err := format.Source(content)
 		if err != nil {
-			return errors.Wrapf(err, "format file %s", filePath)
+			return errors.Wrapf(err, "format file %s", path)
 		}
-		err = os.WriteFile(filePath, formatted, 0600)
+		err = os.WriteFile(path, formatted, 0600)
 		if err != nil {
-			return errors.Wrapf(err, "write file %s", filePath)
+			return errors.Wrapf(err, "write file %s", path)
+		}
+		return nil
+	})
+}
+
+// parse parses the args and set the value to GoArgs
+// todo(chivalryq): generalize the args parsing
+func (args *GoArgs) parse(stringArgs []string) {
+	for _, arg := range stringArgs {
+		parts := strings.Split(arg, "=")
+		if len(parts) != 2 {
+			continue
+		}
+		switch parts[0] {
+		case "MainModuleVersion":
+			args.MainModuleVersion = parts[1]
+		case "GoProxy":
+			args.GoProxy = parts[1]
 		}
 	}
-	return nil
+	if args.GoProxy == "" {
+		args.GoProxy = DefaultGoProxy
+	}
+	if args.MainModuleVersion == "" {
+		args.MainModuleVersion = DefaultMainModuleHash
+	}
 }

--- a/pkg/definition/gen_sdk/go.go
+++ b/pkg/definition/gen_sdk/go.go
@@ -83,6 +83,7 @@ type GoDefModifier struct {
 	defStructPointer *j.Statement
 }
 
+// GoModuleModifier is the Modifier for golang, modify code for each module
 type GoModuleModifier struct {
 	*GenMeta
 	*goArgs
@@ -133,11 +134,7 @@ func (m *GoModuleModifier) Modify() error {
 
 func (m *GoModuleModifier) init() error {
 	m.goArgs = &goArgs{}
-	err := m.goArgs.init(m.GenMeta)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.goArgs.init(m.GenMeta)
 }
 
 func (m *GoModuleModifier) Name() string {
@@ -220,7 +217,8 @@ func (m *GoModuleModifier) addSubGoMod() error {
 			return errors.Wrap(err, "read "+src)
 		}
 		subModuleName := strings.TrimSuffix(fmt.Sprintf("%s/%s", m.Package, m.APIDirectory), "/")
-		srcContent = bytes.ReplaceAll(srcContent, []byte(DefaultPackage), []byte(subModuleName))
+		srcContent = bytes.ReplaceAll(srcContent, []byte("module "+DefaultPackage), []byte("module "+subModuleName))
+		srcContent = bytes.ReplaceAll(srcContent, []byte(DefaultPackage), []byte(m.Package))
 
 		err = os.WriteFile(path.Join(m.apiDir, dst), srcContent, 0644)
 		if err != nil {

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1071,14 +1071,15 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 		Use:   "gen-api DEFINITION.cue",
 		Short: "Generate SDK from X-Definition.",
 		Long: "Generate SDK from X-definition file.\n" +
-			"* This command leverage openapi-generator project. Therefore demands \"docker\" exist in PATH" +
+			"* This command leverage openapi-generator project. Therefore demands \"docker\" exist in PATH\n" +
 			"* Currently, this function is still working in progress and not all formats of parameter in X-definition are supported yet.",
 		Example: "# Generate SDK for golang with scaffold initialized\n" +
 			"> vela def gen-api --init --language go -f /path/to/def -o /path/to/sdk\n" +
 			"# Generate incremental definition files to existing sdk directory\n" +
-			"> vela def gen-api --language go -f /path/to/def -o /path/to/sdk",
+			"> vela def gen-api --language go -f /path/to/def -o /path/to/sdk\n" +
+			"# Generate definitions to a sub-module\n" +
+			"> vela def gen-api --language go -f /path/to/def -o /path/to/sdk --submodule --api-dir path/relative/to/output --language-args arg1=val1,arg2=val2\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			err := meta.Init(c, languageArgs)
 			if err != nil {
 				return err

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1077,7 +1077,7 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 			"# Generate incremental definition files to existing sdk directory\n" +
 			"> vela def gen-api --lang go -f /path/to/def -o /path/to/sdk",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := meta.Init(c)
+			err := meta.Init(c, cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -1100,12 +1100,18 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 	cmd.Flags().StringVarP(&meta.Output, "output", "o", "./apis", "Output directory path")
 	cmd.Flags().StringVar(&meta.APIDirectory, "api-dir", "", "API directory path to put definition API files, relative to output directory. Default value: go: pkg/apis")
 	cmd.Flags().BoolVar(&meta.IsSubModule, "submodule", false, "Whether the generated code is a submodule of the project. If set, the directory specified by `api-dir` will be treated as a submodule of the project")
-	cmd.Flags().StringVarP(&meta.Package, "package", "p", "github.com/kubevela/vela-go-sdk", "Package name of generated code")
+	cmd.Flags().StringVarP(&meta.Package, "package", "p", gen_sdk.DefaultPackage, "Package name of generated code")
 	cmd.Flags().StringVarP(&meta.Lang, "lang", "g", "go", "Language to generate code. Valid languages: go")
 	cmd.Flags().StringVarP(&meta.Template, "template", "t", "", "Template file path, if not specified, the default template will be used")
 	cmd.Flags().StringSliceVarP(&meta.File, "file", "f", nil, "File name of definitions, can be specified multiple times, or use comma to separate multiple files. If directory specified, all files found recursively in the directory will be used")
 	cmd.Flags().BoolVar(&meta.InitSDK, "init", false, "Init the whole SDK project, if not set, only the API file will be generated")
 	cmd.Flags().BoolVarP(&meta.Verbose, "verbose", "v", false, "Print verbose logs")
+	cmd.Flags().StringSlice("go-args", []string{},
+		fmt.Sprintf("Additional arguments to pass to the go generator, available options: "+
+			"MainModuleVersion(specify the version of the main module in submodule, used when set --submodule, default: cd431bb25a9a), "+
+			"GoProxy(specify the GOPROXY environment variable, default: https://goproxy.cn,direct)",
+		),
+	)
 
 	return cmd
 }

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1098,6 +1098,8 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&meta.Output, "output", "o", "./apis", "Output directory path")
+	cmd.Flags().StringVar(&meta.APIDirectory, "api-dir", "", "API directory path to put definition API files, relative to output directory. Default value: go: pkg/apis")
+	cmd.Flags().BoolVar(&meta.IsSubModule, "submodule", false, "Whether the generated code is a submodule of the project. If set, the directory specified by `api-dir` will be treated as a submodule of the project")
 	cmd.Flags().StringVarP(&meta.Package, "package", "p", "github.com/kubevela/vela-go-sdk", "Package name of generated code")
 	cmd.Flags().StringVarP(&meta.Lang, "lang", "g", "go", "Language to generate code. Valid languages: go")
 	cmd.Flags().StringVarP(&meta.Template, "template", "t", "", "Template file path, if not specified, the default template will be used")


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR allows user to generate a group of definitions as sub-module to KubeVela Go SDK. Usage:

```shell
vela def gen-api -f ./addons/fluxcd/definitions -g go -o ../kubevela-go-sdk --api-dir pkg/apis/addon/fluxcd/ --package github.com/kubevela-contrib/kubevela-go-sdk --init --submodule
```

Added flags to `vela def gen-api`

- submodule: generate this group of definitions to a sub-module
- api-dir: which directory to place the generated API
- language-args: specify language-specific arguments for genereting.

Command help output:
```shell
bin/vela def gen-api -h                                                                                                                                                                                
Generate SDK from X-definition file.
* This command leverage openapi-generator project. Therefore demands "docker" exist in PATH* Currently, this function is still working in progress and not all formats of parameter in X-definition are supported yet.

Usage:
  vela def gen-api DEFINITION.cue [flags]

Examples:
# Generate SDK for golang with scaffold initialized
> vela def gen-api --init --language go -f /path/to/def -o /path/to/sdk
# Generate incremental definition files to existing sdk directory
> vela def gen-api --language go -f /path/to/def -o /path/to/sdk

Flags:
      --api-dir string          API directory path to put definition API files, relative to output directory. Default value: go: pkg/apis
  -f, --file strings            File name of definitions, can be specified multiple times, or use comma to separate multiple files. If directory specified, all files found recursively in the directory will be used
  -h, --help                    help for gen-api
      --init                    Init the whole SDK project, if not set, only the API file will be generated
  -g, --language string         Language to generate code. Valid languages: go (default "go")
      --language-args strings   language-specific arguments to pass to the go generator, available options: 
                                go: 
                                        GoProxy: The proxy for go get/go mod tidy command
                                        MainModuleVersion: The version of main module, it will be used in go get command. For example, tag, commit id, branch name
                                
  -o, --output string           Output directory path (default "./apis")
  -p, --package string          Package name of generated code (default "github.com/kubevela/vela-go-sdk")
      --submodule api-dir       Whether the generated code is a submodule of the project. If set, the directory specified by api-dir will be treated as a submodule of the project
  -t, --template string         Template file path, if not specified, the default template will be used
  -v, --verbose                 Print verbose logs
```


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->