### PR TITLE
Feat: only print to stdout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,6 @@ require (
 	github.com/wonderflow/cert-manager-api v1.0.4-0.20210304051430-e08aa76f6c5f
 	github.com/xanzy/go-gitlab v0.83.0
 	github.com/xlab/treeprint v1.2.0
-	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.6.0
 	golang.org/x/oauth2 v0.6.0
@@ -288,6 +287,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f5c7d91</samp>

### Summary
📄🎨📚

<!--
1.  📄 for adding the ability to output CUE schema to a file
2.  🎨 for refactoring the output logic and improving the formatting of the CUE schema
3.  📚 for adding a new example to the help message
-->
Enhance `vela def` command with CUE schema output options and example. Refactor output logic and update help message.

> _The `vela def` command got a boost_
> _Now it can output CUE schema to use_
> _You can send it to STDOUT_
> _Or a file, how about that?_
> _It also has refactored output and a new example to peruse_

### Walkthrough
* Import `io` package to use `io.Writer` interface for writing CUE schema ([link](https://github.com/kubevela/kubevela/pull/5958/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR24))
* Add example to command help message to show how to output CUE schema to STDOUT ([link](https://github.com/kubevela/kubevela/pull/5958/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL1171-R1174))
* Refactor output file creation and writing logic to use a `writer` variable that can be either `os.Stdout` or a file handle ([link](https://github.com/kubevela/kubevela/pull/5958/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL1184-R1202))
* Change `Writer` field of `providergen.Options` struct to use `writer` variable instead of `f` variable ([link](https://github.com/kubevela/kubevela/pull/5958/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL1197-R1208))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->