### PR TITLE
Fix: vela dry-run can not render app if x-def is not installed in vela-system

### DIFF
--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -53,14 +53,14 @@ var _ = Describe("Test Kubectl Plugin", func() {
 			err := os.WriteFile("dry-run-app.yaml", []byte(application), 0644)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() string {
-				output, _ := e2e.Exec("kubectl-vela dry-run -f dry-run-app.yaml -n vela-system")
+				output, _ := e2e.Exec("kubectl-vela dry-run -f dry-run-app.yaml -n default -x default")
 				return output
 			}, 10*time.Second, time.Second).Should(ContainSubstring(dryRunResult))
 		})
 
 		It("Test dry-run application use definitions in local", func() {
 			Eventually(func() string {
-				output, _ := e2e.Exec("kubectl-vela dry-run -f dry-run-app.yaml -d definitions")
+				output, _ := e2e.Exec("kubectl-vela dry-run -f dry-run-app.yaml -n default -d definitions")
 				return output
 			}, 10*time.Second, time.Second).Should(ContainSubstring(dryRunResult))
 		})

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -954,3 +954,29 @@ func TestConvertDefinitionRevName(t *testing.T) {
 		}
 	}
 }
+
+func TestXDefinitionNamespaceInCtx(t *testing.T) {
+	testcases := []struct {
+		namespace         string
+		expectedNamespace string
+	}{{
+		namespace:         "",
+		expectedNamespace: oam.SystemDefinitionNamespace,
+	}, {
+		namespace:         oam.SystemDefinitionNamespace,
+		expectedNamespace: oam.SystemDefinitionNamespace,
+	}, {
+		namespace:         "my-vela-system",
+		expectedNamespace: "my-vela-system"},
+	}
+
+	ctx := context.Background()
+	ns := util.GetXDefinitionNamespaceWithCtx(ctx)
+	assert.Equal(t, oam.SystemDefinitionNamespace, ns)
+
+	for _, tc := range testcases {
+		ctx = util.SetXDefinitionNamespaceInCtx(ctx, tc.namespace)
+		ns = util.GetXDefinitionNamespaceWithCtx(ctx)
+		assert.Equal(t, tc.expectedNamespace, ns)
+	}
+}

--- a/pkg/policy/override_test.go
+++ b/pkg/policy/override_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -39,6 +41,7 @@ func TestParseOverridePolicyRelatedDefinitions(t *testing.T) {
 	r := require.New(t)
 	app := &v1beta1.Application{}
 	app.SetNamespace("test")
+	ctx := oamutil.SetNamespaceInCtx(context.Background(), "test")
 	testCases := map[string]struct {
 		Policy        v1beta1.AppPolicy
 		ComponentDefs []*v1beta1.ComponentDefinition
@@ -71,7 +74,7 @@ func TestParseOverridePolicyRelatedDefinitions(t *testing.T) {
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {
-			compDefs, traitDefs, err := ParseOverridePolicyRelatedDefinitions(context.Background(), cli, app, tt.Policy)
+			compDefs, traitDefs, err := ParseOverridePolicyRelatedDefinitions(ctx, cli, app, tt.Policy)
 			if tt.Error != "" {
 				r.NotNil(err)
 				r.Contains(err.Error(), tt.Error)

--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -18,16 +18,16 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	wfv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
-
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
@@ -236,4 +236,26 @@ var _ = Describe("Testing dry-run", func() {
 		Expect(buff.String()).Should(ContainSubstring("kind: Deployment"))
 		Expect(buff.String()).Should(ContainSubstring("workload.oam.dev/type: myworker"))
 	})
+
+	It("Testing dry-run with default application namespace", func() {
+		c := common2.Args{}
+		c.SetConfig(cfg)
+		c.SetClient(k8sClient)
+		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml"}, OfflineMode: false}
+		buff, err := DryRunApplication(&opt, c, "")
+		Expect(err).Should(BeNil())
+		Expect(buff.String()).Should(ContainSubstring("namespace: default"))
+	})
+
+	It("Testing dry-run with customized application namespace", func() {
+		appNamespace := "test-namespace"
+		c := common2.Args{}
+		c.SetConfig(cfg)
+		c.SetClient(k8sClient)
+		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml"}, OfflineMode: false}
+		buff, err := DryRunApplication(&opt, c, appNamespace)
+		Expect(err).Should(BeNil())
+		Expect(buff.String()).Should(ContainSubstring(fmt.Sprintf("namespace: %s", appNamespace)))
+	})
+
 })


### PR DESCRIPTION
…t/Trait) is not installed to vela-system namespace


### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c9a7a2</samp>

### Summary
🧪🛠️♻️

<!--
1.  🧪 - This emoji represents testing, and can be used for the first change that adds a new test function.
2.  🛠️ - This emoji represents fixing or improving, and can be used for the second and third changes that improve the namespace handling and the `util` package.
3.  ♻️ - This emoji represents refactoring or cleaning, and can be used for the fourth, fifth, and sixth changes that remove unused imports and use a common utility function.
-->
This pull request enhances the `vela system dry-run` command to support customized x-definition namespaces. It also refactors and tests the `oamutil` and `policy` packages to use the namespace from the context when getting x-definitions.

> _`Dry-run` the system, unleash the power_
> _Customize the namespace, don't let them cower_
> _`X-definition` is the key, to control the fate_
> _`Oamutil` is the tool, to test and create_

### Walkthrough
*  Add a new flag `--definition-namespace` to the `vela system dry-run` command to allow the user to specify the namespace where the x-definition is installed ([link](https://github.com/kubevela/kubevela/pull/6135/files?diff=unified&w=0#diff-bb490b4117632c5562036df93592576992d37d74028de1ab0ff26cfe9403d2f1R122), [link](https://github.com/kubevela/kubevela/pull/6135/files?diff=unified&w=0#diff-bb490b4117632c5562036df93592576992d37d74028de1ab0ff26cfe9403d2f1R58)).



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6134 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

1. if user install x-definition(Component/Trait) to customized namespace, which is not default vela-system, user need specify the namespace, when dry run application

```
vela dry-run -f application.yaml -x my-system 
```

2. if user specify `-n`, vela cli will render the  Application to specified namespace

```
[root@I sample]# ../../bin/vela dry-run -f firstapp.yaml -n abc
---
# Application(first-vela-app with topology target-default) -- Component(express-server) 
---

apiVersion: apps/v1
kind: Deployment
metadata:
  annotations: {}
  labels:
    app.oam.dev/appRevision: ""
    app.oam.dev/component: express-server
    app.oam.dev/name: first-vela-app
    app.oam.dev/namespace: abc
    app.oam.dev/resourceType: WORKLOAD
    workload.oam.dev/type: webservice
  name: express-server
  namespace: abc
spec:
  replicas: 1
  selector:
    matchLabels:
      app.oam.dev/component: express-server
  template:
    metadata:
      labels:
        app.oam.dev/component: express-server
        app.oam.dev/name: first-vela-app
    spec:
      containers:
      - image: oamdev/hello-world
        name: express-server
        ports:
        - containerPort: 8000
          name: port-8000
          protocol: TCP

---
```

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->