### PR TITLE
Feat: add vela def gen-cue command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/wonderflow/cert-manager-api v1.0.4-0.20210304051430-e08aa76f6c5f
 	github.com/xanzy/go-gitlab v0.83.0
 	github.com/xlab/treeprint v1.2.0
+	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.6.0
 	golang.org/x/oauth2 v0.6.0
@@ -287,7 +288,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1184,7 +1184,7 @@ func NewDefinitionGenCUECommand(_ common.Args) *cobra.Command {
 			if output == "" {
 				output = strings.TrimSuffix(file, filepath.Ext(file)) + ".cue"
 			}
-			f, err := os.Create(output)
+			f, err := os.Create(filepath.Clean(output))
 			if err != nil {
 				return err
 			}

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -38,6 +38,7 @@ import (
 	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.uber.org/multierr"
 	"gopkg.in/yaml.v3"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,8 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/filters"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/oam-dev/kubevela/references/cuegen"
+	providergen "github.com/oam-dev/kubevela/references/cuegen/generators/provider"
 )
 
 const (
@@ -89,6 +92,7 @@ func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStream
 		NewDefinitionGenDocCommand(c, ioStreams),
 		NewCapabilityShowCommand(c, "", ioStreams),
 		NewDefinitionGenAPICommand(c),
+		NewDefinitionGenCUECommand(c),
 	)
 	return cmd
 }
@@ -1135,6 +1139,75 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 	cmd.Flags().StringSliceVar(&languageArgs, "language-args", []string{},
 		fmt.Sprintf("language-specific arguments to pass to the go generator, available options: \n"+langArgsDescStr),
 	)
+
+	return cmd
+}
+
+// NewDefinitionGenCUECommand create the `vela def gen-cue` command to help user generate CUE schema from the go code
+func NewDefinitionGenCUECommand(_ common.Args) *cobra.Command {
+	const (
+		typeProvider = "provider"
+	)
+
+	var (
+		typ      string
+		output   string
+		typeMap  map[string]string
+		nullable bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gen-cue [flags] SOURCE.go",
+		Args:  cobra.ExactArgs(1),
+		Short: "Generate CUE schema from Go code.",
+		Long: "Generate CUE schema from Go code.\n" +
+			"* This command provide a way to generate CUE schema from Go code,\n" +
+			"* Which can be used to keep consistency between Go code and CUE schema automatically.\n",
+		Example: "# Generate CUE schema for provider type\n" +
+			"> vela def gen-cue -t provider /path/to/myprovider.go\n" +
+			"# Generate CUE schema for provider type with custom types\n" +
+			"> vela def gen-cue -t provider --types *k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis /path/to/myprovider.go\n" +
+			"# Generate CUE schema for provider type with custom output path\n" +
+			"> vela def gen-cue -t provider -o /path/to/myprovider.cue /path/to/myprovider.go\n",
+		RunE: func(cmd *cobra.Command, args []string) (rerr error) {
+			// convert map[string]string to map[string]cuegen.Type
+			newTypeMap := make(map[string]cuegen.Type, len(typeMap))
+			for k, v := range typeMap {
+				newTypeMap[k] = cuegen.Type(v)
+			}
+
+			file := args[0]
+			if !strings.HasSuffix(file, ".go") {
+				return fmt.Errorf("invalid file %s, must be a go file", file)
+			}
+
+			if output == "" {
+				output = strings.TrimSuffix(file, filepath.Ext(file)) + ".cue"
+			}
+			f, err := os.Create(output)
+			if err != nil {
+				return err
+			}
+			defer multierr.AppendInvoke(&rerr, multierr.Close(f))
+
+			switch typ {
+			case typeProvider:
+				return providergen.Generate(providergen.Options{
+					File:     file,
+					Writer:   f,
+					Types:    newTypeMap,
+					Nullable: nullable,
+				})
+			default:
+				return fmt.Errorf("invalid type %s", typ)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&typ, "type", "t", "", "Type of the definition to generate. Valid types: [provider]")
+	cmd.Flags().BoolVar(&nullable, "nullable", false, "Whether to generate null enum for pointer type")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output CUE file path, if not specified, the CUE file will be generated in the same directory")
+	cmd.Flags().StringToStringVar(&typeMap, "types", map[string]string{}, "Special types to generate, format: <package+struct>=[any|ellipsis]. e.g. --types=*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis")
 
 	return cmd
 }

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -180,13 +180,6 @@ func removeDir(dirname string, t *testing.T) {
 }
 
 func compareFile(t *testing.T, got, expected string) {
-	if _, err := os.Stat(got); err != nil {
-		t.Fatalf("failed to stat file %s: %v", got, err)
-	}
-	if _, err := os.Stat(expected); err != nil {
-		t.Fatalf("failed to stat file %s: %v", expected, err)
-	}
-
 	gotBytes, err := os.ReadFile(got)
 	if err != nil {
 		t.Fatalf("failed to read file %s: %v", got, err)

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -679,7 +679,7 @@ func TestNewDefinitionGenCUECommand(t *testing.T) {
 
 	// re-use the provider testdata
 	providerPath := "../cuegen/generators/provider/testdata"
-	output := filepath.Join(os.TempDir(), "output.cue")
+	output := filepath.Join(t.TempDir(), "output.cue")
 	expected := filepath.Join(providerPath, "valid.cue")
 
 	cmd.SetArgs([]string{
@@ -694,7 +694,5 @@ func TestNewDefinitionGenCUECommand(t *testing.T) {
 		t.Fatalf("unexpeced error when executing gencue command: %v", err)
 	}
 
-	t.Logf("output file path: %s", output)
-	t.Logf("expected file path: %s", expected)
 	compareFile(t, output, expected)
 }

--- a/references/cuegen/convert.go
+++ b/references/cuegen/convert.go
@@ -88,7 +88,7 @@ func (g *Generator) convert(typ gotypes.Type) (cueast.Expr, error) {
 		case TypeEllipsis:
 			return &cueast.StructLit{Elts: []cueast.Decl{&cueast.Ellipsis{}}}, nil
 		default:
-			return nil, fmt.Errorf("unsupported special cue type %d", t)
+			return nil, fmt.Errorf("unsupported special cue type: %v", t)
 		}
 	}
 

--- a/references/cuegen/option.go
+++ b/references/cuegen/option.go
@@ -19,13 +19,13 @@ package cuegen
 import goast "go/ast"
 
 // Type is a special cue type
-type Type int
+type Type string
 
 const (
 	// TypeAny converts go type to _(top value) in cue
-	TypeAny Type = iota
+	TypeAny Type = "any"
 	// TypeEllipsis converts go type to {...} in cue
-	TypeEllipsis
+	TypeEllipsis = "ellipsis"
 )
 
 type options struct {

--- a/references/cuegen/option.go
+++ b/references/cuegen/option.go
@@ -25,7 +25,7 @@ const (
 	// TypeAny converts go type to _(top value) in cue
 	TypeAny Type = "any"
 	// TypeEllipsis converts go type to {...} in cue
-	TypeEllipsis = "ellipsis"
+	TypeEllipsis Type = "ellipsis"
 )
 
 type options struct {


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8cffb50</samp>

### Summary
📝🎨✨

<!--
1.  📝 - This emoji represents the change in the error message, which is a minor improvement in the documentation or text of the code.
2.  🎨 - This emoji represents the change in the `Type` type and constants, which is a cosmetic or stylistic change that improves the readability or appearance of the code.
3.  ✨ - This emoji represents the addition of the test case and the subcommand, which are new features or enhancements that add functionality or value to the code.
-->
This pull request adds a new CLI subcommand `vela def gen-cue` to generate CUE schema from Go types for different kinds of definitions. It also adds a test case for the subcommand and improves the error message and the type representation in the `cuegen` package.

> _`vela def gen-cue`_
> _From Go types to CUE schema_
> _Autumn harvest time_

### Walkthrough
*  Add `vela def gen-cue` command to generate CUE schema from Go types ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR95), [link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR1145-R1213), [link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcR681-R707))
  - Use `cuegen` and `providergen` packages to handle different types of definitions ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR61-R62), [link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR1145-R1213))
  - Support custom types and output path with flags and arguments ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR1145-R1213))
  - Test the command with `provider` testdata and compare the output file with the expected file ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcR182-R204), [link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcR681-R707))
* Change `Type` type and constants to string values for readability and consistency ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-deb1b0ed57b456cdd4209cf1460a053ba6a5347a605ef6c859036415718c9be0L22-R28), [link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-f3ec0bb030f3add13296ed258157b227f061b722669287e2ad2cc069d76e2723L91-R91))
* Import `multierr` package to handle multiple errors in a single value ([link](https://github.com/kubevela/kubevela/pull/5956/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR41))



Part of #5364 

Preview:
```
$ ./vela def gen-cue -h
Generate CUE schema from Go code.
* This command provide a way to generate CUE schema from Go code,
* Which can be used to keep consistency between Go code and CUE schema automatically.

Usage:
  vela def gen-cue [flags] SOURCE.go

Examples:
# Generate CUE schema for provider type
> vela def gen-cue -t provider /path/to/myprovider.go
# Generate CUE schema for provider type with custom types
> vela def gen-cue -t provider --types *k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis /path/to/myprovider.go
# Generate CUE schema for provider type with custom output path
> vela def gen-cue -t provider -o /path/to/myprovider.cue /path/to/myprovider.go


Flags:
  -h, --help                   help for gen-cue
      --nullable               Whether to generate null enum for pointer type
  -o, --output string          Output CUE file path, if not specified, the CUE file will be generated in the same directory
  -t, --type string            Type of the definition to generate. Valid types: [provider]
      --types stringToString   Special types to generate, format: <package+struct>=[any|ellipsis]. e.g. --types=*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis (default [])

Global Flags:
  -y, --yes   Assume yes for all user prompts
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->