### PR TITLE
Fix: support get helm chart values from which index.yaml urls is not …

### DIFF
--- a/pkg/utils/helm/helm_helper.go
+++ b/pkg/utils/helm/helm_helper.go
@@ -346,7 +346,13 @@ func (h *Helper) GetValuesFromChart(repoURL string, chartName string, version st
 	var urls []string
 	for _, chartVersion := range chartVersions {
 		if chartVersion.Version == version {
-			urls = chartVersion.URLs
+			for _, url := range chartVersion.URLs {
+				if !(strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://")) {
+					urls = append(urls, fmt.Sprintf("%s/%s", repoURL, url))
+				} else {
+					urls = append(urls, url)
+				}
+			}
 		}
 	}
 	for _, u := range urls {

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -111,12 +111,19 @@ var _ = Describe("Test helm helper", func() {
 		helper := NewHelper()
 		versions, err := helper.ListVersions("./testdata", "autoscalertrait", true, nil)
 		Expect(err).Should(BeNil())
-		Expect(cmp.Diff(len(versions), 2)).Should(BeEmpty())
+		Expect(cmp.Diff(len(versions), 3)).Should(BeEmpty())
 	})
 
 	It("Test getValues from chart", func() {
 		helper := NewHelper()
 		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0", true, "helm", nil)
+		Expect(err).Should(BeNil())
+		Expect(values).ShouldNot(BeNil())
+	})
+
+	It("Test getValues from chart from uncompleted index.yaml url", func() {
+		helper := NewHelper()
+		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0_p1", true, "helm", nil)
 		Expect(err).Should(BeNil())
 		Expect(values).ShouldNot(BeNil())
 	})

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Test helm helper", func() {
 		Expect(values).ShouldNot(BeNil())
 	})
 
-	It("Test getValues from chart from uncompleted index.yaml url", func() {
+	It("Test getValues from chart with uncompleted index.yaml url", func() {
 		helper := NewHelper()
 		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0_p1", true, "helm", nil)
 		Expect(err).Should(BeNil())

--- a/pkg/utils/helm/testdata/index.yaml
+++ b/pkg/utils/helm/testdata/index.yaml
@@ -21,4 +21,14 @@ entries:
     urls:
     - https://charts.kubevela.net/example/autoscalertrait-0.1.0.tgz
     version: 0.2.0
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2021-03-13T23:42:30.9837659+09:00"
+    description: A Helm chart for kubevela autoscalertrait controller
+    digest: 33c4b9eeabf6c26e6aa8c4edaaf0e4a5d2a2f1fd857ffe32b6d3be97d6d971f0
+    name: autoscalertrait
+    type: application
+    urls:
+    - autoscalertrait-0.1.0.tgz
+    version: 0.2.0_p1
 generated: "2021-03-13T23:42:30.9832644+09:00"


### PR DESCRIPTION
…completed


### Description of your changes


Support get  values from helm repository which index.yaml entries url is not completed . 

![image](https://user-images.githubusercontent.com/107997570/229435738-6d4ed954-aded-4188-8822-de177ff584d6.png)





Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->