### PR TITLE
Chore: refactor vela cli entrance

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -137,13 +137,19 @@ const (
 	TypeCD = "Continuous Delivery"
 
 	// TypeExtension defines one category
-	TypeExtension = "Managing Extension"
+	TypeExtension = "Managing Extensions"
 
 	// TypeSystem defines one category
-	TypeSystem = "Others"
+	TypeSystem = "System Tools"
 
-	// TypePlugin defines one category used in Kubectl Plugin
-	TypePlugin = "Plugin Command"
+	// TypeAuxiliary defines auxiliary commands
+	TypeAuxiliary = "Auxiliary Tools"
+
+	// TypePlatform defines platform management commands
+	TypePlatform = "Managing Platform"
+
+	// TypeLegacy defines legacy commands
+	TypeLegacy = "Legacy Commands"
 )
 
 // LabelArg is the argument `label` of a definition

--- a/hack/docgen/cli/gen.go
+++ b/hack/docgen/cli/gen.go
@@ -47,14 +47,13 @@ func PrintCLIByTag(cmd *cobra.Command, all []*cobra.Command, tag string) string 
 		cname := cmd.Name() + " " + c.Name()
 		link := cname
 		link = strings.Replace(link, " ", "_", -1)
-		pl = append(pl, cli.Printable{Order: c.Annotations[types.TagCommandOrder], Short: fmt.Sprintf("* [%s](%s)\t - %s\n", cname, link, c.Long)})
-
+		pl = append(pl, cli.NewPrintable(c, fmt.Sprintf("* [%s](%s)\t - %s\n", cname, link, c.Long)))
 	}
 
 	slices.Sort(pl, func(i, j cli.Printable) bool { return i.Order < j.Order })
 
 	for _, v := range pl {
-		result += v.Short
+		result += v.Desc
 	}
 	result += "\n"
 	return result

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -652,7 +652,7 @@ var (
 )
 
 // NewAdoptCommand command for adopt resources into KubeVela Application
-func NewAdoptCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+func NewAdoptCommand(f velacmd.Factory, order string, streams util.IOStreams) *cobra.Command {
 	o := &AdoptOptions{
 		Type:      adoptTypeNative,
 		Mode:      adoptModeReadOnly,
@@ -660,11 +660,12 @@ func NewAdoptCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:     "adopt",
-		Short:   i18n.T("Adopt resources into new application"),
+		Short:   i18n.T("Adopt resources into new application."),
 		Long:    adoptLong,
 		Example: adoptExample,
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypeCD,
+			types.TagCommandOrder: order,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Init(f, cmd, args))

--- a/references/cli/adopt_test.go
+++ b/references/cli/adopt_test.go
@@ -31,7 +31,7 @@ func TestDefaultNamespace(t *testing.T) {
 	f := velacmd.NewDeferredFactory(config.GetConfig)
 	ioStream := util.IOStreams{}
 	ctx := context.Background()
-	cmd := NewAdoptCommand(f, ioStream)
+	cmd := NewAdoptCommand(f, "", ioStream)
 	cmd.SetContext(ctx)
 	testcase := []struct {
 		namespace string

--- a/references/cli/auth.go
+++ b/references/cli/auth.go
@@ -40,12 +40,13 @@ import (
 )
 
 // AuthCommandGroup commands for create resources or configuration
-func AuthCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+func AuthCommandGroup(f velacmd.Factory, order string, streams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: i18n.T("Manage identity and authorizations."),
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypePlatform,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(NewGenKubeConfigCommand(f, streams))

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -77,61 +77,63 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 
 	cmds.AddCommand(
 		// Getting Start
-		NewEnvCommand(commandArgs, "3", ioStream),
-		NewInitCommand(commandArgs, "2", ioStream),
-		NewUpCommand(f, "1", commandArgs, ioStream),
-		NewCapabilityShowCommand(commandArgs, ioStream),
+		NewInitCommand(commandArgs, "1", ioStream),
+		NewUpCommand(f, "2", commandArgs, ioStream),
+		NewAppStatusCommand(commandArgs, "3", ioStream),
+		NewListCommand(commandArgs, "4", ioStream),
+		NewDeleteCommand(f, "5"),
+		NewEnvCommand(commandArgs, "6", ioStream),
+		NewCapabilityShowCommand(commandArgs, "7", ioStream),
 
 		// Manage Apps
-		NewTopCommand(commandArgs, "11", ioStream),
-		NewListCommand(commandArgs, "10", ioStream),
-		NewAppStatusCommand(commandArgs, "9", ioStream),
-		NewDeleteCommand(f, "7"),
-		NewExecCommand(commandArgs, "6", ioStream),
-		NewPortForwardCommand(commandArgs, "5", ioStream),
-		NewLogsCommand(commandArgs, "4", ioStream),
-		NewQlCommand(commandArgs, "3", ioStream),
+		NewDryRunCommand(commandArgs, "1", ioStream),
 		NewLiveDiffCommand(commandArgs, "2", ioStream),
-		NewDryRunCommand(commandArgs, ioStream),
-		RevisionCommandGroup(commandArgs),
-		NewAdoptCommand(f, ioStream),
+		NewLogsCommand(commandArgs, "3", ioStream),
+		NewPortForwardCommand(commandArgs, "4", ioStream),
+		NewExecCommand(commandArgs, "5", ioStream),
+		RevisionCommandGroup(commandArgs, "6"),
+		NewDebugCommand(commandArgs, "7", ioStream),
 
-		// Workflows
-		NewWorkflowCommand(commandArgs, ioStream),
-		ClusterCommandGroup(f, commandArgs, ioStream),
+		// Continuous Delivery
+		NewWorkflowCommand(commandArgs, "1", ioStream),
+		NewAdoptCommand(f, "2", ioStream),
 
-		// Debug
-		NewDebugCommand(commandArgs, ioStream),
+		// Platform
+		NewTopCommand(commandArgs, "1", ioStream),
+		ClusterCommandGroup(f, "2", commandArgs, ioStream),
+		AuthCommandGroup(f, "3", ioStream),
+		// Config management
+		ConfigCommandGroup(f, "4", ioStream),
+		TemplateCommandGroup(f, "5", ioStream),
 
 		// Extension
-		NewAddonCommand(commandArgs, "9", ioStream),
-		NewUISchemaCommand(commandArgs, "8", ioStream),
-		DefinitionCommandGroup(commandArgs, "7", ioStream),
-		NewRegistryCommand(ioStream, "6"),
-		NewTraitCommand(commandArgs, ioStream),
-		NewComponentsCommand(commandArgs, ioStream),
-		NewProviderCommand(commandArgs, "10", ioStream),
-		AuthCommandGroup(f, ioStream),
-		KubeCommandGroup(f, ioStream),
-		CueXCommandGroup(f),
-
-		// Config management
-		ConfigCommandGroup(f, ioStream),
-		TemplateCommandGroup(f, ioStream),
+		// Addon
+		NewAddonCommand(commandArgs, "1", ioStream),
+		NewUISchemaCommand(commandArgs, "2", ioStream),
+		// Definitions
+		NewComponentsCommand(commandArgs, "3", ioStream),
+		NewTraitCommand(commandArgs, "4", ioStream),
+		DefinitionCommandGroup(commandArgs, "5", ioStream),
 
 		// System
 		NewInstallCommand(commandArgs, "1", ioStream),
 		NewUnInstallCommand(commandArgs, "2", ioStream),
-		NewExportCommand(commandArgs, ioStream),
-		NewVersionCommand(ioStream),
-		NewCompletionCommand(),
-		NewSystemCommand(commandArgs),
+		NewSystemCommand(commandArgs, "3"),
+		NewVersionCommand(ioStream, "4"),
 
-		// helper
-		NewHelpCommand(),
+		// aux
+		KubeCommandGroup(f, "1", ioStream),
+		CueXCommandGroup(f, "2"),
+		NewQlCommand(commandArgs, "3", ioStream),
+		NewCompletionCommand("4"),
+		NewHelpCommand("5"),
 
-		// hide
+		// hide (below commands will not be displayed in help command but still
+		// can be used by direct call)
 		NewWorkloadsCommand(commandArgs, ioStream),
+		NewExportCommand(commandArgs, ioStream),
+		NewRegistryCommand(ioStream, ""),
+		NewProviderCommand(commandArgs, "", ioStream),
 	)
 
 	fset := flag.NewFlagSet("logs", flag.ContinueOnError)
@@ -143,10 +145,10 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 }
 
 // NewVersionCommand print client version
-func NewVersionCommand(ioStream util.IOStreams) *cobra.Command {
+func NewVersionCommand(ioStream util.IOStreams, order string) *cobra.Command {
 	version := &cobra.Command{
 		Use:   "version",
-		Short: "Prints vela build version information",
+		Short: "Prints vela build version information.",
 		Long:  "Prints vela build version information.",
 		Run: func(cmd *cobra.Command, args []string) {
 			clusterVersion, _ := GetOAMReleaseVersion(types.DefaultKubeVelaNS)
@@ -161,7 +163,8 @@ GolangVersion: %v
 				runtime.Version())
 		},
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeSystem,
+			types.TagCommandType:  types.TypeSystem,
+			types.TagCommandOrder: order,
 		},
 	}
 	version.AddCommand(NewVersionListCommand(ioStream))

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -64,13 +64,14 @@ const (
 )
 
 // ClusterCommandGroup create a group of cluster command
-func ClusterCommandGroup(f velacmd.Factory, c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func ClusterCommandGroup(f velacmd.Factory, order string, c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
-		Short: "Manage Kubernetes Clusters",
-		Long:  "Manage Kubernetes Clusters for Continuous Delivery.",
+		Short: "Manage Kubernetes clusters.",
+		Long:  "Manage Kubernetes clusters for continuous delivery.",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypePlatform,
+			types.TagCommandOrder: order,
 		},
 		// check if cluster-gateway is ready
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -104,7 +105,7 @@ func NewClusterListCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "list managed clusters",
+		Short:   "list managed clusters.",
 		Long:    "list worker clusters managed by KubeVela.",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -333,7 +334,7 @@ func NewClusterProbeCommand(c *common.Args) *cobra.Command {
 func NewClusterLabelCommandGroup(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "labels",
-		Short: "Manage Kubernetes Cluster Labels",
+		Short: "Manage Kubernetes Cluster Labels.",
 		Long:  "Manage Kubernetes Cluster Labels for Continuous Delivery.",
 	}
 	cmd.AddCommand(
@@ -371,8 +372,8 @@ func updateClusterLabelAndPrint(cmd *cobra.Command, cli client.Client, vc *multi
 func NewClusterAddLabelsCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add CLUSTER_NAME LABELS",
-		Short:   "add labels to managed cluster",
-		Long:    "add labels to managed cluster",
+		Short:   "add labels to managed cluster.",
+		Long:    "add labels to managed cluster.",
 		Example: "vela cluster labels add my-cluster project=kubevela,owner=oam-dev",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -414,8 +415,8 @@ func NewClusterDelLabelsCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "del CLUSTER_NAME LABELS",
 		Aliases: []string{"delete", "remove"},
-		Short:   "delete labels for managed cluster",
-		Long:    "delete labels for managed cluster",
+		Short:   "Delete labels for managed cluster.",
+		Long:    "Delete labels for managed cluster.",
 		Args:    cobra.ExactArgs(2),
 		Example: "vela cluster labels del my-cluster project,owner",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -449,7 +450,7 @@ func NewClusterExportConfigCommand(f velacmd.Factory, ioStreams cmdutil.IOStream
 	var labelSelector string
 	cmd := &cobra.Command{
 		Use:   "export-config",
-		Short: i18n.T("Export multi-cluster kubeconfig"),
+		Short: i18n.T("Export multi-cluster kubeconfig."),
 		Long: templates.LongDesc(i18n.T(`
 			Export multi-cluster kubeconfig
 

--- a/references/cli/completion.go
+++ b/references/cli/completion.go
@@ -52,14 +52,15 @@ $ vela completion zsh > "${fpath[1]}/_vela"
 `
 
 // NewCompletionCommand Output shell completion code for the specified shell (bash or zsh)
-func NewCompletionCommand() *cobra.Command {
+func NewCompletionCommand(order string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion",
-		Short: "Output shell completion code for the specified shell (bash or zsh)",
+		Short: "Output shell completion code for the specified shell (bash or zsh).",
 		Long:  completionDesc,
 		Args:  nil,
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeSystem,
+			types.TagCommandType:  types.TypeAuxiliary,
+			types.TagCommandOrder: order,
 		},
 	}
 

--- a/references/cli/components.go
+++ b/references/cli/components.go
@@ -37,12 +37,12 @@ import (
 )
 
 // NewComponentsCommand creates `components` command
-func NewComponentsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewComponentsCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	var isDiscover bool
 	cmd := &cobra.Command{
 		Use:     "component",
 		Aliases: []string{"comp", "components"},
-		Short:   "List/get components",
+		Short:   "List/get components.",
 		Long:    "List component types installed and discover more in registry.",
 		Example: `vela comp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -76,7 +76,8 @@ func NewComponentsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Co
 			return PrintInstalledCompDef(c, ioStreams, filter)
 		},
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeExtension,
+			types.TagCommandType:  types.TypeExtension,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.SetOut(ioStreams.Out)

--- a/references/cli/config.go
+++ b/references/cli/config.go
@@ -41,13 +41,14 @@ import (
 )
 
 // ConfigCommandGroup commands for the config
-func ConfigCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+func ConfigCommandGroup(f velacmd.Factory, order string, streams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: i18n.T("Manage the configs."),
 		Long:  i18n.T("Manage the configs, such as the terraform provider, image registry, helm repository, etc."),
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypePlatform,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(NewListConfigCommand(f, streams))
@@ -58,13 +59,14 @@ func ConfigCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Comman
 }
 
 // TemplateCommandGroup commands for the template of the config
-func TemplateCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+func TemplateCommandGroup(f velacmd.Factory, order string, streams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "config-template",
 		Aliases: []string{"ct"},
 		Short:   i18n.T("Manage the template of config."),
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeExtension,
+			types.TagCommandType:  types.TypePlatform,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(NewTemplateApplyCommand(f, streams))

--- a/references/cli/config_test.go
+++ b/references/cli/config_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test apply a template", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := TemplateCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := TemplateCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"apply", "-f", "./test-data/config-templates/image-registry.cue", "--name", "test"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -47,7 +47,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test apply a new template", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := TemplateCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := TemplateCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"apply", "-f", "./test-data/config-templates/image-registry.cue", "--name", "test2"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -56,7 +56,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test list the templates", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := TemplateCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := TemplateCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"list", "-A"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -67,7 +67,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test show the templates", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := TemplateCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := TemplateCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"show", "test2"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -76,7 +76,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test create the config with the args", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"create", "test", "--template=test", "registry=test.kubevela.net", "auth.username=yueda", "auth.password=yueda123", "useHTTP=true"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -85,7 +85,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test create the config with the file", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"create", "testfile", "--template=test2", "--namespace=default", "-f", "./test-data/config/registry.yaml"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -94,7 +94,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test create the config without the template", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"create", "without-template", "--namespace=default", "-f", "./test-data/config/registry.yaml"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -103,7 +103,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test creating and distributing the config", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"create", "distribution", "--namespace=default", "-f", "./test-data/config/registry.yaml", "--target", "test"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -112,7 +112,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test list the configs", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"list", "-A"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -121,7 +121,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test list the configs with the namespace filter", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"list", "-n", "default"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -130,7 +130,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test list the configs with the template filter", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"list", "-A", "-t", "test2"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -139,7 +139,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test dry run the config", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"create", "testfile", "--template=test", "-f", "./test-data/config/registry.yaml", "--dry-run"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -153,7 +153,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Distribute a config", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"distribute", "testfile", "-t", "test"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -162,7 +162,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Recall a config", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"distribute", "testfile", "--recall"})
 		err := cmd.Execute()
 		Expect(err).Should(BeNil())
@@ -171,7 +171,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test delete a config", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := ConfigCommandGroup(arg, util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
+		cmd := ConfigCommandGroup(arg, "", util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"delete", "distribution", "-n", "default"})
 		assumeYes = false
 		err := cmd.Execute()
@@ -181,7 +181,7 @@ var _ = Describe("Test the commands of the config", func() {
 
 	It("Test delete a template", func() {
 		buffer := bytes.NewBuffer(nil)
-		cmd := TemplateCommandGroup(arg, util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
+		cmd := TemplateCommandGroup(arg, "", util.IOStreams{In: strings.NewReader("y\n"), Out: buffer, ErrOut: buffer})
 		cmd.SetArgs([]string{"delete", "test"})
 		assumeYes = false
 		err := cmd.Execute()

--- a/references/cli/cuex.go
+++ b/references/cli/cuex.go
@@ -31,12 +31,13 @@ import (
 )
 
 // CueXCommandGroup commands for cuex management
-func CueXCommandGroup(f velacmd.Factory) *cobra.Command {
+func CueXCommandGroup(f velacmd.Factory, order string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cuex",
 		Short: i18n.T("Manage CueX engine for compile."),
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeExtension,
+			types.TagCommandType:  types.TypeAuxiliary,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(NewCueXEvalCommand(f))

--- a/references/cli/debug.go
+++ b/references/cli/debug.go
@@ -59,7 +59,7 @@ type debugOpts struct {
 }
 
 // NewDebugCommand create `debug` command
-func NewDebugCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewDebugCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	ctx := context.Background()
 	dOpts := &debugOpts{}
 	wargs := &WorkflowArgs{
@@ -69,10 +69,14 @@ func NewDebugCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:     "debug",
 		Aliases: []string{"debug"},
-		Short:   "Debug running application",
+		Short:   "Debug running application.",
 		Long:    "Debug running application with debug policy.",
 		Example: `vela debug <application-name>`,
-		PreRun:  wargs.checkDebugMode(),
+		Annotations: map[string]string{
+			types.TagCommandType:  types.TypeApp,
+			types.TagCommandOrder: order,
+		},
+		PreRun: wargs.checkDebugMode(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("must specify application name")

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -70,7 +70,7 @@ const (
 func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "def",
-		Short: "Manage Definitions",
+		Short: "Manage definitions.",
 		Long:  "Manage X-Definitions for extension.",
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
@@ -87,7 +87,7 @@ func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStream
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
 		NewDefinitionGenDocCommand(c, ioStreams),
-		NewCapabilityShowCommand(c, ioStreams),
+		NewCapabilityShowCommand(c, "", ioStreams),
 		NewDefinitionGenAPICommand(c),
 	)
 	return cmd

--- a/references/cli/delete.go
+++ b/references/cli/delete.go
@@ -373,12 +373,12 @@ func NewDeleteCommand(f velacmd.Factory, order string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "delete",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Delete an application"),
+		Short:                 i18n.T("Delete an application."),
 		Long:                  deleteLong,
 		Example:               deleteExample,
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeApp,
+			types.TagCommandType:  types.TypeStart,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -59,12 +59,12 @@ type DryRunCmdOptions struct {
 }
 
 // NewDryRunCommand creates `dry-run` command
-func NewDryRunCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewDryRunCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	o := &DryRunCmdOptions{IOStreams: ioStreams}
 	cmd := &cobra.Command{
 		Use:                   "dry-run",
 		DisableFlagsInUseLine: true,
-		Short:                 "Dry Run an application, and output the K8s resources as result to stdout",
+		Short:                 "Dry Run an application, and output the K8s resources as result to stdout.",
 		Long: `Dry-run application locally, render the Kubernetes resources as result to stdout.
 	vela dry-run -d /definition/directory/or/file/ -f /path/to/app.yaml
 
@@ -91,7 +91,8 @@ vela dry-run -f app.yaml
 vela dry-run -f app.yaml -f policy.yaml -f workflow.yaml
 `,
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeApp,
+			types.TagCommandType:  types.TypeApp,
+			types.TagCommandOrder: order,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)

--- a/references/cli/exec.go
+++ b/references/cli/exec.go
@@ -87,7 +87,7 @@ func NewExecCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 	}
 	cmd := &cobra.Command{
 		Use:   "exec",
-		Short: "Execute command in a container",
+		Short: "Execute command in a container.",
 		Long:  "Execute command inside container based vela application.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			o.VelaC = c

--- a/references/cli/export.go
+++ b/references/cli/export.go
@@ -34,7 +34,7 @@ func NewExportCommand(c common2.Args, ioStream cmdutil.IOStreams) *cobra.Command
 		Short:                 "Export deploy manifests from appfile",
 		Long:                  "Export deploy manifests from appfile or application.",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeSystem,
+			types.TagCommandType: types.TypeLegacy,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)

--- a/references/cli/kube.go
+++ b/references/cli/kube.go
@@ -50,12 +50,13 @@ import (
 )
 
 // KubeCommandGroup command group for native resource management
-func KubeCommandGroup(f velacmd.Factory, streams util.IOStreams) *cobra.Command {
+func KubeCommandGroup(f velacmd.Factory, order string, streams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kube",
 		Short: i18n.T("Managing native Kubernetes resources across clusters."),
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypeAuxiliary,
+			types.TagCommandOrder: order,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -54,8 +54,8 @@ func NewLiveDiffCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 	cmd := &cobra.Command{
 		Use:                   "live-diff",
 		DisableFlagsInUseLine: true,
-		Short:                 "Compare application and revisions",
-		Long:                  "Compare application and revisions",
+		Short:                 "Compare application and revisions.",
+		Long:                  "Compare application and revisions.",
 		Example: "# compare the current application and the running revision\n" +
 			"> vela live-diff my-app\n" +
 			"# compare the current application and the specified revision\n" +

--- a/references/cli/ls.go
+++ b/references/cli/ls.go
@@ -53,7 +53,7 @@ func NewListCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *c
 		Use:                   "ls",
 		Aliases:               []string{"list"},
 		DisableFlagsInUseLine: true,
-		Short:                 "List applications",
+		Short:                 "List applications.",
 		Long:                  "List all vela applications.",
 		Example:               `vela ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,7 +72,7 @@ func NewListCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *c
 		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeApp,
+			types.TagCommandType:  types.TypeStart,
 		},
 	}
 	addNamespaceAndEnvArg(cmd)

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -34,11 +34,11 @@ import (
 func NewProviderCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",
-		Short: "Authenticate Terraform Cloud Providers",
-		Long:  "Authenticate Terraform Cloud Providers by managing Terraform Controller Providers with its credential secret",
+		Short: "Authenticate terraform cloud providers.",
+		Long:  "Authenticate terraform cloud providers by managing terraform controller providers with its credential secret.",
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeExtension,
+			types.TagCommandType:  types.TypeLegacy,
 		},
 	}
 	cmd.AddCommand(

--- a/references/cli/registry.go
+++ b/references/cli/registry.go
@@ -53,7 +53,7 @@ func NewRegistryCommand(ioStream cmdutil.IOStreams, order string) *cobra.Command
 		Long:  "Manage Registry of X-Definitions for extension.",
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeExtension,
+			types.TagCommandType:  types.TypeLegacy,
 		},
 	}
 	cmd.AddCommand(

--- a/references/cli/revision.go
+++ b/references/cli/revision.go
@@ -40,13 +40,14 @@ const (
 )
 
 // RevisionCommandGroup the commands for managing application revisions
-func RevisionCommandGroup(c common.Args) *cobra.Command {
+func RevisionCommandGroup(c common.Args, order string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "revision",
-		Short: "Manage Application Revisions",
+		Short: "Manage Application Revisions.",
 		Long:  "Manage KubeVela Application Revisions",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeApp,
+			types.TagCommandType:  types.TypeApp,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -65,7 +65,7 @@ var generateDocOnly bool
 var showFormat string
 
 // NewCapabilityShowCommand shows the reference doc for a component type or trait
-func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewCapabilityShowCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	var revision, path, location, i18nPath string
 	cmd := &cobra.Command{
 		Use:   "show",
@@ -121,7 +121,8 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 			return ShowReferenceConsole(ctx, c, ioStreams, capabilityName, namespace, location, i18nPath, int64(ver))
 		},
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeStart,
+			types.TagCommandType:  types.TypeStart,
+			types.TagCommandOrder: order,
 		},
 	}
 

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -172,7 +172,7 @@ func NewAppStatusCommand(c common.Args, order string, ioStreams cmdutil.IOStream
 		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeApp,
+			types.TagCommandType:  types.TypeStart,
 		},
 	}
 	cmd.Flags().StringP("svc", "s", "", "service name")

--- a/references/cli/system.go
+++ b/references/cli/system.go
@@ -54,7 +54,7 @@ const (
 )
 
 // NewSystemCommand print system detail info
-func NewSystemCommand(c common.Args) *cobra.Command {
+func NewSystemCommand(c common.Args, order string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "system",
 		Short: "Manage system.",
@@ -66,7 +66,8 @@ func NewSystemCommand(c common.Args) *cobra.Command {
 			"# Diagnose the system's health:\n" +
 			"> vela system diagnose\n",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeSystem,
+			types.TagCommandType:  types.TypeSystem,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.AddCommand(

--- a/references/cli/top.go
+++ b/references/cli/top.go
@@ -58,7 +58,7 @@ func NewTopCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *co
 		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeApp,
+			types.TagCommandType:  types.TypePlatform,
 		},
 	}
 	addNamespaceAndEnvArg(cmd)

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -45,7 +45,7 @@ var (
 )
 
 // NewTraitCommand creates `traits` command
-func NewTraitCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewTraitCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	var isDiscover bool
 	cmd := &cobra.Command{
 		Use:     "trait",
@@ -85,7 +85,8 @@ func NewTraitCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 			return PrintInstalledTraitDef(c, ioStreams, filter)
 		},
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeExtension,
+			types.TagCommandType:  types.TypeExtension,
+			types.TagCommandOrder: order,
 		},
 	}
 	cmd.SetOut(ioStreams.Out)

--- a/references/cli/traits_test.go
+++ b/references/cli/traits_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Test trait cli", func() {
 			arg.SetClient(k8sClient)
 			buffer := bytes.NewBuffer(nil)
 			ioStreams := util.IOStreams{In: os.Stdin, Out: buffer, ErrOut: buffer}
-			cmd := NewTraitCommand(arg, ioStreams)
+			cmd := NewTraitCommand(arg, "", ioStreams)
 			Expect(cmd.Execute()).Should(BeNil())
 			buf, ok := ioStreams.Out.(*bytes.Buffer)
 			Expect(ok).Should(BeTrue())

--- a/references/cli/uninstall.go
+++ b/references/cli/uninstall.go
@@ -59,7 +59,7 @@ func NewUnInstallCommand(c common.Args, order string, ioStreams util.IOStreams) 
 	}, helmHelper: helm.NewHelper()}
 	cmd := &cobra.Command{
 		Use:     "uninstall",
-		Short:   "Uninstalls KubeVela from a Kubernetes cluster",
+		Short:   "Uninstalls KubeVela from a Kubernetes cluster.",
 		Example: `vela uninstall`,
 		Long:    "Uninstalls KubeVela from a Kubernetes cluster.",
 		Args:    cobra.ExactArgs(0),

--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -249,7 +249,7 @@ func NewUpCommand(f velacmd.Factory, order string, c utilcommon.Args, ioStream u
 	cmd := &cobra.Command{
 		Use:                   "up",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Deploy one application"),
+		Short:                 i18n.T("Deploy one application."),
 		Long:                  upLong,
 		Example:               upExample,
 		Annotations: map[string]string{

--- a/references/cli/velaql.go
+++ b/references/cli/velaql.go
@@ -103,7 +103,7 @@ export: "status"
 		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
-			types.TagCommandType:  types.TypeApp,
+			types.TagCommandType:  types.TypeAuxiliary,
 		},
 	}
 	cmd.Flags().StringVarP(&cueFile, "file", "f", "", "The CUE file path for VelaQL, it could be a remote url.")

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -42,13 +42,14 @@ import (
 )
 
 // NewWorkflowCommand create `workflow` command
-func NewWorkflowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+func NewWorkflowCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workflow",
 		Short: "Operate application delivery workflow.",
 		Long:  "Operate the Workflow during Application Delivery. Note that workflow command is both valid for Application Workflow and WorkflowRun(expect for [restart, rollout] command, they're only valid for Application Workflow). The command will try to find the Application first, if not found, it will try to find WorkflowRun. You can also specify the resource type by using --type flag.",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeCD,
+			types.TagCommandType:  types.TypeCD,
+			types.TagCommandOrder: order,
 		},
 	}
 	wargs := &WorkflowArgs{

--- a/references/cli/workloads.go
+++ b/references/cli/workloads.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/oam-dev/kubevela/apis/types"
 	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
 	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
 	"github.com/oam-dev/kubevela/references/common"
@@ -41,7 +42,9 @@ func NewWorkloadsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Com
 			}
 			return printWorkloadList(namespace, c, ioStreams)
 		},
-		Annotations: map[string]string{},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeLegacy,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	addNamespaceAndEnvArg(cmd)


### PR DESCRIPTION
### Description of your changes

1. Refactor vela cli entrance. Reorder command groups and hide part of the commands. (HIDE means the command can be still used but not displayed on the help page.)
2. Fix incorrect string based order sort.
3. Refactor short description.

```shell
$ vela
A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.

Getting Started:
  init                  Create scaffold for an application.                               
  up                    Deploy one application.                                           
  status                Show status of an application.                                    
  ls                    List applications.                                                
  delete                Delete an application.                                            
  env                   Manage environments for vela applications to run.                 
  show                  Show the reference doc for a component, trait, policy or workflow.

Managing Applications:
  addon                 Manage addons for extension.                                             
  dry-run               Dry Run an application, and output the K8s resources as result to stdout.
  live-diff             Compare application and revisions.                                       
  logs                  Tail logs for application.                                               
  port-forward          Forward local ports to container/service port of vela application.       
  exec                  Execute command in a container.                                          
  revision              Manage Application Revisions.                                            
  debug                 Debug running application.                                               

Continuous Delivery:
  workflow              Operate application delivery workflow.
  adopt                 Adopt resources into new application. 

Managing Platform:
  top                   Launch UI to display the platform overview.
  cluster               Manage Kubernetes clusters.                
  auth                  Manage identity and authorizations.        
  config                Manage the configs.                        
  config-template       Manage the template of config.             

Managing Extensions:
  uischema              Manage UI schema for addons.
  component             List/get components.        
  trait                 List/get traits.            
  def                   Manage definitions.         

System Tools:
  install               Installs or Upgrades Kubevela control plane on a Kubernetes cluster.
  uninstall             Uninstalls KubeVela from a Kubernetes cluster.                      
  system                Manage system.                                                      
  version               Prints vela build version information.                              

Auxiliary Tools:
  kube                  Managing native Kubernetes resources across clusters.              
  cuex                  Manage CueX engine for compile.                                    
  ql                    Show result of executing velaQL.                                   
  completion            Output shell completion code for the specified shell (bash or zsh).
  help                  Help about any command.                                            

Flags:
  -h, --help   help for vela

Use "vela [command] --help" for more information about a command.
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->