### PR TITLE
Chore: revert "Feat: apply-component supports namespace"

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-component.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-component.yaml
@@ -19,7 +19,5 @@ spec:
         	component: string
         	// +usage=Specify the cluster
         	cluster: *"" | string
-        	// +usage=Specify the namespace
-        	namespace: *"" | string
         }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -252,7 +252,6 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 	o := struct {
 		Component string `json:"component"`
 		Cluster   string `json:"cluster"`
-		Namespace string `json:"namespace"`
 	}{}
 	js, err := common.RawExtensionPointer{RawExtension: step.Properties}.MarshalJSON()
 	if err != nil {
@@ -260,9 +259,6 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 	}
 	if err := json.Unmarshal(js, &o); err != nil {
 		return err
-	}
-	if len(o.Namespace) == 0 {
-		o.Namespace = app.Namespace
 	}
 
 	var componentNames []string
@@ -292,9 +288,8 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 			c.Outputs = nil
 			c.DependsOn = nil
 			stepProperties := map[string]interface{}{
-				"value":     c,
-				"cluster":   o.Cluster,
-				"namespace": o.Namespace,
+				"value":   c,
+				"cluster": o.Cluster,
 			}
 			step.Properties = util.Object2RawExtension(stepProperties)
 			return nil

--- a/pkg/workflow/template/static/builtin-apply-component.cue
+++ b/pkg/workflow/template/static/builtin-apply-component.cue
@@ -5,9 +5,8 @@ import (
 oam: op.oam
 // apply component and traits
 apply: oam.#ApplyComponent & {
-	value:     parameter.value
-	cluster:   parameter.cluster
-	namespace: parameter.namespace
+	value:   parameter.value
+	cluster: parameter.cluster
 }
 
 if apply.output != _|_ {
@@ -19,6 +18,5 @@ if apply.outputs != _|_ {
 }
 parameter: {
 	value: {...}
-	cluster:   *"" | string
-	namespace: *"" | string
+	cluster: *"" | string
 }

--- a/references/docgen/def-doc/workflowstep/apply-component.eg.md
+++ b/references/docgen/def-doc/workflowstep/apply-component.eg.md
@@ -24,5 +24,4 @@ spec:
         properties:
           component: express-server
           # cluster: <your cluster name>
-          # namespace: <your namespace name>
 ```

--- a/vela-templates/definitions/internal/workflowstep/apply-component.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-component.cue
@@ -14,7 +14,5 @@ template: {
 		component: string
 		// +usage=Specify the cluster
 		cluster: *"" | string
-		// +usage=Specify the namespace
-		namespace: *"" | string
 	}
 }


### PR DESCRIPTION
Reverts kubevela/kubevela#6228 due to the lack of test to `k8s-objects` type component. 

## details

In a application with `k8s-objects` component, a default workflow will be generated with `apply-component` step with no `namespace` specified. It means the objects in this componets will be dispatched to application's namespace.

Now it is the reason the CI is blocking.