### PR TITLE
Feat: parallel init cluster info

### DIFF
--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/kubevela/pkg/util/singleton"
+	velaslices "github.com/kubevela/pkg/util/slices"
 	"github.com/oam-dev/cluster-gateway/pkg/generated/clientset/versioned"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -62,12 +63,12 @@ func InitClusterInfo(cfg *rest.Config) error {
 		if err != nil {
 			return errors.Wrap(err, "fail to get registered clusters")
 		}
-		for _, cluster := range clusters.Items {
+
+		velaslices.ParFor(clusters.Items, func(cluster v1alpha1.VirtualCluster) {
 			if err = SetClusterVersionInfo(ctx, cfg, cluster.Name); err != nil {
 				klog.Warningf("set cluster version for %s: %v, skip it...", cluster.Name, err)
-				continue
 			}
-		}
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b5ef09e</samp>

### Summary
🚀🙌🔗

<!--
1.  🚀 - This emoji represents the improvement in speed and efficiency that the parallelization brings to the multicluster initialization process.
2.  🙌 - This emoji represents the better handling of errors and failures that the `errgroup` package provides, as well as the simplification of the code logic.
3.  🔗 - This emoji represents the multicluster feature and the connection between different clusters that it enables.
-->
Improve multicluster initialization performance and error handling by using `errgroup` to parallelize cluster version queries in `virtual_cluster.go`.

> _We are the multicluster, we rise from the ashes_
> _We use the `errgroup` to unleash our power_
> _We fetch the versions in parallel, we defy the order_
> _We handle the errors with grace, we are the multicluster_

### Walkthrough
*  Parallelize cluster version fetching using `errgroup.Group` (`[link](https://github.com/kubevela/kubevela/pull/6060/files?diff=unified&w=0#diff-3b863babb08434dd0a998f7b6f89e87f139420f288089d65b778e67595259cb8R25-R26)`, `[link](https://github.com/kubevela/kubevela/pull/6060/files?diff=unified&w=0#diff-3b863babb08434dd0a998f7b6f89e87f139420f288089d65b778e67595259cb8L65-R78)`)



In my case, if there are a lot of virtual clusters (secrets), but their corresponding clusters are temporarily disconnected, this will eventually cause the context to time out, and the requests will accumulate, causing the controller to take a long time to restart, This causes the controller to be rebooted frequently because the ready probe is not satisfied. Therefore, cluster information is initialized in parallel to accelerate the startup speed of controller.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->