### PR TITLE
Feat: support applicator applying resources and update status

### DIFF
--- a/pkg/utils/apply/apply_client.go
+++ b/pkg/utils/apply/apply_client.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// applyClient override the create/update/patch interface and handle status update automatically
+type applyClient struct {
+	client.Client
+}
+
+func (in *applyClient) hasUnstructuredStatus(obj client.Object) (any, bool) {
+	if o, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured && o.Object != nil {
+		status, hasStatus := o.Object["status"]
+		return status, hasStatus
+	}
+	return nil, false
+}
+
+func (in *applyClient) setUnstructuredStatus(obj client.Object, status any) {
+	if o, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured && o.Object != nil {
+		o.Object["status"] = status
+	}
+}
+
+func (in *applyClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	status, hasStatus := in.hasUnstructuredStatus(obj)
+	if err := in.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	_opts := &client.CreateOptions{}
+	for _, opt := range opts {
+		opt.ApplyToCreate(_opts)
+	}
+	if hasStatus && len(_opts.DryRun) == 0 {
+		in.setUnstructuredStatus(obj, status)
+		return in.Client.Status().Update(ctx, obj)
+	}
+	return nil
+}
+
+func (in *applyClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	status, hasStatus := in.hasUnstructuredStatus(obj)
+	if err := in.Client.Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+	if hasStatus {
+		in.setUnstructuredStatus(obj, status)
+		return in.Client.Status().Update(ctx, obj)
+	}
+	return nil
+}
+
+func (in *applyClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	status, hasStatus := in.hasUnstructuredStatus(obj)
+	if err := in.Client.Patch(ctx, obj, patch, opts...); err != nil {
+		return err
+	}
+	if hasStatus {
+		in.setUnstructuredStatus(obj, status)
+		return in.Client.Status().Patch(ctx, obj, patch)
+	}
+	return nil
+}

--- a/pkg/utils/apply/apply_client_test.go
+++ b/pkg/utils/apply/apply_client_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubevela/pkg/util/jsonutil"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyClient(t *testing.T) {
+	cli := applyClient{fake.NewClientBuilder().Build()}
+	deploy, err := jsonutil.AsType[unstructured.Unstructured](&appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       appsv1.DeploymentSpec{Replicas: pointer.Int32(1)},
+		Status:     appsv1.DeploymentStatus{Replicas: 1},
+	})
+	require.NoError(t, err)
+	_ctx := context.Background()
+	require.NoError(t, cli.Create(_ctx, deploy))
+	require.Equal(t, int64(1), deploy.Object["spec"].(map[string]interface{})["replicas"])
+	require.Equal(t, int64(1), deploy.Object["status"].(map[string]interface{})["replicas"])
+
+	deploy.Object["spec"].(map[string]interface{})["replicas"] = 3
+	deploy.Object["status"].(map[string]interface{})["replicas"] = 3
+	require.NoError(t, cli.Update(_ctx, deploy))
+
+	_deploy := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	_deploy.SetAPIVersion("apps/v1")
+	_deploy.SetKind("Deployment")
+	require.NoError(t, cli.Get(_ctx, types.NamespacedName{Namespace: "default", Name: "test"}, _deploy))
+	require.Equal(t, int64(3), _deploy.Object["spec"].(map[string]interface{})["replicas"])
+	require.Equal(t, int64(3), _deploy.Object["status"].(map[string]interface{})["replicas"])
+
+	p := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/spec/replicas","value":5},{"op":"replace","path":"/status/replicas","value":5}]`))
+	require.NoError(t, cli.Patch(_ctx, _deploy, p))
+	require.Equal(t, int64(5), _deploy.Object["spec"].(map[string]interface{})["replicas"])
+	require.Equal(t, int64(5), _deploy.Object["status"].(map[string]interface{})["replicas"])
+}

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -1276,5 +1276,33 @@ var _ = Describe("Test multicluster scenario", func() {
 			Expect(kerrors.IsNotFound(k8sClient.Get(hubCtx, types.NamespacedName{Namespace: namespace, Name: "x"}, &corev1.ConfigMap{}))).Should(BeTrue())
 			Expect(kerrors.IsNotFound(k8sClient.Get(workerCtx, types.NamespacedName{Namespace: namespace, Name: "y"}, &corev1.ConfigMap{}))).Should(BeTrue())
 		})
+
+		It("Test application apply resources with status", func() {
+			ctx := context.Background()
+			def := &unstructured.Unstructured{}
+			bs, err := os.ReadFile("./testdata/def/fake-app.yaml")
+			Expect(err).Should(Succeed())
+			Expect(yaml.Unmarshal(bs, def)).Should(Succeed())
+			def.SetNamespace(namespace)
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, def))).Should(Succeed())
+
+			app := &v1beta1.Application{}
+			bs, err = os.ReadFile("./testdata/app/app-test-subresource.yaml")
+			Expect(err).Should(Succeed())
+			Expect(yaml.Unmarshal(bs, app)).Should(Succeed())
+			app.SetNamespace(namespace)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+			}).WithPolling(2 * time.Second).WithTimeout(5 * time.Second).Should(Succeed())
+			appKey := client.ObjectKeyFromObject(app)
+			Eventually(func(g Gomega) {
+				_app := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, appKey, _app)).Should(Succeed())
+				g.Expect(_app.Status.Phase).Should(Equal(common.ApplicationRunning))
+			}).WithPolling(2 * time.Second).WithTimeout(20 * time.Second).Should(Succeed())
+			_fapp := &v1beta1.Application{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "fake-app"}, _fapp)).Should(Succeed())
+			Expect(string(_fapp.Status.Phase)).Should(Equal("unknown"))
+		})
 	})
 })

--- a/test/e2e-multicluster-test/testdata/app/app-test-subresource.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-test-subresource.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app
+spec:
+  components:
+    - type: fake-app
+      name: fake-app

--- a/test/e2e-multicluster-test/testdata/def/fake-app.yaml
+++ b/test/e2e-multicluster-test/testdata/def/fake-app.yaml
@@ -1,0 +1,22 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: fake-app
+spec:
+  schematic:
+    cue:
+      template: |
+        output: {
+          apiVersion: "core.oam.dev/v1beta1"
+            kind: "Application"
+            metadata: labels: "controller.core.oam.dev/pause": "true"
+            spec: components: []
+            status: {
+              status: "unknown"
+            }
+        }
+        parameter: {}
+  workload:
+    definition:
+      apiVersion: core.oam.dev/v1beta1
+      kind: Application


### PR DESCRIPTION
### Description of your changes

With this PR, KubeVela controller will be able to apply resources with updating the resource status as well, if set.

Normally, KubeVela will not do it for now since we do not have ComponentDefinition or TraitDefinition that output resources with status field. But as mentioned in #3783, in some customized scenario, we might need to allow users to update their custom resource's status with the abstraction capability of KubeVela.

Fixes #3783

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->