### PR TITLE
Fix: fix terminate suspending steps

### DIFF
--- a/pkg/workflow/operation/operation.go
+++ b/pkg/workflow/operation/operation.go
@@ -489,7 +489,7 @@ func TerminateWorkflow(ctx context.Context, kubecli client.Client, app *v1beta1.
 			if step.Reason != wfTypes.StatusReasonFailedAfterRetries && step.Reason != wfTypes.StatusReasonTimeout {
 				steps[i].Reason = wfTypes.StatusReasonTerminate
 			}
-		case workflowv1alpha1.WorkflowStepPhaseRunning:
+		case workflowv1alpha1.WorkflowStepPhaseRunning, workflowv1alpha1.WorkflowStepPhaseSuspending:
 			steps[i].Phase = workflowv1alpha1.WorkflowStepPhaseFailed
 			steps[i].Reason = wfTypes.StatusReasonTerminate
 		default:
@@ -500,7 +500,7 @@ func TerminateWorkflow(ctx context.Context, kubecli client.Client, app *v1beta1.
 				if sub.Reason != wfTypes.StatusReasonFailedAfterRetries && sub.Reason != wfTypes.StatusReasonTimeout {
 					steps[i].SubStepsStatus[j].Reason = wfTypes.StatusReasonTerminate
 				}
-			case workflowv1alpha1.WorkflowStepPhaseRunning:
+			case workflowv1alpha1.WorkflowStepPhaseRunning, workflowv1alpha1.WorkflowStepPhaseSuspending:
 				steps[i].SubStepsStatus[j].Phase = workflowv1alpha1.WorkflowStepPhaseFailed
 				steps[i].SubStepsStatus[j].Reason = wfTypes.StatusReasonTerminate
 			default:

--- a/pkg/workflow/operation/operation_test.go
+++ b/pkg/workflow/operation/operation_test.go
@@ -72,6 +72,17 @@ var _ = Describe("Kruise rollout test", func() {
 	It("Terminate workflow", func() {
 		checkApp := v1beta1.Application{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "opt-app"}, &checkApp)).Should(BeNil())
+		checkApp.Status.Workflow = &common.WorkflowStatus{
+			Steps: []workflowv1alpha1.WorkflowStepStatus{
+				{
+					StepStatus: workflowv1alpha1.StepStatus{
+						Name:  "step1",
+						Type:  "suspend",
+						Phase: workflowv1alpha1.WorkflowStepPhaseSuspending,
+					},
+				},
+			},
+		}
 		operator := NewApplicationWorkflowOperator(k8sClient, nil, checkApp.DeepCopy())
 		Expect(operator.Terminate(ctx)).Should(BeNil())
 		checkApp = v1beta1.Application{}
@@ -98,7 +109,7 @@ var _ = Describe("Kruise rollout test", func() {
 					StepStatus: workflowv1alpha1.StepStatus{
 						Name:  "step1",
 						Type:  "suspend",
-						Phase: workflowv1alpha1.WorkflowStepPhaseRunning,
+						Phase: workflowv1alpha1.WorkflowStepPhaseSuspending,
 					},
 				},
 			},


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ecaa84c</samp>

### Summary
🧪🛑🔄

<!--
1.  🧪 for updating the unit tests
2.  🛑 for terminating suspending workflow steps
3.  🔄 for handling sub-steps
-->
This pull request enhances the `TerminateWorkflow` function to handle suspending workflow steps. It also updates the unit tests in `operation_test.go` to cover this new feature.

> _Oh we are the coders of the `operation` package_
> _We write the tests to make our code more savage_
> _We heave and we ho and we `TerminateWorkflow`_
> _And we don't let the suspending steps slow us down_

### Walkthrough
*  Add a case for suspending workflow steps in `TerminateWorkflow` function ([link](https://github.com/kubevela/kubevela/pull/5872/files?diff=unified&w=0#diff-46bd9f8aec194154eb1769a38eb525fcf02bf30ada116867d1824901604bb53eL492-R492), [link](https://github.com/kubevela/kubevela/pull/5872/files?diff=unified&w=0#diff-46bd9f8aec194154eb1769a38eb525fcf02bf30ada116867d1824901604bb53eL503-R503))
*  Update existing test case for `TerminateWorkflow` function to match new logic ([link](https://github.com/kubevela/kubevela/pull/5872/files?diff=unified&w=0#diff-054ab6fd4869276a1c094dfca5513bc97e1de29f45ef4e036edfbb9baa5da952L101-R112))
*  Add a new test case for `TerminateWorkflow` function to cover suspending scenario ([link](https://github.com/kubevela/kubevela/pull/5872/files?diff=unified&w=0#diff-054ab6fd4869276a1c094dfca5513bc97e1de29f45ef4e036edfbb9baa5da952R75-R85))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->