### PR TITLE
Fix: restrict the rules that automatically add topology strategy to ddons to be valid only for the yaml type

### DIFF
--- a/pkg/addon/render.go
+++ b/pkg/addon/render.go
@@ -421,6 +421,10 @@ func renderResources(addon *InstallPackage, args map[string]interface{}) ([]comm
 // checkNeedAttachTopologyPolicy will check this addon want to deploy to runtime-cluster, but application template doesn't specify the
 // topology policy, then will attach the policy to application automatically.
 func checkNeedAttachTopologyPolicy(app *v1beta1.Application, addon *InstallPackage) bool {
+	// the cue template will not be attached topology policy for the white-box principle
+	if len(addon.AppCueTemplate.Data) != 0 {
+		return false
+	}
 	if !isDeployToRuntime(addon) {
 		return false
 	}

--- a/pkg/addon/render_test.go
+++ b/pkg/addon/render_test.go
@@ -304,6 +304,29 @@ func TestAppComponentRender(t *testing.T) {
 }
 
 func TestCheckNeedAttachTopologyPolicy(t *testing.T) {
+	addon := &InstallPackage{
+		AppCueTemplate: ElementFile{
+			Data: "not empty",
+			Name: "template.cue",
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(&v1beta1.Application{Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{
+		Type: v1alpha1.SharedResourcePolicyType,
+	}}}}, addon), false)
+
+	addon0 := &InstallPackage{
+		AppCueTemplate: ElementFile{
+			Data: "",
+			Name: "template.cue",
+		},
+		Meta: Meta{
+			DeployTo: &DeployTo{RuntimeCluster: true},
+		},
+	}
+	assert.Equal(t, checkNeedAttachTopologyPolicy(&v1beta1.Application{Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{
+		Type: v1alpha1.SharedResourcePolicyType,
+	}}}}, addon0), true)
+
 	addon1 := &InstallPackage{
 		Meta: Meta{
 			DeployTo: nil,
@@ -335,6 +358,7 @@ func TestCheckNeedAttachTopologyPolicy(t *testing.T) {
 	assert.Equal(t, checkNeedAttachTopologyPolicy(&v1beta1.Application{Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{
 		Type: v1alpha1.SharedResourcePolicyType,
 	}}}}, addon4), true)
+
 }
 
 func TestGenerateAppFrameworkWithCue(t *testing.T) {


### PR DESCRIPTION


### Description of your changes

Fixes #5932

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
vela addon enable rollout --version 1.3.1
vela addon enable rollout --version 1.3.2

### Special notes for your reviewer
@wangyikewxgm 