### PR TITLE
Refactor: split Generate function

### DIFF
--- a/references/cuegen/convert_test.go
+++ b/references/cuegen/convert_test.go
@@ -18,7 +18,6 @@ package cuegen
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,11 +30,9 @@ func TestConvert(t *testing.T) {
 	assert.NoError(t, err)
 
 	got := &bytes.Buffer{}
-	assert.NoError(t,
-		g.Generate(got,
-			WithAnyTypes("*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
-		),
-	)
+	decls, err := g.Generate(WithAnyTypes("*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"))
+	assert.NoError(t, err)
+	assert.NoError(t, g.Format(got, decls))
 
 	want, err := os.ReadFile("testdata/valid.cue")
 	assert.NoError(t, err)
@@ -56,7 +53,9 @@ func TestConvertInvalid(t *testing.T) {
 		g, err := NewGenerator(path)
 		assert.NoError(t, err)
 
-		assert.Error(t, g.Generate(io.Discard), path)
+		decls, err := g.Generate()
+		assert.Error(t, err, path)
+		assert.Nil(t, decls)
 
 		return nil
 	}); err != nil {
@@ -69,7 +68,9 @@ func TestConvertNullable(t *testing.T) {
 	assert.NoError(t, err)
 
 	got := &bytes.Buffer{}
-	assert.NoError(t, g.Generate(got, WithNullable()))
+	decls, err := g.Generate(WithNullable())
+	assert.NoError(t, err)
+	assert.NoError(t, g.Format(got, decls))
 
 	want, err := os.ReadFile("testdata/nullable.cue")
 	assert.NoError(t, err)

--- a/references/cuegen/generator_test.go
+++ b/references/cuegen/generator_test.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"testing"
 
+	cueast "cuelang.org/go/cue/ast"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,8 +48,26 @@ func TestNewGenerator(t *testing.T) {
 func TestGeneratorGenerate(t *testing.T) {
 	g := testGenerator(t)
 
-	assert.NoError(t, g.Generate(io.Discard, WithAnyTypes("foo", "bar"), nil))
-	assert.Error(t, g.Generate(nil))
+	decls, err := g.Generate(WithAnyTypes("foo", "bar"), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, decls)
+
+	decls, err = g.Generate()
+	assert.NoError(t, err)
+	assert.NotNil(t, decls)
+}
+
+func TestGeneratorFormat(t *testing.T) {
+	g := testGenerator(t)
+
+	decls, err := g.Generate()
+	assert.NoError(t, err)
+
+	assert.NoError(t, g.Format(io.Discard, decls))
+	assert.NoError(t, g.Format(io.Discard, []cueast.Decl{nil, nil}))
+	assert.Error(t, g.Format(nil, decls))
+	assert.Error(t, g.Format(io.Discard, nil))
+	assert.Error(t, g.Format(io.Discard, []cueast.Decl{}))
 }
 
 func TestLoadPackage(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

Part of #5364 

Split Generate function into Generate and Format functions, so we can modify generated decls before format.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests

### Special notes for your reviewer

