### PR TITLE
Chore: CUE code quality changes - line spaces and typos

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/expose.yaml
+++ b/charts/vela-core/templates/defwithtemplate/expose.yaml
@@ -85,8 +85,9 @@ spec:
         		nodePort?: int
         	}]
 
-        	// +usage=Specify the annotaions of the exposed service
-        	annotations: [string]:  string
+        	// +usage=Specify the annotations of the exposed service
+        	annotations: [string]: string
+
         	matchLabels?: [string]: string
 
         	// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"

--- a/vela-templates/definitions/internal/trait/expose.cue
+++ b/vela-templates/definitions/internal/trait/expose.cue
@@ -114,8 +114,9 @@ template: {
 			nodePort?: int
 		}]
 
-		// +usage=Specify the annotaions of the exposed service
-		annotations: [string]:  string
+		// +usage=Specify the annotations of the exposed service
+		annotations: [string]: string
+
 		matchLabels?: [string]: string
 
 		// +usage=Specify what kind of Service you want. options: "ClusterIP","NodePort","LoadBalancer","ExternalName"


### PR DESCRIPTION
### Description of your changes

Added blank lines and fixed typo in `.cue` file.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 71dbb7e</samp>

### Summary
🐛📝🎨

<!--
1.  🐛 - This emoji represents a bug fix, since the typo could cause confusion or errors for users or developers who use the annotations field of the expose trait.
2.  📝 - This emoji represents a documentation update, since the template and the CUE file are both forms of documentation that describe the expose trait and its parameters.
3.  🎨 - This emoji represents an improvement to the code style or format, since the typo fix makes the code more consistent and readable.
-->
Fix typo in `annotations` field of expose trait definition. This affects both the CUE file `vela-templates/definitions/internal/trait/expose.cue` and the Helm template `charts/vela-core/templates/defwithtemplate/expose.yaml`.

> _`expose` trait typo_
> _fixed in template and CUE_
> _autumn leaves no trace_

### Walkthrough
* Fix typo in annotations field of expose trait definition ([link](https://github.com/kubevela/kubevela/pull/5997/files?diff=unified&w=0#diff-883b1b1772320c4248465e8386ac9549362928d756435035201c93deb1bff6f8L88-R90), [link](https://github.com/kubevela/kubevela/pull/5997/files?diff=unified&w=0#diff-efb87558248ed846fead01df72dbbdf203b1a878fe0f0010766f1b5601a5b7e2L117-R119))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

I'm doing a parser for CUE in Python and these small changes help a lot, thank you for considering this tiny merge 💝