### PR TITLE
Chore: refactor regiestry.go

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -338,10 +338,7 @@ func readTemplate(a *InstallPackage, reader AsyncReader, readPath string) error 
 
 	// try to check it's a valid app template
 	_, _, err = dec.Decode([]byte(data), nil, a.AppTemplate)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func readAppCueTemplate(a *InstallPackage, reader AsyncReader, readPath string) error {
@@ -473,11 +470,7 @@ func readMetadata(a *UIData, reader AsyncReader, readPath string) error {
 	if err != nil {
 		return err
 	}
-	err = yaml.Unmarshal([]byte(b), &a.Meta)
-	if err != nil {
-		return err
-	}
-	return nil
+	return yaml.Unmarshal([]byte(b), &a.Meta)
 }
 
 func readReadme(a *UIData, reader AsyncReader, readPath string) error {
@@ -530,7 +523,7 @@ func createGitlabHelper(content *utils.Content, token string) (*gitlabHelper, er
 	}, err
 }
 
-// readRepo will read relative path (relative to Meta.Path)
+// readRepo will read a relative path (relative to Meta.Path)
 func (h *gitHelper) readRepo(relativePath string) (*github.RepositoryContent, []*github.RepositoryContent, error) {
 	file, items, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.GithubContent.Owner, h.Meta.GithubContent.Repo, path.Join(h.Meta.GithubContent.Path, relativePath), nil)
 	if err != nil {
@@ -539,7 +532,7 @@ func (h *gitHelper) readRepo(relativePath string) (*github.RepositoryContent, []
 	return file, items, nil
 }
 
-// readRepo will read relative path (relative to Meta.Path)
+// readRepo will read a relative path (relative to Meta.Path)
 func (h *giteeHelper) readRepo(relativePath string) (*github.RepositoryContent, []*github.RepositoryContent, error) {
 	file, items, err := h.Client.GetGiteeContents(context.Background(), h.Meta.GiteeContent.Owner, h.Meta.GiteeContent.Repo, path.Join(h.Meta.GiteeContent.Path, relativePath), h.Meta.GiteeContent.Ref)
 	if err != nil {
@@ -723,7 +716,7 @@ func RenderConfigTemplates(addon *InstallPackage, cli client.Client) ([]*unstruc
 func RenderDefinitionSchema(addon *InstallPackage) ([]*unstructured.Unstructured, error) {
 	schemaConfigmaps := make([]*unstructured.Unstructured, 0)
 
-	// No matter runtime mode or control mode , definition schemas only needs to control plane k8s.
+	// No matter runtime mode or control mode, definition schemas only needs to control plane k8s.
 	for _, teml := range addon.DefSchemas {
 		u, err := renderSchemaConfigmap(teml)
 		if err != nil {

--- a/pkg/addon/push.go
+++ b/pkg/addon/push.go
@@ -268,6 +268,8 @@ func handlePushResponse(resp *http.Response) error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
+
 		return getChartMuseumError(b, resp.StatusCode)
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "%s\n", color.GreenString("Done"))

--- a/pkg/cache/informer.go
+++ b/pkg/cache/informer.go
@@ -58,7 +58,7 @@ type ObjectCache[T any] struct {
 // NewObjectCache create an object cache
 func NewObjectCache[T any]() *ObjectCache[T] {
 	return &ObjectCache[T]{
-		objects: map[string]*ObjectCacheEntry[T]{},
+		objects: make(map[string]*ObjectCacheEntry[T]),
 	}
 }
 
@@ -66,6 +66,7 @@ func NewObjectCache[T any]() *ObjectCache[T] {
 func (in *ObjectCache[T]) Get(hash string) *T {
 	in.mu.RLock()
 	defer in.mu.RUnlock()
+
 	if entry, found := in.objects[hash]; found {
 		return entry.ptr
 	}
@@ -76,6 +77,7 @@ func (in *ObjectCache[T]) Get(hash string) *T {
 func (in *ObjectCache[T]) Add(hash string, obj *T, ref string) *T {
 	in.mu.Lock()
 	defer in.mu.Unlock()
+
 	if entry, found := in.objects[hash]; found {
 		entry.refs.Insert(ref)
 		entry.lastAccessed = time.Now()
@@ -93,6 +95,7 @@ func (in *ObjectCache[T]) Add(hash string, obj *T, ref string) *T {
 func (in *ObjectCache[T]) DeleteRef(hash string, ref string) {
 	in.mu.Lock()
 	defer in.mu.Unlock()
+
 	if entry, found := in.objects[hash]; found {
 		entry.refs.Delete(ref)
 		if entry.refs.Len() == 0 {
@@ -197,12 +200,16 @@ func (in *DefinitionCache) Start(ctx context.Context, store cache.Cache, duratio
 	})
 	if err != nil {
 		klog.ErrorS(err, "failed to add event handler for definition cache")
+		return
 	}
+
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
+		case <-ticker.C:
 			t0 := time.Now()
 			compDefPruned := in.ComponentDefinitionCache.Prune(duration)
 			traitDefPruned := in.TraitDefinitionCache.Prune(duration)
@@ -212,7 +219,6 @@ func (in *DefinitionCache) Start(ctx context.Context, store cache.Cache, duratio
 				in.TraitDefinitionCache.Size(), traitDefPruned,
 				in.WorkflowStepDefinitionCache.Size(), wsDefPruned,
 				time.Since(t0).Microseconds())
-			time.Sleep(duration)
 		}
 	}
 }

--- a/pkg/component/ref_objects.go
+++ b/pkg/component/ref_objects.go
@@ -110,7 +110,10 @@ func ClearRefObjectForDispatch(un *unstructured.Unstructured) {
 	un.SetUID("")
 	unstructured.RemoveNestedField(un.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(un.Object, "status")
-	// TODO(somefive): make the following logic more generalizable
+	clearServiceForDispatch(un)
+}
+
+func clearServiceForDispatch(un *unstructured.Unstructured) {
 	if un.GetKind() == "Service" && un.GetAPIVersion() == "v1" {
 		if clusterIP, exist, _ := unstructured.NestedString(un.Object, "spec", "clusterIP"); exist && clusterIP != corev1.ClusterIPNone {
 			unstructured.RemoveNestedField(un.Object, "spec", "clusterIP")


### PR DESCRIPTION
### Description of your changes

Increase some code readability

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 35871b9</samp>

### Summary
🐛♻️🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the first change that prevents a resource leak.
2.  ♻️ - This emoji represents a refactor, which is the case for the second and fourth changes that improve the structure and design of the code.
3.  🎨 - This emoji represents a code style improvement, which is the case for the third and fifth changes that enhance the readability and idiomaticity of the code.
-->
This pull request enhances the code quality, readability, and performance of various files in the `pkg/addon` and `pkg/cache` packages. It fixes typos, simplifies error handling, refactors functions, and adds missing or best practices. It also extracts a new function for clearing services in the `pkg/component` package.

> _We close the body, we clear the service_
> _We fix the typos, we unlock the mutex_
> _We refactor `AddRegistry`, we use `make` for maps_
> _We are the masters of the `pkg` domain_

### Walkthrough
*  Simplify error handling by returning errors directly instead of checking and returning nil ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL341-R341), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL476-R473), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-27533b4b8b95315cfb61b410ba838f06c01d86e798141623f78b94b3490fae28L122-R132), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-27533b4b8b95315cfb61b410ba838f06c01d86e798141623f78b94b3490fae28L145-R153), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-27533b4b8b95315cfb61b410ba838f06c01d86e798141623f78b94b3490fae28L171-R177))
*  Fix typos and add missing articles and commas in comments ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL533-R526), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL542-R535), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL726-R719))
*  Move constants `registryConfigMapName` and `registriesKey` from `pkg/addon/registry.go` to `pkg/addon/addon.go` for better accessibility and consistency ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-27533b4b8b95315cfb61b410ba838f06c01d86e798141623f78b94b3490fae28L33-R36))
*  Extract new function `addRegistryIfNotExist` from `AddRegistry` to reduce complexity and nesting and make logic more clear and reusable ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-27533b4b8b95315cfb61b410ba838f06c01d86e798141623f78b94b3490fae28L86-R92))
*  Add `defer` statements to unlock mutex and close response body after using them to ensure proper resource release and avoid potential leaks ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL218-R219), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-97fa5cdf5bc9e4c57753e2cb8617a481dc2af1c52359aca4d66fe8ac8773726dR271-R274))
*  Replace explicit map initialization with `make` function for idiomatic and consistent code ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L61-R61))
*  Add blank lines to separate function declarations from comments for readability and formatting ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813R69), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813R80), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813R98))
*  Replace `time.Sleep` with `time.Ticker` for periodic pruning of definition cache for efficiency and accuracy and stop pruning when context is done ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L200-R212), [link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-43c1ebfc58ee910a1f1238044422e372460b02454918ab1f1df9f12bdf3a2813L215))
*  Extract new function `clearServiceForDispatch` from `ClearRefObjectForDispatch` to reduce complexity and nesting and make logic more modular and testable ([link](https://github.com/kubevela/kubevela/pull/6131/files?diff=unified&w=0#diff-d9b52ea46ba18325118d266c81330b0c67d4c23d8ce004e38c2fdb6728b47d0fL113-R116))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->