### PR TITLE
custom cmd

### DIFF
--- a/hello_tool.cue
+++ b/hello_tool.cue
@@ -1,0 +1,13 @@
+package foo
+
+import "tool/exec"
+
+city: "Amsterdam"
+who: *"World" | string @tag(who)
+
+// Say hello!
+command: hello: {
+  print: exec.Run & {
+    cmd: "echo Hello \(who)! Welcome to \(city)."
+  }
+}

--- a/references/cli/cmd.go
+++ b/references/cli/cmd.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdCommand(c common.Args, order string, ioStream cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "cmd",
+		DisableFlagsInUseLine: true,
+		Short:                 "Manage environments for vela applications to run.",
+		Long:                  "Manage environments for vela applications to run.",
+		Annotations: map[string]string{
+			types.TagCommandOrder: order,
+			types.TagCommandType:  types.TypeStart,
+		},
+	}
+	cmd.SetOut(ioStream.Out)
+	return cmd
+}

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/oam-dev/kubevela/references/a/preimport"
 	"math/rand"
 	"os"
 	"time"
@@ -26,7 +27,6 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/stdlib"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
-	"github.com/oam-dev/kubevela/references/a/preimport"
 	"github.com/oam-dev/kubevela/references/cli"
 )
 


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5844

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

- [ ] A place to put such definitions is needed, preferably in the user's home directory, like ~/.vela/cli-extensions.
- [ ] Some way of variable injection might also be needed. Because scripts will need user-input to be able to do anything realistic. cue injection might be helpful (see cue help injection)
- [ ] cuex should be preferred over native cue, so we can do much more, like editing k8s resources.

I just simply added `cue cmd` into  `vela CLI`,  for a simple custom cue script below,

```cue
package foo

import "tool/exec"

city: "Amsterdam"
who: *"World" | string @tag(who)

// Say hello!
command: hello: {
  print: exec.Run & {
    cmd: "echo Hello \(who)! Welcome to \(city)."
  }
}
```

`kubectl-vela hello`, the output would be:

<details><summary>OUTPUT</summary>
<p>

```Shell
❯ ./bin/kubectl-vela hello
Hello World! Welcome to Amsterdam.  
```

</p>
</details>

Of cause, this implementation is very crude, but it demonstrates the module function. For further module design, considering the similar function compared to `cue cmd`, should I refer to the implementation in `cue CLI` to achieve a similar function in `vela CLI`?


