### PR TITLE
Refactor: parse trait & scope

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -96,7 +96,7 @@ type Workload struct {
 	SkipApplyWorkload  bool
 }
 
-// EvalContext eval workload template and set result to context
+// EvalContext eval workload template and set the result to context
 func (wl *Workload) EvalContext(ctx process.Context) error {
 	return wl.engine.Complete(ctx, wl.FullTemplate.TemplateStr, wl.Params)
 }
@@ -125,7 +125,7 @@ func (wl *Workload) EvalStatus(templateContext map[string]interface{}) (string, 
 
 // EvalHealth eval workload health check
 func (wl *Workload) EvalHealth(templateContext map[string]interface{}) (bool, error) {
-	// if health of template is not set or standard workload is managed by trait always return true
+	// if the health of template is not set or standard workload is managed by trait always return true
 	if wl.SkipApplyWorkload {
 		return true, nil
 	}

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -21,16 +21,23 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -234,7 +241,7 @@ var _ = Describe("Test application parser", func() {
 		err := yaml.Unmarshal([]byte(appfileYaml), &o)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		// Create mock client
+		// Create a mock client
 		tclient := test.MockClient{
 			MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 				if strings.Contains(key.Name, "notexist") {
@@ -499,3 +506,362 @@ patch: spec: replicas: parameter.replicas
 		})
 	})
 })
+
+func TestParser_parseTraits(t *testing.T) {
+	type args struct {
+		workload *Workload
+		comp     common.ApplicationComponent
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantErr              assert.ErrorAssertionFunc
+		mockTemplateLoaderFn TemplateLoaderFn
+		validateFunc         func(w *Workload) bool
+	}{
+		{
+			name: "test empty traits",
+			args: args{
+				comp: common.ApplicationComponent{},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "test parse trait properties error",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type: "expose",
+							Properties: &runtime.RawExtension{
+								Raw: []byte("invalid properties"),
+							},
+						},
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse trait error",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type: "expose",
+							Properties: &runtime.RawExtension{
+								Raw: []byte(`{"unsupported": "{\"key\":\"value\"}"}`),
+							},
+						},
+					},
+				},
+			},
+			mockTemplateLoaderFn: func(context.Context, discoverymapper.DiscoveryMapper, client.Reader, string, types.CapType) (*Template, error) {
+				return nil, fmt.Errorf("unsupported key not found")
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse trait success",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type: "expose",
+							Properties: &runtime.RawExtension{
+								Raw: []byte(`{"annotation": "{\"key\":\"value\"}"}`),
+							},
+						},
+					},
+				},
+				workload: &Workload{},
+			},
+			wantErr: assert.NoError,
+			mockTemplateLoaderFn: func(ctx context.Context, mapper discoverymapper.DiscoveryMapper, reader client.Reader, s string, capType types.CapType) (*Template, error) {
+				return &Template{
+					TemplateStr:        "template",
+					CapabilityCategory: "network",
+					Health:             "true",
+					CustomStatus:       "healthy",
+				}, nil
+			},
+			validateFunc: func(w *Workload) bool {
+				return w != nil && len(w.Traits) != 0 && w.Traits[0].Name == "expose" && w.Traits[0].Template == "template"
+			},
+		},
+	}
+
+	p := NewApplicationParser(nil, dm, pd)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p.tmplLoader = tt.mockTemplateLoaderFn
+			err := p.parseTraits(context.Background(), tt.args.workload, tt.args.comp)
+			tt.wantErr(t, err, fmt.Sprintf("parseTraits(%v, %v)", tt.args.workload, tt.args.comp))
+			if tt.validateFunc != nil {
+				assert.True(t, tt.validateFunc(tt.args.workload))
+			}
+		})
+	}
+}
+
+func TestParser_parseScopes(t *testing.T) {
+	type args struct {
+		workload *Workload
+		comp     common.ApplicationComponent
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		mockTemplateLoaderFn TemplateLoaderFn
+		mockGetFunc          test.MockGetFn
+		wantErr              assert.ErrorAssertionFunc
+		validateFunc         func(w *Workload) bool
+	}{
+		{
+			name: "test empty scope",
+			args: args{
+				comp:     common.ApplicationComponent{},
+				workload: &Workload{},
+			},
+			wantErr: assert.NoError,
+			validateFunc: func(w *Workload) bool {
+				return w != nil && len(w.Scopes) == 0
+			},
+		},
+		{
+			name: "test get gvk error",
+			args: args{
+				comp: common.ApplicationComponent{
+					Scopes: map[string]string{
+						"cluster1": "namespace1",
+						"cluster2": "namespace2",
+					},
+				},
+				workload: &Workload{},
+			},
+			mockGetFunc: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				return fmt.Errorf("not exist")
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse scopes success",
+			args: args{
+				comp: common.ApplicationComponent{
+					Scopes: map[string]string{
+						"cluster1": "namespace1",
+						"cluster2": "namespace2",
+					},
+				},
+				workload: &Workload{},
+			},
+			mockGetFunc: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				return nil
+			},
+			wantErr: assert.NoError,
+			validateFunc: func(w *Workload) bool {
+				return w != nil && len(w.Scopes) == 2 && w.Scopes[0].Name == "namespace1" && w.Scopes[1].Name == "namespace2"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewApplicationParser(&test.MockClient{MockGet: tt.mockGetFunc}, dm, pd)
+			p.tmplLoader = tt.mockTemplateLoaderFn
+			err := p.parseScopes(context.Background(), tt.args.workload, tt.args.comp)
+			if !tt.wantErr(t, err, fmt.Sprintf("parseScopes(%v, %v)", tt.args.workload, tt.args.comp)) {
+				return
+			}
+			if tt.validateFunc != nil {
+				assert.True(t, tt.validateFunc(tt.args.workload))
+			}
+		})
+	}
+}
+
+func TestParser_parseTraitsFromRevision(t *testing.T) {
+	type args struct {
+		comp     common.ApplicationComponent
+		appRev   *v1beta1.ApplicationRevision
+		workload *Workload
+	}
+	tests := []struct {
+		name         string
+		args         args
+		validateFunc func(w *Workload) bool
+		wantErr      assert.ErrorAssertionFunc
+	}{
+		{
+			name: "test empty traits",
+			args: args{
+				comp: common.ApplicationComponent{},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "test parse traits properties error",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type:       "expose",
+							Properties: &runtime.RawExtension{Raw: []byte("invalid")},
+						},
+					},
+				},
+				workload: &Workload{},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse traits from revision failed",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type:       "expose",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"appRevisionName": "appRevName"}`)},
+						},
+					},
+				},
+				appRev: &v1beta1.ApplicationRevision{
+					Spec: v1beta1.ApplicationRevisionSpec{
+						ApplicationRevisionCompressibleFields: v1beta1.ApplicationRevisionCompressibleFields{
+							TraitDefinitions: map[string]*v1beta1.TraitDefinition{},
+						},
+					},
+				},
+				workload: &Workload{},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse traits from revision success",
+			args: args{
+				comp: common.ApplicationComponent{
+					Traits: []common.ApplicationTrait{
+						{
+							Type:       "expose",
+							Properties: &runtime.RawExtension{Raw: []byte(`{"appRevisionName": "appRevName"}`)},
+						},
+					},
+				},
+				appRev: &v1beta1.ApplicationRevision{
+					Spec: v1beta1.ApplicationRevisionSpec{
+						ApplicationRevisionCompressibleFields: v1beta1.ApplicationRevisionCompressibleFields{
+							TraitDefinitions: map[string]*v1beta1.TraitDefinition{
+								"expose": {
+									Spec: v1beta1.TraitDefinitionSpec{
+										RevisionEnabled:    true,
+										AppliesToWorkloads: []string{"*"},
+									},
+								},
+							},
+						},
+					},
+				},
+				workload: &Workload{},
+			},
+			wantErr: assert.NoError,
+			validateFunc: func(w *Workload) bool {
+				return w != nil && len(w.Traits) == 1 && w.Traits[0].Name == "expose"
+			},
+		},
+	}
+	p := NewApplicationParser(nil, dm, pd)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, p.parseTraitsFromRevision(tt.args.comp, tt.args.appRev, tt.args.workload), fmt.Sprintf("parseTraitsFromRevision(%v, %v, %v)", tt.args.comp, tt.args.appRev, tt.args.workload))
+			if tt.validateFunc != nil {
+				assert.True(t, tt.validateFunc(tt.args.workload))
+			}
+		})
+	}
+}
+
+func TestParser_parseScopesFromRevision(t *testing.T) {
+	type args struct {
+		comp     common.ApplicationComponent
+		appRev   *v1beta1.ApplicationRevision
+		workload *Workload
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantErr      assert.ErrorAssertionFunc
+		validateFunc func(w *Workload) bool
+	}{
+		{
+			name: "test empty scopes",
+			args: args{
+				comp: common.ApplicationComponent{},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "test get scope definition from revision failed",
+			args: args{
+				comp: common.ApplicationComponent{
+					Scopes: map[string]string{
+						"cluster": "namespace",
+					},
+				},
+				appRev: &v1beta1.ApplicationRevision{
+					Spec: v1beta1.ApplicationRevisionSpec{
+						ApplicationRevisionCompressibleFields: v1beta1.ApplicationRevisionCompressibleFields{
+							ScopeDefinitions: map[string]v1beta1.ScopeDefinition{},
+						},
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "test parse scopes from revision success",
+			args: args{
+				comp: common.ApplicationComponent{
+					Scopes: map[string]string{
+						"cluster": "namespace",
+					},
+				},
+				appRev: &v1beta1.ApplicationRevision{
+					Spec: v1beta1.ApplicationRevisionSpec{
+						ApplicationRevisionCompressibleFields: v1beta1.ApplicationRevisionCompressibleFields{
+							ScopeDefinitions: map[string]v1beta1.ScopeDefinition{
+								"cluster": {
+									Spec: v1beta1.ScopeDefinitionSpec{
+										AllowComponentOverlap: true,
+										Reference: common.DefinitionReference{
+											Name:    "cluster",
+											Version: "v1alpha2",
+										},
+									},
+								},
+							},
+							ScopeGVK: map[string]metav1.GroupVersionKind{
+								"cluster/v1alpha2": {
+									Group:   "core.oam.dev",
+									Version: "v1alpha2",
+								},
+							},
+						},
+					},
+				},
+				workload: &Workload{},
+			},
+			wantErr: assert.NoError,
+			validateFunc: func(w *Workload) bool {
+				return w != nil && len(w.Scopes) == 1 && w.Scopes[0].ResourceVersion == "cluster/v1alpha2"
+			},
+		},
+	}
+	p := NewApplicationParser(nil, dm, pd)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, p.parseScopesFromRevision(tt.args.comp, tt.args.appRev, tt.args.workload), fmt.Sprintf("parseScopesFromRevision(%v, %v, %v)", tt.args.comp, tt.args.appRev, tt.args.workload))
+			if tt.validateFunc != nil {
+				assert.True(t, tt.validateFunc(tt.args.workload))
+			}
+		})
+	}
+}

--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -72,7 +72,7 @@ type Template struct {
 // processing.
 func LoadTemplate(ctx context.Context, dm discoverymapper.DiscoveryMapper, cli client.Reader, capName string, capType types.CapType) (*Template, error) {
 	ctx = multicluster.WithCluster(ctx, multicluster.Local)
-	// Application Controller only load template from ComponentDefinition and TraitDefinition
+	// Application Controller only loads template from ComponentDefinition and TraitDefinition
 	switch capType {
 	case types.TypeComponentDefinition, types.TypeWorkload:
 		cd := new(v1beta1.ComponentDefinition)


### PR DESCRIPTION
### Description of your changes

1. refactor `pkg/appfile/parse.go` to improve readability.
2. add some unit tests.
3. fix some typo.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a10a7a4</samp>

### Summary
📝🧪♻️

<!--
1.  📝 - This emoji means "memo" or "document" and can be used to indicate changes related to documentation, comments, or typos.
2.  🧪 - This emoji means "test tube" and can be used to indicate changes related to testing, such as adding or updating tests, or fixing bugs in test code.
3.  ♻️ - This emoji means "recycle" and can be used to indicate changes related to refactoring, improving code quality, or removing redundant or unused code.
-->
This pull request improves the code quality, readability, and test coverage of the `pkg/appfile` package. It also fixes some typos and grammar errors in the comments of various files.

> _Sing, O Muse, of the valiant pull request_
> _That fixed the typos and the grammar flaws_
> _In the `appfile` package, where the best_
> _Of `ApplicationComponent` traits are stored._

### Walkthrough
*  Refactor `parseWorkload` function by extracting logic of parsing traits and scopes into separate functions ([link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L585-R616), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L621-R668), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L645-R677))
*  Add test functions for `parseTraits`, `parseScopes`, `parseTraitsFromRevision`, and `parseScopesFromRevision` in `parser_test.go` ([link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL24-R39), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dR508-R866))
*  Fix typos and add articles in comments of various functions and types in `types.go`, `appfile.go`, `parser.go`, `template.go`, and `helper.go` ([link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-aa529d92b124a03114c61c1f898131434e0a9929e11be368035a34b8f69fb72bL394-R394), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL99-R99), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL128-R128), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL237-R243), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L609-R625), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L731-R763), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L743-R775), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-49aa37bff537c332216dde9de82802d16801ea0d5d91f2c950d5eaeffe02542fL75-R75), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-fc8bae01fae89b52dda289db4de1620bae05bd8c9a2048e3d831dcaba52c1499L289-R289), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-fc8bae01fae89b52dda289db4de1620bae05bd8c9a2048e3d831dcaba52c1499L464-R468), [link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-fc8bae01fae89b52dda289db4de1620bae05bd8c9a2048e3d831dcaba52c1499L475-R479))
*  Refactor `GetDefinition` function by extracting logic of getting definition from default namespace into a separate function in `helper.go` ([link](https://github.com/kubevela/kubevela/pull/6017/files?diff=unified&w=0#diff-fc8bae01fae89b52dda289db4de1620bae05bd8c9a2048e3d831dcaba52c1499L305-R320))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->