### PR TITLE
Fix: clean-jobs not working because the params not match to official docs

### DIFF
--- a/vela-templates/definitions/internal/workflowstep/clean-jobs.cue
+++ b/vela-templates/definitions/internal/workflowstep/clean-jobs.cue
@@ -14,7 +14,7 @@ import (
 template: {
 
 	parameter: {
-		labelselector?: {...}
+		labelSelector?: {...}
 		namespace: *context.namespace | string
 	}
 
@@ -29,10 +29,10 @@ template: {
 		}
 		filter: {
 			namespace: parameter.namespace
-			if parameter.labelselector != _|_ {
-				matchingLabels: parameter.labelselector
+			if parameter.labelSelector != _|_ {
+				matchingLabels: parameter.labelSelector
 			}
-			if parameter.labelselector == _|_ {
+			if parameter.labelSelector == _|_ {
 				matchingLabels: {
 					"workflow.oam.dev/name": context.name
 				}
@@ -51,10 +51,10 @@ template: {
 		}
 		filter: {
 			namespace: parameter.namespace
-			if parameter.labelselector != _|_ {
-				matchingLabels: parameter.labelselector
+			if parameter.labelSelector != _|_ {
+				matchingLabels: parameter.labelSelector
 			}
-			if parameter.labelselector == _|_ {
+			if parameter.labelSelector == _|_ {
 				matchingLabels: {
 					"workflow.oam.dev/name": context.name
 				}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d874c53</samp>

### Summary
🚚🐛🎨

<!--
1.  🚚 This emoji can be used to indicate that something was moved or renamed, as in this case.
2.  🐛 This emoji can be used to indicate that a bug was fixed or an error was avoided, as in this case.
3.  🎨 This emoji can be used to indicate that some code or configuration was improved or made more consistent, as in this case.
-->
Fixed a naming inconsistency in the `clean-jobs` workflow step definition. Updated `labelselector` to `labelSelector` in `vela-templates/definitions/internal/workflowstep/clean-jobs.cue`.

> _Oh we're the crew of the clean-jobs ship, and we work with care and skill_
> _We check our labels and selectors, and we fix them if they're ill_
> _For a typo in the workflow can cause us grief and pain_
> _So we heave away and rename them on the count of three again_

### Walkthrough
*  Rename `labelselector` field to `labelSelector` in `clean-jobs.cue` definition to follow camelCase convention and match Kubernetes API ([link](https://github.com/kubevela/kubevela/pull/5846/files?diff=unified&w=0#diff-9cce08f264c4cc6d16782eba30d4f71057e99da16aec6d8e220c4763ab5dc270L17-R17))
*  Update `parameter.labelselector` expressions to `parameter.labelSelector` in `clean-jobs.cue` definition to reflect field name change and avoid errors ([link](https://github.com/kubevela/kubevela/pull/5846/files?diff=unified&w=0#diff-9cce08f264c4cc6d16782eba30d4f71057e99da16aec6d8e220c4763ab5dc270L32-R35), [link](https://github.com/kubevela/kubevela/pull/5846/files?diff=unified&w=0#diff-9cce08f264c4cc6d16782eba30d4f71057e99da16aec6d8e220c4763ab5dc270L54-R57))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In official docs, the clean-jobs params key is `labelSelector`
<img width="571" alt="image" src="https://user-images.githubusercontent.com/93654253/231691520-ae6ac4be-db1f-4520-8799-0b2dbf1428c9.png">

But in clean-jobs.cue, the params declare is `labelselector`
https://github.com/kubevela/kubevela/blob/fea7ae59354b37cb29a5ccd177053d94c0f61264/vela-templates/definitions/internal/workflowstep/clean-jobs.cue#L16-L19


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->