### PR TITLE
Feat: remove vela install version requirement upper bound

### DIFF
--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -47,7 +47,8 @@ import (
 )
 
 // defaultConstraint
-const defaultConstraint = ">= 1.19, <= 1.24"
+// const defaultConstraint = ">= 1.19, <= 1.24"
+const defaultConstraint = ">= 1.19"
 
 const kubevelaInstallerHelmRepoURL = "https://charts.kubevela.net/core/"
 

--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -113,7 +113,7 @@ func NewInstallCommand(c common.Args, order string, ioStreams util.IOStreams) *c
 			}
 			chart, err := installArgs.helmHelper.LoadCharts(installArgs.ChartFilePath, nil)
 			if err != nil {
-				return fmt.Errorf("loadding the helm chart of kubeVela control plane failure, %w", err)
+				return fmt.Errorf("loading the helm chart of kubeVela control plane failure, %w", err)
 			}
 			ioStreams.Infof("Helm Chart used for KubeVela control plane installation: %s \n", installArgs.ChartFilePath)
 


### PR DESCRIPTION
### Description of your changes

Remove the version upper bound limitation for `vela install`.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->