### PR TITLE
Fix: Restore service creation for gateway trait

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -19,9 +19,28 @@ spec:
         	if parameter.name != _|_ {"-" + parameter.name}
         	if parameter.name == _|_ {""}
         }
+        let serviceOutputName = "service" + nameSuffix
+        let serviceMetaName = context.name + nameSuffix
+
+        outputs: (serviceOutputName): {
+        	apiVersion: "v1"
+        	kind:       "Service"
+        	metadata: name: "\(serviceMetaName)"
+        	spec: {
+        		selector: "app.oam.dev/component": context.name
+        		ports: [
+        			for k, v in parameter.http {
+        				port:       v
+        				targetPort: v
+        			},
+        		]
+        	}
+        }
+
         let ingressOutputName = "ingress" + nameSuffix
         let ingressMetaName = context.name + nameSuffix
         legacyAPI: context.clusterVersion.minor < 19
+
         outputs: (ingressOutputName): {
         	if legacyAPI {
         		apiVersion: "networking.k8s.io/v1beta1"

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -62,9 +62,28 @@ template: {
 		if parameter.name != _|_ {"-" + parameter.name}
 		if parameter.name == _|_ {""}
 	}
+	let serviceOutputName = "service" + nameSuffix
+	let serviceMetaName = context.name + nameSuffix
+
+	outputs: (serviceOutputName): {
+		apiVersion: "v1"
+		kind:       "Service"
+		metadata: name: "\(serviceMetaName)"
+		spec: {
+			selector: "app.oam.dev/component": context.name
+			ports: [
+				for k, v in parameter.http {
+					port:       v
+					targetPort: v
+				},
+			]
+		}
+	}
+
 	let ingressOutputName = "ingress" + nameSuffix
 	let ingressMetaName = context.name + nameSuffix
 	legacyAPI: context.clusterVersion.minor < 19
+
 	outputs: (ingressOutputName): {
 		if legacyAPI {
 			apiVersion: "networking.k8s.io/v1beta1"


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9eb50ac</samp>

### Summary
:sparkles::wrench::memo:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for the new output that creates a Service resource for the gateway trait.
2.  :wrench: - This emoji represents a change that fixes or improves something, which is the case for the change that updates the template file to match the source file.
3.  :memo: - This emoji represents a change that updates documentation or comments, which is the case for the comment that explains the purpose of the new output.
-->
This pull request adds a new output to the gateway trait definition and template that creates a Service resource for the gateway. This enables users to specify custom domain names and use external DNS providers for the gateway.

> _`serviceOutputName`_
> _A new trait for the gateway_
> _Spring brings custom domains_

### Walkthrough
*  Add a new output to the gateway trait template that creates a Service resource for the gateway ([link](https://github.com/kubevela/kubevela/pull/5978/files?diff=unified&w=0#diff-ea69c9becd88df50fc43ae282de36f9655446ef2fa834330853f154d31737e1cL22-R43), [link](https://github.com/kubevela/kubevela/pull/5978/files?diff=unified&w=0#diff-eb6e43f0e2cf800a96e1dac66f3f4871067f865d5c694d9efa5c84cb2529a5a0L65-R86))



Restoring gateway trait service creation as per [post-merge discussion](https://github.com/kubevela/kubevela/pull/5860#issuecomment-1541871344) on [PR 5860](https://github.com/kubevela/kubevela/pull/5860) 

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Local dry-run and simple usage on a cluster.

### Special notes for your reviewer

See https://github.com/kubevela/kubevela/pull/5860#issuecomment-1541871344