### PR TITLE
Fix: refine the erorr output format

### DIFF
--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -285,7 +285,7 @@ func (opt *AdoptOptions) MultipleRun(f velacmd.Factory, cmd *cobra.Command) erro
 			list.SetGroupVersionKind(gvk)
 			if err := f.Client().List(ctx, list, &client.ListOptions{Namespace: opt.AppNamespace, LabelSelector: selector}); err != nil {
 				apiVersion, kind := gvk.ToAPIVersionAndKind()
-				_, _ = fmt.Fprintf(opt.Out, "Warning: failed to list resources from %s/%s: %s", apiVersion, kind, err.Error())
+				_, _ = fmt.Fprintf(opt.Out, "Warning: failed to list resources from %s/%s: %s\n", apiVersion, kind, err.Error())
 				continue
 			}
 			dedup := make([]k8s.ResourceIdentifier, 0)
@@ -304,7 +304,7 @@ func (opt *AdoptOptions) MultipleRun(f velacmd.Factory, cmd *cobra.Command) erro
 				r := []*unstructured.Unstructured{&firstElement}
 				peers, err := engine.GetPeerResources(ctx, itemIdentifier)
 				if err != nil {
-					_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get peer resources for %s/%s: %s", itemIdentifier.APIVersion, itemIdentifier.Kind, err.Error())
+					_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get peer resources for %s/%s: %s\n", itemIdentifier.APIVersion, itemIdentifier.Kind, err.Error())
 					resources = append(resources, r)
 					continue
 				}
@@ -312,13 +312,13 @@ func (opt *AdoptOptions) MultipleRun(f velacmd.Factory, cmd *cobra.Command) erro
 				for _, peer := range peers {
 					gvk, err := k8s.GetGVKFromResource(peer)
 					if err != nil {
-						_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get gvk from resource %s/%s: %s", peer.APIVersion, peer.Kind, err.Error())
+						_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get gvk from resource %s/%s: %s\n", peer.APIVersion, peer.Kind, err.Error())
 						continue
 					}
 					peerResource := &unstructured.Unstructured{}
 					peerResource.SetGroupVersionKind(gvk)
 					if err := f.Client().Get(ctx, apitypes.NamespacedName{Namespace: peer.Namespace, Name: peer.Name}, peerResource); err != nil {
-						_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get resource %s/%s: %s", peer.Namespace, peer.Name, err.Error())
+						_, _ = fmt.Fprintf(opt.Out, "Warning: failed to get resource %s/%s: %s\n", peer.Namespace, peer.Name, err.Error())
 						continue
 					}
 					r = append(r, peerResource)


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33dc8f6</samp>

### Summary
📝🚨🙌

<!--
1.  📝 - This emoji represents the act of writing or editing text, which is what this change does to the warning messages.
2.  🚨 - This emoji represents the concept of a warning or an alert, which is the purpose of the messages that are modified by this change.
3.  🙌 - This emoji represents the idea of improving or enhancing something, which is the effect of this change on the user experience and the output quality.
-->
Improve formatting of warning messages in `adopt` command. Add newline characters to `references/cli/adopt.go` to separate warnings from other output.

> _We're the crew of the CLI, we make the code run smooth_
> _We fix the bugs and add the features, we always improve_
> _We `adopt` the pets and print the warnings, but they need some space_
> _So we add the newline characters, and make them look more ace_

### Walkthrough
*  Add newline characters to the end of warning messages for better readability ([link](https://github.com/kubevela/kubevela/pull/5843/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L288-R288), [link](https://github.com/kubevela/kubevela/pull/5843/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L307-R307), [link](https://github.com/kubevela/kubevela/pull/5843/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L315-R315), [link](https://github.com/kubevela/kubevela/pull/5843/files?diff=unified&w=0#diff-25e16a5553ca15584cbddf24c4c249e67b9cad4f9f42d809e6d76cf51f6c02b5L321-R321)) in `references/cli/adopt.go`



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->