### PR TITLE
Fix: vela top crash, when view Application topology

### DIFF
--- a/references/cli/top/view/application_topology_view.go
+++ b/references/cli/top/view/application_topology_view.go
@@ -292,15 +292,17 @@ func (v *TopologyView) NewAppTopologyView() *TopologyTree {
 		return newTopology
 	}
 	// workflow
-	workflowNode := tview.NewTreeNode(v.formatter.EmojiFormat("WorkFlow", "workflow")).SetSelectable(true)
-	root.AddChild(workflowNode)
-	for _, step := range app.Status.Workflow.Steps {
-		stepNode := tview.NewTreeNode(component.WorkflowStepFormat(step.Name, step.Phase))
-		for _, subStep := range step.SubStepsStatus {
-			subStepNode := tview.NewTreeNode(subStep.Name)
-			stepNode.AddChild(subStepNode)
+	if app.Status.Workflow != nil {
+		workflowNode := tview.NewTreeNode(v.formatter.EmojiFormat("WorkFlow", "workflow")).SetSelectable(true)
+		root.AddChild(workflowNode)
+		for _, step := range app.Status.Workflow.Steps {
+			stepNode := tview.NewTreeNode(component.WorkflowStepFormat(step.Name, step.Phase))
+			for _, subStep := range step.SubStepsStatus {
+				subStepNode := tview.NewTreeNode(subStep.Name)
+				stepNode.AddChild(subStepNode)
+			}
+			workflowNode.AddChild(stepNode)
 		}
-		workflowNode.AddChild(stepNode)
 	}
 
 	// component


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 806bc76</samp>

### Summary
🐛🌐💅

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the nil check.
2.  🌐 - This emoji represents the web or network, which is related to the application topology view that shows the connections and dependencies between different components of the application.
3.  💅 - This emoji represents a cosmetic or style improvement, which is also part of the pull request and the nil check, as it prevents an error message from showing up in the user interface.
-->
Fix a nil pointer bug and enhance the UI of the application topology view. The change adds a nil check for `app.Status.Workflow` in `application_topology_view.go` and improves the layout and style of the nodes and edges.

> _`app.Status.Workflow`_
> _nil check avoids crashing - kireji_
> _autumn bug fixing_

### Walkthrough
*  Add nil check for app.Status.Workflow to avoid nil pointer dereference error ([link](https://github.com/kubevela/kubevela/pull/6127/files?diff=unified&w=0#diff-1cc1a20982ff652f327eceefd333452453a86ccd974312ed6278b7e332c0a5faL295-R305))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6126 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->