### PR TITLE
Fix: issue command permission error

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -1,4 +1,4 @@
-name: Run commands for issues and pull requetss
+name: Run commands for issues and pull requests
 on:
   issues:
     types: [labeled, opened]
@@ -11,6 +11,9 @@ permissions:
 jobs:
   bot:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -29,7 +32,7 @@ jobs:
       - name: Run Commands
         uses: ./actions/commands
         with:
-          token: ${{secrets.VELA_BOT_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           configPath: issue-commands
 
   backport:
@@ -86,7 +89,6 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/retest')
     permissions:
       actions: write
-      contents: write
       pull-requests: write
       issues: write
     steps:


### PR DESCRIPTION
### Description of your changes

The VELA_BOT_TOKEN seems to expire and the issue-command CI breaks. This PR uses the default github workflow token for doing this CI.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->