### PR TITLE
Fix: vela addon registry add allow redirect

### DIFF
--- a/references/cli/addon-registry.go
+++ b/references/cli/addon-registry.go
@@ -86,6 +86,7 @@ add a specified gitlab registry: vela addon registry add my-repo --type gitlab -
 					Username:        registry.Helm.Username,
 					Password:        registry.Helm.Password,
 					InsecureSkipTLS: registry.Helm.InsecureSkipTLS,
+					AllowRedirect:   true,
 				})
 				_, err = versionedRegistry.ListAddon()
 				if err != nil {


### PR DESCRIPTION
### Description of your changes

In #5000, to avoid SSRF security issue, the http client is configured to forbid redirection. However, at the Client side, we do not to handle the SSRF issue and the client-side validation for the registry url should allow redirection.

If not supported, registry like https://kubevela.github.io/catalog/official will not be able to add directly as it is redirected to https://kubevela.io/catalog/official.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->