### PR TITLE
Fix: parse template disable resolve provider functions

### DIFF
--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -76,9 +76,6 @@ const TemplateValidationReturns = SaveTemplateKey + ".validation.$returns"
 // TemplateOutput define the key name for the config-template output
 const TemplateOutput = SaveTemplateKey + ".output"
 
-// TemplateParameter define the key name for the config-template parameter
-const TemplateParameter = SaveTemplateKey + ".parameter"
-
 // TemplateOutputs define the key name for the config-template outputs
 const TemplateOutputs = SaveTemplateKey + ".outputs"
 

--- a/pkg/cue/script/template.go
+++ b/pkg/cue/script/template.go
@@ -65,7 +65,7 @@ func (c CUE) ParseToValue() (*value.Value, error) {
 func (c CUE) ParseToValueWithCueX() (cuelang.Value, error) {
 	// the cue script must be first, it could include the imports
 	template := string(c) + "\n" + cue.BaseTemplate
-	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileString(context.Background(), template)
+	val, err := velacuex.KubeVelaDefaultCompiler.Get().CompileStringWithOptions(context.Background(), template, cuex.DisableResolveProviderFunctions{})
 	if err != nil {
 		return cuelang.Value{}, fmt.Errorf("failed to compile config template: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: wuzhongjian wuzhongjian_yewu@cmss.chinamobile.com

### Description of your changes
parse template disable resolve provider functions

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aad5dd0</samp>

### Summary
🔥🛠️➕

<!--
1.  🔥 - This emoji represents the removal of the `TemplateParameter` constant from the `config` package, which could be seen as a simplification or cleanup of the code.
2.  🛠️ - This emoji represents the modification of the `ParseToValueWithCueX` function to use a different method with a new option, which could be seen as a bug fix or improvement of the functionality.
3.  ➕ - This emoji represents the addition of the `DisableResolveProviderFunctions` option to the `cuex` package, which could be seen as a new feature or enhancement of the library.
-->
Removed unused constant `TemplateParameter` from `config` package and disabled provider function resolution in cue script parsing. This improves the consistency and reliability of cue template processing.

> _`TemplateParameter`_
> _Gone from config package_
> _Redundant, unused_

### Walkthrough
*  Disable provider function resolution in cue script parsing ([link](https://github.com/kubevela/kubevela/pull/5905/files?diff=unified&w=0#diff-dcc0ec36c20763b3796ca20afbe15509650407540d12a2672b1b11084851987fL68-R68), [link](https://github.com/kubevela/kubevela/pull/5905/files?diff=unified&w=0#diff-a7bb21919ecd95689199a6a4f1b1d013c8dbe734306be14b2a916f2a21e1b1e2L79-L81))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->