### PR TITLE
Chore: set CLI verbose output to be hidden by default

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -25,6 +25,7 @@ import (
 	gov "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/helm"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
+	velalog "github.com/oam-dev/kubevela/references/cli/log"
 	"github.com/oam-dev/kubevela/version"
 )
 
@@ -138,9 +140,16 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 
 	fset := flag.NewFlagSet("logs", flag.ContinueOnError)
 	klog.InitFlags(fset)
+	pfset := pflag.NewFlagSet("logs", pflag.ContinueOnError)
+	pfset.AddGoFlagSet(fset)
+	pflg := pfset.Lookup("v")
+	pflg.Name = "verbosity"
+	pflg.Shorthand = "V"
 
+	klog.SetLogger(velalog.NewLogger("vela-cli"))
 	// init global flags
 	cmds.PersistentFlags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes for all user prompts")
+	cmds.PersistentFlags().AddFlag(pflg)
 	return cmds
 }
 

--- a/references/cli/log/logger.go
+++ b/references/cli/log/logger.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/go-logr/logr"
+	"github.com/kubevela/pkg/util/slices"
+	"github.com/kubevela/pkg/util/stringtools"
+	"k8s.io/klog/v2"
+)
+
+var _ logr.LogSink = &logger{}
+
+// NewLogger create a logr.Logger with vela-cli format
+func NewLogger(name string) logr.Logger {
+	return NewLoggerWithWriter(name, os.Stdout, os.Stderr)
+}
+
+// NewLoggerWithWriter create a logr.Logger with vela-cli format and customized writer
+func NewLoggerWithWriter(name string, out io.Writer, errWriter io.Writer) logr.Logger {
+	return logr.New(&logger{name: name, out: out, errWriter: errWriter})
+}
+
+type logger struct {
+	name      string
+	callDepth int
+	values    []interface{}
+	out       io.Writer
+	errWriter io.Writer
+}
+
+// Init init
+func (in *logger) Init(info logr.RuntimeInfo) {
+	in.callDepth += info.CallDepth
+}
+
+// Enabled check if enabled
+func (in *logger) Enabled(level int) bool {
+	return klog.VDepth(in.callDepth+2, klog.Level(level)).Enabled()
+}
+
+func (in *logger) mergeKeysAndValues(keysAndValues []interface{}) string {
+	lookup := map[string]string{}
+	var keys []string
+	for i := 0; i < len(keysAndValues); i += 2 {
+		key := fmt.Sprintf("%s", keysAndValues[i])
+		value := fmt.Sprintf("%s", keysAndValues[i+1])
+		if _, found := lookup[key]; !found {
+			keys = append(keys, key)
+		}
+		lookup[key] = fmt.Sprintf("%s=\"%s\"", key, value)
+	}
+	return strings.Join(slices.Map(keys, func(key string) string { return lookup[key] }), " ")
+}
+
+func (in *logger) print(writer io.Writer, head string, msg string, keysAndValues ...interface{}) {
+	var caller, timeStr, nameStr string
+	if klog.V(4).Enabled() {
+		nameStr = color.MagentaString(fmt.Sprintf("%s ", in.name))
+		if _, file, line, ok := runtime.Caller(7); ok {
+			if !klog.V(7).Enabled() {
+				file = file[strings.LastIndex(file, "/")+1:]
+			}
+			caller = fmt.Sprintf("[%s:%d] ", file, line)
+		}
+		t := time.Now()
+		timeStr = fmt.Sprintf("%02d:%02d:%02d ", t.Hour(), t.Minute(), t.Second())
+		if klog.V(7).Enabled() {
+			timeStr = t.Format(time.RFC3339) + " "
+		}
+	}
+	_, _ = fmt.Fprintf(writer, "%s %s%s%s%s %s\n", head, nameStr, timeStr, caller, strings.TrimSpace(stringtools.Capitalize(msg)), in.mergeKeysAndValues(keysAndValues))
+}
+
+// Info .
+func (in *logger) Info(level int, msg string, keysAndValues ...interface{}) {
+	if level < 1 {
+		level = 1
+	}
+	if in.Enabled(level) {
+		in.print(in.out, color.CyanString("INFO"), msg, append(in.values, keysAndValues...)...)
+	}
+}
+
+// Error .
+func (in *logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if err != nil {
+		keysAndValues = append(keysAndValues, "err", err.Error())
+	}
+	in.print(in.errWriter, color.RedString("ERR "), msg, append(in.values, keysAndValues...)...)
+}
+
+// WithValues fork a logger with given key-values
+func (in *logger) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	sink := &logger{}
+	*sink = *in
+	if len(keysAndValues)%2 != 0 {
+		keysAndValues = append(keysAndValues, "(MISSING)")
+	}
+	sink.values = append(in.values, keysAndValues...) // nolint
+	return sink
+}
+
+// WithName fork a logger with given name
+func (in *logger) WithName(name string) logr.LogSink {
+	sink := &logger{}
+	*sink = *in
+	sink.name = name
+	return sink
+}

--- a/references/cli/log/logger_test.go
+++ b/references/cli/log/logger_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log_test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
+
+	"github.com/oam-dev/kubevela/references/cli/log"
+)
+
+func TestLogger(t *testing.T) {
+	fset := flag.NewFlagSet("logs", flag.ContinueOnError)
+	klog.InitFlags(fset)
+	err := fset.Parse([]string{"-v=7"})
+	require.NoError(t, err)
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	logger := log.NewLoggerWithWriter("test", outBuf, errBuf)
+	forked := logger.WithName("logs").WithValues("key", "value", "nothing")
+	forked.Info("message info", "key", "override")
+	forked.Error(fmt.Errorf("unknown"), "unk", "extra", "extra val")
+
+	errStr := errBuf.String()
+	require.Contains(t, errStr, "key=\"value\"")
+	require.Contains(t, errStr, "extra=\"extra val\"")
+	require.Contains(t, errStr, "Unk")
+
+	outStr := outBuf.String()
+	require.Contains(t, outStr, "Message info")
+	require.Contains(t, outStr, "key=\"override\"")
+	require.Contains(t, outStr, "nothing=\"(MISSING)\"")
+	require.Contains(t, outStr, "logs")
+}


### PR DESCRIPTION
### Description of your changes

Add "--verbosity"/"-V" global flag for vela cli. By default 0.

When 0, all "klog.Info" will be omitted. "klog.Error" will be written to stderr.

![image](https://github.com/kubevela/kubevela/assets/14019297/2d7d0922-06f4-4fe5-b74b-cd3d775bd8f6)

When greater than 0, "klog.Info" will be written to stdout.

![image](https://github.com/kubevela/kubevela/assets/14019297/bfbb3adf-8352-479b-bb80-a00b352231cc)

When greater than 3, the call file and time will be printed.

![image](https://github.com/kubevela/kubevela/assets/14019297/ab61a5cc-a3ce-467d-89a0-8f3e1d7a522f)

When greater than 6, all details will be printed.

![image](https://github.com/kubevela/kubevela/assets/14019297/9c905d8f-6dac-4ad9-af53-9cb68d17d4dd)

Fixes #5561

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->