### PR TITLE
Feat: optimize "application-resource-tree-view"

### DIFF
--- a/charts/vela-core/templates/velaql/resourceTree.yaml
+++ b/charts/vela-core/templates/velaql/resourceTree.yaml
@@ -30,7 +30,7 @@ data:
                 if parameter.name != _|_ {
                     components: [parameter.name]
                 }
-                if parameter.queryNewest != _|_ && parameter.queryNewest == true{
+                if parameter.queryNewest != _|_ {
                     queryNewest: parameter.queryNewest
                 }
             }

--- a/charts/vela-core/templates/velaql/resourceTree.yaml
+++ b/charts/vela-core/templates/velaql/resourceTree.yaml
@@ -1,8 +1,8 @@
 apiVersion: "v1"
-kind: "ConfigMap"
+kind:       "ConfigMap"
 metadata:
-  name: "application-resource-tree-view"
-  namespace: { { include "systemDefinitionNamespace" . } }
+  name:      "application-resource-tree-view"
+  namespace: {{ include "systemDefinitionNamespace" . }}
 data:
   template: |
     import (

--- a/charts/vela-core/templates/velaql/resourceTree.yaml
+++ b/charts/vela-core/templates/velaql/resourceTree.yaml
@@ -1,8 +1,8 @@
 apiVersion: "v1"
-kind:       "ConfigMap"
+kind: "ConfigMap"
 metadata:
-  name:      "application-resource-tree-view"
-  namespace: {{ include "systemDefinitionNamespace" . }}
+  name: "application-resource-tree-view"
+  namespace: { { include "systemDefinitionNamespace" . } }
 data:
   template: |
     import (
@@ -14,6 +14,7 @@ data:
         name?:      string
         cluster?:   string
         clusterNs?: string
+        queryNewest?: bool
     }
     response: ql.#GetApplicationTree & {
         app: {
@@ -28,6 +29,9 @@ data:
                 }
                 if parameter.name != _|_ {
                     components: [parameter.name]
+                }
+                if parameter.queryNewest != _|_ && parameter.queryNewest == true{
+                    queryNewest: parameter.queryNewest
                 }
             }
         }

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -171,6 +171,7 @@
 			cluster?:          string
 			clusterNamespace?: string
 			components?: [...string]
+			queryNewest?: bool
 		}
 		withTree: true
 	}

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -87,6 +87,9 @@ func (c *AppCollector) ListApplicationResources(ctx context.Context, app *v1beta
 	}
 	var managedResources []*types.AppliedResource
 	existResources := make(map[common.ClusterObjectReference]bool, len(app.Spec.Components))
+	if c.opt.Filter.QueryNewest == true {
+		historyRTs = nil
+	}
 	for _, rt := range append(historyRTs, rootRT, currentRT) {
 		if rt != nil {
 			for _, managedResource := range rt.Spec.ManagedResources {

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -87,7 +87,7 @@ func (c *AppCollector) ListApplicationResources(ctx context.Context, app *v1beta
 	}
 	var managedResources []*types.AppliedResource
 	existResources := make(map[common.ClusterObjectReference]bool, len(app.Spec.Components))
-	if c.opt.Filter.QueryNewest == true {
+	if c.opt.Filter.QueryNewest {
 		historyRTs = nil
 	}
 	for _, rt := range append(historyRTs, rootRT, currentRT) {

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -88,6 +88,7 @@ type FilterOption struct {
 	Components       []string `json:"components,omitempty"`
 	APIVersion       string   `json:"apiVersion,omitempty"`
 	Kind             string   `json:"kind,omitempty"`
+	QueryNewest      bool     `json:"queryNewest,omitempty"`
 }
 
 // ListResourcesInApp lists CRs created by Application, this provider queries the object data.


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58f55ec</samp>

### Summary
:sparkles::wrench::chart_with_upwards_trend:

<!--
1.  :sparkles: This emoji is used to indicate the addition of a new feature or enhancement. In this case, the new feature is the `queryNewest` field and parameter that allows users to query the newest or the historical resources in the resource tree.
2.  :wrench: This emoji is used to indicate the modification or improvement of an existing feature or functionality. In this case, the modification is the `ListApplicationResources` function that skips collecting the history resources if the `queryNewest` option is true.
3.  :chart_with_upwards_trend: This emoji is used to indicate the improvement or optimization of performance or efficiency. In this case, the improvement is the `velaql` chart and service that support querying the newest or the historical resources in the resource tree, which can reduce the response time and the resource consumption.
-->
This pull request adds a new feature to the `velaql` service and chart to allow querying the newest or the historical resources in the resource tree. It updates the `query` package of the `stdlib` and the `query` provider of the `velaql` to support the new feature.

> _Oh we are the `velaql` crew and we have a job to do_
> _We query the resources with a flag that's new_
> _We heave and we haul on the `queryNewest` option_
> _And we skip the history if we want the latest version_

### Walkthrough
*  Add `queryNewest` parameter to `velaql` template to enable filtering history resources ([link](https://github.com/kubevela/kubevela/pull/6096/files?diff=unified&w=0#diff-b2fe6d37d0656ae4ccfe91a72eb080a0dfee80399dda2a3c5db4d65fe044a144R17), [link](https://github.com/kubevela/kubevela/pull/6096/files?diff=unified&w=0#diff-b2fe6d37d0656ae4ccfe91a72eb080a0dfee80399dda2a3c5db4d65fe044a144R33-R35))
*  Store `queryNewest` parameter value in `Query` struct of `query` package ([link](https://github.com/kubevela/kubevela/pull/6096/files?diff=unified&w=0#diff-621a7afddb94658bc5ff994bc40e7066cabe18422d55a410178fbd2b3439187dR174))
*  Parse `queryNewest` parameter from `velaql` service request and store it in `FilterOption` struct of `handler` package ([link](https://github.com/kubevela/kubevela/pull/6096/files?diff=unified&w=0#diff-9664c17eda779d7442d276bbbfa324d302351e53d5354ba85fac42f9b246e149R91))
*  Skip collecting history resources in `ListApplicationResources` function of `collector` package if `queryNewest` option is true ([link](https://github.com/kubevela/kubevela/pull/6096/files?diff=unified&w=0#diff-fcbbd032b71e076ff83ed5f3c7086a3a84281185813a6f08ed0742cbd56655cdR90-R92))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6092 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
add `queryNewest=true` in velaql
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->