### PR TITLE
[Backport release-1.8] Chore: add e2e ci env bootstrap & remove multlcluster legacy rollout ci #5926

### DIFF
--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
 
   e2e-multi-cluster-tests:
-    runs-on: aliyun
+    runs-on: self-hosted
     needs: [ detect-noop ]
     if: needs.detect-noop.outputs.noop != 'true'
     strategy:
@@ -106,13 +106,14 @@ jobs:
           sed -i "s/0.0.0.0:[0-9]\+/$internal_ip:6443/"  /tmp/worker.kubeconfig
 
       - name: Load image to k3d cluster (hub and worker)
-        run: make image-load
+        run: make image-load image-load-runtime-cluster
 
       - name: Cleanup for e2e tests
         run: |
           make vela-cli
           make e2e-cleanup
           make e2e-setup-core-auth
+          make setup-runtime-e2e-cluster
 
       - name: Run e2e multicluster tests
         run: |

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -49,10 +49,17 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true
 
-
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install make gcc jq ca-certificates curl gnupg -y
+          snap install docker
+          snap install kubectl --classic
+          snap install helm --classic
 
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
@@ -99,14 +106,13 @@ jobs:
           sed -i "s/0.0.0.0:[0-9]\+/$internal_ip:6443/"  /tmp/worker.kubeconfig
 
       - name: Load image to k3d cluster (hub and worker)
-        run: make image-load image-load-runtime-cluster
+        run: make image-load
 
       - name: Cleanup for e2e tests
         run: |
           make vela-cli
           make e2e-cleanup
           make e2e-setup-core-auth
-          make setup-runtime-e2e-cluster
 
       - name: Run e2e multicluster tests
         run: |

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
 
   e2e-rollout-tests:
-    runs-on: aliyun
+    runs-on: self-hosted
     needs: [ detect-noop ]
     if: needs.detect-noop.outputs.noop != 'true'
     strategy:
@@ -62,6 +62,8 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
+          go install github.com/onsi/ginkgo/ginkgo
+          go get github.com/onsi/gomega/...
 
       - name: Tear down K3d if exist
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
 
   e2e-tests:
-    runs-on: aliyun
+    runs-on: self-hosted
     needs: [ detect-noop ]
     if: needs.detect-noop.outputs.noop != 'true'
     strategy:
@@ -70,6 +70,8 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
+          go install github.com/onsi/ginkgo/ginkgo
+          go get github.com/onsi/gomega/...
 
       - name: Tear down K3d if exist
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
 
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install make gcc jq ca-certificates curl gnupg -y
+          snap install docker
+          snap install kubectl --classic
+          snap install helm --classic
+
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:


### PR DESCRIPTION
### Description of your changes

Cherry-pick #5926 to release-1.8.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->