### PR TITLE
Fix: install dependency is invalid for runtime addon when it's cluster arg is nil

### DIFF
--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -196,13 +196,6 @@ var _ = Describe("Addon Test", func() {
 				}
 				Expect(topologyPolicyValue["clusterLabelSelector"]).Should(Equal(map[string]interface{}{}))
 			}, 30*time.Second).Should(Succeed())
-			// disable mock-dependence-rely and mock-dependence addon
-			/*output1, err := e2e.LongTimeExec("vela addon disable mock-dependence-rely", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output1).To(ContainSubstring("Successfully disable addon"))
-			output2, err := e2e.LongTimeExec("vela addon disable mock-dependence", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output2).To(ContainSubstring("Successfully disable addon"))*/
 		})
 
 		It("enable mock-dependence-rely without specified clusters when mock-dependence addon was enabled with specified clusters", func() {
@@ -248,13 +241,6 @@ var _ = Describe("Addon Test", func() {
 				Expect(topologyPolicyValue["clusterLabelSelector"]).Should(Equal(map[string]interface{}{}))
 				Expect(topologyPolicyValue["clusters"]).Should(BeNil())
 			}, 30*time.Second).Should(Succeed())
-			// 4. disable mock-dependence-rely and mock-dependence addon
-			/*output2, err := e2e.LongTimeExec("vela addon disable mock-dependence-rely", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output2).To(ContainSubstring("Successfully disable addon"))
-			output3, err := e2e.LongTimeExec("vela addon disable mock-dependence", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output3).To(ContainSubstring("Successfully disable addon"))*/
 		})
 
 		It("Test addon dependency with specified clusters", func() {

--- a/e2e/addon/addon_test.go
+++ b/e2e/addon/addon_test.go
@@ -142,11 +142,128 @@ var _ = Describe("Addon Test", func() {
 			Expect(output).To(ContainSubstring("you can try another version by command"))
 			Expect(err).NotTo(HaveOccurred())
 		})
+	})
+
+	Context("Addon registry test", func() {
+		It("List all addon registry", func() {
+			output, err := e2e.Exec("vela addon registry list")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("KubeVela"))
+		})
+
+		It("Get addon registry", func() {
+			output, err := e2e.Exec("vela addon registry get KubeVela")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("KubeVela"))
+		})
+
+		It("Add test addon registry", func() {
+			output, err := e2e.LongTimeExec("vela addon registry add my-repo --type=git --endpoint=https://github.com/oam-dev/catalog --path=/experimental/addons", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("Successfully add an addon registry my-repo"))
+
+			Eventually(func() error {
+				output, err := e2e.LongTimeExec("vela addon registry update my-repo --type=git --endpoint=https://github.com/oam-dev/catalog --path=/addons", 300*time.Second)
+				if err != nil {
+					return err
+				}
+				if !strings.Contains(output, "Successfully update an addon registry my-repo") {
+					return fmt.Errorf("cannot update addon registry")
+				}
+				return nil
+			}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+
+			output, err = e2e.LongTimeExec("vela addon registry delete my-repo", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("Successfully delete an addon registry my-repo"))
+		})
+	})
+
+	Context("Enable dependency addon test", func() {
+		It(" enable mock-dependence-rely without specified clusters when mock-dependence addon is not enabled", func() {
+			output, err := e2e.Exec("vela addon enable mock-dependence-rely")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("enabled successfully."))
+			Eventually(func(g Gomega) {
+				app := &v1beta1.Application{}
+				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "addon-mock-dependence", Namespace: "vela-system"}, app)).Should(Succeed())
+				topologyPolicyValue := map[string]interface{}{}
+				for _, policy := range app.Spec.Policies {
+					if policy.Type == "topology" {
+						Expect(json.Unmarshal(policy.Properties.Raw, &topologyPolicyValue)).Should(Succeed())
+						break
+					}
+				}
+				Expect(topologyPolicyValue["clusterLabelSelector"]).Should(Equal(map[string]interface{}{}))
+			}, 30*time.Second).Should(Succeed())
+			// disable mock-dependence-rely and mock-dependence addon
+			/*output1, err := e2e.LongTimeExec("vela addon disable mock-dependence-rely", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output1).To(ContainSubstring("Successfully disable addon"))
+			output2, err := e2e.LongTimeExec("vela addon disable mock-dependence", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output2).To(ContainSubstring("Successfully disable addon"))*/
+		})
+
+		It("enable mock-dependence-rely without specified clusters when mock-dependence addon was enabled with specified clusters", func() {
+			// 1. enable mock-dependence addon with local clusters
+			output, err := e2e.InteractiveExec("vela addon enable mock-dependence --clusters local myparam=test", func(c *expect.Console) {
+				_, err = c.SendLine("y")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("enabled successfully."))
+			Eventually(func(g Gomega) {
+				// check application render cluster
+				app := &v1beta1.Application{}
+				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "addon-mock-dependence", Namespace: "vela-system"}, app)).Should(Succeed())
+				topologyPolicyValue := map[string]interface{}{}
+				for _, policy := range app.Spec.Policies {
+					if policy.Type == "topology" {
+						Expect(json.Unmarshal(policy.Properties.Raw, &topologyPolicyValue)).Should(Succeed())
+						break
+					}
+				}
+				Expect(topologyPolicyValue["clusters"]).Should(Equal([]interface{}{"local"}))
+				Expect(topologyPolicyValue["clusterLabelSelector"]).Should(BeNil())
+			}, 600*time.Second).Should(Succeed())
+			// 2. enable mock-dependence-rely addon without clusters
+			output1, err := e2e.InteractiveExec("vela addon enable mock-dependence-rely", func(c *expect.Console) {
+				_, err = c.SendLine("y")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output1).To(ContainSubstring("enabled successfully."))
+			// 3. enable mock-dependence-rely addon changes the mock-dependence topology policy
+			Eventually(func(g Gomega) {
+				app := &v1beta1.Application{}
+				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "addon-mock-dependence", Namespace: "vela-system"}, app)).Should(Succeed())
+				topologyPolicyValue := map[string]interface{}{}
+				for _, policy := range app.Spec.Policies {
+					if policy.Type == "topology" {
+						Expect(json.Unmarshal(policy.Properties.Raw, &topologyPolicyValue)).Should(Succeed())
+						break
+					}
+				}
+				Expect(topologyPolicyValue["clusterLabelSelector"]).Should(Equal(map[string]interface{}{}))
+				Expect(topologyPolicyValue["clusters"]).Should(BeNil())
+			}, 30*time.Second).Should(Succeed())
+			// 4. disable mock-dependence-rely and mock-dependence addon
+			/*output2, err := e2e.LongTimeExec("vela addon disable mock-dependence-rely", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output2).To(ContainSubstring("Successfully disable addon"))
+			output3, err := e2e.LongTimeExec("vela addon disable mock-dependence", 600*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output3).To(ContainSubstring("Successfully disable addon"))*/
+		})
 
 		It("Test addon dependency with specified clusters", func() {
 			const clusterName = "k3s-default"
 			// enable addon
-			output, err := e2e.Exec("vela addon enable mock-dependence --clusters local myparam=test")
+			output, err := e2e.InteractiveExec("vela addon enable mock-dependence --clusters local myparam=test", func(c *expect.Console) {
+				_, err = c.SendLine("y")
+				Expect(err).NotTo(HaveOccurred())
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("enabled successfully."))
 			output1, err := e2e.Exec("vela ls -A")
@@ -185,7 +302,10 @@ var _ = Describe("Addon Test", func() {
 				Expect(topologyPolicyValue["clusters"]).Should(Equal([]interface{}{"local"}))
 			}, 600*time.Second).Should(Succeed())
 			// enable addon which rely on mock-dependence addon
-			e2e.Exec("vela addon enable mock-dependence-rely --clusters local," + clusterName)
+			e2e.InteractiveExec("vela addon enable mock-dependence-rely --clusters local,"+clusterName, func(c *expect.Console) {
+				_, err = c.SendLine("y")
+				Expect(err).NotTo(HaveOccurred())
+			})
 			// check mock-dependence application parameter
 			Eventually(func(g Gomega) {
 				sec := &v1.Secret{}
@@ -210,38 +330,4 @@ var _ = Describe("Addon Test", func() {
 		})
 	})
 
-	Context("Addon registry test", func() {
-		It("List all addon registry", func() {
-			output, err := e2e.Exec("vela addon registry list")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("KubeVela"))
-		})
-
-		It("Get addon registry", func() {
-			output, err := e2e.Exec("vela addon registry get KubeVela")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("KubeVela"))
-		})
-
-		It("Add test addon registry", func() {
-			output, err := e2e.LongTimeExec("vela addon registry add my-repo --type=git --endpoint=https://github.com/oam-dev/catalog --path=/experimental/addons", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("Successfully add an addon registry my-repo"))
-
-			Eventually(func() error {
-				output, err := e2e.LongTimeExec("vela addon registry update my-repo --type=git --endpoint=https://github.com/oam-dev/catalog --path=/addons", 300*time.Second)
-				if err != nil {
-					return err
-				}
-				if !strings.Contains(output, "Successfully update an addon registry my-repo") {
-					return fmt.Errorf("cannot update addon registry")
-				}
-				return nil
-			}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
-
-			output, err = e2e.LongTimeExec("vela addon registry delete my-repo", 600*time.Second)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("Successfully delete an addon registry my-repo"))
-		})
-	})
 })

--- a/e2e/addon/mock/testdata/mock-dependence-rely2/README.md
+++ b/e2e/addon/mock/testdata/mock-dependence-rely2/README.md
@@ -1,0 +1,3 @@
+# mock-dependence-rely2
+
+This is an addon template. Check how to build your own addon: https://kubevela.net/docs/platform-engineers/addon/intro

--- a/e2e/addon/mock/testdata/mock-dependence-rely2/metadata.yaml
+++ b/e2e/addon/mock/testdata/mock-dependence-rely2/metadata.yaml
@@ -1,0 +1,10 @@
+description: An addon for testing addon dependency with specified clusters.
+icon: ""
+invisible: false
+name: mock-dependence-rely2
+tags:
+- my-tag
+version: 1.0.0
+dependencies:
+  # install controller by helm.
+  - name: mock-dependence2

--- a/e2e/addon/mock/testdata/mock-dependence-rely2/parameter.cue
+++ b/e2e/addon/mock/testdata/mock-dependence-rely2/parameter.cue
@@ -1,0 +1,4 @@
+parameter: {
+	// +usage=Custom parameter description
+	myparam: *"mynsrely" | string
+}

--- a/e2e/addon/mock/testdata/mock-dependence-rely2/template.cue
+++ b/e2e/addon/mock/testdata/mock-dependence-rely2/template.cue
@@ -1,0 +1,9 @@
+package main
+output: {
+	apiVersion: "core.oam.dev/v1beta1"
+	kind:       "Application"
+	spec: {
+		components: []
+		policies: []
+	}
+}

--- a/e2e/addon/mock/testdata/mock-dependence2/README.md
+++ b/e2e/addon/mock/testdata/mock-dependence2/README.md
@@ -1,0 +1,3 @@
+# mock-dependence2
+
+This is an addon template. Check how to build your own addon: https://kubevela.net/docs/platform-engineers/addon/intro

--- a/e2e/addon/mock/testdata/mock-dependence2/metadata.yaml
+++ b/e2e/addon/mock/testdata/mock-dependence2/metadata.yaml
@@ -1,0 +1,7 @@
+description: An addon for testing addon dependency with specified clusters.
+icon: ""
+invisible: false
+name: mock-dependence2
+tags:
+- my-tag
+version: 1.0.0

--- a/e2e/addon/mock/testdata/mock-dependence2/parameter.cue
+++ b/e2e/addon/mock/testdata/mock-dependence2/parameter.cue
@@ -1,0 +1,6 @@
+parameter: {
+	// +usage=Custom parameter description
+	myparam: *"myns" | string
+        //+usage=Deploy to specified clusters. Leave empty to deploy to all clusters.
+	clusters?: [...string]
+}

--- a/e2e/addon/mock/testdata/mock-dependence2/template.cue
+++ b/e2e/addon/mock/testdata/mock-dependence2/template.cue
@@ -1,0 +1,24 @@
+package main
+_targetNamespace: parameter.myparam
+output: {
+	apiVersion: "core.oam.dev/v1beta1"
+	kind:       "Application"
+	spec: {
+		components: [],
+		policies: [
+			{
+				type: "topology"
+				name: "deploy-mock-dependency-ns"
+				properties: {
+					namespace: _targetNamespace
+					if parameter.clusters != _|_ {
+						clusters: parameter.clusters
+					}
+					if parameter.clusters == _|_ {
+						clusterLabelSelector: {}
+					}
+				}
+			},
+		]
+	}
+}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1079,7 +1079,7 @@ func checkDependencyNeedInstall(ctx context.Context, k8sClient client.Client, de
 		if !apierrors.IsNotFound(err) {
 			return false, nil, err
 		}
-		// depApp is not exist
+		// dependent addon is not exist
 		return true, addonClusters, nil
 	}
 	topologyPolicyValue := map[string]interface{}{}
@@ -1092,15 +1092,18 @@ func checkDependencyNeedInstall(ctx context.Context, k8sClient client.Client, de
 			break
 		}
 	}
+	// nil clusters indicates that the dependent addon is installed on all clusters
 	if topologyPolicyValue["clusters"] == nil {
 		return false, nil, nil
 	}
+	// nil addonClusters indicates the addon will be installed,
+	// thus we should set the dependent addon's clusters arg to be nil so that it is installed on all clusters
 	if addonClusters == nil {
 		return true, nil, nil
 	}
+	// Determine whether the dependent addon's existing clusters can cover the new addon's clusters
 	var needInstallAddonDep = false
 	var depClusters []string
-	// 判断原有的clusters是否能cover住addonClusters
 	originClusters := topologyPolicyValue["clusters"].([]interface{})
 	for _, r := range originClusters {
 		depClusters = append(depClusters, r.(string))

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -200,6 +200,30 @@ var _ = Describe("Addon test", func() {
 		Expect(needInstallAddonDep2).Should(BeFalse())
 		Expect(depClusters2).Should(BeNil())
 		Expect(err).Should(BeNil())
+
+		// case4: addonClusters is nil, and app has topology policy
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacy2AppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		Eventually(func(g Gomega) {
+			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, "legacy-addon2", nil)
+			Expect(err).Should(BeNil())
+			Expect(needInstallAddonDep).Should(BeTrue())
+			Expect(depClusters).Should(BeNil())
+		}, 60*time.Second).Should(Succeed())
+
+		// case5: addonClusters is nil, and app has topology policy, and clusterLabelSelector is not nil
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacy3AppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		Eventually(func(g Gomega) {
+			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, "legacy-addon3", nil)
+			Expect(err).Should(BeNil())
+			Expect(needInstallAddonDep).Should(BeFalse())
+			Expect(depClusters).Should(BeNil())
+		}, 60*time.Second).Should(Succeed())
 	})
 
 	It("getDependencyArgs func test", func() {
@@ -213,11 +237,28 @@ var _ = Describe("Addon test", func() {
 		app = v1beta1.Application{}
 		Expect(yaml.Unmarshal([]byte(legacyAppYaml), &app)).Should(BeNil())
 		app.SetNamespace(testns)
-		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		//Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
 		depClusters := []string{"cluster1", "cluster2"}
 		depArgs2, err := getDependencyArgs(ctx, k8sClient, depAddonName, depClusters)
 		Expect(depArgs2["clusters"]).Should(Equal(depClusters))
 		Expect(err).Should(BeNil())
+
+		// clusters exist, depClusters is nil
+		sec := v1.Secret{}
+		Expect(yaml.Unmarshal([]byte(secretYaml), &sec)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &sec)).Should(BeNil())
+		depArgs3, err := getDependencyArgs(ctx, k8sClient, "fluxcd", nil)
+		Expect(depArgs3).ToNot(BeNil())
+		Expect(depArgs3["clusters"]).Should(BeNil())
+		Expect(err).Should(BeNil())
+
+		// getArgs throw exception
+		sec1 := v1.Secret{}
+		Expect(yaml.Unmarshal([]byte(secretErrorYaml), &sec1)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &sec1)).Should(BeNil())
+		depArgs4, err := getDependencyArgs(ctx, k8sClient, "fluxcd1", nil)
+		Expect(depArgs4).Should(BeNil())
+		Expect(err).ToNot(BeNil())
 	})
 
 	It(" determineAddonAppName func test", func() {
@@ -623,6 +664,60 @@ spec:
       properties:
         image: crccheck/hello-world
         port: 8000
+`
+	legacy2AppYaml = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: legacy-addon2
+spec:
+  components:
+    - name: express-server
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+        port: 8000
+  policies:
+    - name: target-default
+      type: topology
+      properties:
+        clusters: ["local"]
+        namespace: "default"
+`
+	legacy3AppYaml = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: legacy-addon3
+spec:
+  components:
+    - name: express-server
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+        port: 8000
+  policies:
+    - name: target-default
+      type: topology
+      properties:
+        clusterLabelSelector: {}
+        namespace: "default"
+`
+	secretYaml = `apiVersion: v1
+data:
+  addonParameterDataKey: eyJjbHVzdGVycyI6WyJsb2NhbCIsInZlbGEtbTEiXX0K
+kind: Secret
+metadata:
+  name: addon-secret-fluxcd
+  namespace: vela-system
+type: Opaque
+`
+	secretErrorYaml = `apiVersion: v1
+data:
+  addonParameterDataKey: eyJjbHVzdGVycyI6WyJsb2NhbCIsInZlbGEtbTEiXQo=
+kind: Secret
+metadata:
+  name: addon-secret-fluxcd1
+  namespace: vela-system
+type: Opaque
 `
 	deployYaml = `apiVersion: apps/v1
 kind: Deployment

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Addon test", func() {
 	})
 
 	It("checkDependencyNeedInstall func test", func() {
-		// case1: dependency addon not enable
+		// case1: dependency addon not exist, adonClusters is not nil
 		depAddonName := "legacy-addon"
 		addonClusters := []string{"cluster1", "cluster2"}
 		needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, depAddonName, addonClusters)
@@ -183,7 +183,13 @@ var _ = Describe("Addon test", func() {
 		Expect(depClusters).Should(Equal(addonClusters))
 		Expect(err).Should(BeNil())
 
-		// case2: dependency addon enable
+		// case1.1: dependency addon not exist, adonClusters is nil
+		needInstallAddonDep1, depClusters1, err := checkDependencyNeedInstall(ctx, k8sClient, depAddonName, nil)
+		Expect(needInstallAddonDep1).Should(BeTrue())
+		Expect(depClusters1).Should(BeNil())
+		Expect(err).Should(BeNil())
+
+		// case2: dependency addon exist, no topology policy, addonClusters is not nil
 		app = v1beta1.Application{}
 		Expect(yaml.Unmarshal([]byte(legacyAppYaml), &app)).Should(BeNil())
 		app.SetNamespace(testns)
@@ -191,17 +197,29 @@ var _ = Describe("Addon test", func() {
 		Eventually(func(g Gomega) {
 			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, depAddonName, addonClusters)
 			Expect(err).Should(BeNil())
-			Expect(needInstallAddonDep).Should(BeTrue())
-			Expect(depClusters).Should(Equal(addonClusters))
+			Expect(needInstallAddonDep).Should(BeFalse())
+			Expect(depClusters).Should(BeNil())
 		}, 30*time.Second).Should(Succeed())
 
-		// case3: addonClusters is nil
+		// case3: clusters is nil (no topology policy), addonClusters is nil
 		needInstallAddonDep2, depClusters2, err := checkDependencyNeedInstall(ctx, k8sClient, depAddonName, nil)
 		Expect(needInstallAddonDep2).Should(BeFalse())
 		Expect(depClusters2).Should(BeNil())
 		Expect(err).Should(BeNil())
 
-		// case4: addonClusters is nil, and app has topology policy
+		// case4: clusters is nil, addonClusters is nil
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacy3AppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		Eventually(func(g Gomega) {
+			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, "legacy-addon3", nil)
+			Expect(err).Should(BeNil())
+			Expect(needInstallAddonDep).Should(BeFalse())
+			Expect(depClusters).Should(BeNil())
+		}, 60*time.Second).Should(Succeed())
+
+		// case5: clusters is not nil, addonClusters is nil,
 		app = v1beta1.Application{}
 		Expect(yaml.Unmarshal([]byte(legacy2AppYaml), &app)).Should(BeNil())
 		app.SetNamespace(testns)
@@ -213,16 +231,12 @@ var _ = Describe("Addon test", func() {
 			Expect(depClusters).Should(BeNil())
 		}, 60*time.Second).Should(Succeed())
 
-		// case5: addonClusters is nil, and app has topology policy, and clusterLabelSelector is not nil
-		app = v1beta1.Application{}
-		Expect(yaml.Unmarshal([]byte(legacy3AppYaml), &app)).Should(BeNil())
-		app.SetNamespace(testns)
-		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		// case6: clusters is [local], addonClusters is ["cluster1", "cluster2"]
 		Eventually(func(g Gomega) {
-			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, "legacy-addon3", nil)
+			needInstallAddonDep, depClusters, err := checkDependencyNeedInstall(ctx, k8sClient, "legacy-addon2", addonClusters)
 			Expect(err).Should(BeNil())
-			Expect(needInstallAddonDep).Should(BeFalse())
-			Expect(depClusters).Should(BeNil())
+			Expect(needInstallAddonDep).Should(BeTrue())
+			Expect(depClusters).Should(Equal(append([]string{"local"}, addonClusters...)))
 		}, 60*time.Second).Should(Succeed())
 	})
 

--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -194,6 +194,30 @@ var _ = Describe("Addon test", func() {
 			Expect(needInstallAddonDep).Should(BeTrue())
 			Expect(depClusters).Should(Equal(addonClusters))
 		}, 30*time.Second).Should(Succeed())
+
+		// case3: addonClusters is nil
+		needInstallAddonDep2, depClusters2, err := checkDependencyNeedInstall(ctx, k8sClient, depAddonName, nil)
+		Expect(needInstallAddonDep2).Should(BeFalse())
+		Expect(depClusters2).Should(BeNil())
+		Expect(err).Should(BeNil())
+	})
+
+	It("getDependencyArgs func test", func() {
+		// case1: depClusters is nil
+		depAddonName := "legacy-addon"
+		depArgs, err := getDependencyArgs(ctx, k8sClient, depAddonName, nil)
+		Expect(depArgs).Should(BeNil())
+		Expect(err).Should(BeNil())
+
+		// case2: depClusters is not nil
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacyAppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+		depClusters := []string{"cluster1", "cluster2"}
+		depArgs2, err := getDependencyArgs(ctx, k8sClient, depAddonName, depClusters)
+		Expect(depArgs2["clusters"]).Should(Equal(depClusters))
+		Expect(err).Should(BeNil())
 	})
 
 	It(" determineAddonAppName func test", func() {


### PR DESCRIPTION

### Description of your changes

install dependency is invalid for runtime addon when it's cluster arg is nil. Because the runtime addon will be render all clusters when there is no clusters arg.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
`vela cluster join config --name devops`
`vela addon enable fluxcd --clusters={local}`
`vela addon enable rollout`
then you will find the fluxcd is not automatically installed on the devops cluster after enable rollout.


### Special notes for your reviewer
@wangyikewxgm 