### PR TITLE
Feat: apply-component supports namespace

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-component.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-component.yaml
@@ -19,5 +19,7 @@ spec:
         	component: string
         	// +usage=Specify the cluster
         	cluster: *"" | string
+        	// +usage=Specify the namespace
+        	namespace: *"" | string
         }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -254,6 +254,7 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 	o := struct {
 		Component string `json:"component"`
 		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
 	}{}
 	js, err := common.RawExtensionPointer{RawExtension: step.Properties}.MarshalJSON()
 	if err != nil {
@@ -292,6 +293,9 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 			stepProperties := map[string]interface{}{
 				"value":   c,
 				"cluster": o.Cluster,
+			}
+			if o.Namespace != "" {
+				stepProperties["namespace"] = o.Namespace
 			}
 			step.Properties = util.Object2RawExtension(stepProperties)
 			return nil

--- a/pkg/workflow/template/static/builtin-apply-component.cue
+++ b/pkg/workflow/template/static/builtin-apply-component.cue
@@ -5,8 +5,9 @@ import (
 oam: op.oam
 // apply component and traits
 apply: oam.#ApplyComponent & {
-	value:   parameter.value
-	cluster: parameter.cluster
+	value:     parameter.value
+	cluster:   parameter.cluster
+	namespace: parameter.namespace
 }
 
 if apply.output != _|_ {
@@ -18,5 +19,6 @@ if apply.outputs != _|_ {
 }
 parameter: {
 	value: {...}
-	cluster: *"" | string
+	cluster:   *"" | string
+	namespace: *"" | string
 }

--- a/references/docgen/def-doc/workflowstep/apply-component.eg.md
+++ b/references/docgen/def-doc/workflowstep/apply-component.eg.md
@@ -24,4 +24,5 @@ spec:
         properties:
           component: express-server
           # cluster: <your cluster name>
+          # namespace: <your namespace name>
 ```

--- a/vela-templates/definitions/internal/workflowstep/apply-component.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-component.cue
@@ -14,5 +14,7 @@ template: {
 		component: string
 		// +usage=Specify the cluster
 		cluster: *"" | string
+		// +usage=Specify the namespace
+		namespace: *"" | string
 	}
 }


### PR DESCRIPTION
Signed-off-by: wuzhongjian wuzhongjian_yewu@cmss.chinamobile.com

### Description of your changes
1. Adding a namespace parameter in `apply-component.cue` and `builtin-apply-component.cue` to support setting namespace for `apply-component` step.
2.  if the namespace of the `apply-component` is not set, it will not be assigned a default value to the override namespace.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa271ab</samp>

### Summary
🆕📝🚀

<!--
1.  🆕 - This emoji represents the addition of a new parameter to the workflow step definition and the CUE template, as well as the new feature of applying components and traits to different namespaces.
3.  📝 - This emoji represents the modification of the documentation to show the example usage of the new parameter and the feature.
4.  🚀 - This emoji represents the enhancement of the application definition and the `oam.#ApplyComponent` trait to support the namespace parameter and the feature.
-->
This pull request adds a new `namespace` parameter to the `apply-component` workflow step, which allows applying components and traits to different namespaces in the application definition. It also updates the generator, the Helm chart template, the CUE definition, and the documentation to support this feature.

> _`namespace` added_
> _to `apply-component` step_
> _autumn leaves scatter_

### Walkthrough
* Add a new parameter `namespace` to the `apply-component` workflow step definition, which allows users to specify the namespace where the component and traits will be applied. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-d04ff4062f6d641448d51084a8340da502252bad348799cd4f8d89f5fdbbdfa7R22-R23), [link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-17fef7796b683f2995e4bd6650af842e7d1c0c116471d2f206ec405b5c192256R17-R18), [link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-b294236ceeaba10f0beef13117ca02e3063a2c33a6f7c67ae0f2195e865fa9e2L21-R23))
* Pass the `namespace` parameter to the `oam.#ApplyComponent` trait in the CUE template for the `apply` task, which will use it to apply the component and traits to the specified namespace. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-b294236ceeaba10f0beef13117ca02e3063a2c33a6f7c67ae0f2195e865fa9e2L8-R10))
* Add a new field `Namespace` to the `StepProperties` struct in the Go code, which will store the value of the `namespace` parameter from the workflow step definition. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212R255))
* Set a default value for the `Namespace` field in the `StepProperties` struct, which will use the same namespace as the application if the user does not specify the `namespace` parameter. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212R264-R266))
* Modify the logic of converting the `StepProperties` struct to a raw extension for the workflow step, which will exclude the `namespace` parameter if the component type is `raw` or `k8s-objects`, and include it otherwise. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212L290-R305))
* Modify the example usage of the `apply-component` workflow step in the documentation, which shows how to optionally specify the `namespace` parameter for the step. ([link](https://github.com/kubevela/kubevela/pull/6248/files?diff=unified&w=0#diff-9e546a8bf33fb0f29a44924f3621c3016273cc56d76682fd38be99e39f1bca1aL27-R28))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->