### PR TITLE
Feat: support force resource location with dispatch

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -429,7 +429,7 @@ func overrideTraits(appRev *v1beta1.ApplicationRevision, readyTraits []*unstruct
 	for index, readyTrait := range readyTraits {
 		for _, trait := range appRev.Spec.TraitDefinitions {
 			if trait.Spec.ControlPlaneOnly && trait.Name == readyTrait.GetLabels()[oam.TraitTypeLabel] {
-				oam.SetCluster(traits[index], "local")
+				oam.SetCluster(traits[index], multicluster.ClusterLocalName)
 				traits[index].SetNamespace(appRev.GetNamespace())
 				break
 			}
@@ -481,9 +481,9 @@ func renderComponentsAndTraits(client client.Client, manifest *types.ComponentMa
 		return nil, nil, errors.WithMessage(err, "assemble resources before apply fail")
 	}
 	if clusterName != "" {
-		oam.SetCluster(readyWorkload, clusterName)
+		oam.SetClusterIfEmpty(readyWorkload, clusterName)
 		for _, readyTrait := range readyTraits {
-			oam.SetCluster(readyTrait, clusterName)
+			oam.SetClusterIfEmpty(readyTrait, clusterName)
 		}
 	}
 	if overrideNamespace != "" {

--- a/pkg/multicluster/utils.go
+++ b/pkg/multicluster/utils.go
@@ -72,9 +72,7 @@ func ResourcesWithClusterName(clusterName string, objs ...*unstructured.Unstruct
 	var _objs []*unstructured.Unstructured
 	for _, obj := range objs {
 		if obj != nil {
-			if oam.GetCluster(obj) == "" {
-				oam.SetCluster(obj, clusterName)
-			}
+			oam.SetClusterIfEmpty(obj, clusterName)
 			_objs = append(_objs, obj)
 		}
 	}

--- a/pkg/oam/auxiliary.go
+++ b/pkg/oam/auxiliary.go
@@ -28,6 +28,13 @@ func SetCluster(o client.Object, clusterName string) {
 	meta.AddLabels(o, map[string]string{LabelAppCluster: clusterName})
 }
 
+// SetClusterIfEmpty set cluster label to object if the label is empty
+func SetClusterIfEmpty(o client.Object, clusterName string) {
+	if GetCluster(o) == "" {
+		SetCluster(o, clusterName)
+	}
+}
+
 // GetCluster get cluster from object
 func GetCluster(o client.Object) string {
 	if labels := o.GetLabels(); labels != nil {

--- a/pkg/oam/auxliary_test.go
+++ b/pkg/oam/auxliary_test.go
@@ -28,6 +28,6 @@ func TestGetSetCluster(t *testing.T) {
 	deploy := &v1.Deployment{}
 	r.Equal("", GetCluster(deploy))
 	clusterName := "cluster"
-	SetCluster(deploy, clusterName)
+	SetClusterIfEmpty(deploy, clusterName)
 	r.Equal(clusterName, GetCluster(deploy))
 }

--- a/references/cli/adopt-templates/default.cue
+++ b/references/cli/adopt-templates/default.cue
@@ -92,8 +92,8 @@ import (
 			_category: key
 		}
 		_cluster: *"local" | string
-		if r.metadata.annotations != _|_ if r.metadata.annotations["app.oam.dev/cluster"] != _|_ {
-			_cluster: r.metadata.annotations["app.oam.dev/cluster"]
+		if r.metadata.labels != _|_ if r.metadata.labels["app.oam.dev/cluster"] != _|_ {
+			_cluster: r.metadata.labels["app.oam.dev/cluster"]
 		}
 	}]
 

--- a/references/cli/adopt.go
+++ b/references/cli/adopt.go
@@ -65,15 +65,14 @@ import (
 )
 
 const (
-	adoptTypeNative     = "native"
-	adoptTypeHelm       = "helm"
-	adoptModeReadOnly   = v1alpha1.ReadOnlyPolicyType
-	adoptModeTakeOver   = v1alpha1.TakeOverPolicyType
-	helmDriverEnvKey    = "HELM_DRIVER"
-	defaultHelmDriver   = "secret"
-	adoptCUETempVal     = "adopt"
-	adoptCUETempFunc    = "#Adopt"
-	defaultLocalCluster = "local"
+	adoptTypeNative   = "native"
+	adoptTypeHelm     = "helm"
+	adoptModeReadOnly = v1alpha1.ReadOnlyPolicyType
+	adoptModeTakeOver = v1alpha1.TakeOverPolicyType
+	helmDriverEnvKey  = "HELM_DRIVER"
+	defaultHelmDriver = "secret"
+	adoptCUETempVal   = "adopt"
+	adoptCUETempFunc  = "#Adopt"
 )
 
 //go:embed adopt-templates/default.cue
@@ -155,7 +154,7 @@ func (opt *AdoptOptions) parseResourceRef(f velacmd.Factory, cmd *cobra.Command,
 		return nil, fmt.Errorf("no mappings found for resource %s: %w", arg, err)
 	}
 	mapping := mappings[0]
-	or := &resourceRef{GroupVersionKind: gvk, Cluster: defaultLocalCluster, Arg: arg}
+	or := &resourceRef{GroupVersionKind: gvk, Cluster: multicluster.Local, Arg: arg}
 	switch len(parts) {
 	case 2:
 		or.Name = parts[1]
@@ -446,7 +445,7 @@ func (opt *AdoptOptions) loadNative(f velacmd.Factory, cmd *cobra.Command) error
 		if err := f.Client().Get(multicluster.WithCluster(cmd.Context(), ref.Cluster), apitypes.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}, obj); err != nil {
 			return fmt.Errorf("fail to get resource for %s: %w", ref.Arg, err)
 		}
-		_ = k8s.AddAnnotation(obj, oam.LabelAppCluster, ref.Cluster)
+		_ = k8s.AddLabel(obj, oam.LabelAppCluster, ref.Cluster)
 		opt.Resources = append(opt.Resources, obj)
 	}
 	return nil
@@ -472,10 +471,7 @@ func (opt *AdoptOptions) loadHelm() error {
 			klog.Warningf("unable to decode object %s: %s", val, err)
 			continue
 		}
-		annos := map[string]string{
-			oam.LabelAppCluster: defaultLocalCluster,
-		}
-		obj.SetAnnotations(annos)
+		_ = k8s.AddLabel(obj, oam.LabelAppCluster, multicluster.Local)
 		objs = append(objs, obj)
 	}
 	opt.Resources = objs

--- a/test/e2e-multicluster-test/testdata/app/app-with-fixed-location.yaml
+++ b/test/e2e-multicluster-test/testdata/app/app-with-fixed-location.yaml
@@ -1,0 +1,29 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app
+spec:
+  components:
+    - type: k8s-objects
+      name: app
+      properties:
+        objects:
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: "x"
+              labels:
+                app.oam.dev/cluster: local
+            data:
+              key: "x"
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: "y"
+            data:
+              key: "y"
+  policies:
+    - type: topology
+      name: topology
+      properties:
+        clusters: ["cluster-worker"]


### PR DESCRIPTION
### Description of your changes

In this PR, we support setting the cluster to dispatch with the rendered resource directly, through setting the "app.oam.dev/cluster" label manually.

For example,
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: app
spec:
  components:
    - type: k8s-objects
      name: app
      properties:
        objects:
          - apiVersion: v1
            kind: ConfigMap
            metadata:
              name: "x"
              labels:
                app.oam.dev/cluster: local
            data:
              key: "x"
          - apiVersion: v1
            kind: ConfigMap
            metadata:
              name: "y"
            data:
              key: "y"
  policies:
    - type: topology
      name: topology
      properties:
        clusters: ["cluster-worker"]
```
The above application will create the ConfigMap "x" in the local cluster and the ConfigMap "y" in the "cluster-worker" cluster.

With this capability, it is possible for users to design ComponentDefinition/TraitDefinitions that only deliver resources to the hub control plane no matter what topology is used.

NOTE: This label is originally attached to the rendered resources before they are applied with the topology policy. So this PR reuse that label and does not affect existing system.

Fixes #6032

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->