### PR TITLE
Fix: adding topology strategy to addons to be valid only for the yaml type.

### DIFF
--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -424,6 +424,10 @@ func checkNeedAttachTopologyPolicy(app *v1beta1.Application, addon *InstallPacka
 	if !isDeployToRuntime(addon) {
 		return false
 	}
+	// To achieve a completely white-box definition of cue type addons, adding topology strategy to addons to be valid only for the yaml type.
+	if len(addon.AppCueTemplate.Data) != 0 {
+		return false
+	}
 	for _, policy := range app.Spec.Policies {
 		if policy.Type == v1alpha1.TopologyPolicyType {
 			klog.Warningf("deployTo in metadata will NOT have any effect. It conflicts with %s policy named %s. Consider removing deployTo field in addon metadata.", v1alpha1.TopologyPolicyType, policy.Name)


### PR DESCRIPTION
### Description of your changes

To achieve a completely white-box definition of cue type addons, adding topology strategy to addons to be valid only for the yaml type.

So when determining whether to attach the policy, to consider whether the addon was generated from a cue file.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5932

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->