### PR TITLE
Fix: addon status list addon info error when there are mulitiple registries

### DIFF
--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -322,6 +322,7 @@ func (r *Registry) GetUIData(meta *SourceMeta, opt ListOptions) (*UIData, error)
 	if len(addon.GlobalParameters) != 0 {
 		addon.Parameters = addon.GlobalParameters
 	}
+	addon.RegistryName = r.Name
 	return addon, nil
 }
 

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -702,6 +702,14 @@ func generateAddonInfo(c client.Client, name string) (string, pkgaddon.Status, e
 		}
 		if len(addonPackages) != 0 {
 			addonPackage = addonPackages[0]
+			if status.InstalledRegistry != "" {
+				for _, ap := range addonPackages {
+					if ap.RegistryName == status.InstalledRegistry {
+						addonPackage = ap
+						break
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION

### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4456bd3</samp>

### Summary
:sparkles::bug::mag:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for assigning the registry name to the addon object and allowing users to install addons from different registries.
2.  :bug: - This emoji represents a bug fix or improvement, which is the case for finding the addon package that matches the installed registry of the addon status and avoiding using the default addon package.
3.  :mag: - This emoji represents a code refactoring or improvement, which is the case for adding a logic to find the addon package that matches the installed registry of the addon status.
-->
This pull request enhances the addon installation feature by assigning and using the registry name of the addon. This allows the UI to show the correct addon information and the CLI to find the compatible addon package. The changes affect the files `pkg/addon/source.go` and `references/cli/addon.go`.

> _`addon` gets a name_
> _to show in web console_
> _autumn leaves fall_

### Walkthrough
*  Assign registry name to addon object for UI data ([link](https://github.com/kubevela/kubevela/pull/6073/files?diff=unified&w=0#diff-3b5d99a64f9772948c557f6a0c4fedf4356a7edaa6ccad7a3d99baebd7968578R325))
*  Find matching addon package from installed registry ([link](https://github.com/kubevela/kubevela/pull/6073/files?diff=unified&w=0#diff-5c1ce01bb88762ec6a5abb96531e8ac946cff33a1fa7ff2e033131f8dcf0e2b8R705-R712))



Fixes #6072

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
1. add zhh-repo2 registry
2. modify fluxcd addon parameter: add a deployGroup argument
3. push the new fluxcd to zhh-repo2
4. vela addon enable fluxcd from the zhh-repo2
5. vela addon status fluxcd -v


### Special notes for your reviewer
@wangyikewxgm 