### PR TITLE
Chore: CUE code quality changes

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
@@ -85,7 +85,7 @@ spec:
         	region?: string
         	// +usage=the envs for job
         	jobEnv?: {...}
-        	// +usae=forceDelete will force delete Configuration no matter which state it is or whether it has provisioned some resources
+        	// +usage=forceDelete will force delete Configuration no matter which state it is or whether it has provisioned some resources
         	forceDelete: *false | bool
         }
 

--- a/charts/vela-core/templates/defwithtemplate/expose.yaml
+++ b/charts/vela-core/templates/defwithtemplate/expose.yaml
@@ -72,6 +72,7 @@ spec:
         parameter: {
         	// +usage=Deprecated, the old way to specify the exposion ports
         	port?: [...int]
+
         	// +usage=Specify portsyou want customer traffic sent to
         	ports?: [...{
         		// +usage=Number of port to expose on the pod's IP address
@@ -83,9 +84,11 @@ spec:
         		// +usage=exposed node port. Only Valid when exposeType is NodePort
         		nodePort?: int
         	}]
+
         	// +usage=Specify the annotaions of the exposed service
         	annotations: [string]:  string
         	matchLabels?: [string]: string
+
         	// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
         	type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
         }

--- a/charts/vela-core/templates/defwithtemplate/topologyspreadconstraints.yaml
+++ b/charts/vela-core/templates/defwithtemplate/topologyspreadconstraints.yaml
@@ -53,7 +53,7 @@ spec:
         	topologyKey: string
         	// +usage=Indicate how to deal with a Pod if it doesn't satisfy the spread constraint
         	whenUnsatisfiable: *"DoNotSchedule" | "ScheduleAnyway"
-        	// +usage: labelSelector to find matching Pods
+        	// +usage=labelSelector to find matching Pods
         	labelSelector: #labSelector
         	// +usage=Indicate a minimum number of eligible domains
         	minDomains?: int

--- a/vela-templates/definitions/internal/trait/expose.cue
+++ b/vela-templates/definitions/internal/trait/expose.cue
@@ -101,6 +101,7 @@ template: {
 	parameter: {
 		// +usage=Deprecated, the old way to specify the exposion ports
 		port?: [...int]
+		
 		// +usage=Specify portsyou want customer traffic sent to
 		ports?: [...{
 			// +usage=Number of port to expose on the pod's IP address
@@ -112,9 +113,11 @@ template: {
 			// +usage=exposed node port. Only Valid when exposeType is NodePort
 			nodePort?: int
 		}]
+		
 		// +usage=Specify the annotaions of the exposed service
 		annotations: [string]:  string
 		matchLabels?: [string]: string
+		
 		// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
 		type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
 	}

--- a/vela-templates/definitions/internal/trait/expose.cue
+++ b/vela-templates/definitions/internal/trait/expose.cue
@@ -101,7 +101,7 @@ template: {
 	parameter: {
 		// +usage=Deprecated, the old way to specify the exposion ports
 		port?: [...int]
-		
+
 		// +usage=Specify portsyou want customer traffic sent to
 		ports?: [...{
 			// +usage=Number of port to expose on the pod's IP address
@@ -113,11 +113,11 @@ template: {
 			// +usage=exposed node port. Only Valid when exposeType is NodePort
 			nodePort?: int
 		}]
-		
+
 		// +usage=Specify the annotaions of the exposed service
 		annotations: [string]:  string
 		matchLabels?: [string]: string
-		
+
 		// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"
 		type: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
 	}

--- a/vela-templates/definitions/internal/trait/topologyspreadconstraints.cue
+++ b/vela-templates/definitions/internal/trait/topologyspreadconstraints.cue
@@ -47,7 +47,7 @@ template: {
 			topologyKey: string
 			// +usage=Indicate how to deal with a Pod if it doesn't satisfy the spread constraint
 			whenUnsatisfiable: *"DoNotSchedule" | "ScheduleAnyway"
-			// +usage: labelSelector to find matching Pods
+			// +usage=labelSelector to find matching Pods
 			labelSelector: #labSelector
 			// +usage=Indicate a minimum number of eligible domains
 			minDomains?: int

--- a/vela-templates/definitions/internal/workflowstep/apply-terraform-config.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-terraform-config.cue
@@ -82,7 +82,7 @@ template: {
 		region?: string
 		// +usage=the envs for job
 		jobEnv?: {...}
-		// +usae=forceDelete will force delete Configuration no matter which state it is or whether it has provisioned some resources
+		// +usage=forceDelete will force delete Configuration no matter which state it is or whether it has provisioned some resources
 		forceDelete: *false | bool
 	}
 }


### PR DESCRIPTION
Small textual changes to CUE files for conformity across files.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0db49ac</samp>

### Summary
📝📝🎨

<!--
1.  📝 for fixing a typo in the usage annotation of the labelSelector field of the topologySpreadConstraints trait spec.
2.  📝 for fixing a typo in the usage annotation of the forceDelete field of the apply-terraform-config workflow step spec.
3.  🎨 for improving the code style and readability of the `expose` trait definition by adding blank lines between sections and fields.
-->
This pull request improves the code quality and documentation of some internal trait and workflow step definitions in `vela-templates`. It fixes typos in the `usage` annotations of the `labelSelector` and `forceDelete` fields in `topologySpreadConstraints` and `apply-terraform-config` respectively, and adds blank lines for better readability in `expose`.

> _A typo was found in `usage`_
> _It was spelled as `usae` by mistake_
> _So they fixed it with care_
> _In two places to spare_
> _The confusion that it would create_

### Walkthrough
*  Add blank lines to improve readability of expose trait definition ([link](https://github.com/kubevela/kubevela/pull/5987/files?diff=unified&w=0#diff-efb87558248ed846fead01df72dbbdf203b1a878fe0f0010766f1b5601a5b7e2R104), [link](https://github.com/kubevela/kubevela/pull/5987/files?diff=unified&w=0#diff-efb87558248ed846fead01df72dbbdf203b1a878fe0f0010766f1b5601a5b7e2L115-R120))
*  Fix typos in usage annotations of labelSelector and forceDelete fields in `topologySpreadConstraints` trait and `apply-terraform-config` workflow step ([link](https://github.com/kubevela/kubevela/pull/5987/files?diff=unified&w=0#diff-fd0f437450b5ee6c768f4417170dc70f15251b3cf109655c822f2e81062d7113L50-R50), [link](https://github.com/kubevela/kubevela/pull/5987/files?diff=unified&w=0#diff-d764b6e43c982abb7011a00a85a3ddad3f5db3188d8eaa76a7f6255435ebdd5eL85-R85))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->