### PR TITLE
Fix: add deploy as built-in step to avoid parse in offline mode

### DIFF
--- a/pkg/workflow/step/generator.go
+++ b/pkg/workflow/step/generator.go
@@ -174,7 +174,7 @@ func (g *DeployWorkflowStepGenerator) Generate(app *v1beta1.Application, existin
 			steps = append(steps, workflowv1alpha1.WorkflowStep{
 				WorkflowStepBase: workflowv1alpha1.WorkflowStepBase{
 					Name:       "deploy",
-					Type:       "deploy",
+					Type:       DeployWorkflowStep,
 					Properties: util.Object2RawExtension(map[string]interface{}{"policies": append([]string{}, overrides...)}),
 				},
 			})
@@ -190,6 +190,7 @@ func IsBuiltinWorkflowStepType(wfType string) bool {
 		wftypes.WorkflowStepTypeApplyComponent,
 		wftypes.WorkflowStepTypeBuiltinApplyComponent,
 		wftypes.WorkflowStepTypeStepGroup,
+		DeployWorkflowStep,
 	} {
 		if _type == wfType {
 			return true

--- a/pkg/workflow/step/generator_test.go
+++ b/pkg/workflow/step/generator_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -289,4 +290,12 @@ func TestWorkflowStepGenerator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsBuiltinWorkflowStepType(t *testing.T) {
+	assert.True(t, IsBuiltinWorkflowStepType("deploy"))
+	assert.True(t, IsBuiltinWorkflowStepType("suspend"))
+	assert.True(t, IsBuiltinWorkflowStepType("apply-component"))
+	assert.True(t, IsBuiltinWorkflowStepType("step-group"))
+	assert.True(t, IsBuiltinWorkflowStepType("builtin-apply-component"))
 }


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 390384c</samp>

### Summary
🧪🔧🚀

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a unit test for a function.
2.  🔧 - This emoji represents tools, fixing, or improvement, and can be used to indicate the refactoring of a workflow step type to use a constant and improve code quality.
3.  🚀 - This emoji represents launching, deploying, or advancing, and can be used to indicate the enhancement of the workflow engine functionality by adding a builtin workflow step type check.
-->
Added a unit test and refactored the `deploy` workflow step type in `pkg/workflow/step` package. This enhances the test coverage and the readability of the workflow engine code.

> _`deploy` refactored_
> _unit test checks builtin types_
> _autumn of code quality_

### Walkthrough
*  Add `assert` package for testing assertions in `generator_test.go` ([link](https://github.com/kubevela/kubevela/pull/6201/files?diff=unified&w=0#diff-f1bbd89fedcec7c9078d1c6955b770dad4f78c0f35cf36d449728968dbe78412R23))
*  Change `deploy` workflow step type to use constant `DeployWorkflowStep` instead of literal string ([link](https://github.com/kubevela/kubevela/pull/6201/files?diff=unified&w=0#diff-52623efed6ef4e01aebb39fc38ebb2b35cd1ea3503e16deb1c2f40fb44c587d9L177-R177))
*  Define `DeployWorkflowStep` constant in `generator.go` and add it to builtin workflow step types ([link](https://github.com/kubevela/kubevela/pull/6201/files?diff=unified&w=0#diff-52623efed6ef4e01aebb39fc38ebb2b35cd1ea3503e16deb1c2f40fb44c587d9R193))
*  Test `IsBuiltinWorkflowStepType` function with various input values in `generator_test.go` ([link](https://github.com/kubevela/kubevela/pull/6201/files?diff=unified&w=0#diff-f1bbd89fedcec7c9078d1c6955b770dad4f78c0f35cf36d449728968dbe78412R294-R301))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6200

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->