### PR TITLE
Fix: The addon page displays the deleted addon

### DIFF
--- a/pkg/addon/cache.go
+++ b/pkg/addon/cache.go
@@ -342,8 +342,8 @@ func (u *Cache) listVersionRegistryUIDataAndCache(r Registry) ([]*UIData, error)
 		u.putVersionedUIData2Cache(r.Name, addon.Name, "latest", uiData)
 	}
 	// delete the addon has been deleted form the addonRegistryCache
-	if addonUiDatas, ok := u.versionedUIData[r.Name]; ok {
-		for k := range addonUiDatas {
+	if addonUIDatas, ok := u.versionedUIData[r.Name]; ok {
+		for k := range addonUIDatas {
 			lastInd := strings.LastIndex(k, "-")
 			var needDelete = true
 			for _, addon := range uiDatas {
@@ -353,7 +353,7 @@ func (u *Cache) listVersionRegistryUIDataAndCache(r Registry) ([]*UIData, error)
 				}
 			}
 			if needDelete {
-				delete(addonUiDatas, k)
+				delete(addonUIDatas, k)
 			}
 		}
 	}

--- a/pkg/addon/cache.go
+++ b/pkg/addon/cache.go
@@ -341,5 +341,21 @@ func (u *Cache) listVersionRegistryUIDataAndCache(r Registry) ([]*UIData, error)
 		// we also no version key, if use get addonUIData without version will return this vale as latest data.
 		u.putVersionedUIData2Cache(r.Name, addon.Name, "latest", uiData)
 	}
+	// delete the addon has been deleted form the addonRegistryCache
+	if addonUiDatas, ok := u.versionedUIData[r.Name]; ok {
+		for k := range addonUiDatas {
+			lastInd := strings.LastIndex(k, "-")
+			var needDelete = true
+			for _, addon := range uiDatas {
+				if k[:lastInd] == addon.Name {
+					needDelete = false
+					break
+				}
+			}
+			if needDelete {
+				delete(addonUiDatas, k)
+			}
+		}
+	}
 	return uiDatas, nil
 }


### PR DESCRIPTION
### Description of your changes

After you delete an addon from the addon repository, the addon management page shouldn't display the addon.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5750

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->