### PR TITLE
Chore: remove useless envbinding env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.sum go.sum
 
 # It's a proxy for CN developer, please unblock it if you have network issue
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY:-https://goproxy.cn}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 # Build the cli binary
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19-alpine@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb as builder
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY:-https://goproxy.cn}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -334,12 +334,11 @@ const (
 type OAMObjectReference struct {
 	Component string `json:"component,omitempty"`
 	Trait     string `json:"trait,omitempty"`
-	Env       string `json:"env,omitempty"`
 }
 
 // Equal check if two references are equal
 func (in OAMObjectReference) Equal(r OAMObjectReference) bool {
-	return in.Component == r.Component && in.Trait == r.Trait && in.Env == r.Env
+	return in.Component == r.Component && in.Trait == r.Trait
 }
 
 // AddLabelsToObject add labels to object if properties are not empty
@@ -354,9 +353,6 @@ func (in OAMObjectReference) AddLabelsToObject(obj client.Object) {
 	if in.Trait != "" {
 		labels[oam.TraitTypeLabel] = in.Trait
 	}
-	if in.Env != "" {
-		labels[oam.LabelAppEnv] = in.Env
-	}
 	obj.SetLabels(labels)
 }
 
@@ -366,7 +362,6 @@ func NewOAMObjectReferenceFromObject(obj client.Object) OAMObjectReference {
 		return OAMObjectReference{
 			Component: labels[oam.LabelAppComponent],
 			Trait:     labels[oam.TraitTypeLabel],
-			Env:       labels[oam.LabelAppEnv],
 		}
 	}
 	return OAMObjectReference{}

--- a/apis/core.oam.dev/common/types_test.go
+++ b/apis/core.oam.dev/common/types_test.go
@@ -29,13 +29,12 @@ func TestOAMObjectReference(t *testing.T) {
 	o1 := OAMObjectReference{
 		Component: "component",
 		Trait:     "trait",
-		Env:       "env",
 	}
 	obj := &unstructured.Unstructured{}
 	o2 := NewOAMObjectReferenceFromObject(obj)
 	r.False(o2.Equal(o1))
 	o1.AddLabelsToObject(obj)
-	r.Equal(3, len(obj.GetLabels()))
+	r.Equal(2, len(obj.GetLabels()))
 	o3 := NewOAMObjectReferenceFromObject(obj)
 	r.True(o1.Equal(o3))
 	o3.Component = "comp"

--- a/apis/core.oam.dev/v1beta1/resourcetracker_types.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types.go
@@ -185,7 +185,7 @@ func (in *ManagedResource) ResourceKey() string {
 
 // ComponentKey computes the key for the component which managed resource belongs to
 func (in *ManagedResource) ComponentKey() string {
-	return strings.Join([]string{in.Env, in.Component}, "/")
+	return strings.Join([]string{in.Cluster, in.Component}, "/")
 }
 
 // UnmarshalTo unmarshal ManagedResource into target object

--- a/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types_test.go
@@ -124,14 +124,13 @@ func TestManagedResourceKeys(t *testing.T) {
 			},
 		},
 		OAMObjectReference: common.OAMObjectReference{
-			Env:       "env",
 			Component: "component",
 			Trait:     "trait",
 		},
 	}
 	r.Equal("namespace/name", input.NamespacedName().String())
 	r.Equal("apps/Deployment/cluster/namespace/name", input.ResourceKey())
-	r.Equal("env/component", input.ComponentKey())
+	r.Equal("cluster/component", input.ComponentKey())
 	r.Equal("Deployment name (Cluster: cluster, Namespace: namespace)", input.DisplayName())
 	var deploy1, deploy2 appsv1.Deployment
 	deploy1.Spec.Replicas = pointer.Int32(5)

--- a/charts/vela-core/crds/core.oam.dev_resourcetrackers.yaml
+++ b/charts/vela-core/crds/core.oam.dev_resourcetrackers.yaml
@@ -82,8 +82,6 @@ spec:
                     deleted:
                       description: Deleted marks the resource to be deleted
                       type: boolean
-                    env:
-                      type: string
                     fieldPath:
                       description: 'If referring to a piece of an object instead of
                         an entire object, this string should contain a valid JSON/Go

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -80,9 +80,6 @@ const (
 	// LabelAddonRegistry indicates the name of addon-registry
 	LabelAddonRegistry = "addons.oam.dev/registry"
 
-	// LabelAppEnv records the name of Env
-	LabelAppEnv = "envbinding.oam.dev/env"
-
 	// LabelNamespaceOfEnvName records the env name of namespace
 	LabelNamespaceOfEnvName = "namespace.oam.dev/env"
 

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -345,7 +345,7 @@ HealthCheck:
 			break HealthCheck
 		}
 		checkResults := slices.ParMap[*applyTask, *applyTaskResult](checkTasks, func(task *applyTask) *applyTaskResult {
-			healthy, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace, "")
+			healthy, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
 			task.healthy = pointer.Bool(healthy)
 			if healthy {
 				err = task.generateOutput(output, outputs, cache, makeValue)
@@ -381,7 +381,7 @@ HealthCheck:
 			if err != nil {
 				return &applyTaskResult{healthy: false, err: err, task: task}
 			}
-			_, _, healthy, err := apply(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace, "")
+			_, _, healthy, err := apply(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
 			if err != nil {
 				return &applyTaskResult{healthy: healthy, err: err, task: task}
 			}

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -114,12 +114,12 @@ func TestApplyComponentsDepends(t *testing.T) {
 	}
 
 	applyMap := &sync.Map{}
-	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
 		return nil, nil, true, nil
 	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
 		return found, nil, nil, nil
 	}
@@ -158,12 +158,12 @@ func TestApplyComponentsIO(t *testing.T) {
 		applyMap    = new(sync.Map)
 		ctx         = context.Background()
 	)
-	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+	apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
 		return nil, nil, true, nil
 	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
 		return found, &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -293,7 +293,7 @@ func TestApplyComponentsIO(t *testing.T) {
 			output  *unstructured.Unstructured
 			outputs []*unstructured.Unstructured
 		}
-		apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+		apply := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 			time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 			key := storeKey(clusterName, comp)
 			result := applyResult{
@@ -320,7 +320,7 @@ func TestApplyComponentsIO(t *testing.T) {
 			applyMap.Store(storeKey(clusterName, comp), result)
 			return nil, nil, true, nil
 		}
-		healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+		healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 			key := storeKey(clusterName, comp)
 			r, found := applyMap.Load(key)
 			result, _ := r.(applyResult)

--- a/pkg/workflow/providers/oam/apply_test.go
+++ b/pkg/workflow/providers/oam/apply_test.go
@@ -185,7 +185,7 @@ func TestLoadComponentInOrder(t *testing.T) {
 
 var testHealthy bool
 
-func simpleComponentApplyForTest(_ context.Context, comp common.ApplicationComponent, _ *value.Value, _, _, _ string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+func simpleComponentApplyForTest(_ context.Context, comp common.ApplicationComponent, _ *value.Value, _, _ string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 	workload := new(unstructured.Unstructured)
 	workload.UnmarshalJSON([]byte(`{
   "apiVersion": "v1",


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The "env" parameter for envbinding is not used as the envbinding is deprecated for a while and removed in this version.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->