### PR TITLE
Feat: support def gen-doc command

### DIFF
--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1220,7 +1220,7 @@ func NewDefinitionGenDocCommand(_ common.Args, streams util.IOStreams) *cobra.Co
 					return fmt.Errorf("invalid file %s, must be a cue file", arg)
 				}
 
-				f, err := os.ReadFile(arg)
+				f, err := os.ReadFile(filepath.Clean(arg))
 				if err != nil {
 					return fmt.Errorf("read file %s: %w", arg, err)
 				}

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -1201,15 +1201,15 @@ func NewDefinitionGenCUECommand(_ common.Args, streams util.IOStreams) *cobra.Co
 	return cmd
 }
 
-// NewDefinitionGenDocCommand create the `vela def doc-gen` command to generate documentation of definitions
+// NewDefinitionGenDocCommand create the `vela def gen-doc` command to generate documentation of definitions
 func NewDefinitionGenDocCommand(_ common.Args, streams util.IOStreams) *cobra.Command {
 	var typ string
 
 	cmd := &cobra.Command{
 		Use:   "gen-doc [flags] SOURCE.cue...",
 		Args:  cobra.MinimumNArgs(1),
-		Short: "Generate documentation for non component, trait, policy, workload definitions",
-		Long:  "Generate documentation for non component, trait, policy, workload definitions",
+		Short: "Generate documentation for non component, trait, policy and workflow definitions",
+		Long:  "Generate documentation for non component, trait, policy and workflow definitions",
 		Example: "1. Generate documentation for provider definitions\n" +
 			"> vela def gen-doc -t provider provider1.cue provider2.cue > provider.md",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -59,6 +60,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/util"
 	"github.com/oam-dev/kubevela/references/cuegen"
 	providergen "github.com/oam-dev/kubevela/references/cuegen/generators/provider"
+	"github.com/oam-dev/kubevela/references/docgen"
 )
 
 const (
@@ -88,10 +90,11 @@ func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStream
 		NewDefinitionDelCommand(c),
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
-		NewDefinitionGenDocCommand(c, ioStreams),
+		NewDefinitionDocGenCommand(c, ioStreams),
 		NewCapabilityShowCommand(c, "", ioStreams),
 		NewDefinitionGenAPICommand(c),
 		NewDefinitionGenCUECommand(c, ioStreams),
+		NewDefinitionGenDocCommand(c, ioStreams),
 	)
 	return cmd
 }
@@ -521,8 +524,8 @@ func NewDefinitionGetCommand(c common.Args) *cobra.Command {
 	return cmd
 }
 
-// NewDefinitionGenDocCommand create the `vela def doc-gen` command to generate documentation of definitions
-func NewDefinitionGenDocCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
+// NewDefinitionDocGenCommand create the `vela def doc-gen` command to generate documentation of definitions
+func NewDefinitionDocGenCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
 	var docPath, location, i18nPath string
 	cmd := &cobra.Command{
 		Use:   "doc-gen NAME",
@@ -1142,12 +1145,12 @@ func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 	return cmd
 }
 
+const (
+	genTypeProvider = "provider"
+)
+
 // NewDefinitionGenCUECommand create the `vela def gen-cue` command to help user generate CUE schema from the go code
 func NewDefinitionGenCUECommand(_ common.Args, streams util.IOStreams) *cobra.Command {
-	const (
-		typeProvider = "provider"
-	)
-
 	var (
 		typ      string
 		typeMap  map[string]string
@@ -1178,7 +1181,7 @@ func NewDefinitionGenCUECommand(_ common.Args, streams util.IOStreams) *cobra.Co
 			}
 
 			switch typ {
-			case typeProvider:
+			case genTypeProvider:
 				return providergen.Generate(providergen.Options{
 					File:     file,
 					Writer:   streams.Out,
@@ -1194,6 +1197,47 @@ func NewDefinitionGenCUECommand(_ common.Args, streams util.IOStreams) *cobra.Co
 	cmd.Flags().StringVarP(&typ, "type", "t", "", "Type of the definition to generate. Valid types: [provider]")
 	cmd.Flags().BoolVar(&nullable, "nullable", false, "Whether to generate null enum for pointer type")
 	cmd.Flags().StringToStringVar(&typeMap, "types", map[string]string{}, "Special types to generate, format: <package+struct>=[any|ellipsis]. e.g. --types=*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis")
+
+	return cmd
+}
+
+// NewDefinitionGenDocCommand create the `vela def doc-gen` command to generate documentation of definitions
+func NewDefinitionGenDocCommand(_ common.Args, streams util.IOStreams) *cobra.Command {
+	var typ string
+
+	cmd := &cobra.Command{
+		Use:   "gen-doc [flags] SOURCE.cue...",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Generate documentation for non component, trait, policy, workload definitions",
+		Long:  "Generate documentation for non component, trait, policy, workload definitions",
+		Example: "1. Generate documentation for provider definitions\n" +
+			"> vela def gen-doc -t provider provider1.cue provider2.cue > provider.md",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			readers := make([]io.Reader, 0, len(args))
+
+			for _, arg := range args {
+				if !strings.HasSuffix(arg, ".cue") {
+					return fmt.Errorf("invalid file %s, must be a cue file", arg)
+				}
+
+				f, err := os.ReadFile(arg)
+				if err != nil {
+					return fmt.Errorf("read file %s: %w", arg, err)
+				}
+
+				readers = append(readers, bytes.NewReader(f))
+			}
+
+			switch typ {
+			case genTypeProvider:
+				return docgen.GenerateProvidersMarkdown(cmd.Context(), readers, streams.Out)
+			default:
+				return fmt.Errorf("invalid type %s", typ)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&typ, "type", "t", "", "Type of the definition to generate. Valid types: [provider]")
 
 	return cmd
 }

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -459,9 +459,9 @@ func TestNewDefinitionGetCommand(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNewDefinitionGenDocCommand(t *testing.T) {
+func TestNewDefinitionDocGenCommand(t *testing.T) {
 	c := initArgs()
-	cmd := NewDefinitionGenDocCommand(c, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	cmd := NewDefinitionDocGenCommand(c, util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	assert.NotNil(t, cmd.Execute())
 
 	cmd.SetArgs([]string{"alibaba-xxxxxxx"})
@@ -657,25 +657,44 @@ func TestNewDefinitionGenAPICommand(t *testing.T) {
 	}
 }
 
+// re-use the provider testdata
+const providerTestDataPath = "../cuegen/generators/provider/testdata"
+
 func TestNewDefinitionGenCUECommand(t *testing.T) {
 	c := initArgs()
 	got := bytes.NewBuffer(nil)
 	cmd := NewDefinitionGenCUECommand(c, util.IOStreams{Out: got})
 	initCommand(cmd)
 
-	// re-use the provider testdata
-	providerPath := "../cuegen/generators/provider/testdata"
-
 	cmd.SetArgs([]string{
-		"-t", "provider",
+		"-t", genTypeProvider,
 		"--types", "*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis",
 		"--types", "*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList=ellipsis",
-		filepath.Join(providerPath, "valid.go"),
+		filepath.Join(providerTestDataPath, "valid.go"),
 	})
 
 	require.NoError(t, cmd.Execute())
 
-	expected, err := os.ReadFile(filepath.Join(providerPath, "valid.cue"))
+	expected, err := os.ReadFile(filepath.Join(providerTestDataPath, "valid.cue"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), got.String())
+}
+
+func TestNewDefinitionGenDocCommand(t *testing.T) {
+	c := initArgs()
+	got := bytes.NewBuffer(nil)
+	cmd := NewDefinitionGenDocCommand(c, util.IOStreams{Out: got})
+	initCommand(cmd)
+
+	cmd.SetArgs([]string{
+		"-t", genTypeProvider,
+		filepath.Join(providerTestDataPath, "valid.cue"),
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	expected, err := os.ReadFile(filepath.Join(providerTestDataPath, "valid.md"))
 	require.NoError(t, err)
 
 	assert.Equal(t, string(expected), got.String())


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f9b3899</samp>

### Summary
🛠️📝📚

<!--
1.  🛠️ - This emoji represents the refactoring and testing of the definition generation commands, as well as the extraction and replacement of some constants and variables. It suggests that the pull request improves the code quality and structure of the cli package.
2.  📝 - This emoji represents the addition of a new subcommand to generate documentation for provider definitions from cue files. It suggests that the pull request adds a new feature and functionality to the vela cli tool.
3.  📚 - This emoji represents the generation of documentation for provider definitions, which can help users and developers understand and use the cue files and the vela framework. It suggests that the pull request enhances the documentation and knowledge base of the project.
-->
This pull request enhances the cli package with new features and tests for definition generation. It adds a `vela def gen-doc` subcommand to create markdown files from cue definitions, and refactors the code and constants for cue and markdown generation. It also improves the test coverage for the definition commands in `def_test.go`.

> _`vela def gen-doc`_
> _New subcommand for cue files_
> _Autumn of refactoring_

### Walkthrough
*  Rename `NewDefinitionGenDocCommand` function to `NewDefinitionDocGenCommand` and update its comment and usage ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcL462-R464), [link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL91-R97), [link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL524-R528))
*  Extract and rename constant `genTypeProvider` for the type flag value of `gen-cue` and `gen-doc` subcommands ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL1145-R1153))
*  Replace literal string `provider` with constant `genTypeProvider` in `NewDefinitionGenCUECommand` function ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeL1181-R1184), [link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcL666-R701))
*  Add constant `providerTestDataPath` for the relative path to the provider testdata directory ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-21d4c7864884250de747fe68c3ca0c1a3fcacf64bb613ea06f242075d5909fdcR660-R662))
*  Add `NewDefinitionGenDocCommand` function to create `vela def gen-doc` subcommand for generating documentation for provider definitions ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR1203-R1243))
   *  Import `io` and `docgen` packages for reading cue files and generating markdown output ([link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR24), [link](https://github.com/kubevela/kubevela/pull/5975/files?diff=unified&w=0#diff-739f4f64cd699090ae6f9705af491dc7e42decf8d0340ef88109bc2333f32bdeR63))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Part of #5364 

Preview:

```
$ ./vela def gen-doc -h
Generate documentation for non component, trait, policy and workflow definitions

Usage:
  vela def gen-doc [flags] SOURCE.cue...

Examples:
1. Generate documentation for provider definitions
> vela def gen-doc -t provider provider1.cue provider2.cue > provider.md

Flags:
  -h, --help          help for gen-doc
  -t, --type string   Type of the definition to generate. Valid types: [provider]

Global Flags:
  -y, --yes   Assume yes for all user prompts
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->