### PR TITLE
Fix: vela top cannot set theme

### DIFF
--- a/references/cli/top/config/color.go
+++ b/references/cli/top/config/color.go
@@ -291,7 +291,7 @@ func makeThemeConfigFileIfNotExist() bool {
 	if _, err := os.Open(filepath.Clean(themeConfigFilePath)); err != nil {
 		if os.IsNotExist(err) {
 			// make file if not exist
-			_ = os.MkdirAll(filepath.Clean(velaThemeHome), 0600)
+			_ = os.MkdirAll(filepath.Clean(velaThemeHome), 0700)
 			_ = os.WriteFile(filepath.Clean(themeConfigFilePath), []byte("name : "+DefaultTheme), 0600)
 		}
 		return false

--- a/references/cli/top/config/color_test.go
+++ b/references/cli/top/config/color_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -34,4 +36,12 @@ func TestColor(t *testing.T) {
 	assert.Equal(t, c1.Color(), tcell.GetColor("#ff0000"))
 	c2 := Color("red")
 	assert.Equal(t, c2.Color(), tcell.GetColor("red").TrueColor())
+}
+
+func TestPersistentThemeConfig(t *testing.T) {
+	defer PersistentThemeConfig(DefaultTheme)
+	PersistentThemeConfig("foo")
+	bytes, err := os.ReadFile(themeConfigFilePath)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(string(bytes), "foo"))
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/kubevela/kubevela/issues/5744

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
run `vela top` to switch theme.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

`~/.vela/theme` doesn't have executable permission.