### PR TITLE
Fix: can not get the APISchema when registry is not version registry

### DIFF
--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -254,7 +254,7 @@ func FindAddonPackagesDetailFromRegistry(ctx context.Context, k8sClient client.C
 				if !ok {
 					continue
 				}
-				uiData, err := r.GetUIData(&sourceMeta, CLIMetaOptions)
+				uiData, err := r.GetUIData(&sourceMeta, UIMetaOptions)
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d6f6fa</samp>

### Summary
🐛🌐🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to `FindAddonPackagesDetailFromRegistry`.
2.  🌐 - This emoji represents a web-related change, which is relevant since the change affects the web console UI of kubevela.
3.  🚀 - This emoji represents a feature improvement, which is also applicable since the change enhances the addon management feature of kubevela.
-->
Fixed a bug in displaying UI data of addon packages in the web console. Changed `FindAddonPackagesDetailFromRegistry` to use `UIMetaOptions` instead of `CLIMetaOptions` in `pkg/addon/helper.go`.

> _`UIMetaOptions`_
> _Fix addon UI data bug_
> _Winter console glows_

### Walkthrough
* Fix UI data bug for addon packages by using `UIMetaOptions` instead of `CLIMetaOptions` in `FindAddonPackagesDetailFromRegistry` ([link](https://github.com/kubevela/kubevela/pull/6066/files?diff=unified&w=0#diff-c2cf26c57a54e0094a439c4c9f01e066d75f01eefc0264bfbcdc9d1524161d7cL257-R257))



FindAddonPackagesDetailFromRegistry can not get the APISchema data when registry is not version registry

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
1. add git type addon registry
2. enable fluxcd from this registry with local clusters
3. enable fluxcd from this registry without args

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
@wangyikewxgm 