### PR TITLE
Chore: add cache/informer ut

### DIFF
--- a/pkg/cache/informer_test.go
+++ b/pkg/cache/informer_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+)
+
+func TestObjectCache_Get(t *testing.T) {
+	type testCase[T any] struct {
+		name string
+		in   ObjectCache[T]
+		hash string
+		want *T
+	}
+	tests := []testCase[string]{
+		{
+			name: "test cache not found",
+			in:   ObjectCache[string]{},
+			hash: "test",
+			want: nil,
+		},
+		{
+			name: "test cache found",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr:  pointer.String("test"),
+						refs: map[string]sets.Empty{},
+					},
+				},
+			},
+			hash: "test",
+			want: pointer.String("test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Get(tt.hash); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectCache_Add(t *testing.T) {
+	type args[T any] struct {
+		hash string
+		obj  *T
+		ref  string
+	}
+	type testCase[T any] struct {
+		name string
+		in   ObjectCache[T]
+		args args[T]
+		want *T
+	}
+	tests := []testCase[string]{
+		{
+			name: "test cache not found should add",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr:  pointer.String("test"),
+						refs: map[string]sets.Empty{},
+					},
+				},
+			},
+			args: args[string]{
+				hash: "test2",
+				obj:  pointer.String("test2"),
+			},
+			want: pointer.String("test2"),
+		},
+		{
+			name: "test cache found should update",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr:  pointer.String("test"),
+						refs: map[string]sets.Empty{},
+					},
+				},
+			},
+			args: args[string]{
+				hash: "test",
+				obj:  pointer.String("test"),
+			},
+			want: pointer.String("test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Add(tt.args.hash, tt.args.obj, tt.args.ref); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Add() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectCache_DeleteRef(t *testing.T) {
+	type args struct {
+		hash string
+		ref  string
+	}
+	type testCase[T any] struct {
+		name     string
+		in       ObjectCache[T]
+		args     args
+		validate func(in *ObjectCache[T]) bool
+	}
+	tests := []testCase[string]{
+		{
+			name: "test cache not found should do nothing",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr:  pointer.String("test"),
+						refs: map[string]sets.Empty{},
+					},
+				},
+			},
+			args: args{
+				hash: "test2",
+				ref:  "test2",
+			},
+			validate: func(in *ObjectCache[string]) bool {
+				return len(in.objects) == 1
+			},
+		},
+		{
+			name: "test cache found should delete",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr: pointer.String("test"),
+					},
+				},
+			},
+			args: args{
+				hash: "test",
+				ref:  "test",
+			},
+			validate: func(in *ObjectCache[string]) bool {
+				return len(in.objects) == 0
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.in.DeleteRef(tt.args.hash, tt.args.ref)
+			if !tt.validate(&tt.in) {
+				t.Errorf("DeleteRef() = %v", tt.in)
+			}
+		})
+	}
+}
+
+func TestObjectCache_Size(t *testing.T) {
+	type testCase[T any] struct {
+		name string
+		in   ObjectCache[T]
+		want int
+	}
+	tests := []testCase[string]{
+		{
+			name: "normal test",
+			in: ObjectCache[string]{
+				objects: map[string]*ObjectCacheEntry[string]{
+					"test": {
+						ptr:  pointer.String("test"),
+						refs: map[string]sets.Empty{},
+					},
+					"test2": {
+						ptr:  pointer.String("test2"),
+						refs: map[string]sets.Empty{},
+					},
+				},
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Size(); got != tt.want {
+				t.Errorf("Size() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectCache_Prune(t *testing.T) {
+	in := NewObjectCache[string]()
+	in.Add("test", pointer.String("test"), "test")
+	in.Add("test2", pointer.String("test2"), "test")
+	in.Add("test3", pointer.String("test3"), "test")
+	time.Sleep(200 * time.Millisecond)
+	in.Prune(100 * time.Millisecond)
+	assert.True(t, in.Size() == 0)
+}


### PR DESCRIPTION
### Description of your changes

fix cache/informer some NPE and add ut.
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a322902</samp>

### Summary
🧪🐛⚡

<!--
1.  🧪 for adding unit tests
2.  🐛 for fixing bugs
3.  ⚡ for optimizing performance
-->
This pull request improves the reliability and performance of the `ObjectCache` struct in the `pkg/cache` package, which is used to cache Kubernetes resources and definitions. It fixes some potential nil pointer errors, and uses a more efficient way to prune the cache periodically. It also adds unit tests for the cache functionality.



### Walkthrough
* Fix nil pointer dereference bugs in `ObjectCache` struct and methods ([link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813R69-R73), [link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L79-R94), [link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813R110-R114))
* Add unit tests for `ObjectCache` struct and methods in `informer_test.go` ([link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-93215eea536be8aa68981f2a480908f7f76e11eda020161a24ec75b9f53a1623R1-R221))
* Optimize periodic pruning of caches by using `time.Ticker` channel instead of `time.Sleep` ([link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L201-R226), [link](https://github.com/kubevela/kubevela/pull/6130/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L215))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->