### PR TITLE
Fix: addon args is not changed when reinstall it without args

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -844,6 +844,18 @@ func RenderArgsSecret(addon *InstallPackage, args map[string]interface{}) *unstr
 	return u
 }
 
+// deleteArgsSecret delete the addon's args secret file
+func deleteArgsSecret(ctx context.Context, k8sClient client.Client, addonName string) {
+	var sec v1.Secret
+	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: addonutil.Addon2SecName(addonName)}, &sec)
+	if err == nil {
+		err = k8sClient.Delete(ctx, &sec)
+		if err != nil {
+			fmt.Printf("fail to delete %v addon parameter file", addonName)
+		}
+	}
+}
+
 // FetchArgsFromSecret fetch addon args from secrets
 func FetchArgsFromSecret(sec *v1.Secret) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
@@ -1290,6 +1302,9 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 		if err != nil {
 			return err
 		}
+	} else {
+		// delete addon args secret file
+		deleteArgsSecret(h.ctx, h.cli, addon.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 49c21b8</samp>

### Summary
🗑️🧩🔧

<!--
1.  🗑️ - This emoji represents deleting something, which is what the `deleteArgsSecret` function does when it removes the secret file that stores the addon's arguments.
2.  🧩 - This emoji represents addons, which are the main focus of this pull request and the feature it implements.
3.  🔧 - This emoji represents configuration or settings, which are related to the addon's arguments and the secret file that stores them.
-->
Add feature to uninstall addons by deleting secret file. Modify `pkg/addon/addon.go` to delete the secret file that stores the addon's arguments when uninstalling an addon.

> _`deleteArgsSecret`_
> _Uninstalling addons now_
> _Autumn leaves fall fast_

### Walkthrough
*  Add a function to delete the secret file for addon arguments (`[link](https://github.com/kubevela/kubevela/pull/6065/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbR847-R858)` in `pkg/addon/addon.go`)



Fixes #6064

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1、vela addon enable fluxcd --clusters={local}
2、vela addon enable fluxcd

### Special notes for your reviewer
@wangyikewxgm 