### PR TITLE
Chore: pend issue-command bot action

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -9,31 +9,31 @@ permissions:
   contents: read
 
 jobs:
-  bot:
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Checkout Actions
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          repository: "oam-dev/kubevela-github-actions"
-          path: ./actions
-          ref: v0.4.2
-      - name: Setup Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version: '14'
-          cache: 'npm'
-          cache-dependency-path: ./actions/package-lock.json
-      - name: Install Dependencies
-        run: npm ci --production --prefix ./actions
-      - name: Run Commands
-        uses: ./actions/commands
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          configPath: issue-commands
+#  bot:
+#    runs-on: ubuntu-22.04
+#    permissions:
+#      pull-requests: write
+#      issues: write
+#    steps:
+#      - name: Checkout Actions
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+#        with:
+#          repository: "oam-dev/kubevela-github-actions"
+#          path: ./actions
+#          ref: v0.4.2
+#      - name: Setup Node.js
+#        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+#        with:
+#          node-version: '14'
+#          cache: 'npm'
+#          cache-dependency-path: ./actions/package-lock.json
+#      - name: Install Dependencies
+#        run: npm ci --production --prefix ./actions
+#      - name: Run Commands
+#        uses: ./actions/commands
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          configPath: issue-commands
 
   backport:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description of your changes

Pend the "bot" action for issue-command github workflow as it always fails (due to lack of permission) and has not been working for a long time (but report errors everytime anyone make a comment).

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->