### PR TITLE
Feat: support connecting cluster via proxy url

### DIFF
--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -136,6 +136,9 @@ func (clusterConfig *KubeClusterConfig) createOrUpdateClusterSecret(ctx context.
 		data["tls.crt"] = clusterConfig.AuthInfo.ClientCertificateData
 		data["tls.key"] = clusterConfig.AuthInfo.ClientKeyData
 	}
+	if clusterConfig.Cluster.ProxyURL != "" {
+		data["proxy-url"] = []byte(clusterConfig.Cluster.ProxyURL)
+	}
 	secret := &corev1.Secret{}
 	if err := cli.Get(ctx, apitypes.NamespacedName{Name: clusterConfig.ClusterName, Namespace: ClusterGatewaySecretNamespace}, secret); client.IgnoreNotFound(err) != nil {
 		return err


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6158cfa</samp>

### Summary
🌐🔗🛡️

<!--
1.  🌐 - This emoji represents the concept of a proxy or a network connection, which is relevant to this change.
2.  🔗 - This emoji represents the idea of linking or connecting different clusters, which is also related to this change.
3.  🛡️ - This emoji represents the notion of security or protection, which is important for this change as it involves secret data and encryption.
-->
Support proxy settings for multicluster communication. Add cluster proxy URL to secret data in `cluster_management.go`.

> _`proxy` in secret_
> _linking clusters across space_
> _autumn wind whispers_

### Walkthrough
*  Add proxy URL to secret data for multicluster communication ([link](https://github.com/kubevela/kubevela/pull/5875/files?diff=unified&w=0#diff-3556436411fdafe2fcf7d562ffa44d9c620a4c8db2d251b9e8cd309bb411d92cR139-R141))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->