### PR TITLE
Fix: fix vela-minimal helm chart unrecognised options

### DIFF
--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -65,7 +65,6 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 | `controllerArgs.reSyncPeriod` | The period for resync the applications                                                        | `5m`                 |
 | `OAMSpecVer`                  | OAMSpecVer is the oam spec version controller want to setup                                   | `minimal`            |
 | `disableCaps`                 | Disable capability                                                                            | `envbinding,rollout` |
-| `applyOnceOnly`               | Valid applyOnceOnly values: true/false/on/off/force                                           | `off`                |
 | `dependCheckWait`             | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`                |
 
 
@@ -97,20 +96,29 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 | `healthCheck.port`          | KubeVela health check port           | `9440`             |
 
 
+### KubeVela controller optimization parameters
+
+| Name                     | Description                                                                                                                           | Value   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `featureGates.applyOnce` | if enabled, the apply-once feature will be applied to all applications, no state-keep and no resource data storage in ResourceTracker | `false` |
+
+
 ### MultiCluster parameters
 
-| Name                                                  | Description                      | Value                            |
-| ----------------------------------------------------- | -------------------------------- | -------------------------------- |
-| `multicluster.enabled`                                | Whether to enable multi-cluster  | `true`                           |
-| `multicluster.clusterGateway.replicaCount`            | ClusterGateway replica count     | `1`                              |
-| `multicluster.clusterGateway.port`                    | ClusterGateway port              | `9443`                           |
-| `multicluster.clusterGateway.image.repository`        | ClusterGateway image repository  | `oamdev/cluster-gateway`         |
-| `multicluster.clusterGateway.image.tag`               | ClusterGateway image tag         | `v1.7.0`                         |
-| `multicluster.clusterGateway.image.pullPolicy`        | ClusterGateway image pull policy | `IfNotPresent`                   |
-| `multicluster.clusterGateway.resources.limits.cpu`    | ClusterGateway cpu limit         | `100m`                           |
-| `multicluster.clusterGateway.resources.limits.memory` | ClusterGateway memory limit      | `200Mi`                          |
-| `multicluster.clusterGateway.secureTLS.enabled`       | Whether to enable secure TLS     | `true`                           |
-| `multicluster.clusterGateway.secureTLS.certPath`      | Path to the certificate file     | `/etc/k8s-cluster-gateway-certs` |
+| Name                                                    | Description                      | Value                            |
+| ------------------------------------------------------- | -------------------------------- | -------------------------------- |
+| `multicluster.enabled`                                  | Whether to enable multi-cluster  | `true`                           |
+| `multicluster.clusterGateway.replicaCount`              | ClusterGateway replica count     | `1`                              |
+| `multicluster.clusterGateway.port`                      | ClusterGateway port              | `9443`                           |
+| `multicluster.clusterGateway.image.repository`          | ClusterGateway image repository  | `oamdev/cluster-gateway`         |
+| `multicluster.clusterGateway.image.tag`                 | ClusterGateway image tag         | `v1.8.0-alpha.3`                 |
+| `multicluster.clusterGateway.image.pullPolicy`          | ClusterGateway image pull policy | `IfNotPresent`                   |
+| `multicluster.clusterGateway.resources.requests.cpu`    | ClusterGateway cpu request       | `50m`                            |
+| `multicluster.clusterGateway.resources.requests.memory` | ClusterGateway memory request    | `20Mi`                           |
+| `multicluster.clusterGateway.resources.limits.cpu`      | ClusterGateway cpu limit         | `500m`                           |
+| `multicluster.clusterGateway.resources.limits.memory`   | ClusterGateway memory limit      | `200Mi`                          |
+| `multicluster.clusterGateway.secureTLS.enabled`         | Whether to enable secure TLS     | `true`                           |
+| `multicluster.clusterGateway.secureTLS.certPath`        | Path to the certificate file     | `/etc/k8s-cluster-gateway-certs` |
 
 
 ### Test parameters

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -166,10 +166,8 @@ spec:
             - "--use-webhook=true"
             - "--webhook-port={{ .Values.webhookService.port }}"
             - "--webhook-cert-dir={{ .Values.admissionWebhooks.certificate.mountPath }}"
-            - "--autogen-workload-definition={{ .Values.admissionWebhooks.autoGenWorkloadDefinition }}"
             {{ end }}
             - "--health-addr=:{{ .Values.healthCheck.port }}"
-            - "--apply-once-only={{ .Values.applyOnceOnly }}"
             {{ if ne .Values.disableCaps "" }}
             - "--disable-caps={{ .Values.disableCaps }}"
             {{ end }}
@@ -188,6 +186,7 @@ spec:
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
             - "--feature-gates=EnableSuspendOnFailure={{- .Values.workflow.enableSuspendOnFailure | toString -}}"
             - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
+            - "--feature-gates=ApplyOnce={{- .Values.featureGates.applyOnce | toString -}}"
             {{ if .Values.authentication.enabled }}
             {{ if .Values.authentication.withUser }}
             - "--authentication-with-user"

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -83,8 +83,9 @@ webhookService:
 healthCheck:
   port: 9440
 
+## @section KubeVela controller optimization parameters
+
 ##@param featureGates.applyOnce if enabled, the apply-once feature will be applied to all applications, no state-keep and no resource data storage in ResourceTracker
-##@param
 featureGates:
   applyOnce: false
 
@@ -96,6 +97,8 @@ featureGates:
 ## @param multicluster.clusterGateway.image.repository ClusterGateway image repository
 ## @param multicluster.clusterGateway.image.tag ClusterGateway image tag
 ## @param multicluster.clusterGateway.image.pullPolicy ClusterGateway image pull policy
+## @param multicluster.clusterGateway.resources.requests.cpu ClusterGateway cpu request
+## @param multicluster.clusterGateway.resources.requests.memory ClusterGateway memory request
 ## @param multicluster.clusterGateway.resources.limits.cpu ClusterGateway cpu limit
 ## @param multicluster.clusterGateway.resources.limits.memory ClusterGateway memory limit
 ## @param multicluster.clusterGateway.secureTLS.enabled Whether to enable secure TLS

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -26,9 +26,6 @@ OAMSpecVer: "minimal"
 ## @param disableCaps Disable capability
 disableCaps: "envbinding,rollout"
 
-## @param applyOnceOnly Valid applyOnceOnly values: true/false/on/off/force
-applyOnceOnly: "off"
-
 ## @param dependCheckWait dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready
 dependCheckWait: 30s
 
@@ -86,6 +83,10 @@ webhookService:
 healthCheck:
   port: 9440
 
+##@param featureGates.applyOnce if enabled, the apply-once feature will be applied to all applications, no state-keep and no resource data storage in ResourceTracker
+##@param
+featureGates:
+  applyOnce: false
 
 ## @section MultiCluster parameters
 
@@ -106,11 +107,14 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: v1.7.0
+      tag: v1.8.0-alpha.3
       pullPolicy: IfNotPresent
     resources:
+      requests:
+        cpu: 50m
+        memory: 20Mi
       limits:
-        cpu: 100m
+        cpu: 500m
         memory: 200Mi
     secureTLS:
       enabled: true


### PR DESCRIPTION
### Description of your changes
It seems that the `vela-minimal` helm chart became out of sync from the `vela-core`  chart and rest of the repo.

The following issues have been witnessed on instantiation of the controller when using the `vela-minimal` chart
```
Error: invalid argument "" for "--autogen-workload-definition" flag: strconv.ParseBool: parsing "": invalid syntax
```

```
Error: unknown flag: --apply-once-only
```

Fixes #
Made the mimimum alignment changes in `vela-minimal` chart to resolve the above errors and have it aligned with `vela-core`

Other changes may be required to cover some of the gap introduced in configuration that still exist between the 2 charts.

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have run the vela-minimal chart with the changes
