### PR TITLE
Fix: add cluster description for vela adopt help

### DIFF
--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -602,7 +602,7 @@ var (
 		vela adopt --all
 		vela adopt deployment --all --resource-topology-rule myrule.cue
 
-		## Use: vela adopt <resources-type>[/<resource-namespace>]/<resource-name> <resources-type>[/<resource-namespace>]/<resource-name> ...
+		## Use: vela adopt <resources-type>[/<resource-cluster>][/<resource-namespace>]/<resource-name> <resources-type>[/<resource-cluster>][/<resource-namespace>]/<resource-name> ...
 		vela adopt deployment/my-app configmap/my-app
 
 		## Adopt resources into new application with specified app name


### PR DESCRIPTION
### Description of your changes

Vela adopt cli support multi-cluster. So add cluster description for vela adopt help. 

Fixes #5959

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->