### PR TITLE
Refactor: transparent and extensible cuegen decl

### DIFF
--- a/references/cuegen/decl.go
+++ b/references/cuegen/decl.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cuegen
+
+import (
+	goast "go/ast"
+
+	cueast "cuelang.org/go/cue/ast"
+	cuetoken "cuelang.org/go/cue/token"
+)
+
+// Decl is an interface that can build a cueast.Decl.
+type Decl interface {
+	Build() cueast.Decl
+}
+
+// CommonFields is a struct that contains common fields for all decls.
+type CommonFields struct {
+	Expr    cueast.Expr
+	Name    string
+	Comment *goast.CommentGroup
+	Doc     *goast.CommentGroup
+	Pos     cuetoken.Pos
+}
+
+// Struct is a struct that represents a CUE struct.
+type Struct struct {
+	CommonFields
+}
+
+// Build creates a cueast.Decl from Struct.
+func (s *Struct) Build() cueast.Decl {
+	d := &cueast.Field{
+		Label: cueast.NewIdent(s.Name),
+		Value: s.Expr,
+	}
+
+	makeComments(d, &commentUnion{comment: s.Comment, doc: s.Doc})
+	cueast.SetPos(d, s.Pos)
+
+	return d
+}

--- a/references/cuegen/decl_test.go
+++ b/references/cuegen/decl_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cuegen
+
+import (
+	goast "go/ast"
+	"testing"
+
+	cueast "cuelang.org/go/cue/ast"
+	cuetoken "cuelang.org/go/cue/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructBuild(t *testing.T) {
+	s := Struct{CommonFields{
+		Expr:    cueast.NewIdent("foo"),
+		Name:    "bar",
+		Comment: &goast.CommentGroup{List: []*goast.Comment{{Text: "foo"}}},
+		Doc:     &goast.CommentGroup{List: []*goast.Comment{{Text: "bar"}}},
+		Pos:     cuetoken.Newline.Pos(),
+	}}
+
+	expected := &cueast.Field{
+		Label: cueast.NewIdent("bar"),
+		Value: cueast.NewIdent("foo"),
+	}
+	makeComments(expected, &commentUnion{
+		comment: &goast.CommentGroup{List: []*goast.Comment{{Text: "foo"}}},
+		doc:     &goast.CommentGroup{List: []*goast.Comment{{Text: "bar"}}},
+	})
+	cueast.SetPos(expected, cuetoken.Newline.Pos())
+
+	assert.Equal(t, expected, s.Build())
+}

--- a/references/cuegen/generator.go
+++ b/references/cuegen/generator.go
@@ -65,7 +65,7 @@ func (g *Generator) Package() *packages.Package {
 // And it can be called multiple times with different options.
 //
 // NB: it's not thread-safe.
-func (g *Generator) Generate(opts ...Option) (decls []cueast.Decl, _ error) {
+func (g *Generator) Generate(opts ...Option) (decls []Decl, _ error) {
 	g.opts = newDefaultOptions() // reset options for each call
 	for _, opt := range opts {
 		if opt != nil {
@@ -89,7 +89,7 @@ func (g *Generator) Generate(opts ...Option) (decls []cueast.Decl, _ error) {
 }
 
 // Format formats CUE ast decls with package header and writes to w.
-func (g *Generator) Format(w io.Writer, decls []cueast.Decl) error {
+func (g *Generator) Format(w io.Writer, decls []Decl) error {
 	if w == nil {
 		return fmt.Errorf("nil writer")
 	}
@@ -104,7 +104,7 @@ func (g *Generator) Format(w io.Writer, decls []cueast.Decl) error {
 		if decl == nil {
 			continue
 		}
-		f.Decls = append(f.Decls, decl)
+		f.Decls = append(f.Decls, decl.Build())
 	}
 
 	if err := astutil.Sanitize(f); err != nil {

--- a/references/cuegen/generator_test.go
+++ b/references/cuegen/generator_test.go
@@ -20,8 +20,6 @@ import (
 	"io"
 	"testing"
 
-	cueast "cuelang.org/go/cue/ast"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,10 +74,10 @@ func TestGeneratorFormat(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, g.Format(io.Discard, decls))
-	assert.NoError(t, g.Format(io.Discard, []cueast.Decl{nil, nil}))
+	assert.NoError(t, g.Format(io.Discard, []Decl{nil, nil}))
 	assert.Error(t, g.Format(nil, decls))
 	assert.Error(t, g.Format(io.Discard, nil))
-	assert.Error(t, g.Format(io.Discard, []cueast.Decl{}))
+	assert.Error(t, g.Format(io.Discard, []Decl{}))
 }
 
 func TestLoadPackage(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b3c4005</samp>

### Summary
🧪🏗️♻️

<!--
1.  🧪 This emoji represents the addition of a unit test for the `Struct` type and its `Build` method. This emoji conveys the idea of testing, experimentation, and verification.
2.  🏗️ This emoji represents the creation of a new file `decl.go` that defines the `Decl` interface and the `Struct` type that implements it. This emoji conveys the idea of building, construction, and abstraction.
3.  ♻️ This emoji represents the refactoring of the `convertDecls`, `Generate`, `Format`, and `modifyDecls` methods to use the new `Decl` interface. This emoji conveys the idea of recycling, improving, and simplifying code.
-->
This pull request refactors the CUE generator code to use a new `Decl` interface for different kinds of CUE declarations, such as structs, and adds a `Struct` type that implements the interface. This simplifies the code structure, makes it more extensible, and enables common fields and methods for CUE declarations. The pull request also updates the test cases and modifies the `provider.go` file to use the new interface.

> _We're the CUE generator crew, we make the code for you_
> _We use the `Decl` interface to handle any case_
> _We build the structs and fields with common methods and skills_
> _We heave away and haul away and format them with grace_

### Walkthrough
*  Introduce a new interface `Decl` and a new type `Struct` that implement it in `decl.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-37f23cfa5958e500eb30dc6f44a9291c4dc39b24adb03eeab838069010863b61R1-R56), [link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-37f23cfa5958e500eb30dc6f44a9291c4dc39b24adb03eeab838069010863b61R1-R56))
* Change the return type of `Generate` and `convertDecls` methods from `[]cueast.Decl` to `[]Decl` in `convert.go` and `generator.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-f3ec0bb030f3add13296ed258157b227f061b722669287e2ad2cc069d76e2723L31-R31), [link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-6efe5e648c61f9bbd881b7a5563a2902b65001b70021d5389fe62cefa08a59feL68-R68))
* Change the parameter type of `Format` and `modifyDecls` functions from `[]cueast.Decl` to `[]Decl` in `generator.go` and `provider.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-6efe5e648c61f9bbd881b7a5563a2902b65001b70021d5389fe62cefa08a59feL92-R92), [link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-b4082105fe42785752e19dbde9787e6f0f242e2012d483498e3ff92f0dd4d282L148-R148))
* Refactor the logic of `convertDecls` to use a switch statement instead of an if statement for handling different kinds of underlying types in `convert.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-f3ec0bb030f3add13296ed258157b227f061b722669287e2ad2cc069d76e2723L58-R74))
* Modify the logic of `Format` to call the `Build` method of each `Decl` and append the result to the `f.Decls` slice in `generator.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-6efe5e648c61f9bbd881b7a5563a2902b65001b70021d5389fe62cefa08a59feL107-R107))
* Modify the logic of `modifyDecls` to use a type assertion to check if each `Decl` is a `Struct` and use its fields to populate the `mapping` map in `provider.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-b4082105fe42785752e19dbde9787e6f0f242e2012d483498e3ff92f0dd4d282L154-R156))
* Modify the logic of `modifyDecls` to create and append a `Struct` instance instead of a `cueast.Field` instance to the `decls` slice in `provider.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-b4082105fe42785752e19dbde9787e6f0f242e2012d483498e3ff92f0dd4d282L178-R183))
* Remove the unused import of `cueast` in `generator_test.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-bfcb3613ef0c10f2c396ce08c4d7c4c9af1ba79df9d84adc44cce60bbfc29d98L23-L24))
* Change the parameter type and the argument type of the `Format` method calls in `TestGeneratorFormat` function from `[]cueast.Decl` to `[]Decl` in `generator_test.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-bfcb3613ef0c10f2c396ce08c4d7c4c9af1ba79df9d84adc44cce60bbfc29d98L79-R80))
* Add a unit test for the `Struct` type and its `Build` method in `decl_test.go` ([link](https://github.com/kubevela/kubevela/pull/6006/files?diff=unified&w=0#diff-8fa1039aafedc195c03905bfe7d868d74d91ee4ccba16408939c4c23df8ef7d1R1-R48))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Part of #5364 

We may support more CUE types in the future, so we need transparent and extensible cuegen decl.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

No break changes and no modified unit tests. 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->