### PR TITLE
Feat: remove comp name dup check

### DIFF
--- a/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/validation.go
@@ -102,7 +102,7 @@ func (h *ValidatingHandler) ValidateComponents(ctx context.Context, app *v1beta1
 		// cannot generate appfile, no need to validate further
 		return componentErrs
 	}
-	if i, err := appParser.ValidateComponentNames(ctx, af); err != nil {
+	if i, err := appParser.ValidateComponentNames(app); err != nil {
 		componentErrs = append(componentErrs, field.Invalid(field.NewPath(fmt.Sprintf("components[%d].name", i)), app, err.Error()))
 	}
 	if err := appParser.ValidateCUESchematicAppfile(af); err != nil {

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -292,22 +292,6 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(k8sClient.Create(ctx, &newApp)).ShouldNot(BeNil())
 	})
 
-	It("Test two app have component with same name", func() {
-		By("Apply an application")
-		var firstApp v1beta1.Application
-		Expect(common.ReadYamlToObject("testdata/app/app9.yaml", &firstApp)).Should(BeNil())
-		firstApp.Namespace = namespaceName
-		firstApp.Name = "first-app"
-		Expect(k8sClient.Create(ctx, &firstApp)).Should(BeNil())
-
-		time.Sleep(time.Second)
-		var secondApp v1beta1.Application
-		Expect(common.ReadYamlToObject("testdata/app/app9.yaml", &secondApp)).Should(BeNil())
-		secondApp.Namespace = namespaceName
-		secondApp.Name = "second-app"
-		Expect(k8sClient.Create(ctx, &secondApp)).ShouldNot(BeNil())
-	})
-
 	It("Test app failed after retries", func() {
 		By("Apply an application")
 		var newApp v1beta1.Application


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Remove component name duplication check in Webhook. Now we allow duplicated component name across different applications.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->