### PR TITLE
Fix: application gc not blocked by apprev gc

### DIFF
--- a/pkg/resourcekeeper/gc_rev_test.go
+++ b/pkg/resourcekeeper/gc_rev_test.go
@@ -463,7 +463,7 @@ func Test_cleanUpWorkflowComponentRevision(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := cleanUpWorkflowComponentRevision(context.Background(), tt.args.h); (err != nil) != tt.wantErr {
+			if err := cleanUpComponentRevision(context.Background(), tt.args.h); (err != nil) != tt.wantErr {
 				t.Errorf("cleanUpWorkflowComponentRevision() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -1336,5 +1336,60 @@ var _ = Describe("Test multicluster scenario", func() {
 				g.Expect(pods.Items[0].Name).Should(ContainSubstring("orphan"))
 			}).WithPolling(2 * time.Second).WithTimeout(20 * time.Second).Should(Succeed())
 		})
+
+		It("Test application revision gc block application gc", func() {
+			ctx := context.Background()
+			app := &v1beta1.Application{}
+			bs, err := os.ReadFile("./testdata/app/app-lite.yaml")
+			Expect(err).Should(Succeed())
+			Expect(yaml.Unmarshal(bs, app)).Should(Succeed())
+			app.SetNamespace(namespace)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+			}).WithPolling(2 * time.Second).WithTimeout(5 * time.Second).Should(Succeed())
+			appKey := client.ObjectKeyFromObject(app)
+			Eventually(func(g Gomega) {
+				_app := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, appKey, _app)).Should(Succeed())
+				g.Expect(_app.Status.Phase).Should(Equal(common.ApplicationRunning))
+			}).WithPolling(2 * time.Second).WithTimeout(20 * time.Second).Should(Succeed())
+
+			By("Add finalizer to application revision")
+			Eventually(func(g Gomega) {
+				_rev := &v1beta1.ApplicationRevision{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: appKey.Name + "-v1"}, _rev)).Should(Succeed())
+				_rev.SetFinalizers([]string{"mine"})
+				g.Expect(k8sClient.Update(ctx, _rev)).Should(Succeed())
+			}).WithPolling(2 * time.Second).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("Deleting")
+			_app := &v1beta1.Application{}
+			Expect(k8sClient.Get(ctx, appKey, _app)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, _app)).Should(Succeed())
+
+			By("Check application existing after rt recycled")
+			Eventually(func(g Gomega) {
+				rts := &v1beta1.ResourceTrackerList{}
+				g.Expect(k8sClient.List(ctx, rts, client.MatchingLabels{oam.LabelAppName: _app.Name, oam.LabelAppNamespace: _app.Namespace})).Should(Succeed())
+				g.Expect(len(rts.Items)).Should(Equal(0))
+			}).WithPolling(2 * time.Second).WithTimeout(10 * time.Second).Should(Succeed())
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, appKey, _app)).Should(Succeed())
+			}).WithPolling(2 * time.Second).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("Remove finalizer from application revision")
+			Eventually(func(g Gomega) {
+				_rev := &v1beta1.ApplicationRevision{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: appKey.Name + "-v1"}, _rev)).Should(Succeed())
+				_rev.SetFinalizers([]string{})
+				g.Expect(k8sClient.Update(ctx, _rev)).Should(Succeed())
+			}).WithPolling(2 * time.Second).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("Check application deletion")
+			Eventually(func(g Gomega) {
+				g.Expect(kerrors.IsNotFound(k8sClient.Get(ctx, appKey, _app))).Should(BeTrue())
+				g.Expect(kerrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: appKey.Name + "-v1"}, &v1beta1.ApplicationRevision{}))).Should(BeTrue())
+			}).WithPolling(2 * time.Second).WithTimeout(10 * time.Second).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
### Description of your changes

Issue #5710 mention that we should let the application controller to handle the garbage collection of application revision. Previously we rely on the ownerReference mechanism to recycle application revision for application. However, in the case that Kubernetes does not recycle those revisions immediately, it could lead to problems for recreated same-named applications.

PR #5739 refactors the code, moving the gc part into resourceKeeper but does not solve this problem. This PR is to work continue on that and let the application controller to delete application revisions before removing the finalizer of application.

Fixes #5710

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->