### PR TITLE
Fix: ignore kind not match err for vela def

### DIFF
--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -32,6 +32,7 @@ import (
 	"cuelang.org/go/encoding/gocode/gocodec"
 	"cuelang.org/go/tools/fix"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -491,6 +492,9 @@ func SearchDefinition(c client.Client, definitionType, namespace string, additio
 			Kind:    kind + "List",
 		})
 		if err := c.List(ctx, &objs, listOptions...); err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
 			return nil, errors.Wrapf(err, "failed to get %s", kind)
 		}
 


### PR DESCRIPTION
### Description of your changes

The ScopeDefinition CRD is removed from the chart in v1.9.0 but it will report kind not found error for `vela def` command as it will search all the possible XXXDefinition when not specified. This will break when the ScopeDefinition CRD is not installed in the cluster. This PR fixes it.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->