### PR TITLE
Feat: allow empty policy name

### DIFF
--- a/apis/core.oam.dev/v1beta1/application_types.go
+++ b/apis/core.oam.dev/v1beta1/application_types.go
@@ -44,8 +44,9 @@ const (
 // AppPolicy defines a global policy for all components in the app.
 type AppPolicy struct {
 	// Name is the unique name of the policy.
-	Name string `json:"name"`
-
+	// +optional
+	Name string `json:"name,omitempty"`
+	// Type is the type of the policy
 	Type string `json:"type"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Properties *runtime.RawExtension `json:"properties,omitempty"`

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -2243,9 +2243,9 @@ spec:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                             type:
+                              description: Type is the type of the policy
                               type: string
                           required:
-                          - name
                           - type
                           type: object
                         type: array

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -1010,9 +1010,9 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     type:
+                      description: Type is the type of the policy
                       type: string
                   required:
-                  - name
                   - type
                   type: object
                 type: array

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -2243,9 +2243,9 @@ spec:
                               type: object
                               
                             type:
+                              description: Type is the type of the policy
                               type: string
                           required:
-                          - name
                           - type
                           type: object
                         type: array

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -1010,9 +1010,9 @@ spec:
                       type: object
                       
                     type:
+                      description: Type is the type of the policy
                       type: string
                   required:
-                  - name
                   - type
                   type: object
                 type: array

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -112,6 +112,12 @@ func (p *Parser) GenerateAppFileFromApp(ctx context.Context, app *v1beta1.Applic
 	ns := app.Namespace
 	appName := app.Name
 
+	for idx := range app.Spec.Policies {
+		if app.Spec.Policies[idx].Name == "" {
+			app.Spec.Policies[idx].Name = fmt.Sprintf("%s:auto-gen:%d", app.Spec.Policies[idx].Type, idx)
+		}
+	}
+
 	appfile := p.newAppfile(appName, ns, app)
 	if app.Status.LatestRevision != nil {
 		appfile.AppRevisionName = app.Status.LatestRevision.Name

--- a/test/e2e-multicluster-test/testdata/app/app-anonymous-policies.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-anonymous-policies.yaml
@@ -1,0 +1,21 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: test
+spec:
+  components:
+    - type: webservice
+      name: test
+      properties:
+        image: nginx
+  policies:
+    - type: topology
+      properties:
+        clusters: ["cluster-worker"]
+    - type: override
+      properties:
+        components:
+          - traits:
+              - type: scaler
+                properties:
+                  replicas: 0


### PR DESCRIPTION
### Description of your changes

Support using anonymous policy, like
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: test
spec:
  components:
    - type: webservice
      name: test
      properties:
        image: nginx
  policies:
    - type: topology
      properties:
        clusters: ["cluster-worker"]
    - type: override
      properties:
        components:
          - properties:
              image: nginx:1.21
```

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->