### PR TITLE
Feat: expose probe params in helm chart

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -338,14 +338,20 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-            initialDelaySeconds: 30
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 90
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
           volumeMounts:
             - mountPath: {{ .Values.admissionWebhooks.certificate.mountPath }}
               name: tls-cert-vol

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -83,6 +83,21 @@ webhookService:
 healthCheck:
   port: 9440
 
+## @skip readinessProbe
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 1
+## @skip livenessProbe
+livenessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 90
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 1
+
 ## @section KubeVela controller optimization parameters
 ##@param optimize.cachedGvks Optimize types of resources to be cached.
 ##@param optimize.markWithProb Optimize ResourceTracker GC by only run mark with probability. Side effect: outdated ResourceTracker might not be able to be removed immediately.


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc00aa2</samp>

### Summary
📝🛠️🎛️

<!--
1.  📝 for the change to the README.md file, as this emoji is often used to indicate documentation updates.
2.  🛠️ for the change to the `kubevela-controller.yaml` template file, as this emoji is often used to indicate bug fixes or improvements to the code.
3.  🎛️ for the change to the `values.yaml` file, as this emoji is often used to indicate configuration or settings changes.
-->
This pull request updates the `vela-core` helm chart to support configuration options for the controller's readiness and liveness probes. It modifies the `README.md`, `kubevela-controller.yaml`, and `values.yaml` files to document, use, and define the new parameters.

> _`controller` probes_
> _added to helm chart values_
> _autumn of docs `cut`_

### Walkthrough
*  Add configuration options for controller's readiness and liveness probes ([link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-0d6c1bc86a173ca628e23dd085ed459b1e0f36255936a1d9184af1c651d759b5L135-R167), [link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-f146e9421802c295d5211f6b034ebc41ff86c0a14617de0f8f80849c418f8c76L341-R354), [link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-5de38b74432257fd0da10f3a511568790f1856d14e3385d82d2f0b8b72f6163fR289-R315))
  - Update `README.md` to document the new parameters in the `Common parameters` section ([link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-0d6c1bc86a173ca628e23dd085ed459b1e0f36255936a1d9184af1c651d759b5L135-R167))
  - Modify `kubevela-controller.yaml` template to use the values from `controller.readinessProbe` and `controller.livenessProbe` instead of hard-coded values ([link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-f146e9421802c295d5211f6b034ebc41ff86c0a14617de0f8f80849c418f8c76L341-R354))
  - Add default values for the new parameters in `values.yaml` file ([link](https://github.com/kubevela/kubevela/pull/6044/files?diff=unified&w=0#diff-5de38b74432257fd0da10f3a511568790f1856d14e3385d82d2f0b8b72f6163fR289-R315))



expose readiness & liveness probe params in values.yaml so that users can customize the probe configuration.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->