### PR TITLE
Fix: add volume bottom check in resource topology rule

### DIFF
--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -277,9 +277,9 @@ func (opt *AdoptOptions) MultipleRun(f velacmd.Factory, cmd *cobra.Command) erro
 				_, _ = fmt.Fprintf(opt.Out, "Warning: failed to list resources from %s/%s: %s", apiVersion, kind, err.Error())
 				continue
 			}
-			engine := resourcetopology.New(opt.ResourceTopologyRule)
 			dedup := make([]k8s.ResourceIdentifier, 0)
 			for _, item := range list.Items {
+				engine := resourcetopology.New(opt.ResourceTopologyRule)
 				itemIdentifier := k8s.ResourceIdentifier{
 					Name:       item.GetName(),
 					Namespace:  item.GetNamespace(),

--- a/references/cli/resource-topology/builtin-rule.cue
+++ b/references/cli/resource-topology/builtin-rule.cue
@@ -58,8 +58,10 @@ commonPeerResources: [{
 	resource: "configMap"
 	selectors: {
 		name: [
-			for v in context.data.spec.template.spec.volumes if v.configMap != _|_ if v.configMap.name != _|_ {
-				v.configMap.name
+			if context.data.spec.template.spec.volumes != _|_ {
+				for v in context.data.spec.template.spec.volumes if v.configMap != _|_ if v.configMap.name != _|_ {
+					v.configMap.name
+				},
 			},
 		]
 	}
@@ -68,8 +70,10 @@ commonPeerResources: [{
 	resource: "secret"
 	selectors: {
 		name: [
-			for v in context.data.spec.template.spec.volumes if v.secret != _|_ if v.secret.name != _|_ {
-				v.secret.name
+			if context.data.spec.template.spec.volumes != _|_ {
+				for v in context.data.spec.template.spec.volumes if v.secret != _|_ if v.secret.name != _|_ {
+					v.secret.name
+				},
 			},
 		]
 	}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77ac0d0</samp>

### Summary
🐛🔧🔄

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the first change.
2.  🔧 - This emoji represents a configuration or adjustment, which is the effect of the second change on the builtin rules.
3.  🔄 - This emoji represents a loop or iteration, which is the mechanism of the first change and the context of the second change.
-->
This pull request fixes a bug in the `adopt` command of the CLI that prevented the resource topology rule from being applied correctly to multiple resources. It also adds error handling to the builtin rules for config maps and secrets in `references/cli/resource-topology/builtin-rule.cue`.

> _We are the engines of the loop_
> _We run the rule for every group_
> _We face the errors of the volumes_
> _We are the secrets of the runes_

### Walkthrough
* Fix a bug that caused the resource topology rule to be applied only to the first item in the list of resources to be adopted ([link](https://github.com/kubevela/kubevela/pull/5835/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L280-R282))
* Add conditions to check if the `volumes` field is not empty before iterating over it, to avoid errors when the field is missing or undefined ([link](https://github.com/kubevela/kubevela/pull/5835/files?diff=unified&w=0#diff-15c407d611d2b53f4f10a2f581a0ee87f82fb050664bc30fbf1fe8ae62ef2d70L61-R64), [link](https://github.com/kubevela/kubevela/pull/5835/files?diff=unified&w=0#diff-15c407d611d2b53f4f10a2f581a0ee87f82fb050664bc30fbf1fe8ae62ef2d70L71-R76))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->