### PR TITLE
Fix: arm64 build, rm --platform flags in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19-alpine@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb as builder
+FROM golang:1.19-alpine3.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -34,7 +34,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
 # You can replace distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
-FROM ${BASE_IMAGE:-alpine@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501}
+FROM ${BASE_IMAGE:-alpine:3.18}
 # This is required by daemon connecting with cri
 RUN apk add --no-cache ca-certificates bash expat
 


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 26b3271</samp>

### Summary
🐳🌐🛠️

<!--
1.  🐳 - This emoji represents Docker and anything related to containerization, so it is suitable for changes in the Dockerfile or the build process of the image.
2.  🌐 - This emoji represents the web or the internet, so it is suitable for changes that enable multi-arch support or cross-platform compatibility, as these features expand the reach and accessibility of the application.
3.  🛠️ - This emoji represents tools or improvements, so it is suitable for changes that enhance the functionality or performance of the application, such as removing hard-coded values or enabling more flexibility.
-->
Improved Dockerfile to support multi-arch builds. Removed platform and digest constraints from `Dockerfile`.

> _No more chains of platform and digest_
> _We break free from the Dockerfile_
> _Multi-arch builds for kubevela_
> _We unleash the power of the cloud_

### Walkthrough
* Remove hard-coded platform from `FROM` instruction to enable multi-arch builds ([link](https://github.com/kubevela/kubevela/pull/6170/files?diff=unified&w=0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3))
* Remove digest from default `BASE_IMAGE` value to pull latest alpine image based on platform ([link](https://github.com/kubevela/kubevela/pull/6170/files?diff=unified&w=0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L37-R37))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6167,  fixes #6164

I have:

- [x ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- forked repo
- done changes
- run gh actions (registry.yml) https://github.com/audacioustux/kubevela/actions/runs/5416564251/jobs/9846449553
- tested image pushed in docker hub in my own account, on aarch64 architecture `docker run --rm -it tanjim/vela-core:latest`

### Special notes for your reviewer

i might be wrong, but i had tried only removing the @sha256 part (that points to amd64 image) - and that didn't work. so removed both --platform and `@sha256:*`