### PR TITLE
Feat: add gen-cue to Makefile

### DIFF
--- a/hack/cuegen/cuegen.sh
+++ b/hack/cuegen/cuegen.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Usage: cuegen.sh dir [flagsToVela]
+# Example: cuegen.sh references/cuegen/generators/provider/testdata/ \
+#           -t provider \
+#           --types *k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured=ellipsis
+
+
+# check vela binary
+if ! [ -x "$(command -v vela)" ]; then
+  echo "Please put vela binary in the PATH"
+  exit 1
+fi
+
+# get dir from first arg
+dir="$1"
+if [ -z "$dir" ]; then
+  echo "Please provide a directory"
+  exit 1
+fi
+
+echo "Generating CUE files from go files in $dir"
+echo "========"
+
+find "$dir" -name "*.go" | while read -r file; do
+  echo "- Generating CUE file for $file"
+
+  # redirect output if command exits successfully
+  (out=$(vela def gen-cue ${*:2} "$file") && echo "$out" > "${file%.go}".cue) &
+done
+
+echo "========"
+echo "Waiting for all background processes to finish"
+
+wait
+sleep 5s # wait for all stderr to be printed
+
+echo "Done"

--- a/makefiles/develop.mk
+++ b/makefiles/develop.mk
@@ -25,3 +25,8 @@ core-debug-run: fmt vet manifests
 .PHONY: core-run
 core-run: fmt vet manifests
 	go run ./cmd/core/main.go
+
+## gen-cue: Generate CUE files from Go files. Variable DIR is the directory of the Go files, FLAGS is the flags for vela def gen-cue command.
+.PHONY: gen-cue
+gen-cue:
+	./hack/cuegen/cuegen.sh $(DIR) $(FLAGS)


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Part of #5364 

```
$ make help | grep gen-cue
  gen-cue                        Generate CUE files from Go files. Variable DIR is the directory of the Go files, FLAGS is the flags for vela def gen-cue command.
$ make gen-cue DIR=references/cuegen/generators/provider/testdata/ FLAGS='-t provider'
./hack/cuegen/cuegen.sh references/cuegen/generators/provider/testdata/ -t provider
Generating CUE files from go files in references/cuegen/generators/provider/testdata/
========
- Generating CUE file for references/cuegen/generators/provider/testdata/invalid/no_provider_map.go
- Generating CUE file for references/cuegen/generators/provider/testdata/valid.go
========
Waiting for all background processes to finish
Error: no provider function map found like 'map[string]github.com/kubevela/pkg/cue/cuex/runtime.ProviderFn'
Done
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->