### PR TITLE
Fix: fix bug when dependency  addon parameter is Empty

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1018,7 +1018,9 @@ func (h *Installer) installDependency(addon *InstallPackage) error {
 		// get dependency addon original parameters
 		depArgs, depArgsErr := GetAddonLegacyParameters(h.ctx, h.cli, dep.Name)
 		if depArgsErr != nil {
-			return depArgsErr
+			if !apierrors.IsNotFound(depArgsErr) {
+				return depArgsErr
+			}
 		}
 		if depArgs == nil {
 			depArgs = map[string]interface{}{}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ebc631d</samp>

### Summary
🛠️🚀🔧

<!--
1.  🛠️ - This emoji represents a fix or improvement of something that was not working well or as expected. The change improves the installation logic by handling a possible error scenario.
2.  🚀 - This emoji represents a feature or enhancement that adds value or functionality to the project. The change enhances the installation experience by allowing the addon dependency to be installed with default parameters if no legacy ones are found.
3.  🔧 - This emoji represents a configuration or setting change that affects how the project works or behaves. The change affects the configuration of the addon dependency installation by adding a condition to check for a not found error.
-->
Handle missing legacy parameter files for addon dependencies in `pkg/addon/addon.go`. Ignore not found errors and use default parameters instead.

> _`GetAddonLegacyParameters`_
> _Not found error? No matter_
> _Install with defaults_

### Walkthrough
*  Add a condition to ignore not found errors when getting legacy parameters for addon dependencies ([link](https://github.com/kubevela/kubevela/pull/5856/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL1021-R1023))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

This [pr](https://github.com/kubevela/kubevela/pull/5206) introduced a bug, if the dependent addon is enabled without any parameters, the corresponding secret does not exist. The logic implemented in this code did not consider this scenario.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->