### PR TITLE
Feat: add type filter option

### DIFF
--- a/references/cuegen/convert.go
+++ b/references/cuegen/convert.go
@@ -40,6 +40,10 @@ func (g *Generator) convertDecls(x *goast.GenDecl) (decls []cueast.Decl, _ error
 			continue
 		}
 
+		if g.opts.typeFilter != nil && !g.opts.typeFilter(typeSpec) {
+			continue
+		}
+
 		// only process struct
 		typ := g.pkg.TypesInfo.TypeOf(typeSpec.Name)
 

--- a/references/cuegen/convert_test.go
+++ b/references/cuegen/convert_test.go
@@ -18,8 +18,10 @@ package cuegen
 
 import (
 	"bytes"
+	goast "go/ast"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +32,14 @@ func TestConvert(t *testing.T) {
 	assert.NoError(t, err)
 
 	got := &bytes.Buffer{}
-	decls, err := g.Generate(WithAnyTypes("*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"))
+	decls, err := g.Generate(
+		WithAnyTypes("*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
+		WithTypeFilter(func(typ *goast.TypeSpec) bool {
+			if typ.Name == nil {
+				return true
+			}
+			return !strings.HasPrefix(typ.Name.Name, "TypeFilter")
+		}))
 	assert.NoError(t, err)
 	assert.NoError(t, g.Format(got, decls))
 

--- a/references/cuegen/option.go
+++ b/references/cuegen/option.go
@@ -16,9 +16,12 @@ limitations under the License.
 
 package cuegen
 
+import goast "go/ast"
+
 type options struct {
-	anyTypes map[string]struct{}
-	nullable bool
+	anyTypes   map[string]struct{}
+	nullable   bool
+	typeFilter func(typ *goast.TypeSpec) bool
 }
 
 var defaultOptions = &options{
@@ -26,7 +29,8 @@ var defaultOptions = &options{
 		"map[string]interface{}": {}, "map[string]any": {},
 		"interface{}": {}, "any": {},
 	},
-	nullable: false,
+	nullable:   false,
+	typeFilter: func(_ *goast.TypeSpec) bool { return true },
 }
 
 // Option is a function that configures generation options
@@ -49,5 +53,17 @@ func WithAnyTypes(types ...string) Option {
 func WithNullable() Option {
 	return func(opts *options) {
 		opts.nullable = true
+	}
+}
+
+// WithTypeFilter filters top struct types to be generated, and filter returns true to generate the type, otherwise false
+func WithTypeFilter(filter func(typ *goast.TypeSpec) bool) Option {
+	// return invalid option if filter is nil, so that it will not be applied
+	if filter == nil {
+		return nil
+	}
+
+	return func(opts *options) {
+		opts.typeFilter = filter
 	}
 }

--- a/references/cuegen/testdata/valid.go
+++ b/references/cuegen/testdata/valid.go
@@ -321,3 +321,12 @@ type Skip struct {
 	Field3 string `json:"-"`
 	Field4 string `json:"field4"`
 }
+
+// TypeFilter should be ignored
+type TypeFilter http.Header
+
+// TypeFilterStruct should be ignored
+type TypeFilterStruct struct {
+	Field1 string `json:"field1"`
+	Field2 string `json:"field2"`
+}


### PR DESCRIPTION
### Description of your changes

Part of #5364 

cuegen previously ignored the generation of field and embedded struct by json tag, now we need type filter to ignore the generation of top struct. This will be used by provider-gen to filter out the required structs, such as `providers.Params[T]` and `providers.Returns[T]`

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->