### PR TITLE
Fix: add cluster information for vela adopt cue definition

### DIFF
--- a/references/cli/adopt-templates/default.cue
+++ b/references/cli/adopt-templates/default.cue
@@ -143,6 +143,9 @@ import (
 				if r.metadata.namespace != _|_ {
 					metadata: namespace: r.metadata.namespace
 				}
+				if r._cluster != _|_ {
+					metadata: annotations: "app.oam.dev/cluster": (r._cluster)
+				}
 				spec: r.spec
 			}]
 		},


### PR DESCRIPTION
### Description of your changes

Add cluster annotaion when vela adopt resource is workload or service. If not, the application workflow is nil, and the application will failed when excute vela adopt multi-cluster

Fixes #5970

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->