### PR TITLE
Fix: fix multi clusters bottom in vela adopt

### DIFF
--- a/references/cli/adopt-templates/default.cue
+++ b/references/cli/adopt-templates/default.cue
@@ -90,9 +90,11 @@ import (
 		for key, kinds in resourceCategoryMap if list.Contains(kinds, r.kind) {
 			_category: key
 		},
-		_cluster: r.metadata.annotations["app.oam.dev/cluster"]
+		if r.metadata.annotations != _|_ if r.metadata.annotations["app.oam.dev/cluster"] != _|_ {
+			_cluster: r.metadata.annotations["app.oam.dev/cluster"]
+		}
 	}]
-	_clusters: [ for r in _resources {r._cluster} ]
+	_clusters: [ for r in _resources if r._cluster != _|_ {r._cluster} ]
 	resourceMap: {
 		for key, val in resourceCategoryMap {
 			"\(key)": [ for r in _resources if r._category == key {r}]
@@ -114,7 +116,9 @@ import (
 				apiVersion: r.apiVersion
 				kind:       r.kind
 				metadata: name: r.metadata.name
-				metadata: annotations: "app.oam.dev/cluster": "\(r._cluster)"
+				if r._cluster != _|_ {
+					metadata: annotations: "app.oam.dev/cluster": (r._cluster)
+				}
 			}]
 		},
 		if len(resourceMap.ns) > 0 {
@@ -124,7 +128,9 @@ import (
 				apiVersion: r.apiVersion
 				kind:       r.kind
 				metadata: name: r.metadata.name
-				metadata: annotations: "app.oam.dev/cluster": "\(r._cluster)"
+				if r._cluster != _|_ {
+					metadata: annotations: "app.oam.dev/cluster": (r._cluster)
+				}
 			}]
 		},
 		for r in resourceMap.workload + resourceMap.service {
@@ -150,7 +156,9 @@ import (
 				if r.metadata.namespace != _|_ {
 					metadata: namespace: r.metadata.namespace
 				}
-				metadata: annotations: "app.oam.dev/cluster": "\(r._cluster)"
+				if r._cluster != _|_ {
+					metadata: annotations: "app.oam.dev/cluster": (r._cluster)
+				}
 			}]
 		},
 		for kind, rs in unknownByKinds {
@@ -160,19 +168,21 @@ import (
 				apiVersion: r.apiVersion
 				kind:       r.kind
 				metadata: name: r.metadata.name
-				metadata: annotations: "app.oam.dev/cluster": "\(r._cluster)"
+				if r._cluster != _|_ {
+					metadata: annotations: "app.oam.dev/cluster": (r._cluster)
+				}
 			}]
 		},
 	]
 
 	clusterCompMap: {
 		for cluster in _clusters {
-			"\(cluster)": [ for comp in comps if comp.properties.objects[0].metadata.annotations["app.oam.dev/cluster"] == cluster {comp.name} ]
+			"\(cluster)": [ for comp in comps if comp.properties.objects[0].metadata.annotations != _|_  if comp.properties.objects[0].metadata.annotations["app.oam.dev/cluster"] == cluster {comp.name} ]
 		}
 	}
 
 	compClusterMap: {
-		for comp in comps {
+		for comp in comps if comp.properties.objects[0].metadata.annotations != _|_ {
 			"\(comp.name)": comp.properties.objects[0].metadata.annotations["app.oam.dev/cluster"]
 		}
 	}

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -288,9 +288,9 @@ func (opt *AdoptOptions) MultipleRun(f velacmd.Factory, cmd *cobra.Command) erro
 				_, _ = fmt.Fprintf(opt.Out, "Warning: failed to list resources from %s/%s: %s", apiVersion, kind, err.Error())
 				continue
 			}
-			engine := resourcetopology.New(opt.ResourceTopologyRule)
 			dedup := make([]k8s.ResourceIdentifier, 0)
 			for _, item := range list.Items {
+				engine := resourcetopology.New(opt.ResourceTopologyRule)
 				itemIdentifier := k8s.ResourceIdentifier{
 					Name:       item.GetName(),
 					Namespace:  item.GetNamespace(),

--- a/references/cli/resource-topology/builtin-rule.cue
+++ b/references/cli/resource-topology/builtin-rule.cue
@@ -58,8 +58,10 @@ commonPeerResources: [{
 	resource: "configMap"
 	selectors: {
 		name: [
-			for v in context.data.spec.template.spec.volumes if v.configMap != _|_ if v.configMap.name != _|_ {
-				v.configMap.name
+			if context.data.spec.template.spec.volumes != _|_ {
+				for v in context.data.spec.template.spec.volumes if v.configMap != _|_ if v.configMap.name != _|_ {
+					v.configMap.name
+				},
 			},
 		]
 	}
@@ -68,8 +70,10 @@ commonPeerResources: [{
 	resource: "secret"
 	selectors: {
 		name: [
-			for v in context.data.spec.template.spec.volumes if v.secret != _|_ if v.secret.name != _|_ {
-				v.secret.name
+			if context.data.spec.template.spec.volumes != _|_ {
+				for v in context.data.spec.template.spec.volumes if v.secret != _|_ if v.secret.name != _|_ {
+					v.secret.name
+				},
 			},
 		]
 	}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0f5a5de</samp>

### Summary
🔧🛡️🐛

<!--
1.  🔧 for fixing the engine initialization bug
2.  🛡️ for adding conditions to handle missing annotations
3.  🐛 for improving the error handling of the cue file
-->
This pull request enhances the `adopt` command of the CLI by adding more conditions and error handling to the CUE templates and the `adopt.go` file. This improves the compatibility and reliability of the command when dealing with different kinds of resources and components.

> _`engine` in the loop_
> _better `adopt` command_
> _error handling_

### Walkthrough
*  Add conditions to check for `app.oam.dev/cluster` annotation and `_cluster` field in default template ([link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL93-R97), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL117-R121), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL127-R133), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL153-R161), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL163-R173), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-427e86e8427d3fcad2f4e607c89c31d08383bb32f3e19e93c01ed7c6b47a611fL170-R185))
*  Initialize engine with correct resource topology rule for each list item in `adopt.go` ([link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L291-R293))
*  Add conditions to check for `volumes` field in builtin rule ([link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-15c407d611d2b53f4f10a2f581a0ee87f82fb050664bc30fbf1fe8ae62ef2d70L61-R64), [link](https://github.com/kubevela/kubevela/pull/5834/files?diff=unified&w=0#diff-15c407d611d2b53f4f10a2f581a0ee87f82fb050664bc30fbf1fe8ae62ef2d70L71-R76))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->