### PR TITLE
Feat: refactor vela help

### DIFF
--- a/hack/docgen/cli/gen.go
+++ b/hack/docgen/cli/gen.go
@@ -23,9 +23,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
+	"github.com/kubevela/pkg/util/slices"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
@@ -36,7 +36,7 @@ import (
 // PrintCLIByTag print custom defined index
 func PrintCLIByTag(cmd *cobra.Command, all []*cobra.Command, tag string) string {
 	var result string
-	pl := cli.PrintList{}
+	var pl []cli.Printable
 	for _, c := range all {
 		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 			continue
@@ -47,14 +47,14 @@ func PrintCLIByTag(cmd *cobra.Command, all []*cobra.Command, tag string) string 
 		cname := cmd.Name() + " " + c.Name()
 		link := cname
 		link = strings.Replace(link, " ", "_", -1)
-		pl = append(pl, cli.Printable{Order: c.Annotations[types.TagCommandOrder], Long: fmt.Sprintf("* [%s](%s)\t - %s\n", cname, link, c.Long)})
+		pl = append(pl, cli.Printable{Order: c.Annotations[types.TagCommandOrder], Short: fmt.Sprintf("* [%s](%s)\t - %s\n", cname, link, c.Long)})
 
 	}
 
-	sort.Sort(pl)
+	slices.Sort(pl, func(i, j cli.Printable) bool { return i.Order < j.Order })
 
 	for _, v := range pl {
-		result += v.Long
+		result += v.Short
 	}
 	result += "\n"
 	return result

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -52,17 +52,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 		Use:                "vela",
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			allCommands := cmd.Commands()
-			cmd.Printf("A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.\n\nUsage:\n  vela [flags]\n  vela [command]\n\nAvailable Commands:\n\n")
-			PrintHelpByTag(cmd, allCommands, types.TypeStart)
-			PrintHelpByTag(cmd, allCommands, types.TypeApp)
-			PrintHelpByTag(cmd, allCommands, types.TypeCD)
-			PrintHelpByTag(cmd, allCommands, types.TypeExtension)
-			PrintHelpByTag(cmd, allCommands, types.TypeSystem)
-			cmd.Println("Flags:")
-			cmd.Println("  -h, --help   help for vela")
-			cmd.Println()
-			cmd.Println(`Use "vela [command] --help" for more information about a command.`)
+			runHelp(cmd, cmd.Commands(), nil)
 		},
 		SilenceUsage: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/references/cli/exec.go
+++ b/references/cli/exec.go
@@ -86,7 +86,7 @@ func NewExecCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 		},
 	}
 	cmd := &cobra.Command{
-		Use:   "exec [flags] APP_NAME -- COMMAND [args...]",
+		Use:   "exec",
 		Short: "Execute command in a container",
 		Long:  "Execute command inside container based vela application.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -128,6 +128,8 @@ func NewExecCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 			types.TagCommandType:  types.TypeApp,
 		},
 		Example: `
+		exec [flags] APP_NAME -- COMMAND [args...]
+
 		# Get output from running 'date' command from app pod, using the first container by default
 		vela exec my-app -- date
 

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -41,7 +41,7 @@ var re = regexp.MustCompile(`"((?:[^"\\]|\\.)*)"`)
 func NewLogsCommand(c common.Args, order string, ioStreams util.IOStreams) *cobra.Command {
 	largs := &Args{Args: c}
 	cmd := &cobra.Command{
-		Use:   "logs APP_NAME",
+		Use:   "logs",
 		Short: "Tail logs for application.",
 		Long:  "Tail logs for vela application.",
 		Args:  cobra.ExactArgs(1),

--- a/references/cli/portforward.go
+++ b/references/cli/portforward.go
@@ -85,7 +85,7 @@ func NewPortForwardCommand(c common.Args, order string, ioStreams util.IOStreams
 		},
 	}
 	cmd := &cobra.Command{
-		Use:     "port-forward APP_NAME",
+		Use:     "port-forward",
 		Short:   "Forward local ports to container/service port of vela application.",
 		Long:    "Forward local ports to container/service port of vela application.",
 		Example: "port-forward APP_NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -61,20 +61,6 @@ import (
 // HealthStatus represents health status strings.
 type HealthStatus = v1alpha2.HealthStatus
 
-const (
-	// HealthStatusNotDiagnosed means there's no health scope referred or unknown health status returned
-	HealthStatusNotDiagnosed HealthStatus = "NOT DIAGNOSED"
-)
-
-const (
-	// HealthStatusHealthy represents healthy status.
-	HealthStatusHealthy = v1alpha2.StatusHealthy
-	// HealthStatusUnhealthy represents unhealthy status.
-	HealthStatusUnhealthy = v1alpha2.StatusUnhealthy
-	// HealthStatusUnknown represents unknown status.
-	HealthStatusUnknown = v1alpha2.StatusUnknown
-)
-
 // WorkloadHealthCondition holds health status of any resource
 type WorkloadHealthCondition = v1alpha2.WorkloadHealthCondition
 
@@ -101,7 +87,7 @@ func NewAppStatusCommand(c common.Args, order string, ioStreams cmdutil.IOStream
 	var outputFormat string
 	var detail bool
 	cmd := &cobra.Command{
-		Use:   "status APP_NAME",
+		Use:   "status",
 		Short: "Show status of an application.",
 		Long:  "Show status of vela application.",
 		Example: `  # Get basic app info


### PR DESCRIPTION
### Description of your changes

Refactor `vela help` command.

NOTE: `vela` / `vela -h` / `vela help` output the same thing.

```shell
$ vela help
A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.

Getting Started:
  show           	Show the reference doc for a component, trait, policy or workflow.
  up             	Deploy one application                                            
  init           	Create scaffold for an application.                               
  env            	Manage environments for vela applications to run.                 

Managing Applications:
  dry-run        	Dry Run an application, and output the K8s resources as result to stdout
  revision       	Manage Application Revisions                                            
  ls             	List applications                                                       
  top            	Launch UI to display the platform overview.                             
  live-diff      	Compare application and revisions                                       
  ql             	Show result of executing velaQL.                                        
  logs           	Tail logs for application.                                              
  port-forward   	Forward local ports to container/service port of vela application.      
  exec           	Execute command in a container                                          
  delete         	Delete an application                                                   
  addon          	Manage addons for extension.                                            
  status         	Show status of an application.                                          

Continuous Delivery:
  adopt          	Adopt resources into new application                 
  auth           	Manage identity and authorizations.                  
  cluster        	Manage Kubernetes Clusters                           
  config         	Manage the configs.                                  
  kube           	Managing native Kubernetes resources across clusters.
  workflow       	Operate application delivery workflow.               

Managing Extension:
  component      	List/get components                   
  config-template	Manage the template of config.        
  trait          	List/get traits.                      
  provider       	Authenticate Terraform Cloud Providers
  registry       	Manage Registry                       
  def            	Manage Definitions                    
  uischema       	Manage UI schema for addons.          

Others:
  completion     	Output shell completion code for the specified shell (bash or zsh)  
  export         	Export deploy manifests from appfile                                
  system         	Manage system.                                                      
  version        	Prints vela build version information                               
  install        	Installs or Upgrades Kubevela control plane on a Kubernetes cluster.
  uninstall      	Uninstalls KubeVela from a Kubernetes cluster                       

Flags:
  -h, --help   help for vela

Use "vela [command] --help" for more information about a command.
```

```shell
$ vela help delete
Delete applications

 Delete KubeVela applications. KubeVela application deletion is associated with the recycle of underlying resources. By
default, the resources created by the KubeVela application will be deleted once it is not in use or the application is
deleted. There is garbage-collect policy in KubeVela application that you can use to configure customized recycle rules.

 This command supports delete application in various modes. Natively, you can use it like "kubectl delete app
[app-name]". In the cases you only want to delete the application but leave the resources there, you can use the
--orphan parameter. In the cases the server-side controller is uninstalled, or you want to manually skip some errors in
the deletion process (like lack privileges or handle cluster disconnection), you can use the --force parameter.

Usage:
  vela delete

Examples:
  # Delete an application
  vela delete my-app
  
  # Delete multiple applications in a namespace
  vela delete app-1 app-2 -n example
  
  # Delete all applications in one namespace
  vela delete -n example --all
  
  # Delete application without waiting to be deleted
  vela delete my-app --wait=false
  
  # Delete application without confirmation
  vela delete my-app -y
  
  # Force delete application at client-side
  vela delete my-app -f
  
  # Delete application by orphaning resources and skip recycling them
  vela delete my-app --orphan
  
  # Delete application interactively
  vela delete my-app -i

Flags:
      --all                delete all the application under the given namespace
  -e, --env string         The environment name for the CLI request
  -f, --force              force delete the application
  -i, --interactive        delete the application interactively
  -n, --namespace string   If present, the namespace scope for this CLI request
  -o, --orphan             delete the application and orphan managed resources
  -w, --wait               wait util the application is deleted completely (default true)

Global Flags:
  -y, --yes   Assume yes for all user prompts
```

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->