### PR TITLE
fix: when upgrade addon without version, the addon's version will be update by mistake

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -324,9 +324,14 @@ non-empty new arg
 					return fmt.Errorf("addon directory %s not found in local", addonOrDir)
 				}
 				name = addonOrDir
-				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, addonOrDir)
+				app, err := pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, addonOrDir)
 				if err != nil {
 					return errors.Wrapf(err, "cannot fetch addon related addon %s", addonOrDir)
+				}
+				labels := app.GetLabels()
+				installedVersion := labels[oam.LabelAddonVersion]
+				if addonVersion == "" {
+					addonVersion = installedVersion
 				}
 				addonArgs, err := pkgaddon.MergeAddonInstallArgs(ctx, k8sClient, name, addonInputArgs)
 				if err != nil {


### PR DESCRIPTION

### Description of your changes

Fixes # when upgrade addon without version, the addon's version will be update by mistake

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. `vela addon enable fluxcd --version 2.1.9`
2. `vela upgrade enable fluxcd onlyHelmComponents=true`
after upgrade fluxcd, you will find the fluxcd version is the latest version on the addon registry.

### Special notes for your reviewer
@wangyikewxgm 