### PR TITLE
Feat: Fix ingress service name for multiple gateway traits

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -82,12 +82,12 @@ spec:
         					pathType: parameter.pathType
         					backend: {
         						if legacyAPI {
-        							serviceName: context.name
+        							serviceName: serviceMetaName
         							servicePort: v
         						}
         						if !legacyAPI {
         							service: {
-        								name: context.name
+        								name: serviceMetaName
         								port: number: v
         							}
         						}

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -125,12 +125,12 @@ template: {
 						pathType: parameter.pathType
 						backend: {
 							if legacyAPI {
-								serviceName: context.name
+								serviceName: serviceMetaName
 								servicePort: v
 							}
 							if !legacyAPI {
 								service: {
-									name: context.name
+									name: serviceMetaName
 									port: number: v
 								}
 							}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc2867e</samp>

### Summary
🐛🔄🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `backend` field.
2.  🔄 - This emoji represents a change or update, which is what the change to the `backend` field also does by using a different parameter for the service name fields.
3.  🚀 - This emoji represents an improvement or enhancement, which is the result of the change to the `backend` field by making the gateway trait more compatible and flexible with different workload types.
-->
Updated `gateway` trait definition to use `serviceMetaName` parameter for service name fields. This fixes a compatibility issue with the `service` workload type.

> _`gateway` trait fixed_
> _`serviceMetaName` for both_
> _`service` and `web` - autumn_

### Walkthrough
* Fix gateway trait compatibility with service workload type by using serviceMetaName parameter for backend serviceName and service.name fields ([link](https://github.com/kubevela/kubevela/pull/6067/files?diff=unified&w=0#diff-eb6e43f0e2cf800a96e1dac66f3f4871067f865d5c694d9efa5c84cb2529a5a0L128-R133))



This fixes an issue that the multiple gateway ingress do not hook up to the created services.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Local use only, unit tests beyond my kubevela repo knowledge.


### Special notes for your reviewer

Orignal feature PR : https://github.com/kubevela/kubevela/pull/5860
later fix to add service creation back: https://github.com/kubevela/kubevela/pull/5978
This PR is to correctly hooks up to those created services added back in last PR