### PR TITLE
Fix: addon registry use kubevela.github.io and support redirect

### DIFF
--- a/charts/vela-core/templates/addon_registry.yaml
+++ b/charts/vela-core/templates/addon_registry.yaml
@@ -8,7 +8,7 @@ data:
   "KubeVela":{
     "name": "KubeVela",
     "helm": {
-      "url": "https://addons.kubevela.net"
+      "url": "https://kubevela.github.io/catalog/official"
     }
   }
 }'

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -996,6 +996,7 @@ func listAddons(ctx context.Context, clt client.Client, registry string) (*uitab
 				Username:        r.Helm.Username,
 				Password:        r.Helm.Password,
 				InsecureSkipTLS: r.Helm.InsecureSkipTLS,
+				AllowRedirect:   true,
 			})
 			addonList, err = versionedRegistry.ListAddon()
 			if err != nil {


### PR DESCRIPTION
### Description of your changes

1. Let the default addon registry installed to be "kubevela.github.io".
2. Fix redirect forbidden while running `vela addon list`.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->