### PR TITLE
Feat: list addon with specify registry

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -58,6 +58,7 @@ var enabledAddonColor = color.New(color.Bold, color.FgGreen)
 
 var (
 	forceDisable  bool
+	addonRegistry string
 	addonVersion  string
 	addonClusters string
 	verboseStatus bool
@@ -94,17 +95,22 @@ func NewAddonCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *
 
 // NewAddonListCommand create addon list command
 func NewAddonListCommand(c common.Args) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List addons",
 		Long:    "List addons in KubeVela",
+		Example: `  List addon by:
+	vela addon ls
+  List addon with specify registry:
+    vela addon ls --registry <registry-name>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			k8sClient, err := c.GetClient()
 			if err != nil {
 				return err
 			}
-			table, err := listAddons(context.Background(), k8sClient, "")
+			table, err := listAddons(context.Background(), k8sClient, addonRegistry)
 			if err != nil {
 				return err
 			}
@@ -112,6 +118,8 @@ func NewAddonListCommand(c common.Args) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVarP(&addonRegistry, "registry", "r", "", "specify the registry name to list")
+	return cmd
 }
 
 // NewAddonEnableCommand create addon enable command

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -102,7 +102,7 @@ func NewAddonListCommand(c common.Args) *cobra.Command {
 		Long:    "List addons in KubeVela",
 		Example: `  List addon by:
 	vela addon ls
-  List addon with specify registry:
+  List addons in a specific registry, useful to reveal addons with duplicated names:
     vela addon ls --registry <registry-name>
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
### Description of your changes
add list addon with specify registry. 
when there are multiple registry,` vela addon ls` command merges the addon's occures in multiple registry. Thus, we can not list all addon in specify registry.

for exampla:
in kubevela and testzhh registry, there are both fluxcd/rollout/vegeta
![image](https://user-images.githubusercontent.com/6092586/228839162-a4a57d82-0dd8-4dd9-9b23-8003eaf8adcf.png)
vela addon ls commond only displays the fluxcd/rollout/vege addon in kubevela registry.
![image](https://user-images.githubusercontent.com/6092586/228838381-8ac5dde3-9c4a-463a-b700-1246d4f522b9.png)


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
1. add testzhh registry to addon
2. push fluxcd/rollout/vegeta addon to testzhh registry
3. run command `vela addon ls`


### Special notes for your reviewer

@wangyikewxgm 