### PR TITLE
Feat: add timeout ctx

### DIFF
--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -116,7 +116,7 @@ func run(ctx context.Context, s *options.CoreOptions) error {
 		}
 
 		if s.EnableClusterMetrics {
-			_, err := multicluster.NewClusterMetricsMgr(context.Background(), client, s.ClusterMetricsInterval)
+			_, err := multicluster.NewClusterMetricsMgr(ctx, client, s.ClusterMetricsInterval)
 			if err != nil {
 				klog.ErrorS(err, "failed to enable multi-cluster-metrics capability")
 				return err

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -307,7 +307,7 @@ non-empty new arg
 					return errors.Wrapf(err, "cannot open directory %s", addonOrDir)
 				}
 				name = filepath.Base(abs)
-				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)
+				_, err = pkgaddon.FetchAddonRelatedApp(ctx, k8sClient, name)
 				if err != nil {
 					return errors.Wrapf(err, "cannot fetch addon related addon %s", name)
 				}
@@ -324,7 +324,7 @@ non-empty new arg
 					return fmt.Errorf("addon directory %s not found in local", addonOrDir)
 				}
 				name = addonOrDir
-				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, addonOrDir)
+				_, err = pkgaddon.FetchAddonRelatedApp(ctx, k8sClient, addonOrDir)
 				if err != nil {
 					return errors.Wrapf(err, "cannot fetch addon related addon %s", addonOrDir)
 				}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 485280a</samp>

### Summary
🔄⏲️🛑

<!--
1.  🔄 - This emoji represents the replacement of `context.Background()` with the `ctx` variable, which is a common refactoring pattern in Go to improve context propagation and cancellation.
2. ⏲️ - This emoji represents the improvement of timeout handling and consistency in the `addon` package, which is important for ensuring the reliability and performance of the HTTP and `oauth2` clients.
3. 🛑 - This emoji represents the use of the `ctx` variable in the `runAddon` function, which improves the cancellation handling for the `FetchAddonRelatedApp` function, which may involve a long-running or blocking operation.
-->
This pull request improves the context and timeout handling for the `addon` and `app` packages. It introduces a `defaultTimeout` variable for the `addon` package and uses it consistently for different git clients. It also replaces `context.Background()` with the `ctx` variable in several places to respect the parent context.

> _`ctx` propagates_
> _better timeout and retry_
> _autumn leaves falling_

### Walkthrough
*  Set the timeout for HTTP clients that interact with git providers to 20 seconds using a new variable `defaultTimeout` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbR79-R80), [link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL502-R501), [link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL516-R515))
*  Add a custom retry option to the `gitlab` client to handle network errors or rate limits more gracefully ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL525-R524))
*  Use the `ctx` variable instead of `context.Background()` to pass the parent context to the `ClusterMetricsMgr` in `server.go` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-a57ee75b273fb895d1187cd441b0ad88c832a42c02121b246d6ce6d55f58cf5eL115-R115))
*  Use a new context with a timeout of `defaultTimeout` and cancel it with a defer statement to avoid blocking or leaking resources when reading repository contents from `github` or `gitee` in `addon.go` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL535-R536), [link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL544-R547))
*  Simplify the `readMetadata` function by returning the result of `yaml.Unmarshal` directly in `addon.go` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL476-R479))
*  Use the `ctx` variable instead of `context.Background()` to pass the parent context to the `hasClustersParameters` function in `addon.go` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-dfc3f6e3b7231b7b41cf82b8e561f3cbf8191d214886e21d798f287f693806dbL1415-R1418))
*  Use the `ctx` variable instead of `context.Background()` to pass the parent context to the `FetchAddonRelatedApp` function in `addon.go` ([link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-5c1ce01bb88762ec6a5abb96531e8ac946cff33a1fa7ff2e033131f8dcf0e2b8L310-R310), [link](https://github.com/kubevela/kubevela/pull/6211/files?diff=unified&w=0#diff-5c1ce01bb88762ec6a5abb96531e8ac946cff33a1fa7ff2e033131f8dcf0e2b8L327-R327))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->