### PR TITLE
feat: CLI command `vela cuex eval <file>`

### DIFF
--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -18,6 +18,10 @@ package cuex
 
 import (
 	"github.com/kubevela/pkg/cue/cuex"
+	"github.com/kubevela/pkg/cue/cuex/providers/base64"
+	cueext "github.com/kubevela/pkg/cue/cuex/providers/cue"
+	"github.com/kubevela/pkg/cue/cuex/providers/http"
+	"github.com/kubevela/pkg/cue/cuex/providers/kube"
 	"github.com/kubevela/pkg/util/singleton"
 
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/config"
@@ -27,6 +31,10 @@ import (
 var KubeVelaDefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
 	compiler := cuex.NewCompilerWithInternalPackages(
 		config.Package,
+		base64.Package,
+		http.Package,
+		kube.Package,
+		cueext.Package,
 	)
 	return compiler
 })

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -120,6 +120,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 		NewRegistryCommand(ioStream, "6"),
 		NewTraitCommand(commandArgs, ioStream),
 		NewComponentsCommand(commandArgs, ioStream),
+		NewCuexCommand(commandArgs, ioStream),
 		NewProviderCommand(commandArgs, "10", ioStream),
 		AuthCommandGroup(f, ioStream),
 		KubeCommandGroup(f, ioStream),

--- a/references/cli/cuex.go
+++ b/references/cli/cuex.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/format"
+	cuetoken "cuelang.org/go/cue/token"
+	"cuelang.org/go/pkg/encoding/yaml"
+	"encoding/json"
+	"fmt"
+	"github.com/oam-dev/kubevela/apis/types"
+	kubecuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var (
+	defaultCuexCompiler = kubecuex.KubeVelaDefaultCompiler.Get()
+)
+
+func NewCuexCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "cuex",
+		Short:   "Execute cuex compiler",
+		Long:    "Leverage cuex compiler to evaluate cue files",
+		Example: `vela cuex`,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeExtension,
+		},
+	}
+
+	cmd.AddCommand(newCuexEvalCommand(c, ioStreams))
+
+	return cmd
+}
+
+func newCuexEvalCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	var (
+		expression string
+		out        string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "eval <cue file>",
+		Long:    "eval evaluates, validates, and prints a configuration.",
+		Example: `vela cuex eval`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("a file is needed")
+			}
+
+			bytes, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+			value, err := defaultCuexCompiler.CompileString(cmd.Context(), string(bytes))
+			if err != nil {
+				return fmt.Errorf("failed to evaluate cue file: %w", err)
+			}
+
+			if expression != "" {
+				value = value.LookupPath(cue.ParsePath(expression))
+				if err := value.Validate(); err != nil {
+					return fmt.Errorf("failed to parse: %w", err)
+				}
+			}
+
+			switch out {
+			case "", "cue":
+				synOpts := []cue.Option{
+					cue.Final(), // for backwards compatibility
+					cue.Definitions(true),
+					cue.Docs(true),
+					cue.Attributes(true),
+					cue.Optional(true),
+					cue.Definitions(true),
+					cue.DisallowCycles(true),
+					cue.InlineImports(true),
+				}
+
+				// Keep for legacy reasons. Note that `cue eval` is to be deprecated by
+				// `cue` eventually.
+				opts := []format.Option{
+					format.UseSpaces(4),
+					format.TabIndent(false),
+					format.Simplify(),
+				}
+
+				//root := value.Eval()
+				b, err := format.Node(ToFile(value.Syntax(synOpts...)), opts...)
+				if err != nil {
+					return fmt.Errorf("failed to format output: %w", err)
+				}
+				_, err = ioStreams.Out.Write(b)
+			case "json":
+				d := json.NewEncoder(ioStreams.Out)
+				d.SetIndent("", "    ")
+				d.SetEscapeHTML(true)
+				err = d.Encode(value)
+			case "yaml":
+				str, err := yaml.Marshal(value)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(ioStreams.Out, str)
+			default:
+				return fmt.Errorf("unknown out format: %s", out)
+			}
+
+			return err
+		},
+	}
+
+	cmd.SetOut(ioStreams.Out)
+	cmd.Flags().StringVarP(&expression, "expression", "e", "", "evaluate this expression only")
+	cmd.Flags().StringVar(&out, "out", "", "output format[cue|yaml|json]")
+
+	return cmd
+}
+
+// ToFile converts an expression to a file.
+//
+// Adjusts the spacing of x when needed.
+func ToFile(n ast.Node) *ast.File {
+	switch x := n.(type) {
+	case nil:
+		return nil
+	case *ast.StructLit:
+		return &ast.File{Decls: x.Elts}
+	case ast.Expr:
+		ast.SetRelPos(x, cuetoken.NoSpace)
+		return &ast.File{Decls: []ast.Decl{&ast.EmbedDecl{Expr: x}}}
+	case *ast.File:
+		return x
+	default:
+		panic(fmt.Sprintf("Unsupported node type %T", x))
+	}
+}

--- a/references/cli/cuex_test.go
+++ b/references/cli/cuex_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"bytes"
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testdataDir = "test-data/cuex"
+)
+
+func TestCuexEval(t *testing.T) {
+	c := initArgs()
+	buffer := bytes.NewBuffer(nil)
+	ioStream := cmdutil.IOStreams{In: os.Stdin, Out: buffer, ErrOut: os.Stderr}
+
+	cmd := newCuexEvalCommand(c, ioStream)
+
+	testCases := map[string]struct {
+		filepath   string
+		expression string
+		out        string
+		expect     string
+	}{
+		"normal evaluate": {
+			filepath.Join(testdataDir, "foo.cue"),
+			"S.name",
+			"",
+			"\"Postgres\"",
+		},
+		"json": {
+			filepath.Join(testdataDir, "foo.cue"),
+			"",
+			"json",
+			`
+{
+    "label": "app",
+    "S": {
+        "name": "Postgres",
+        "version": "13",
+        "label": "app",
+        "image": "docker.io/postgres:13"
+    }
+}
+`,
+		},
+		"yaml": {
+			filepath.Join(testdataDir, "foo.cue"),
+			"",
+			"yaml",
+			`
+label: app
+S:
+  name: Postgres
+  version: "13"
+  label: app
+  image: docker.io/postgres:13
+`,
+		},
+		"http": {
+			filepath.Join(testdataDir, "httpget.cue"),
+			"statusCode",
+			"",
+			"200",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			buffer.Truncate(0)
+			r := require.New(t)
+			cmd.SetArgs([]string{tc.filepath, "-e", tc.expression, "--out", tc.out})
+			err := cmd.Execute()
+			r.NoError(err)
+			r.Equal(trimNextLine(tc.expect), trimNextLine(buffer.String()))
+		})
+	}
+}
+
+func trimNextLine(s string) string {
+	return strings.TrimLeft(strings.TrimRight(s, "\n"), "\n")
+}

--- a/references/cli/test-data/cuex/foo.cue
+++ b/references/cli/test-data/cuex/foo.cue
@@ -1,0 +1,13 @@
+import "strings"
+
+label: "app"
+// alias for label
+let L = label
+S: {
+	name: "Postgres"
+	// intermediate value
+	let lower = strings.ToLower(name)
+	version: "13"
+	label:   L
+	image:   "docker.io/\(lower):\(version)"
+}

--- a/references/cli/test-data/cuex/httpget.cue
+++ b/references/cli/test-data/cuex/httpget.cue
@@ -1,0 +1,10 @@
+import "vela/http"
+
+req: http.#Get & {
+  $params: {
+    url: "https://cuelang.org"
+  }
+}
+
+body: req.$returns.body
+statusCode: req.$returns.statusCode


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c932ef2</samp>

### Summary
🚀🧪🌐

<!--
1.  🚀 This emoji represents the addition of a new feature or subcommand to the `vela` tool, which is the `cuex` command that allows users to execute the cuex compiler on cue files and print the results.
2.  🧪 This emoji represents the addition of unit tests for the `cuex` command and its subcommand `eval`, which use test data files and check the output against the expected results.
3.  🌐 This emoji represents the use of cuex syntax and functions in cue files, which enable cue expressions to interact with external data sources and functions such as HTTP requests.
-->
This pull request adds support for cuex syntax and functions in cue files and introduces a new `cuex` subcommand for the `vela` CLI tool. The `cuex` subcommand allows users to evaluate cue expressions with cuex features and print the results in different formats. The pull request also includes unit tests and test data files for the `cuex` subcommand.

> _To run cuex on cue files with ease_
> _We added a new `vela` subcommand `cuex`_
> _It can `eval` expressions with flags_
> _And use cuex functions and tags_
> _To fetch data from sources like HTTP_

### Walkthrough
*  Add `cuex` subcommand to `vela` CLI tool to execute cuex compiler on cue files ([link](https://github.com/kubevela/kubevela/pull/5888/files?diff=unified&w=0#diff-004b35966c6dda784fba0fe64ddc863a10d0bab72fbedf97929daebc8d18d93dR123), [link](https://github.com/kubevela/kubevela/pull/5888/files?diff=unified&w=0#diff-0996a059631759d163ac0497917dbb8ef62d375c656c8166a3b9ae94fcf5b2b3R1-R140))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5862

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->