### PR TITLE
Template

### DIFF
--- a/pkg/cue/script/template.go
+++ b/pkg/cue/script/template.go
@@ -22,12 +22,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubevela/pkg/cue/cuex"
+
 	cuelang "cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
 
 	"github.com/oam-dev/kubevela/pkg/cue"
-	"github.com/oam-dev/kubevela/pkg/cue/cuex"
+	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
 )
 
 // CUE the cue script with the template format
@@ -63,7 +65,7 @@ func (c CUE) ParseToValue() (*value.Value, error) {
 func (c CUE) ParseToValueWithCueX() (cuelang.Value, error) {
 	// the cue script must be first, it could include the imports
 	template := string(c) + "\n" + cue.BaseTemplate
-	val, err := cuex.KubeVelaDefaultCompiler.Get().CompileString(context.Background(), template)
+	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileString(context.Background(), template)
 	if err != nil {
 		return cuelang.Value{}, fmt.Errorf("failed to compile config template: %w", err)
 	}
@@ -168,6 +170,35 @@ func (c CUE) RunAndOutput(context interface{}, properties map[string]interface{}
 	return render.LookupValue(outputField...)
 }
 
+// RunAndOutputWithCueX run the cue script and return the values of the specified field.
+// The output field must be under the template field.
+func (c CUE) RunAndOutputWithCueX(ctx context.Context, context interface{}, properties map[string]interface{}, outputField ...string) (cuelang.Value, error) {
+	// Validate the properties
+	if err := c.ValidatePropertiesWithCueX(properties); err != nil {
+		return cuelang.Value{}, err
+	}
+	contextOption := cuex.WithExtraData("context", context)
+	parameterOption := cuex.WithExtraData("template.parameter", properties)
+	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileStringWithOptions(ctx, string(c), contextOption, parameterOption)
+	if !val.Exists() {
+		return cuelang.Value{}, fmt.Errorf("failed to compile config template")
+	}
+	if err != nil {
+		return cuelang.Value{}, fmt.Errorf("failed to compile config template: %w", err)
+	}
+	if Error(val) != nil {
+		return cuelang.Value{}, fmt.Errorf("failed to compile config template: %w", Error(val))
+	}
+	if len(outputField) == 0 {
+		return val, nil
+	}
+	outputFieldVal := val.LookupPath(cuelang.ParsePath(strings.Join(outputField, ".")))
+	if !outputFieldVal.Exists() {
+		return cuelang.Value{}, fmt.Errorf("failed to lookup value: var(path=%s) not exist", strings.Join(outputField, "."))
+	}
+	return outputFieldVal, nil
+}
+
 // ValidateProperties validate the input properties by the template
 func (c CUE) ValidateProperties(properties map[string]interface{}) error {
 	template, err := c.ParseToTemplateValue()
@@ -203,6 +234,31 @@ func (c CUE) ValidateProperties(properties map[string]interface{}) error {
 	return nil
 }
 
+// ValidatePropertiesWithCueX validate the input properties by the template
+func (c CUE) ValidatePropertiesWithCueX(properties map[string]interface{}) error {
+	template, err := c.ParseToTemplateValueWithCueX()
+	if err != nil {
+		return err
+	}
+	paramPath := cuelang.ParsePath("template.parameter")
+	parameter := template.LookupPath(paramPath)
+	if !parameter.Exists() {
+		return fmt.Errorf("failed to lookup value: var(path=template.parameter) not exist")
+	}
+	props := parameter.FillPath(cuelang.ParsePath(""), properties)
+	if props.Err() != nil {
+		return ConvertFieldError(props.Err())
+	}
+	if err := props.Validate(); err != nil {
+		return ConvertFieldError(err)
+	}
+	_, err = props.MarshalJSON()
+	if err != nil {
+		return ConvertFieldError(err)
+	}
+	return nil
+}
+
 // ParameterError the error report of the parameter field validation
 type ParameterError struct {
 	Name    string
@@ -231,4 +287,23 @@ func ConvertFieldError(err error) error {
 		}
 	}
 	return err
+}
+
+// Error return value's error information.
+func Error(val cuelang.Value) error {
+	if !val.Exists() {
+		return errors.New("empty value")
+	}
+	if err := val.Err(); err != nil {
+		return err
+	}
+	var gerr error
+	val.Walk(func(value cuelang.Value) bool {
+		if err := value.Eval().Err(); err != nil {
+			gerr = err
+			return false
+		}
+		return true
+	}, nil)
+	return gerr
 }

--- a/pkg/cue/script/template.go
+++ b/pkg/cue/script/template.go
@@ -65,7 +65,7 @@ func (c CUE) ParseToValue() (*value.Value, error) {
 func (c CUE) ParseToValueWithCueX() (cuelang.Value, error) {
 	// the cue script must be first, it could include the imports
 	template := string(c) + "\n" + cue.BaseTemplate
-	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileString(context.Background(), template)
+	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileStringWithOptions(context.Background(), template, cuex.DisableResolveProviderFunctions{})
 	if err != nil {
 		return cuelang.Value{}, fmt.Errorf("failed to compile config template: %w", err)
 	}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3dc8190</samp>

### Summary
🛠️📝🔒

<!--
1.  🛠️ - This emoji conveys the idea of refactoring, simplifying, and improving the code quality and structure.
2.  📝 - This emoji suggests the use of templates, scripts, and cue language to generate and parse config files and data.
3.  🔒 - This emoji implies the enhancement of security and validation by disabling the resolution of provider functions and handling errors.
-->
This pull request improves the configuration and script management in `kubevela` by using new CUE-related packages and refactoring existing code. It simplifies the config template parsing in `pkg/config/factory.go` and enhances the cue script handling in `pkg/cue/script/template.go` with more functions and error handling.

> _Sing, O Muse, of the valiant pull request_
> _That simplified the imports and refactored the config_
> _Using `velacue` and `CUE`, the tools of the wise and adept_
> _That shape the data and the logic with skill and effect_

### Walkthrough
*  Simplify import statements in `factory.go` ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-a7bb21919ecd95689199a6a4f1b1d013c8dbe734306be14b2a916f2a21e1b1e2L27-R27))
*  Import `velacue` package in `factory.go` to use its functions ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-a7bb21919ecd95689199a6a4f1b1d013c8dbe734306be14b2a916f2a21e1b1e2R48))
*  Refactor `ParseConfig` function in `factory.go` to use `RunAndOutputWithCueX` method of `template.Template` object ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-a7bb21919ecd95689199a6a4f1b1d013c8dbe734306be14b2a916f2a21e1b1e2L477-R476))
*  Import and alias `cuex` package in `template.go` to use its options for cue compiler ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fR25-R26), [link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fL30-R32))
*  Modify `ParseToValueWithCueX` function in `template.go` to use `DisableResolveProviderFunctions` option for cue compiler ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fL66-R68))
*  Add `RunAndOutputWithCueX` function to `CUE` type in `template.go` to run cue script and return output values ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fR173-R201))
*  Add `ValidatePropertiesWithCueX` function to `CUE` type in `template.go` to validate input properties by template ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fR237-R261))
*  Add `Error` function to `template.go` to return error information of cue value ([link](https://github.com/kubevela/kubevela/pull/5904/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fR291-R309))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->