### PR TITLE
Feat: added code to fetch the x definitions from the apiserver

### DIFF
--- a/vscode/src/fetching.go
+++ b/vscode/src/fetching.go
@@ -14,12 +14,9 @@ func main() {
 	// Set up the kubeconfig file path.
 	kubeconfig := "../.kube/config" // Update the path to your kubeconfig file.
 
-	// Set the namespace.
-	namespace := "vela-system" // Replace with your desired namespace.
-
 
 	// Build the configuration from the kubeconfig file.
-	cfg, err := config.GetConfigWithContext("kubeconfig")
+	cfg, err := config.GetConfigWithContext(kubeconfig)
 	if err != nil {
 		panic(err)
 		return

--- a/vscode/src/fetching.go
+++ b/vscode/src/fetching.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+func main() {
+	// Set up the kubeconfig file path.
+	kubeconfig := "../.kube/config" // Update the path to your kubeconfig file.
+
+	// Set the namespace.
+	namespace := "vela-system" // Replace with your desired namespace.
+
+
+	// Build the configuration from the kubeconfig file.
+	cfg, err := config.GetConfigWithContext("kubeconfig")
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// Create a client using the configuration.
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// Set the ComponentDefinition list.
+	componentDefinitionList := &v1beta1.ComponentDefinitionList{}
+
+
+	// Retrieve the ComponentDefinition resources using the client and ListOptions.
+	err = c.List(context.TODO(), componentDefinitionList, client.InNamespace("vela-system"))
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// Print the retrieved ComponentDefinition resources.
+	for _, cd := range componentDefinitionList.Items {
+		fmt.Printf("ComponentDefinition: %s\n", cd.Name)
+	}
+}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 98a2d8a</samp>

### Summary
:sparkles::books::bulb:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which in this case is the Go program that fetches and prints the ComponentDefinition resources.
2.  :books: - This emoji represents the addition of documentation or comments, which in this case is the explanation of the code and the pull request purpose.
3.  :bulb: - This emoji represents the addition of an idea or suggestion, which in this case is the demonstration of how to use the controller-runtime client library to interact with the KubeVela API.
-->
Added a Go program in `vscode/src/fetching.go` that fetchs and prints ComponentDefinition resources using the controller-runtime client library. The program is an example for users who want to use the client library to interact with the KubeVela API.

> _`Go` code fetches `ComponentDefinition`_
> _Using controller-runtime client_
> _A KubeVela example_

### Walkthrough
* Create a Go program to fetch and print ComponentDefinition resources from a Kubernetes cluster using the controller-runtime client library ([link](https://github.com/kubevela/kubevela/pull/6100/files?diff=unified&w=0#diff-df31637c24d1d32504702035b9a1f6b8d813a36003468fba0b78158fecc93c02R1-R50)-)



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5366 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->