### PR TITLE
Fix: can't reuse modified ref options

### DIFF
--- a/references/cuegen/generator.go
+++ b/references/cuegen/generator.go
@@ -50,7 +50,7 @@ func NewGenerator(f string) (*Generator, error) {
 	g := &Generator{
 		pkg:   pkg,
 		types: types,
-		opts:  defaultOptions,
+		opts:  newDefaultOptions(),
 	}
 
 	return g, nil
@@ -61,7 +61,7 @@ func NewGenerator(f string) (*Generator, error) {
 //
 // NB: it's not thread-safe.
 func (g *Generator) Generate(opts ...Option) (decls []cueast.Decl, _ error) {
-	g.opts = defaultOptions // reset options for each call
+	g.opts = newDefaultOptions() // reset options for each call
 	for _, opt := range opts {
 		if opt != nil {
 			opt(g.opts)

--- a/references/cuegen/generator_test.go
+++ b/references/cuegen/generator_test.go
@@ -40,7 +40,10 @@ func TestNewGenerator(t *testing.T) {
 
 	assert.NotNil(t, g.pkg)
 	assert.NotNil(t, g.types)
-	assert.Equal(t, g.opts, defaultOptions)
+	assert.Equal(t, g.opts.anyTypes, newDefaultOptions().anyTypes)
+	assert.Equal(t, g.opts.nullable, newDefaultOptions().nullable)
+	// assert can't compare function
+	assert.True(t, g.opts.typeFilter(nil))
 
 	assert.Greater(t, len(g.types), 0)
 }

--- a/references/cuegen/option.go
+++ b/references/cuegen/option.go
@@ -24,17 +24,19 @@ type options struct {
 	typeFilter func(typ *goast.TypeSpec) bool
 }
 
-var defaultOptions = &options{
-	anyTypes: map[string]struct{}{
-		"map[string]interface{}": {}, "map[string]any": {},
-		"interface{}": {}, "any": {},
-	},
-	nullable:   false,
-	typeFilter: func(_ *goast.TypeSpec) bool { return true },
-}
-
 // Option is a function that configures generation options
 type Option func(opts *options)
+
+func newDefaultOptions() *options {
+	return &options{
+		anyTypes: map[string]struct{}{
+			"map[string]interface{}": {}, "map[string]any": {},
+			"interface{}": {}, "any": {},
+		},
+		nullable:   false,
+		typeFilter: func(_ *goast.TypeSpec) bool { return true },
+	}
+}
 
 // WithAnyTypes appends go types as any type({...}) in CUE
 //

--- a/references/cuegen/option_test.go
+++ b/references/cuegen/option_test.go
@@ -123,3 +123,15 @@ func TestWithTypeFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultOptions(t *testing.T) {
+	opts := newDefaultOptions()
+
+	assert.Equal(t, opts.anyTypes, map[string]struct{}{
+		"map[string]interface{}": {}, "map[string]any": {},
+		"interface{}": {}, "any": {},
+	})
+	assert.Equal(t, opts.nullable, false)
+	// assert can't compare function
+	assert.True(t, opts.typeFilter(nil))
+}


### PR DESCRIPTION
### Description of your changes

Part of #5364 

Current default options can't be used repeatly. It's a ref type so any change will be permanently remained in `var defaultOptions`. Now I use a new builder to return default options just like deepcopy.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->