### PR TITLE
Feat: vela cluster join support overwrite

### DIFF
--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -201,7 +201,14 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 					IoStreams:              ioStreams,
 					HubConfig:              restConfig,
 					TrackingSpinnerFactory: newTrackingSpinner,
-				})
+				},
+				multicluster.JoinClusterAlreadyExistCallback(func(name string) bool {
+					if !NewUserInput().AskBool(fmt.Sprintf("Cluster %s already exists, do you want to overwrite it?", name), &UserInputOptions{AssumeYes: assumeYes}) {
+						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Terminated.\n")
+						return false
+					}
+					return true
+				}))
 			if err != nil {
 				return err
 			}

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -86,6 +86,8 @@ var _ = Describe("Test multicluster scenario", func() {
 			Expect(err).Should(Succeed())
 			_, err = execCommand("cluster", "join", "/tmp/worker.kubeconfig", "--name", oldClusterName)
 			Expect(err).Should(Succeed())
+			_, err = execCommand("cluster", "join", "/tmp/worker.kubeconfig", "--name", oldClusterName, "-y")
+			Expect(err).Should(Succeed())
 			out, err := execCommand("cluster", "list")
 			Expect(err).Should(Succeed())
 			Expect(out).Should(ContainSubstring(oldClusterName))


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Previous `vela cluster join --name <cluster-name>` will report `cluster already exist error` when the target cluster already exists.

Now it will ask you if you would like to overwrite the old one or pass `-y/--yes` to overwrite it by default.

```shell
$ vela cluster join --name cluster-worker my.kubeconfig                                                                                                                                                            
Cluster already exists, do you want to overwrite it? (y/n)y
Successfully add cluster cluster-worker, endpoint: <endpoint>
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->