### PR TITLE
Chore: swtich between old and new registry in vela install

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -190,7 +190,7 @@ func NewVersionListCommand(ioStream util.IOStreams) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			helmHelper := helm.NewHelper()
-			versions, err := helmHelper.ListVersions(kubevelaInstallerHelmRepoURL, kubeVelaChartName, true, nil)
+			versions, err := helmHelper.ListVersions(LegacyKubeVelaInstallerHelmRepoURL, kubeVelaChartName, true, nil)
 			if err != nil {
 				return err
 			}

--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -46,8 +46,6 @@ import (
 	innerVersion "github.com/oam-dev/kubevela/version"
 )
 
-// defaultConstraint
-// const defaultConstraint = ">= 1.19
 const defaultConstraint = ">= 1.19"
 
 const (
@@ -111,7 +109,7 @@ func NewInstallCommand(c common.Args, order string, ioStreams util.IOStreams) *c
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			v, err := version.NewVersion(innerVersion.VelaVersion)
+			v, err := version.NewVersion(installArgs.Version)
 			if err != nil {
 				return err
 			}

--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -50,8 +50,12 @@ import (
 // const defaultConstraint = ">= 1.19
 const defaultConstraint = ">= 1.19"
 
-const LegacyKubeVelaInstallerHelmRepoURL = "https://charts.kubevela.net/core/"
-const KubeVelaInstallerHelmRepoURL = "https://kubevela.github.io/charts/"
+const (
+	// LegacyKubeVelaInstallerHelmRepoURL is used for kubevela version < v1.9.0
+	LegacyKubeVelaInstallerHelmRepoURL = "https://charts.kubevela.net/core/"
+	// KubeVelaInstallerHelmRepoURL is used for kubevela version >= v1.9.0
+	KubeVelaInstallerHelmRepoURL = "https://kubevela.github.io/charts/"
+)
 
 // kubeVelaReleaseName release name
 const kubeVelaReleaseName = "kubevela"

--- a/references/cli/install_test.go
+++ b/references/cli/install_test.go
@@ -19,14 +19,37 @@ package cli
 import (
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetKubeVelaHelmChartRepoURL(t *testing.T) {
-	assert.Equal(t, getKubeVelaHelmChartRepoURL("v1.2.2"), "https://kubevela.github.io/charts/vela-core-1.2.2.tgz")
-	assert.Equal(t, getKubeVelaHelmChartRepoURL("1.1.11"), "https://kubevela.github.io/charts/vela-core-1.1.11.tgz")
+	cases := []struct {
+		ver string
+		url string
+	}{
+		{
+			ver: "v1.2.2",
+			url: "https://charts.kubevela.net/core/vela-core-1.2.2.tgz",
+		},
+		{
+			ver: "1.1.11",
+			url: "https://charts.kubevela.net/core/vela-core-1.1.11.tgz",
+		},
+		{
+			ver: "1.9.2",
+			// new helm repo
+			url: "https://kubevela.github.io/charts/vela-core-1.9.2.tgz",
+		},
+	}
+
+	for _, c := range cases {
+		v, err := version.NewVersion(c.ver)
+		assert.Nil(t, err)
+		assert.Equal(t, getKubeVelaHelmChartRepoURL(v), c.url)
+	}
 }
 
 var _ = Describe("Test Install Command", func() {

--- a/version/version.go
+++ b/version/version.go
@@ -44,3 +44,22 @@ func GetOfficialKubeVelaVersion(versionStr string) (string, error) {
 	}
 	return v[:len(v)-len(metadata)], nil
 }
+
+// ShouldUseLegacyHelmRepo checks whether the provided version should use the legacy helm repo
+func ShouldUseLegacyHelmRepo(ver *version.Version) bool {
+	if ver.LessThan(version.Must(version.NewVersion("1.8.2"))) {
+		return true
+	}
+
+	if ver.GreaterThanOrEqual(version.Must(version.NewVersion("1.9.0"))) {
+		return false
+	}
+
+	// After v1.9.0-beta.1.post1, we use the new helm repo
+	switch ver.Prerelease() {
+	case "beta.1.post1", "beta.2", "beta.3":
+		return false
+	default:
+		return true
+	}
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -19,6 +19,7 @@ package version
 import (
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,4 +41,34 @@ func TestGetVersion(t *testing.T) {
 	version, err = GetOfficialKubeVelaVersion("v1.2+myvela")
 	assert.Nil(t, err)
 	assert.Equal(t, "1.2.0", version)
+}
+
+func TestShouldUseLegacyHelmRepo(t *testing.T) {
+	tests := []struct {
+		ver  string
+		want bool
+	}{
+		{
+			ver:  "v1.2.0",
+			want: true,
+		},
+		{
+			ver:  "v1.9.0-beta.1",
+			want: true,
+		},
+		{
+			ver:  "v1.9.0-beta.1.post1",
+			want: false,
+		},
+		{
+			ver:  "v1.9.1",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ver, func(t *testing.T) {
+			ver := version.Must(version.NewVersion(tt.ver))
+			assert.Equalf(t, tt.want, ShouldUseLegacyHelmRepo(ver), "ShouldUseLegacyHelmRepo(%v)", tt.ver)
+		})
+	}
 }


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e14a0cb</samp>

### Summary
🐛🎁✅

<!--
1.  🐛 for fixing a bug in the `NewVersionListCommand` function.
2.  🎁 for adding a new function to the `version` package.
3.  ✅ for adding tests for the `cli` and `version` packages.
-->
This pull request updates the `cli` and `version` packages to support both the legacy and the new helm repo URLs for kubevela based on the current version. It also adds tests and fixes a bug in the `vela version list` command.

> _Sing, O Muse, of the valiant `cli` package, that fixed a bug_
> _In the `vela version list` command, which showed the wrong versions of kubevela_
> _By using the `version` package, which knows the helm repo URL to pick_
> _Whether the `LegacyKubeVelaInstallerHelmRepoURL` or the new one, as swift as a winged arrow_

### Walkthrough
*  Fix `vela version list` bug by using `LegacyKubeVelaInstallerHelmRepoURL` for legacy versions ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-004b35966c6dda784fba0fe64ddc863a10d0bab72fbedf97929daebc8d18d93dL193-R193))
*  Define two helm repo URLs for kubevela: `LegacyKubeVelaInstallerHelmRepoURL` and `KubeVelaInstallerHelmRepoURL` in `cli.go` ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-53f92465be81be5699bb1e7bcf9df14145e0cbada128d6b1e092e98f4b126132L50-R54))
*  Parse current kubevela version as a `version.Version` object in `NewInstallCommand` function in `install.go` ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-53f92465be81be5699bb1e7bcf9df14145e0cbada128d6b1e092e98f4b126132L109-R117))
*  Refactor `getKubeVelaHelmChartRepoURL` function in `install.go` to use `version` package and `ShouldUseLegacyHelmRepo` function ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-53f92465be81be5699bb1e7bcf9df14145e0cbada128d6b1e092e98f4b126132L285-R297))
*  Add `ShouldUseLegacyHelmRepo` function to `version` package to determine which helm repo URL to use based on the version ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-f6bf0ae0d21c9408c6624174da11dafb369ce306f2cdcea704285d8acc87e19eR47-R65))
*  Test `ShouldUseLegacyHelmRepo` function with different versions in `version_test.go` ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-ada1c2c495158d71be5d391cdacd2a0493a1b10a0eb161841f923d4d2345fc64R45-R74))
*  Test `getKubeVelaHelmChartRepoURL` function with different versions in `install_test.go` ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-d2908230bea8ed30b641fb44aef6e4f86be27d618e734aedf268400db60de452L28-R52))
*  Import `version` package in `install_test.go` and `version_test.go` ([link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-d2908230bea8ed30b641fb44aef6e4f86be27d618e734aedf268400db60de452R22), [link](https://github.com/kubevela/kubevela/pull/6173/files?diff=unified&w=0#diff-ada1c2c495158d71be5d391cdacd2a0493a1b10a0eb161841f923d4d2345fc64R22))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->