### PR TITLE
Test: pend multicluster rollout test

### DIFF
--- a/test/e2e-multicluster-test/multicluster_rollout_test.go
+++ b/test/e2e-multicluster-test/multicluster_rollout_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var _ = Describe("Test MultiCluster Rollout", func() {
+var _ = PDescribe("Test MultiCluster Rollout", func() {
 	Context("Test Runtime Cluster Rollout", func() {
 		var namespace string
 		var hubCtx context.Context


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3dcab1c</samp>

### Summary
🚧🐛🌐

<!--
1.  🚧 This emoji means construction or work in progress, and it can be used to indicate that the test is temporarily disabled and needs to be fixed or improved.
2.  🐛 This emoji means bug or issue, and it can be used to indicate that the test is flaky or failing due to some underlying problem that needs to be resolved.
3.  🌐 This emoji means globe or world, and it can be used to indicate that the test is related to the multi-cluster feature, which involves deploying applications across different regions or clusters.
-->
Mark `multicluster_rollout_test.go` as pending to disable a flaky test. This test checks the multi-cluster rollout feature of `kubevela`.

> _`PDescribe` test_
> _Flaky multi-cluster rollout_
> _Pending until spring_

### Walkthrough
*  Mark the test for multi-cluster rollout as pending ([link](https://github.com/kubevela/kubevela/pull/5873/files?diff=unified&w=0#diff-ebddfd9e9094b0621aa61f705f9a207c6ab28aea1e88b369694dfe65efb4c543L38-R38)). This test is in the file `multicluster_rollout_test.go` and it is disabled until the flaky behavior is fixed. The test uses the `PDescribe` function instead of `Describe` to skip the execution.



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->