### PR TITLE
Chore: add CoreOptions flags test

### DIFF
--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/pflag"
+
+	oamcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+)
+
+func TestCoreOptions_Flags(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opt := &CoreOptions{
+		ControllerArgs: &oamcontroller.Args{},
+	}
+
+	for _, f := range opt.Flags().FlagSets {
+		fs.AddFlagSet(f)
+	}
+
+	args := []string{
+		"--application-re-sync-period=5s",
+		"--cluster-metrics-interval=5s",
+		"--disable-caps=true",
+		"--enable-cluster-gateway=true",
+		"--enable-cluster-metrics=true",
+		"--enable-leader-election=true",
+		"--health-addr=/healthz",
+		"--informer-sync-period=3s",
+		"--kube-api-burst=500",
+		"--kube-api-qps=200",
+		"--leader-election-lease-duration=3s",
+		"--leader-election-namespace=test-namespace",
+		"--leader-election-renew-deadline=5s",
+		"--leader-election-resource-lock=/leases",
+		"--leader-election-retry-period=3s",
+		"--log-debug=true",
+		"--log-file-max-size=50",
+		"--log-file-path=/path/to/log",
+		"--max-dispatch-concurrent=5",
+		"--max-workflow-failed-backoff-time=30",
+		"--max-workflow-step-error-retry-times=5",
+		"--max-workflow-wait-backoff-time=5",
+		"--metrics-addr=/metrics",
+		"--perf-enabled=true",
+		"--pprof-addr=/debug/pprof",
+		"--use-webhook=true",
+		"--webhook-cert-dir=/path/to/cert",
+		"--webhook-port=8080",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		t.Errorf("Failed to parse args: %v", err)
+	}
+
+	expected := &CoreOptions{
+		UseWebhook:                 true,
+		CertDir:                    "/path/to/cert",
+		WebhookPort:                8080,
+		MetricsAddr:                "/metrics",
+		EnableLeaderElection:       true,
+		LeaderElectionNamespace:    "test-namespace",
+		LogFilePath:                "/path/to/log",
+		LogFileMaxSize:             50,
+		LogDebug:                   true,
+		ControllerArgs:             &oamcontroller.Args{},
+		HealthAddr:                 "/healthz",
+		DisableCaps:                "true",
+		StorageDriver:              "",
+		InformerSyncPeriod:         3 * time.Second,
+		QPS:                        200,
+		Burst:                      500,
+		PprofAddr:                  "/debug/pprof",
+		LeaderElectionResourceLock: "/leases",
+		LeaseDuration:              3 * time.Second,
+		RenewDeadLine:              5 * time.Second,
+		RetryPeriod:                3 * time.Second,
+		EnableClusterGateway:       true,
+		EnableClusterMetrics:       true,
+		ClusterMetricsInterval:     5 * time.Second,
+	}
+
+	if !cmp.Equal(opt, expected, cmp.AllowUnexported(CoreOptions{})) {
+		t.Errorf("Flags() diff: %v", cmp.Diff(opt, expected, cmp.AllowUnexported(CoreOptions{})))
+	}
+}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5e8b737</samp>

### Summary
🧪🚩🎛️

<!--
1.  🧪 This emoji represents testing, experimentation, or science. It can be used to indicate that the change involves adding or modifying tests or test-related code. In this case, the change is about creating a new test file for the `CoreOptions` struct and its `Flags` method.
2.  🚩 This emoji represents flags, banners, or indicators. It can be used to indicate that the change involves parsing, setting, or using command-line flags or other configuration options. In this case, the change is about testing the `Flags` method of the `CoreOptions` struct, which parses and stores the command-line flags for the core controller.
3.  🎛️ This emoji represents knobs, dials, or controls. It can be used to indicate that the change involves adjusting, tuning, or configuring some parameters or settings. In this case, the change is about testing the `CoreOptions` struct, which refactors and improves the configuration of the core controller.
-->
Add unit test for `CoreOptions` struct in `cmd/core/app/options/options_test.go`. The test verifies that the struct can parse and store the core controller flags correctly. The test is part of a refactoring effort to improve the core controller configuration.

> _`CoreOptions` test_
> _Parsing and storing flags well_
> _Autumn of refactor_

### Walkthrough
*  Add a new test file for the `CoreOptions` struct and its `Flags` method ([link](https://github.com/kubevela/kubevela/pull/6007/files?diff=unified&w=0#diff-cf0769b94b1d398ad5f7ba2b318595d0723a79c483755fb699f8545107c35f44R1-R103)). The test file `options_test.go` verifies that the `CoreOptions` struct can parse and store the command-line flags for the core controller, such as `metrics-addr`, `enable-leader-election`, and `webhook-cert-dir`. The test file is located in the same package as the `CoreOptions` struct and follows the naming convention of `options_test.go`. The test file also includes the license header and the necessary imports for the test.



add unit test for `CoreOptions.Flags()`.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->