### PR TITLE
Fix:  filter rollout created by rolling-release in `vela workflow resume`

### DIFF
--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -235,6 +235,9 @@ const (
 
 	// AnnotationAddonDefinitionBondCompKey indicates the definition in addon bond component.
 	AnnotationAddonDefinitionBondCompKey = "addon.oam.dev/bind-component"
+
+	// AnnotationSkipResume annotation indicates that the resource does not need to be resumed.
+	AnnotationSkipResume = "controller.core.oam.dev/skip-resume"
 )
 
 const (

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/pkg/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
 
 	kruisev1alpha1 "github.com/openkruise/rollouts/api/v1alpha1"
 

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -64,7 +64,7 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 					}
 					return nil, errors.Wrapf(err, "failed to get kruise rollout %s/%s in cluster %s", mr.Namespace, mr.Name, mr.Cluster)
 				}
-				if rollout.Labels[oam.TraitTypeLabel] == "rolling-release" {
+				if value, ok := rollout.Annotations[oam.AnnotationSkipResume]; ok && value == "true" {
 					continue
 				}
 				rollouts = append(rollouts, &ClusterRollout{Rollout: rollout, Cluster: mr.Cluster})

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/pkg/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -61,6 +62,9 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 						continue
 					}
 					return nil, errors.Wrapf(err, "failed to get kruise rollout %s/%s in cluster %s", mr.Namespace, mr.Name, mr.Cluster)
+				}
+				if rollout.Labels[oam.TraitTypeLabel] == "rolling-release" {
+					continue
 				}
 				rollouts = append(rollouts, &ClusterRollout{Rollout: rollout, Cluster: mr.Cluster})
 			}

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -19,13 +19,14 @@ package rollout
 import (
 	"context"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kruisev1alpha1 "github.com/openkruise/rollouts/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -19,14 +19,13 @@ package rollout
 import (
 	"context"
 
+	"github.com/oam-dev/kubevela/pkg/oam"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kruisev1alpha1 "github.com/openkruise/rollouts/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/oam-dev/kubevela/pkg/oam"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -179,8 +178,8 @@ var rollingReleaseRollout = kruisev1alpha1.Rollout{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "rolling-release-rollout",
 		Namespace: "default",
-		Labels: map[string]string{
-			oam.TraitTypeLabel: "rolling-release",
+		Annotations: map[string]string{
+			oam.AnnotationSkipResume: "true",
 		},
 	},
 	Spec: kruisev1alpha1.RolloutSpec{

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -19,7 +19,6 @@ package rollout
 import (
 	"context"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kruisev1alpha1 "github.com/openkruise/rollouts/api/v1alpha1"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 


### PR DESCRIPTION
[PR](https://github.com/kubevela/catalog/pull/648)  provides a rolling-release trait for using Kruise-rollout in workflow. However, our `vela workflow resume` command currently resumes both the app workflow and the rollout under the app. This PR filters out the rollout resources created by the rolling-release trait.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->