### PR TITLE
Fix: make any as top value in cue

### DIFF
--- a/references/cuegen/README.md
+++ b/references/cuegen/README.md
@@ -28,13 +28,13 @@ Auto generation of CUE schema and docs from Go struct
 |       `byte`       |  `uint8`  |
 |     `uintptr`      | `uint64`  |
 |      `[]byte`      |  `bytes`  |
-| `interface{}/any`  |  `{...}`  |
+| `interface{}/any`  |    `_`    |
 | `interface{ ... }` |    `_`    |
 
 ### Map Type
 
 - CUE only supports `map[string]T` type, which is converted to `[string]: T` in CUE schema
-- All `map[string]any/map[string]interface{}` are converted to `{...}` in CUE schema
+- All `map[string]any/map[string]interface{}` are converted to `_`(top value) in CUE schema
 
 ### Struct Type
 

--- a/references/cuegen/README.md
+++ b/references/cuegen/README.md
@@ -29,12 +29,11 @@ Auto generation of CUE schema and docs from Go struct
 |     `uintptr`      | `uint64`  |
 |      `[]byte`      |  `bytes`  |
 | `interface{}/any`  |    `_`    |
-| `interface{ ... }` |    `_`    |
 
 ### Map Type
 
 - CUE only supports `map[string]T` type, which is converted to `[string]: T` in CUE schema
-- All `map[string]any/map[string]interface{}` are converted to `_`(top value) in CUE schema
+- All `map[string]any/map[string]interface{}` are converted to `{...}` in CUE schema
 
 ### Struct Type
 

--- a/references/cuegen/convert.go
+++ b/references/cuegen/convert.go
@@ -80,7 +80,7 @@ func (g *Generator) convertDecls(x *goast.GenDecl) (decls []cueast.Decl, _ error
 }
 
 func (g *Generator) convert(typ gotypes.Type) (cueast.Expr, error) {
-	// if type is registered as any, return {...}
+	// if type is registered as any, return top value
 	if _, ok := g.opts.anyTypes[typ.String()]; ok {
 		return anyLit(), nil
 	}

--- a/references/cuegen/convert.go
+++ b/references/cuegen/convert.go
@@ -80,9 +80,16 @@ func (g *Generator) convertDecls(x *goast.GenDecl) (decls []cueast.Decl, _ error
 }
 
 func (g *Generator) convert(typ gotypes.Type) (cueast.Expr, error) {
-	// if type is registered as any, return top value
-	if _, ok := g.opts.anyTypes[typ.String()]; ok {
-		return anyLit(), nil
+	// if type is registered as special type, use it directly
+	if t, ok := g.opts.types[typ.String()]; ok {
+		switch t {
+		case TypeAny:
+			return Ident("_", false), nil
+		case TypeEllipsis:
+			return &cueast.StructLit{Elts: []cueast.Decl{&cueast.Ellipsis{}}}, nil
+		default:
+			return nil, fmt.Errorf("unsupported special cue type %d", t)
+		}
 	}
 
 	switch t := typ.(type) {

--- a/references/cuegen/convert_test.go
+++ b/references/cuegen/convert_test.go
@@ -33,7 +33,9 @@ func TestConvert(t *testing.T) {
 
 	got := &bytes.Buffer{}
 	decls, err := g.Generate(
-		WithAnyTypes("*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
+		WithTypes(map[string]Type{
+			"*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured": TypeAny,
+		}),
 		WithTypeFilter(func(typ *goast.TypeSpec) bool {
 			if typ.Name == nil {
 				return true

--- a/references/cuegen/convert_test.go
+++ b/references/cuegen/convert_test.go
@@ -34,7 +34,7 @@ func TestConvert(t *testing.T) {
 	got := &bytes.Buffer{}
 	decls, err := g.Generate(
 		WithTypes(map[string]Type{
-			"*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured": TypeAny,
+			"*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured": TypeEllipsis,
 		}),
 		WithTypeFilter(func(typ *goast.TypeSpec) bool {
 			if typ.Name == nil {

--- a/references/cuegen/generator_test.go
+++ b/references/cuegen/generator_test.go
@@ -40,7 +40,7 @@ func TestNewGenerator(t *testing.T) {
 
 	assert.NotNil(t, g.pkg)
 	assert.NotNil(t, g.types)
-	assert.Equal(t, g.opts.anyTypes, newDefaultOptions().anyTypes)
+	assert.Equal(t, g.opts.types, newDefaultOptions().types)
 	assert.Equal(t, g.opts.nullable, newDefaultOptions().nullable)
 	// assert can't compare function
 	assert.True(t, g.opts.typeFilter(nil))
@@ -57,7 +57,10 @@ func TestGeneratorPackage(t *testing.T) {
 func TestGeneratorGenerate(t *testing.T) {
 	g := testGenerator(t)
 
-	decls, err := g.Generate(WithAnyTypes("foo", "bar"), nil)
+	decls, err := g.Generate(WithTypes(map[string]Type{
+		"foo": TypeAny,
+		"bar": TypeAny,
+	}), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, decls)
 

--- a/references/cuegen/option.go
+++ b/references/cuegen/option.go
@@ -38,7 +38,7 @@ func newDefaultOptions() *options {
 	}
 }
 
-// WithAnyTypes appends go types as any type({...}) in CUE
+// WithAnyTypes appends go types as cue top value in CUE
 //
 // Example:*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
 //

--- a/references/cuegen/option_test.go
+++ b/references/cuegen/option_test.go
@@ -27,32 +27,45 @@ func TestWithAnyTypes(t *testing.T) {
 	tests := []struct {
 		name  string
 		opts  []Option
-		extra map[string]struct{}
+		extra map[string]Type
 	}{
 		{
 			name:  "default",
 			opts:  nil,
-			extra: map[string]struct{}{},
+			extra: map[string]Type{},
 		},
 		{
-			name:  "single",
-			opts:  []Option{WithAnyTypes("foo", "bar")},
-			extra: map[string]struct{}{"foo": {}, "bar": {}},
+			name: "single",
+			opts: []Option{WithTypes(map[string]Type{
+				"foo": TypeAny,
+				"bar": TypeEllipsis,
+			})},
+			extra: map[string]Type{"foo": TypeAny, "bar": TypeEllipsis},
 		},
 		{
 			name: "multiple",
-			opts: []Option{WithAnyTypes("foo", "bar"),
-				WithAnyTypes("baz", "qux")},
-			extra: map[string]struct{}{"foo": {}, "bar": {}, "baz": {}, "qux": {}},
+			opts: []Option{WithTypes(map[string]Type{
+				"foo": TypeAny,
+				"bar": TypeEllipsis,
+			}), WithTypes(map[string]Type{
+				"baz": TypeEllipsis,
+				"qux": TypeAny,
+			})},
+			extra: map[string]Type{
+				"foo": TypeAny,
+				"bar": TypeEllipsis,
+				"baz": TypeEllipsis,
+				"qux": TypeAny,
+			},
 		},
 	}
 
 	for _, tt := range tests {
-		opts := options{anyTypes: map[string]struct{}{}}
+		opts := options{types: map[string]Type{}}
 		for _, opt := range tt.opts {
 			opt(&opts)
 		}
-		assert.Equal(t, opts.anyTypes, tt.extra, tt.name)
+		assert.Equal(t, opts.types, tt.extra, tt.name)
 	}
 }
 
@@ -127,9 +140,9 @@ func TestWithTypeFilter(t *testing.T) {
 func TestDefaultOptions(t *testing.T) {
 	opts := newDefaultOptions()
 
-	assert.Equal(t, opts.anyTypes, map[string]struct{}{
-		"map[string]interface{}": {}, "map[string]any": {},
-		"interface{}": {}, "any": {},
+	assert.Equal(t, opts.types, map[string]Type{
+		"map[string]interface{}": TypeEllipsis, "map[string]any": TypeEllipsis,
+		"interface{}": TypeAny, "any": TypeAny,
 	})
 	assert.Equal(t, opts.nullable, false)
 	// assert can't compare function

--- a/references/cuegen/testdata/valid.cue
+++ b/references/cuegen/testdata/valid.cue
@@ -89,12 +89,16 @@ EmbedStruct: {
 MapField: {
 	field1: [string]: string
 	field2: [string]: int
-	field3: _
+	field3: {
+		...
+	}
 	field4: [string]: {
 		field1: string
 		field2: string
 	}
-	field5: _
+	field5: {
+		...
+	}
 }
 EmptyStruct: {}
 // Comment is a test struct1

--- a/references/cuegen/testdata/valid.cue
+++ b/references/cuegen/testdata/valid.cue
@@ -18,12 +18,8 @@ BasicType: {
 	field15: uint64
 	field16: uint8
 	field17: rune
-	field18: {
-		...
-	}
-	field19: {
-		...
-	}
+	field18: _
+	field19: _
 }
 TagName: {
 	f1: string
@@ -93,16 +89,12 @@ EmbedStruct: {
 MapField: {
 	field1: [string]: string
 	field2: [string]: int
-	field3: {
-		...
-	}
+	field3: _
 	field4: [string]: {
 		field1: string
 		field2: string
 	}
-	field5: {
-		...
-	}
+	field5: _
 }
 EmptyStruct: {}
 // Comment is a test struct1
@@ -247,9 +239,7 @@ DoReturns: $returns: {
 	trailer: [string]: [...string]
 	statusCode: int
 }
-ResourceReturns: $returns: {
-	...
-}
+ResourceReturns: $returns: _
 InlineStruct1: {
 	// Field1 comment
 	// Field1 doc

--- a/references/cuegen/testdata/valid.cue
+++ b/references/cuegen/testdata/valid.cue
@@ -243,7 +243,9 @@ DoReturns: $returns: {
 	trailer: [string]: [...string]
 	statusCode: int
 }
-ResourceReturns: $returns: _
+ResourceReturns: $returns: {
+	...
+}
 InlineStruct1: {
 	// Field1 comment
 	// Field1 doc

--- a/references/cuegen/util.go
+++ b/references/cuegen/util.go
@@ -46,10 +46,6 @@ func basicType(x *gotypes.Basic) cueast.Expr {
 	}
 }
 
-func anyLit() cueast.Expr {
-	return Ident("_", false)
-}
-
 func basicLabel(t *gotypes.Basic, v string) (cueast.Expr, error) {
 	switch {
 	case t.Info()&gotypes.IsInteger != 0:

--- a/references/cuegen/util.go
+++ b/references/cuegen/util.go
@@ -47,7 +47,7 @@ func basicType(x *gotypes.Basic) cueast.Expr {
 }
 
 func anyLit() cueast.Expr {
-	return &cueast.StructLit{Elts: []cueast.Decl{&cueast.Ellipsis{}}}
+	return Ident("_", false)
 }
 
 func basicLabel(t *gotypes.Basic, v string) (cueast.Expr, error) {

--- a/references/cuegen/util_test.go
+++ b/references/cuegen/util_test.go
@@ -74,7 +74,7 @@ func TestBasicType(t *testing.T) {
 }
 
 func TestAnyLit(t *testing.T) {
-	assert.Equal(t, anyLit(), &cueast.StructLit{Elts: []cueast.Decl{&cueast.Ellipsis{}}})
+	assert.Equal(t, anyLit(), Ident("_", false))
 }
 
 func TestBasicLabel(t *testing.T) {

--- a/references/cuegen/util_test.go
+++ b/references/cuegen/util_test.go
@@ -73,10 +73,6 @@ func TestBasicType(t *testing.T) {
 	}
 }
 
-func TestAnyLit(t *testing.T) {
-	assert.Equal(t, anyLit(), Ident("_", false))
-}
-
 func TestBasicLabel(t *testing.T) {
 	overflowInt64 := strconv.FormatInt(math.MaxInt64, 10) + "0"
 	overflowUint64 := strconv.FormatUint(math.MaxUint64, 10) + "0"


### PR DESCRIPTION
### Description of your changes

Part of #5364 

After an offline discussion, we decided to treat top value as any. This way there is no need to distinguish between `{...}` `[... {...}]` .

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->