### PR TITLE
Fix: list addon commond displays only the first 20 entries when addon  registry is gitlab type

### DIFF
--- a/references/cli/addon-registry.go
+++ b/references/cli/addon-registry.go
@@ -75,7 +75,7 @@ func NewAddAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *cob
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --gitToken=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>`,
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registry, err := getRegistryFromArgs(cmd, args)
 			if err != nil {

--- a/references/cli/addon-registry.go
+++ b/references/cli/addon-registry.go
@@ -72,8 +72,10 @@ func NewAddAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *cob
 		Short: "Add an addon registry.",
 		Long:  "Add an addon registry.",
 		Example: `add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --gitToken=<git token>" 
-add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --gitToken=<git token>`,
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
+add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --gitToken=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registry, err := getRegistryFromArgs(cmd, args)
 			if err != nil {
@@ -308,11 +310,11 @@ func parseArgsFromFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(addonRegistryType, "", "", "specify the addon registry type")
 	cmd.Flags().StringP(addonEndpoint, "", "", "specify the addon registry endpoint")
 	cmd.Flags().StringP(addonOssBucket, "", "", "specify the OSS bucket name")
-	cmd.Flags().StringP(addonPath, "", "", "specify the addon registry OSS path")
+	cmd.Flags().StringP(addonPath, "", "", "specify the addon registry path, must be set when addons are not in root of registry")
 	cmd.Flags().StringP(addonGitToken, "", "", "specify the github repo token")
 	cmd.Flags().StringP(addonUsername, "", "", "specify the Helm addon registry username")
 	cmd.Flags().StringP(addonPassword, "", "", "specify the Helm addon registry password")
-	cmd.Flags().StringP(addonRepoName, "", "", "specify the gitlab addon registry repoName")
+	cmd.Flags().StringP(addonRepoName, "", "", "specify the gitlab addon registry repoName, must be set when registry is gitlab")
 	cmd.Flags().BoolP(addonHelmInsecureSkipTLS, "", false,
 		"specify the Helm addon registry skip tls verify")
 }


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6460120</samp>

### Summary
:recycle::sparkles::zap:

<!--
1.  :recycle: - This emoji can be used to indicate that the code was refactored or improved to handle a new feature or requirement. In this case, the code was updated to support the new pagination scheme of the GitLab API.
2.  :sparkles: - This emoji can be used to indicate that the code added a new feature or functionality. In this case, the code can now list all the addon metadata files, regardless of how many pages they are spread across in the GitLab repository.
3.  :zap: - This emoji can be used to indicate that the code improved the performance or speed of the function. In this case, the code can potentially reduce the number of API calls to GitLab by fetching multiple tree nodes per page, instead of one node per call.
-->
Fix GitLab addon metadata listing to support keyset pagination. Update `ListAddonMeta` function in `pkg/addon/reader_gitlab.go` to fetch and concatenate all pages of the tree.

> _`ListAddonMeta` changed_
> _To fetch all tree pages_
> _Looping through keysets_

### Walkthrough
* Implement keyset-based pagination for GitLab ListTree API ([link](https://github.com/kubevela/kubevela/pull/5999/files?diff=unified&w=0#diff-7f81d0811dc0f7bbfd3e715748d66b540d7106a5d0e8ad09eb0b042e4b7199d4L87-R105))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5998 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
add gitlab type registry
vela addon ls


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
@wangyikewxgm 