### PR TITLE
Refactor: capabilities and workload in appfile parsing

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -32,22 +32,6 @@ type CRDInfo struct {
 	Kind       string `json:"kind"`
 }
 
-// Chart defines all necessary information to install a whole chart
-type Chart struct {
-	Repo      string                 `json:"repo"`
-	URL       string                 `json:"url"`
-	Name      string                 `json:"name"`
-	Namespace string                 `json:"namespace,omitempty"`
-	Version   string                 `json:"version"`
-	Values    map[string]interface{} `json:"values"`
-}
-
-// Installation defines the installation method for this Capability, currently only helm is supported
-type Installation struct {
-	Helm Chart `json:"helm"`
-	// TODO(wonderflow) add raw yaml file support for install capability
-}
-
 // CapType defines the type of capability
 type CapType string
 
@@ -107,7 +91,6 @@ type Capability struct {
 	CueTemplateURI string             `json:"templateURI,omitempty"`
 	Parameters     []Parameter        `json:"parameters,omitempty"`
 	CrdName        string             `json:"crdName,omitempty"`
-	Center         string             `json:"center,omitempty"`
 	Status         string             `json:"status,omitempty"`
 	Description    string             `json:"description,omitempty"`
 	Example        string             `json:"example,omitempty"`
@@ -121,8 +104,7 @@ type Capability struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// Plugin Source
-	Source  *Source  `json:"source,omitempty"`
-	CrdInfo *CRDInfo `json:"crdInfo,omitempty"`
+	Source *Source `json:"source,omitempty"`
 
 	// Terraform
 	TerraformConfiguration string `json:"terraformConfiguration,omitempty"`

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -47,7 +47,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/auth"
 	"github.com/oam-dev/kubevela/pkg/cache"
 	commonconfig "github.com/oam-dev/kubevela/pkg/controller/common"
-	oamv1alpha2 "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1beta1"
+	oamv1beta1 "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1beta1/application"
 	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/monitor/watcher"
@@ -227,7 +227,7 @@ func prepareRun(ctx context.Context, mgr manager.Manager, s *options.CoreOptions
 		}
 	}
 
-	if err := oamv1alpha2.Setup(mgr, *s.ControllerArgs); err != nil {
+	if err := oamv1beta1.Setup(mgr, *s.ControllerArgs); err != nil {
 		klog.ErrorS(err, "Unable to setup the oam controller")
 		return err
 	}

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -559,7 +559,7 @@ spec:
 `
 
 var dryRunResult = `---
-# Application(test-vela-app) -- ParsedComponents(express-server) 
+# Application(test-vela-app) -- Component(express-server) 
 ---
 
 apiVersion: apps/v1
@@ -671,7 +671,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
       type: test-webservice
   status: {}
   
-* ParsedComponents (express-server) has been removed(-)
+* Component (express-server) has been removed(-)
 - apiVersion: apps/v1
 - kind: Deployment
 - metadata:
@@ -698,7 +698,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -         ports:
 -         - containerPort: 80
   
-* ParsedComponents (express-server) / Trait (test-ingress/service) has been removed(-)
+* Component (express-server) / Trait (test-ingress/service) has been removed(-)
 - apiVersion: v1
 - kind: Service
 - metadata:
@@ -718,7 +718,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -   selector:
 -     app.oam.dev/component: express-server
   
-* ParsedComponents (express-server) / Trait (test-ingress/ingress) has been removed(-)
+* Component (express-server) / Trait (test-ingress/ingress) has been removed(-)
 - apiVersion: networking.k8s.io/v1beta1
 - kind: Ingress
 - metadata:
@@ -741,7 +741,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -           servicePort: 80
 -         path: /
   
-* ParsedComponents (new-express-server) has been added(+)
+* Component (new-express-server) has been added(+)
 + apiVersion: apps/v1
 + kind: Deployment
 + metadata:
@@ -773,7 +773,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 +           requests:
 +             cpu: "0.5"
   
-* ParsedComponents (new-express-server) / Trait (test-ingress/service) has been added(+)
+* Component (new-express-server) / Trait (test-ingress/service) has been added(+)
 + apiVersion: v1
 + kind: Service
 + metadata:
@@ -793,7 +793,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 +   selector:
 +     app.oam.dev/component: new-express-server
   
-* ParsedComponents (new-express-server) / Trait (test-ingress/ingress) has been added(+)
+* Component (new-express-server) / Trait (test-ingress/ingress) has been added(+)
 + apiVersion: networking.k8s.io/v1beta1
 + kind: Ingress
 + metadata:

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -559,7 +559,7 @@ spec:
 `
 
 var dryRunResult = `---
-# Application(test-vela-app) -- Component(express-server) 
+# Application(test-vela-app) -- ParsedComponents(express-server) 
 ---
 
 apiVersion: apps/v1
@@ -671,7 +671,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
       type: test-webservice
   status: {}
   
-* Component (express-server) has been removed(-)
+* ParsedComponents (express-server) has been removed(-)
 - apiVersion: apps/v1
 - kind: Deployment
 - metadata:
@@ -698,7 +698,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -         ports:
 -         - containerPort: 80
   
-* Component (express-server) / Trait (test-ingress/service) has been removed(-)
+* ParsedComponents (express-server) / Trait (test-ingress/service) has been removed(-)
 - apiVersion: v1
 - kind: Service
 - metadata:
@@ -718,7 +718,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -   selector:
 -     app.oam.dev/component: express-server
   
-* Component (express-server) / Trait (test-ingress/ingress) has been removed(-)
+* ParsedComponents (express-server) / Trait (test-ingress/ingress) has been removed(-)
 - apiVersion: networking.k8s.io/v1beta1
 - kind: Ingress
 - metadata:
@@ -741,7 +741,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 -           servicePort: 80
 -         path: /
   
-* Component (new-express-server) has been added(+)
+* ParsedComponents (new-express-server) has been added(+)
 + apiVersion: apps/v1
 + kind: Deployment
 + metadata:
@@ -773,7 +773,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 +           requests:
 +             cpu: "0.5"
   
-* Component (new-express-server) / Trait (test-ingress/service) has been added(+)
+* ParsedComponents (new-express-server) / Trait (test-ingress/service) has been added(+)
 + apiVersion: v1
 + kind: Service
 + metadata:
@@ -793,7 +793,7 @@ var livediffResult = `Application (test-vela-app) has been modified(*)
 +   selector:
 +     app.oam.dev/component: new-express-server
   
-* Component (new-express-server) / Trait (test-ingress/ingress) has been added(+)
+* ParsedComponents (new-express-server) / Trait (test-ingress/ingress) has been added(+)
 + apiVersion: networking.k8s.io/v1beta1
 + kind: Ingress
 + metadata:

--- a/hack/docgen/def/mods/component.go
+++ b/hack/docgen/def/mods/component.go
@@ -42,7 +42,7 @@ var ComponentDefDirs = []string{"./vela-templates/definitions/internal/component
 
 // CustomComponentHeaderEN .
 var CustomComponentHeaderEN = `---
-title: Built-in Component Type
+title: Built-in ParsedComponents Type
 ---
 
 This documentation will walk through all the built-in component types sorted alphabetically.

--- a/pkg/appfile/appfile_test.go
+++ b/pkg/appfile/appfile_test.go
@@ -135,7 +135,7 @@ variable "password" {
 `
 		)
 
-		wl := &Workload{
+		wl := &Component{
 			Name: "sample-db",
 			FullTemplate: &Template{
 				Terraform: &common.Terraform{
@@ -161,10 +161,10 @@ variable "password" {
 		}
 
 		af := &Appfile{
-			Workloads:       []*Workload{wl},
-			Name:            appName,
-			AppRevisionName: revision,
-			Namespace:       ns,
+			ParsedComponents: []*Component{wl},
+			Name:             appName,
+			AppRevisionName:  revision,
+			Namespace:        ns,
 		}
 
 		variable := map[string]interface{}{"account_name": "oamtest"}
@@ -319,13 +319,13 @@ var _ = Describe("Test evalWorkloadWithContext", func() {
 			err      error
 		)
 		type appArgs struct {
-			wl       *Workload
+			wl       *Component
 			appName  string
 			revision string
 		}
 
 		args := appArgs{
-			wl: &Workload{
+			wl: &Component{
 				Name: compName,
 				FullTemplate: &Template{
 					Terraform: &common.Terraform{
@@ -595,7 +595,7 @@ func TestGenerateTerraformConfigurationWorkload(t *testing.T) {
 				}
 			}
 
-			wl := &Workload{
+			wl := &Component{
 				FullTemplate: template,
 				Name:         name,
 				Params:       tc.args.params,
@@ -730,7 +730,7 @@ if context.componentType == "stateless" {
   publishVersion:         context.publishVersion
 }`,
 	}
-	wl := &Workload{Type: "stateful", Traits: []*Trait{tr}}
+	wl := &Component{Type: "stateful", Traits: []*Trait{tr}}
 	cm, err := baseGenerateComponent(pContext, wl, appName, ns)
 	assert.NoError(t, err)
 	assert.Equal(t, cm.Traits[0].Object["kind"], "StatefulSet")
@@ -751,7 +751,7 @@ var _ = Describe("Test use context.appLabels& context.appAnnotations in componen
 				"ak1": "av1",
 				"ak2": "av2",
 			},
-			Workloads: []*Workload{
+			ParsedComponents: []*Component{
 				{
 					Name: "comp1",
 					Type: "deployment",

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -105,8 +105,6 @@ func (p *Parser) GenerateAppFile(ctx context.Context, app *v1beta1.Application) 
 
 // GenerateAppFileFromApp converts an application to an Appfile
 func (p *Parser) GenerateAppFileFromApp(ctx context.Context, app *v1beta1.Application) (*Appfile, error) {
-	ns := app.Namespace
-	appName := app.Name
 
 	for idx := range app.Spec.Policies {
 		if app.Spec.Policies[idx].Name == "" {
@@ -114,54 +112,32 @@ func (p *Parser) GenerateAppFileFromApp(ctx context.Context, app *v1beta1.Applic
 		}
 	}
 
-	appFile := p.newAppFile(appName, ns, app)
+	appFile := newAppFile(app)
 	if app.Status.LatestRevision != nil {
 		appFile.AppRevisionName = app.Status.LatestRevision.Name
 	}
 
 	var err error
-	var wds []*Workload
-	if wds, err = p.parseWorkloads(ctx, appFile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parseWorkloads")
+	if err = p.parseComponents(ctx, appFile); err != nil {
+		return nil, errors.Wrap(err, "failed to parseComponents")
 	}
 	if err = p.parseWorkflowSteps(ctx, appFile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parseWorkflowSteps")
+		return nil, errors.Wrap(err, "failed to parseWorkflowSteps")
 	}
 	if err = p.parsePolicies(ctx, appFile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parsePolicies")
+		return nil, errors.Wrap(err, "failed to parsePolicies")
 	}
 	if err = p.parseReferredObjects(ctx, appFile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parseReferredObjects")
-	}
-
-	for _, w := range wds {
-		if w == nil {
-			continue
-		}
-		if w.FullTemplate.ComponentDefinition != nil {
-			cd := w.FullTemplate.ComponentDefinition.DeepCopy()
-			cd.Status = v1beta1.ComponentDefinitionStatus{}
-			appFile.RelatedComponentDefinitions[w.FullTemplate.ComponentDefinition.Name] = cd
-		}
-		for _, t := range w.Traits {
-			if t == nil {
-				continue
-			}
-			if t.FullTemplate.TraitDefinition != nil {
-				td := t.FullTemplate.TraitDefinition.DeepCopy()
-				td.Status = v1beta1.TraitDefinitionStatus{}
-				appFile.RelatedTraitDefinitions[t.FullTemplate.TraitDefinition.Name] = td
-			}
-		}
+		return nil, errors.Wrap(err, "failed to parseReferredObjects")
 	}
 
 	return appFile, nil
 }
 
-func (p *Parser) newAppFile(appName, ns string, app *v1beta1.Application) *Appfile {
+func newAppFile(app *v1beta1.Application) *Appfile {
 	file := &Appfile{
-		Name:      appName,
-		Namespace: ns,
+		Name:      app.Name,
+		Namespace: app.Namespace,
 
 		AppLabels:                      make(map[string]string),
 		AppAnnotations:                 make(map[string]string),
@@ -171,8 +147,7 @@ func (p *Parser) newAppFile(appName, ns string, app *v1beta1.Application) *Appfi
 
 		ExternalPolicies: make(map[string]*v1alpha1.Policy),
 
-		parser: p,
-		app:    app,
+		app: app,
 	}
 	for k, v := range app.Annotations {
 		file.AppAnnotations[k] = v
@@ -238,10 +213,8 @@ func (p *Parser) GenerateAppFileFromRevision(appRev *v1beta1.ApplicationRevision
 
 	inheritLabelAndAnnotationFromAppRev(appRev)
 
-	app := appRev.Spec.Application.DeepCopy()
-	ns := app.Namespace
-	appName := app.Name
-	appfile := p.newAppFile(appName, ns, app)
+	ctx := context.Background()
+	appfile := newAppFile(appRev.Spec.Application.DeepCopy())
 	appfile.AppRevision = appRev
 	appfile.AppRevisionName = appRev.Name
 	appfile.AppRevisionHash = appRev.Labels[oam.LabelAppRevisionHash]
@@ -251,60 +224,50 @@ func (p *Parser) GenerateAppFileFromRevision(appRev *v1beta1.ApplicationRevision
 	}
 	appfile.ExternalWorkflow = appRev.Spec.Workflow
 
-	var wds []*Workload
-	for _, comp := range app.Spec.Components {
-		wd, err := p.ParseWorkloadFromRevision(comp, appRev)
-		if err != nil {
-			return nil, err
-		}
-		wds = append(wds, wd)
+	if err := p.parseComponentsFromRevision(appfile); err != nil {
+		return nil, errors.Wrap(err, "failed to parseComponentsFromRevision")
 	}
-	appfile.Workloads = wds
-	appfile.Components = app.Spec.Components
-	if err := p.parseWorkflowStepsFromRevision(context.Background(), appfile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parseWorkflowStepsFromRevision")
+	if err := p.parseWorkflowStepsFromRevision(ctx, appfile); err != nil {
+		return nil, errors.Wrap(err, "failed to parseWorkflowStepsFromRevision")
 	}
-	if err := p.parsePoliciesFromRevision(context.Background(), appfile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parsePolicies")
+	if err := p.parsePoliciesFromRevision(ctx, appfile); err != nil {
+		return nil, errors.Wrap(err, "failed to parsePolicies")
 	}
 	if err := p.parseReferredObjectsFromRevision(appfile); err != nil {
-		return nil, errors.Wrapf(err, "failed to parseReferredObjects")
-	}
-
-	for k, v := range appRev.Spec.ComponentDefinitions {
-		appfile.RelatedComponentDefinitions[k] = v.DeepCopy()
-	}
-	for k, v := range appRev.Spec.TraitDefinitions {
-		appfile.RelatedTraitDefinitions[k] = v.DeepCopy()
-	}
-	for k, v := range appRev.Spec.WorkflowStepDefinitions {
-		appfile.RelatedWorkflowStepDefinitions[k] = v.DeepCopy()
+		return nil, errors.Wrap(err, "failed to parseReferredObjects")
 	}
 
 	// add compatible code for upgrading to v1.3 as the workflow steps were not recorded before v1.2
 	if len(appfile.RelatedWorkflowStepDefinitions) == 0 && len(appfile.WorkflowSteps) > 0 {
-		ctx := context.Background()
-		for _, workflowStep := range appfile.WorkflowSteps {
-			if step.IsBuiltinWorkflowStepType(workflowStep.Type) {
-				continue
-			}
-			if _, found := appfile.RelatedWorkflowStepDefinitions[workflowStep.Type]; found {
-				continue
-			}
-			def := &v1beta1.WorkflowStepDefinition{}
-			if err := util.GetCapabilityDefinition(ctx, p.client, def, workflowStep.Type); err != nil {
-				return nil, errors.Wrapf(err, "failed to get workflow step definition %s", workflowStep.Type)
-			}
-			appfile.RelatedWorkflowStepDefinitions[workflowStep.Type] = def
-		}
-
-		appRev.Spec.WorkflowStepDefinitions = make(map[string]*v1beta1.WorkflowStepDefinition)
-		for name, def := range appfile.RelatedWorkflowStepDefinitions {
-			appRev.Spec.WorkflowStepDefinitions[name] = def
+		if err := p.parseWorkflowStepsForLegacyRevision(ctx, appfile); err != nil {
+			return nil, errors.Wrap(err, "failed to parseWorkflowStepsForLegacyRevision")
 		}
 	}
 
 	return appfile, nil
+}
+
+// parseWorkflowStepsForLegacyRevision compatible for upgrading to v1.3 as the workflow steps were not recorded before v1.2
+func (p *Parser) parseWorkflowStepsForLegacyRevision(ctx context.Context, af *Appfile) error {
+	for _, workflowStep := range af.WorkflowSteps {
+		if step.IsBuiltinWorkflowStepType(workflowStep.Type) {
+			continue
+		}
+		if _, found := af.RelatedWorkflowStepDefinitions[workflowStep.Type]; found {
+			continue
+		}
+		def := &v1beta1.WorkflowStepDefinition{}
+		if err := util.GetCapabilityDefinition(ctx, p.client, def, workflowStep.Type); err != nil {
+			return errors.Wrapf(err, "failed to get workflow step definition %s", workflowStep.Type)
+		}
+		af.RelatedWorkflowStepDefinitions[workflowStep.Type] = def
+	}
+
+	af.AppRevision.Spec.WorkflowStepDefinitions = make(map[string]*v1beta1.WorkflowStepDefinition)
+	for name, def := range af.RelatedWorkflowStepDefinitions {
+		af.AppRevision.Spec.WorkflowStepDefinitions[name] = def
+	}
+	return nil
 }
 
 func (p *Parser) parseReferredObjectsFromRevision(af *Appfile) error {
@@ -381,11 +344,11 @@ func (p *Parser) parsePoliciesFromRevision(ctx context.Context, af *Appfile) (er
 		case v1alpha1.DebugPolicyType:
 			af.Debug = true
 		default:
-			w, err := p.makeWorkloadFromRevision(policy.Name, policy.Type, types.TypePolicy, policy.Properties, af.AppRevision)
+			w, err := p.makeComponentFromRevision(policy.Name, policy.Type, types.TypePolicy, policy.Properties, af.AppRevision)
 			if err != nil {
 				return err
 			}
-			af.PolicyWorkloads = append(af.PolicyWorkloads, w)
+			af.ParsedPolicies = append(af.ParsedPolicies, w)
 		}
 	}
 	return nil
@@ -424,11 +387,11 @@ func (p *Parser) parsePolicies(ctx context.Context, af *Appfile) (err error) {
 				af.RelatedTraitDefinitions[def.Name] = def
 			}
 		default:
-			w, err := p.makeWorkload(ctx, policy.Name, policy.Type, types.TypePolicy, policy.Properties)
+			w, err := p.makeComponent(ctx, policy.Name, policy.Type, types.TypePolicy, policy.Properties)
 			if err != nil {
 				return err
 			}
-			af.PolicyWorkloads = append(af.PolicyWorkloads, w)
+			af.ParsedPolicies = append(af.ParsedPolicies, w)
 		}
 	}
 	return nil
@@ -472,7 +435,14 @@ func (p *Parser) loadWorkflowToAppfile(ctx context.Context, af *Appfile) error {
 }
 
 func (p *Parser) parseWorkflowStepsFromRevision(ctx context.Context, af *Appfile) error {
-	return p.loadWorkflowToAppfile(ctx, af)
+	if err := p.loadWorkflowToAppfile(ctx, af); err != nil {
+		return err
+	}
+	// Definitions are already in AppRevision
+	for k, v := range af.AppRevision.Spec.WorkflowStepDefinitions {
+		af.RelatedWorkflowStepDefinitions[k] = v.DeepCopy()
+	}
+	return nil
 }
 
 func (p *Parser) parseWorkflowSteps(ctx context.Context, af *Appfile) error {
@@ -480,14 +450,14 @@ func (p *Parser) parseWorkflowSteps(ctx context.Context, af *Appfile) error {
 		return err
 	}
 	for _, workflowStep := range af.WorkflowSteps {
-		err := p.parseWorkflowStep(ctx, af, workflowStep.Type)
+		err := p.fetchAndSetWorkflowStepDefinition(ctx, af, workflowStep.Type)
 		if err != nil {
 			return err
 		}
 
 		if workflowStep.SubSteps != nil {
 			for _, workflowSubStep := range workflowStep.SubSteps {
-				err := p.parseWorkflowStep(ctx, af, workflowSubStep.Type)
+				err := p.fetchAndSetWorkflowStepDefinition(ctx, af, workflowSubStep.Type)
 				if err != nil {
 					return err
 				}
@@ -497,7 +467,7 @@ func (p *Parser) parseWorkflowSteps(ctx context.Context, af *Appfile) error {
 	return nil
 }
 
-func (p *Parser) parseWorkflowStep(ctx context.Context, af *Appfile, workflowStepType string) error {
+func (p *Parser) fetchAndSetWorkflowStepDefinition(ctx context.Context, af *Appfile, workflowStepType string) error {
 	if step.IsBuiltinWorkflowStepType(workflowStepType) {
 		return nil
 	}
@@ -512,36 +482,36 @@ func (p *Parser) parseWorkflowStep(ctx context.Context, af *Appfile, workflowSte
 	return nil
 }
 
-func (p *Parser) makeWorkload(ctx context.Context, name, typ string, capType types.CapType, props *runtime.RawExtension) (*Workload, error) {
+func (p *Parser) makeComponent(ctx context.Context, name, typ string, capType types.CapType, props *runtime.RawExtension) (*Component, error) {
 	templ, err := p.tmplLoader.LoadTemplate(ctx, p.client, typ, capType)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "fetch component/policy type of %s", name)
 	}
-	return p.convertTemplate2Workload(name, typ, props, templ)
+	return p.convertTemplate2Component(name, typ, props, templ)
 }
 
-func (p *Parser) makeWorkloadFromRevision(name, typ string, capType types.CapType, props *runtime.RawExtension, appRev *v1beta1.ApplicationRevision) (*Workload, error) {
+func (p *Parser) makeComponentFromRevision(name, typ string, capType types.CapType, props *runtime.RawExtension, appRev *v1beta1.ApplicationRevision) (*Component, error) {
 	templ, err := LoadTemplateFromRevision(typ, capType, appRev, p.client.RESTMapper())
 	if err != nil {
 		return nil, errors.WithMessagef(err, "fetch component/policy type of %s from revision", name)
 	}
 
-	return p.convertTemplate2Workload(name, typ, props, templ)
+	return p.convertTemplate2Component(name, typ, props, templ)
 }
 
-func (p *Parser) convertTemplate2Workload(name, typ string, props *runtime.RawExtension, templ *Template) (*Workload, error) {
+func (p *Parser) convertTemplate2Component(name, typ string, props *runtime.RawExtension, templ *Template) (*Component, error) {
 	settings, err := util.RawExtension2Map(props)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "fail to parse settings for %s", name)
 	}
-	wlType, err := util.ConvertDefinitionRevName(typ)
+	cpType, err := util.ConvertDefinitionRevName(typ)
 	if err != nil {
-		wlType = typ
+		cpType = typ
 	}
-	return &Workload{
+	return &Component{
 		Traits:             []*Trait{},
 		Name:               name,
-		Type:               wlType,
+		Type:               cpType,
 		CapabilityCategory: templ.CapabilityCategory,
 		FullTemplate:       templ,
 		Params:             settings,
@@ -549,25 +519,61 @@ func (p *Parser) convertTemplate2Workload(name, typ string, props *runtime.RawEx
 	}, nil
 }
 
-// parseWorkloads resolve an Application Components and Traits to generate Workloads
-func (p *Parser) parseWorkloads(ctx context.Context, af *Appfile) ([]*Workload, error) {
-	var wds []*Workload
-	for _, comp := range af.app.Spec.Components {
-		wd, err := p.parseWorkload(ctx, comp)
+// parseComponents resolve an Application Components and Traits to generate Component
+func (p *Parser) parseComponents(ctx context.Context, af *Appfile) error {
+	var comps []*Component
+	for _, c := range af.app.Spec.Components {
+		comp, err := p.parseComponent(ctx, c)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		wds = append(wds, wd)
+		comps = append(comps, comp)
 	}
-	af.Workloads = wds
+
+	af.ParsedComponents = comps
 	af.Components = af.app.Spec.Components
-	return wds, nil
+	setComponentDefinitions(af, comps)
+
+	return nil
 }
 
-// parseWorkload resolve an ApplicationComponent and generate a Workload
+func setComponentDefinitions(af *Appfile, comps []*Component) {
+	for _, comp := range comps {
+		if comp == nil {
+			continue
+		}
+		if comp.FullTemplate.ComponentDefinition != nil {
+			cd := comp.FullTemplate.ComponentDefinition.DeepCopy()
+			cd.Status = v1beta1.ComponentDefinitionStatus{}
+			af.RelatedComponentDefinitions[comp.FullTemplate.ComponentDefinition.Name] = cd
+		}
+		for _, t := range comp.Traits {
+			if t == nil {
+				continue
+			}
+			if t.FullTemplate.TraitDefinition != nil {
+				td := t.FullTemplate.TraitDefinition.DeepCopy()
+				td.Status = v1beta1.TraitDefinitionStatus{}
+				af.RelatedTraitDefinitions[t.FullTemplate.TraitDefinition.Name] = td
+			}
+		}
+	}
+}
+
+// setComponentDefinitionsFromRevision can set related definitions directly from app revision
+func setComponentDefinitionsFromRevision(af *Appfile) {
+	for k, v := range af.AppRevision.Spec.ComponentDefinitions {
+		af.RelatedComponentDefinitions[k] = v.DeepCopy()
+	}
+	for k, v := range af.AppRevision.Spec.TraitDefinitions {
+		af.RelatedTraitDefinitions[k] = v.DeepCopy()
+	}
+}
+
+// parseComponent resolve an ApplicationComponent and generate a Component
 // containing ALL information required by an Appfile.
-func (p *Parser) parseWorkload(ctx context.Context, comp common.ApplicationComponent) (*Workload, error) {
-	workload, err := p.makeWorkload(ctx, comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties)
+func (p *Parser) parseComponent(ctx context.Context, comp common.ApplicationComponent) (*Component, error) {
+	workload, err := p.makeComponent(ctx, comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +584,7 @@ func (p *Parser) parseWorkload(ctx context.Context, comp common.ApplicationCompo
 	return workload, nil
 }
 
-func (p *Parser) parseTraits(ctx context.Context, workload *Workload, comp common.ApplicationComponent) error {
+func (p *Parser) parseTraits(ctx context.Context, workload *Component, comp common.ApplicationComponent) error {
 	for _, traitValue := range comp.Traits {
 		properties, err := util.RawExtension2Map(traitValue.Properties)
 		if err != nil {
@@ -594,10 +600,26 @@ func (p *Parser) parseTraits(ctx context.Context, workload *Workload, comp commo
 	return nil
 }
 
-// ParseWorkloadFromRevision resolve an ApplicationComponent and generate a Workload
+func (p *Parser) parseComponentsFromRevision(af *Appfile) error {
+	var comps []*Component
+	for _, c := range af.app.Spec.Components {
+		comp, err := p.ParseComponentFromRevision(c, af.AppRevision)
+		if err != nil {
+			return err
+		}
+		comps = append(comps, comp)
+	}
+	af.ParsedComponents = comps
+	af.Components = af.app.Spec.Components
+	// Definitions are already in AppRevision
+	setComponentDefinitionsFromRevision(af)
+	return nil
+}
+
+// ParseComponentFromRevision resolve an ApplicationComponent and generate a Component
 // containing ALL information required by an Appfile from app revision.
-func (p *Parser) ParseWorkloadFromRevision(comp common.ApplicationComponent, appRev *v1beta1.ApplicationRevision) (*Workload, error) {
-	workload, err := p.makeWorkloadFromRevision(comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties, appRev)
+func (p *Parser) ParseComponentFromRevision(comp common.ApplicationComponent, appRev *v1beta1.ApplicationRevision) (*Component, error) {
+	workload, err := p.makeComponentFromRevision(comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties, appRev)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +631,7 @@ func (p *Parser) ParseWorkloadFromRevision(comp common.ApplicationComponent, app
 	return workload, nil
 }
 
-func (p *Parser) parseTraitsFromRevision(comp common.ApplicationComponent, appRev *v1beta1.ApplicationRevision, workload *Workload) error {
+func (p *Parser) parseTraitsFromRevision(comp common.ApplicationComponent, appRev *v1beta1.ApplicationRevision, workload *Component) error {
 	for _, traitValue := range comp.Traits {
 		properties, err := util.RawExtension2Map(traitValue.Properties)
 		if err != nil {
@@ -625,35 +647,35 @@ func (p *Parser) parseTraitsFromRevision(comp common.ApplicationComponent, appRe
 	return nil
 }
 
-// ParseWorkloadFromRevisionAndClient resolve an ApplicationComponent and generate a Workload
+// ParseComponentFromRevisionAndClient resolve an ApplicationComponent and generate a Component
 // containing ALL information required by an Appfile from app revision, and will fall back to
 // load external definitions if not found
-func (p *Parser) ParseWorkloadFromRevisionAndClient(ctx context.Context, comp common.ApplicationComponent, appRev *v1beta1.ApplicationRevision) (*Workload, error) {
-	workload, err := p.makeWorkloadFromRevision(comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties, appRev)
+func (p *Parser) ParseComponentFromRevisionAndClient(ctx context.Context, c common.ApplicationComponent, appRev *v1beta1.ApplicationRevision) (*Component, error) {
+	comp, err := p.makeComponentFromRevision(c.Name, c.Type, types.TypeComponentDefinition, c.Properties, appRev)
 	if IsNotFoundInAppRevision(err) {
-		workload, err = p.makeWorkload(ctx, comp.Name, comp.Type, types.TypeComponentDefinition, comp.Properties)
+		comp, err = p.makeComponent(ctx, c.Name, c.Type, types.TypeComponentDefinition, c.Properties)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	for _, traitValue := range comp.Traits {
+	for _, traitValue := range c.Traits {
 		properties, err := util.RawExtension2Map(traitValue.Properties)
 		if err != nil {
-			return nil, errors.Errorf("fail to parse properties of %s for %s", traitValue.Type, comp.Name)
+			return nil, errors.Errorf("fail to parse properties of %s for %s", traitValue.Type, c.Name)
 		}
 		trait, err := p.parseTraitFromRevision(traitValue.Type, properties, appRev)
 		if IsNotFoundInAppRevision(err) {
 			trait, err = p.parseTrait(ctx, traitValue.Type, properties)
 		}
 		if err != nil {
-			return nil, errors.WithMessagef(err, "component(%s) parse trait(%s)", comp.Name, traitValue.Type)
+			return nil, errors.WithMessagef(err, "component(%s) parse trait(%s)", c.Name, traitValue.Type)
 		}
 
-		workload.Traits = append(workload.Traits, trait)
+		comp.Traits = append(comp.Traits, trait)
 	}
 
-	return workload, nil
+	return comp, nil
 }
 
 func (p *Parser) parseTrait(ctx context.Context, name string, properties map[string]interface{}) (*Trait, error) {
@@ -692,7 +714,7 @@ func (p *Parser) convertTemplate2Trait(name string, properties map[string]interf
 	}, nil
 }
 
-// ValidateComponentNames validate all component names whether repeat in cluster and template
+// ValidateComponentNames validate all component names whether repeat in app
 func (p *Parser) ValidateComponentNames(app *v1beta1.Application) (int, error) {
 	compNames := map[string]struct{}{}
 	for idx, comp := range app.Spec.Components {

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -46,7 +46,7 @@ import (
 
 var expectedExceptApp = &Appfile{
 	Name: "application-sample",
-	Workloads: []*Workload{
+	ParsedComponents: []*Component{
 		{
 			Name: "myweb",
 			Type: "worker",
@@ -286,11 +286,11 @@ var _ = Describe("Test application parser", func() {
 })
 
 func equal(af, dest *Appfile) bool {
-	if af.Name != dest.Name || len(af.Workloads) != len(dest.Workloads) {
+	if af.Name != dest.Name || len(af.ParsedComponents) != len(dest.ParsedComponents) {
 		return false
 	}
-	for i, wd := range af.Workloads {
-		destWd := dest.Workloads[i]
+	for i, wd := range af.ParsedComponents {
+		destWd := dest.ParsedComponents[i]
 		if wd.Name != destWd.Name || len(wd.Traits) != len(destWd.Traits) {
 			return false
 		}
@@ -327,7 +327,7 @@ var _ = Describe("Test application parser", func() {
 		// prepare verify data
 		expectedExceptAppfile = &Appfile{
 			Name: "backport-1-2-test-demo",
-			Workloads: []*Workload{
+			ParsedComponents: []*Component{
 				{
 					Name: "backport-1-2-test-demo",
 					Type: "webservice",
@@ -509,7 +509,7 @@ patch: spec: replicas: parameter.replicas
 
 func TestParser_parseTraits(t *testing.T) {
 	type args struct {
-		workload *Workload
+		workload *Component
 		comp     common.ApplicationComponent
 	}
 	tests := []struct {
@@ -517,7 +517,7 @@ func TestParser_parseTraits(t *testing.T) {
 		args                 args
 		wantErr              assert.ErrorAssertionFunc
 		mockTemplateLoaderFn TemplateLoaderFn
-		validateFunc         func(w *Workload) bool
+		validateFunc         func(w *Component) bool
 	}{
 		{
 			name: "test empty traits",
@@ -574,7 +574,7 @@ func TestParser_parseTraits(t *testing.T) {
 						},
 					},
 				},
-				workload: &Workload{},
+				workload: &Component{},
 			},
 			wantErr: assert.NoError,
 			mockTemplateLoaderFn: func(ctx context.Context, reader client.Client, s string, capType types.CapType) (*Template, error) {
@@ -585,7 +585,7 @@ func TestParser_parseTraits(t *testing.T) {
 					CustomStatus:       "healthy",
 				}, nil
 			},
-			validateFunc: func(w *Workload) bool {
+			validateFunc: func(w *Component) bool {
 				return w != nil && len(w.Traits) != 0 && w.Traits[0].Name == "expose" && w.Traits[0].Template == "template"
 			},
 		},
@@ -608,12 +608,12 @@ func TestParser_parseTraitsFromRevision(t *testing.T) {
 	type args struct {
 		comp     common.ApplicationComponent
 		appRev   *v1beta1.ApplicationRevision
-		workload *Workload
+		workload *Component
 	}
 	tests := []struct {
 		name         string
 		args         args
-		validateFunc func(w *Workload) bool
+		validateFunc func(w *Component) bool
 		wantErr      assert.ErrorAssertionFunc
 	}{
 		{
@@ -634,7 +634,7 @@ func TestParser_parseTraitsFromRevision(t *testing.T) {
 						},
 					},
 				},
-				workload: &Workload{},
+				workload: &Component{},
 			},
 			wantErr: assert.Error,
 		},
@@ -656,7 +656,7 @@ func TestParser_parseTraitsFromRevision(t *testing.T) {
 						},
 					},
 				},
-				workload: &Workload{},
+				workload: &Component{},
 			},
 			wantErr: assert.Error,
 		},
@@ -685,10 +685,10 @@ func TestParser_parseTraitsFromRevision(t *testing.T) {
 						},
 					},
 				},
-				workload: &Workload{},
+				workload: &Component{},
 			},
 			wantErr: assert.NoError,
-			validateFunc: func(w *Workload) bool {
+			validateFunc: func(w *Component) bool {
 				return w != nil && len(w.Traits) == 1 && w.Traits[0].Name == "expose"
 			},
 		},

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -502,7 +502,10 @@ patch: spec: replicas: parameter.replicas
 
 			_, err := NewApplicationParser(&mockClient, pd).GenerateAppFile(context.TODO(), &app)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error() == "failed to get workflow step definition apply-application-unknown: not found").Should(BeTrue())
+			Expect(err.Error()).Should(SatisfyAll(
+				ContainSubstring("failed to get workflow step definition apply-application-unknown: not found"),
+				ContainSubstring("failed to parseWorkflowStepsForLegacyRevision")),
+			)
 		})
 	})
 })

--- a/pkg/appfile/unit_test.go
+++ b/pkg/appfile/unit_test.go
@@ -38,7 +38,7 @@ func TestIsNotFoundInAppRevision(t *testing.T) {
 	require.True(t, IsNotFoundInAppRevision(fmt.Errorf("ComponentDefinition XXX not found in app revision")))
 }
 
-func TestParseWorkloadFromRevisionAndClient(t *testing.T) {
+func TestParseComponentFromRevisionAndClient(t *testing.T) {
 	ctx := context.Background()
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 	p := &Parser{
@@ -63,21 +63,21 @@ func TestParseWorkloadFromRevisionAndClient(t *testing.T) {
 	require.NoError(t, cli.Create(ctx, cd))
 	require.NoError(t, cli.Create(ctx, td))
 	appRev.Spec.TraitDefinitions = map[string]*v1beta1.TraitDefinition{"internal": {}}
-	_, err := p.ParseWorkloadFromRevisionAndClient(ctx, comp, appRev)
+	_, err := p.ParseComponentFromRevisionAndClient(ctx, comp, appRev)
 	require.NoError(t, err)
 
 	_comp1 := comp.DeepCopy()
 	_comp1.Type = "bad"
-	_, err = p.ParseWorkloadFromRevisionAndClient(ctx, *_comp1, appRev)
+	_, err = p.ParseComponentFromRevisionAndClient(ctx, *_comp1, appRev)
 	require.Error(t, err)
 
 	_comp2 := comp.DeepCopy()
 	_comp2.Traits[0].Type = "bad"
-	_, err = p.ParseWorkloadFromRevisionAndClient(ctx, *_comp2, appRev)
+	_, err = p.ParseComponentFromRevisionAndClient(ctx, *_comp2, appRev)
 	require.Error(t, err)
 
 	_comp3 := comp.DeepCopy()
 	_comp3.Traits[0].Properties = &runtime.RawExtension{Raw: []byte(`bad`)}
-	_, err = p.ParseWorkloadFromRevisionAndClient(ctx, *_comp3, appRev)
+	_, err = p.ParseComponentFromRevisionAndClient(ctx, *_comp3, appRev)
 	require.Error(t, err)
 }

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -30,7 +30,7 @@ import (
 
 // ValidateCUESchematicAppfile validates CUE schematic workloads in an Appfile
 func (p *Parser) ValidateCUESchematicAppfile(a *Appfile) error {
-	for _, wl := range a.Workloads {
+	for _, wl := range a.ParsedComponents {
 		// because helm & kube schematic has no CUE template
 		// it only validates CUE schematic workload
 		if wl.CapabilityCategory != types.CUECategory || wl.Type == v1alpha1.RefObjectsComponentType {
@@ -53,7 +53,7 @@ func (p *Parser) ValidateCUESchematicAppfile(a *Appfile) error {
 	return nil
 }
 
-func newValidationProcessContext(wl *Workload, ctxData velaprocess.ContextData) (process.Context, error) {
+func newValidationProcessContext(c *Component, ctxData velaprocess.ContextData) (process.Context, error) {
 	baseHooks := []process.BaseHook{
 		// add more hook funcs here to validate CUE base
 	}
@@ -65,7 +65,7 @@ func newValidationProcessContext(wl *Workload, ctxData velaprocess.ContextData) 
 	ctxData.BaseHooks = baseHooks
 	ctxData.AuxiliaryHooks = auxiliaryHooks
 	pCtx := velaprocess.NewContext(ctxData)
-	if err := wl.EvalContext(pCtx); err != nil {
+	if err := c.EvalContext(pCtx); err != nil {
 		return nil, errors.Wrapf(err, "evaluate base template app=%s in namespace=%s", ctxData.AppName, ctxData.Namespace)
 	}
 	return pCtx, nil

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Test validate CUE schematic Appfile", func() {
 
 	DescribeTable("Test validate outputs name unique", func(tc SubTestCase) {
 		Expect("").Should(BeEmpty())
-		wl := &Workload{
+		wl := &Component{
 			Name:               "myweb",
 			Type:               "worker",
 			CapabilityCategory: types.CUECategory,

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
@@ -258,7 +258,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	var phase = common.ApplicationRunning
-	if !hasHealthCheckPolicy(appFile.PolicyWorkloads) {
+	if !hasHealthCheckPolicy(appFile.ParsedPolicies) {
 		app.Status.Services = handler.services
 		if !isHealthy(handler.services) {
 			phase = common.ApplicationUnhealthy
@@ -498,7 +498,7 @@ func (r *Reconciler) doWorkflowFinish(logCtx monitorContext.Context, app *v1beta
 	logCtx.Info("Application manifests has applied by workflow successfully")
 }
 
-func hasHealthCheckPolicy(policies []*appfile.Workload) bool {
+func hasHealthCheckPolicy(policies []*appfile.Component) bool {
 	for _, p := range policies {
 		if p.FullTemplate != nil && p.FullTemplate.PolicyDefinition != nil &&
 			p.FullTemplate.PolicyDefinition.Spec.ManageHealthCheck {

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -108,8 +108,8 @@ func (h *AppHandler) GenerateApplicationSteps(ctx monitorContext.Context,
 	oamProvider.Install(handlerProviders, app, af, h.r.Client, h.applyComponentFunc(
 		appParser, appRev, af), h.renderComponentFunc(appParser, appRev, af))
 	pCtx := velaprocess.NewContext(generateContextDataFromApp(app, appRev.Name))
-	renderer := func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Workload, error) {
-		return appParser.ParseWorkloadFromRevisionAndClient(ctx, comp, appRev)
+	renderer := func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Component, error) {
+		return appParser.ParseComponentFromRevisionAndClient(ctx, comp, appRev)
 	}
 	multiclusterProvider.Install(handlerProviders, h.r.Client, app, af,
 		h.applyComponentFunc(appParser, appRev, af),
@@ -439,8 +439,8 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 	comp common.ApplicationComponent,
 	appRev *v1beta1.ApplicationRevision,
 	patcher *value.Value,
-	af *appfile.Appfile) (*appfile.Workload, *types.ComponentManifest, error) {
-	wl, err := appParser.ParseWorkloadFromRevisionAndClient(ctx, comp, appRev)
+	af *appfile.Appfile) (*appfile.Component, *types.ComponentManifest, error) {
+	wl, err := appParser.ParseComponentFromRevisionAndClient(ctx, comp, appRev)
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "ParseWorkload")
 	}
@@ -490,10 +490,10 @@ func renderComponentsAndTraits(client client.Client, manifest *types.ComponentMa
 	return readyWorkload, readyTraits, nil
 }
 
-func checkSkipApplyWorkload(wl *appfile.Workload) {
-	for _, trait := range wl.Traits {
+func checkSkipApplyWorkload(comp *appfile.Component) {
+	for _, trait := range comp.Traits {
 		if trait.FullTemplate.TraitDefinition.Spec.ManageWorkload {
-			wl.SkipApplyWorkload = true
+			comp.SkipApplyWorkload = true
 			break
 		}
 	}

--- a/pkg/controller/core.oam.dev/v1beta1/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/revision.go
@@ -213,7 +213,7 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 			},
 		},
 	}
-	for _, w := range af.Workloads {
+	for _, w := range af.ParsedComponents {
 		if w == nil {
 			continue
 		}
@@ -238,7 +238,7 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 			}
 		}
 	}
-	for _, p := range af.PolicyWorkloads {
+	for _, p := range af.ParsedPolicies {
 		if p == nil || p.FullTemplate == nil {
 			continue
 		}

--- a/pkg/controller/core.oam.dev/v1beta1/application/revision_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/revision_test.go
@@ -177,7 +177,7 @@ var _ = Describe("test generate revision ", func() {
 		Expect(handler.FinalizeAndApplyAppRevision(ctx)).Should(Succeed())
 		prevHash := generatedAppfile.AppRevisionHash
 		handler.app.Status.LatestRevision = &common.Revision{Name: generatedAppfile.AppRevisionName, Revision: 1, RevisionHash: generatedAppfile.AppRevisionHash}
-		generatedAppfile.Workloads[0].FullTemplate.ComponentDefinition = nil
+		generatedAppfile.ParsedComponents[0].FullTemplate.ComponentDefinition = nil
 		generatedAppfile.RelatedComponentDefinitions = map[string]*v1beta1.ComponentDefinition{}
 		Expect(handler.PrepareCurrentAppRevision(ctx, generatedAppfile)).Should(Succeed())
 		nonChangeHash := generatedAppfile.AppRevisionHash

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -23,8 +23,6 @@ const (
 	LabelAppName = "app.oam.dev/name"
 	// LabelAppRevision records the name of Application, it's equal to name of AppConfig created by Application
 	LabelAppRevision = "app.oam.dev/appRevision"
-	// LabelAppDeployment records the name of AppDeployment.
-	LabelAppDeployment = "app.oam.dev/appDeployment"
 	// LabelAppComponent records the name of Component
 	LabelAppComponent = "app.oam.dev/component"
 	// LabelReplicaKey records the replica key of Component
@@ -62,11 +60,6 @@ const (
 
 	// LabelControllerRevisionComponent indicate which component the revision belong to
 	LabelControllerRevisionComponent = "controller.oam.dev/component"
-	// LabelComponentRevisionHash records the hash value of a component
-	LabelComponentRevisionHash = "app.oam.dev/component-revision-hash"
-
-	// LabelAddonsName records the name of initializer stored in configMap
-	LabelAddonsName = "addons.oam.dev/type"
 
 	// LabelAddonName indicates the name of the corresponding Addon
 	LabelAddonName = "addons.oam.dev/name"
@@ -142,13 +135,6 @@ const (
 	//	its controller should not try to reconcile it
 	AnnotationAppRevision = "app.oam.dev/app-revision"
 
-	// AnnotationAppRevisionOnly the Application update should only generate revision,
-	// not any appContexts or components.
-	AnnotationAppRevisionOnly = "app.oam.dev/revision-only"
-
-	// AnnotationWorkflowContext is used to pass in the workflow context marshalled in json format.
-	AnnotationWorkflowContext = "app.oam.dev/workflow-context"
-
 	// AnnotationKubeVelaVersion is used to record current KubeVela version
 	AnnotationKubeVelaVersion = "oam.dev/kubevela-version"
 
@@ -158,14 +144,8 @@ const (
 	// AnnotationFilterLabelKeys is used to filter labels passed to workload and trait, split by comma
 	AnnotationFilterLabelKeys = "filter.oam.dev/label-keys"
 
-	// AnnotationSkipGC is used to tell application to skip gc workload/trait
-	AnnotationSkipGC = "app.oam.dev/skipGC"
-
 	// AnnotationDefinitionRevisionName is used to specify the name of DefinitionRevision in component/trait definition
 	AnnotationDefinitionRevisionName = "definitionrevision.oam.dev/name"
-
-	// AnnotationAddonsName records the name of initializer stored in configMap
-	AnnotationAddonsName = "addons.oam.dev/name"
 
 	// AnnotationLastAppliedConfiguration is kubectl annotations for 3-way merge
 	AnnotationLastAppliedConfiguration = "kubectl.kubernetes.io/last-applied-configuration"
@@ -188,12 +168,6 @@ const (
 
 	// AnnotationAppAlias specifies the alias for application in db.
 	AnnotationAppAlias = "app.oam.dev/appAlias"
-
-	// AnnotationWorkloadGVK indicates the managed workload's GVK by trait
-	AnnotationWorkloadGVK = "trait.oam.dev/workload-gvk"
-
-	// AnnotationWorkloadName indicates the managed workload's name by trait
-	AnnotationWorkloadName = "trait.oam.dev/workload-name"
 
 	// AnnotationControllerRequirement indicates the controller version that can process the application/definition.
 	AnnotationControllerRequirement = "app.oam.dev/controller-version-require"

--- a/pkg/workflow/providers/oam/apply.go
+++ b/pkg/workflow/providers/oam/apply.go
@@ -53,7 +53,7 @@ type ComponentRender func(ctx context.Context, comp common.ApplicationComponent,
 type ComponentHealthCheck func(ctx context.Context, comp common.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (bool, *unstructured.Unstructured, []*unstructured.Unstructured, error)
 
 // WorkloadRenderer renderer to render application component into workload
-type WorkloadRenderer func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Workload, error)
+type WorkloadRenderer func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Component, error)
 
 type provider struct {
 	render ComponentRender

--- a/pkg/workflow/providers/terraform/terraform_test.go
+++ b/pkg/workflow/providers/terraform/terraform_test.go
@@ -33,14 +33,14 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile"
 )
 
-func fakeWorkloadRenderer(_ context.Context, comp apicommon.ApplicationComponent) (*appfile.Workload, error) {
+func fakeWorkloadRenderer(_ context.Context, comp apicommon.ApplicationComponent) (*appfile.Component, error) {
 	if strings.HasPrefix(comp.Name, "error") {
 		return nil, errors.New(comp.Name)
 	}
 	if strings.HasPrefix(comp.Name, "terraform") {
-		return &appfile.Workload{CapabilityCategory: types.TerraformCategory}, nil
+		return &appfile.Component{CapabilityCategory: types.TerraformCategory}, nil
 	}
-	return &appfile.Workload{CapabilityCategory: types.CUECategory}, nil
+	return &appfile.Component{CapabilityCategory: types.CUECategory}, nil
 }
 
 func TestLoadTerraformComponents(t *testing.T) {

--- a/references/appfile/addon.go
+++ b/references/appfile/addon.go
@@ -71,7 +71,7 @@ func ApplyTerraform(app *v1beta1.Application, k8sClient client.Client, ioStream 
 		return nil, err
 	}
 
-	for i, wl := range appFile.Workloads {
+	for i, wl := range appFile.ParsedComponents {
 		switch wl.CapabilityCategory {
 		case types.TerraformCategory:
 			name := wl.Name
@@ -191,8 +191,8 @@ func generateSecretFromTerraformOutput(k8sClient client.Client, outputList []str
 }
 
 // getTerraformJSONFiles gets Terraform JSON files or modules from workload
-func getTerraformJSONFiles(wl *appfile.Workload, ctxData process.ContextData) ([]byte, error) {
-	pCtx, err := appfile.PrepareProcessContext(wl, ctxData)
+func getTerraformJSONFiles(comp *appfile.Component, ctxData process.ContextData) ([]byte, error) {
+	pCtx, err := appfile.PrepareProcessContext(comp, ctxData)
 	if err != nil {
 		return nil, err
 	}

--- a/references/cli/components.go
+++ b/references/cli/components.go
@@ -190,7 +190,7 @@ func PrintComponentListFromRegistry(registry Registry, ioStreams cmdutil.IOStrea
 
 // InstallCompByNameFromRegistry will install given componentName comp to cluster from registry
 func InstallCompByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStreams, compName string, registry Registry) error {
-	capObj, data, err := registry.GetCap(compName)
+	_, data, err := registry.GetCap(compName)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func InstallCompByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStreams
 		return err
 	}
 
-	err = common.InstallComponentDefinition(k8sClient, data, ioStream, &capObj)
+	err = common.InstallComponentDefinition(k8sClient, data, ioStream)
 	if err != nil {
 		return err
 	}

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -189,7 +189,7 @@ func PrintTraitListFromRegistry(registry Registry, ioStreams cmdutil.IOStreams, 
 
 // InstallTraitByNameFromRegistry will install given traitName trait to cluster
 func InstallTraitByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStreams, traitName string, registry Registry) error {
-	capObj, data, err := registry.GetCap(traitName)
+	_, data, err := registry.GetCap(traitName)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func InstallTraitByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStream
 		return err
 	}
 
-	err = common.InstallTraitDefinition(k8sClient, data, ioStream, &capObj)
+	err = common.InstallTraitDefinition(k8sClient, data, ioStream)
 	if err != nil {
 		return err
 	}

--- a/references/docgen/cluster_test.go
+++ b/references/docgen/cluster_test.go
@@ -77,10 +77,6 @@ var _ = Describe("DefinitionFiles", func() {
 				Name: "env",
 			},
 		},
-		CrdInfo: &types.CRDInfo{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		Labels: map[string]string{"usecase": "forplugintest"},
 	}
 
@@ -110,11 +106,7 @@ var _ = Describe("DefinitionFiles", func() {
 			},
 		},
 		CrdName: "deployments.apps",
-		CrdInfo: &types.CRDInfo{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		Labels: map[string]string{"usecase": "forplugintest"},
+		Labels:  map[string]string{"usecase": "forplugintest"},
 	}
 
 	req, _ := labels.NewRequirement("usecase", selection.Equals, []string{"forplugintest"})


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

### Description of your changes

Main changes are:

1. Tidy appfile parse process, remove unused properties, rename workload->component
2. Tidy Capability properties

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d4d2734</samp>

### Summary
🚚🛠️📝

<!--
1.  🚚 - This emoji represents the renaming and moving of types and functions from one package or file to another, as well as the removal of unused or deprecated code. It conveys the idea of refactoring and cleaning up the codebase.
3.  🛠️ - This emoji represents the updating and fixing of the code to use the latest versions of dependencies, packages, and APIs, as well as the alignment of the code with the application model and the appfile package. It conveys the idea of improving the functionality and compatibility of the code.
4.  📝 - This emoji represents the updating and improving of the documentation, comments, and error messages in the code, as well as the simplification and clarification of the code logic and structure. It conveys the idea of enhancing the readability and maintainability of the code.
-->
Refactor the appfile package and related controllers to use the `Component` and `ParsedComponents` types instead of the `Workload` and `Workloads` types, and remove unused or deprecated code related to helm charts, CRDs, and labels. This improves the consistency, readability, and maintainability of the code and aligns with the application model.

> _Oh we're the crew of the appfile ship, and we sail the code sea_
> _We've changed the `Workload` to `Component`, and the `ParsedComponents` we need_
> _So heave away, heave away, heave away on the count of three_
> _We've simplified the types and names, and improved the consistency_

### Walkthrough
*  Remove unused types and fields from the `types` and `Capability` packages ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4ecb3b46e3a0cddc31ab54aa1f8e4fbcba0bd0d4e153dfbc81c04b57af95d7c9L35-L50), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4ecb3b46e3a0cddc31ab54aa1f8e4fbcba0bd0d4e153dfbc81c04b57af95d7c9L110), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4ecb3b46e3a0cddc31ab54aa1f8e4fbcba0bd0d4e153dfbc81c04b57af95d7c9L124-R107))
*  Update the import path and setup function of the `oamv1beta1` package in the `server` package ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-a57ee75b273fb895d1187cd441b0ad88c832a42c02121b246d6ce6d55f58cf5eL50-R50), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-a57ee75b273fb895d1187cd441b0ad88c832a42c02121b246d6ce6d55f58cf5eL230-R230))
*  Update the expected output of the `dry-run` and `diff` commands in the `plugin` test, from `Component` to `ParsedComponents` ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L562-R562), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L674-R674), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L701-R701), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L721-R721), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L744-R744), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L776-R776), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-369eee1021766571ad6e20efdb16848f23ec8837cf6ce240acfd7db01407f7f5L796-R796))
*  Update the title of the custom component header in the `mods` package, from `Built-in Component Type` to `Built-in ParsedComponents Type` ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-754c819708a45a816796192b7a5575be2ea8774e30b6c0b7c8b712e74e6caa30L45-R45))
*  Rename the `Workload` type to `Component` and the `Workloads` field to `ParsedComponents` in the `appfile` package, and remove unused fields and parameters ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL77-R80), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL92-R106), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL110-R126), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL171-R176), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL186-R193), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL197-R199), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL207-R208), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL217-R218), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL234-R238), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL243-R244), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL252-R253), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL286-R290), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL304-R319), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL396-R405), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL419-R423), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL494-R502), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL513-R534), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL548-R553), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL558-R559), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL564-R585), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL596-R597), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL608-R619), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL625-R628), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL638-R639), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-43788a1ca93b9153bf14f7c6ded757be167657dee1c088fa87bbbca5b345cb8bL645-R658))
*  Update the calls and signatures of the `newAppFile`, `parseComponents`, `parseWorkflowSteps`, `fetchAndSetWorkflowStepDefinition`, `makeComponent`, `convertTemplate2Component`, `ParseComponentFromRevision`, `ParseComponentFromRevisionAndClient`, and `parseWorkflowStepsForLegacyRevision` functions in the `appfile` package ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L108-L109), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L117-R115), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L123-R140), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L174-R150), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L241-R217), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L254-R270), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L384-R351), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L427-R394), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L475-R445), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L483-R453), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L490-R460), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L500-R470), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L515-R493), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L529-R514), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L552-R576), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L581-R587), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L597-R622), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L612-R634), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L628-R656), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L640-R665), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-72491e6e5c2c0f6891265e6a4a636ff88e7db16e330f8c913873bd69b190a803L695-R717))
*  Update the tests in the `appfile` package to use the `Component` and `ParsedComponents` types ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L138-R138), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L164-R167), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L322-R322), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L328-R328), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L598-R598), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L733-R733), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1862f643abc85049d047af33bc97640f6b9ce4ff598a8fa599c76abc6bec4543L754-R754), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL49-R49), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL289-R293), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL330-R330), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL512-R512), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL520-R520), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL577-R577), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL588-R588), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL611-R616), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL637-R637), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL659-R659), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-7cdddac425afab7c81799a3f7f1af9a89d0d9e7522aaf6a6ec8bc72984d9f56dL688-R691), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4d423c9d60c3d9380e615eb3008847b221d22b5e9d07a45ba4c8d86eae4ffe2fL41-R41), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4d423c9d60c3d9380e615eb3008847b221d22b5e9d07a45ba4c8d86eae4ffe2fL66-R81), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-9ee22834e92bbd8ab9ec3b17a168b74ad52bf57592f84e9a2e632ab56bf85922L37-R37))
*  Update the `ValidateCUESchematicAppfile` and `newValidationProcessContext` functions in the `appfile` package to use the `Component` type ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-ea4007d5b146cac649e6ba69c9ec540ce09e09c2e1f632c4b87464b675edef46L33-R33), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-ea4007d5b146cac649e6ba69c9ec540ce09e09c2e1f632c4b87464b675edef46L56-R56), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-ea4007d5b146cac649e6ba69c9ec540ce09e09c2e1f632c4b87464b675edef46L68-R68))
*  Update the `application` controller to use the `ParsedPolicies` and `Component` types ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-06ebcb8218d602c23bb47744120b519432420537cc359982de19dd04f2586456L261-R261), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-06ebcb8218d602c23bb47744120b519432420537cc359982de19dd04f2586456L501-R501))
*  Update the `apply` and `generator` functions in the `application` controller to use the `Component` type and change the parameter and return types accordingly ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L230-R236), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L252-R252), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L259-R259), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L265-R265), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L272-R283), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L290-R300), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L309-R309), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L315-R316), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L327-R327), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L335-R335), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-1231f1d18480e1146845f10b71802bdbec731f2ab350d6143baded165e865db6L343-R343), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212L111-R112), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212L442-R443), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-4170e9b730a11fdd789c7b33a0871e4a67c4e37910815cc262286ac8ec076212L493-R496))
*  Update the `revision` functions in the `application` controller to use the `ParsedComponents` and `ParsedPolicies` types ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-c21f292d942528312440bd97a929675d5aaff3e5981f800ba492efea10dea032L216-R216), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-c21f292d942528312440bd97a929675d5aaff3e5981f800ba492efea10dea032L241-R241), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-15edf9bc627f1ed3a0159da11bcb8f313c2419a07c07517f577bf6bc90b787acL180-R180))
*  Remove unused constants from the `oam` package ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-6e8fb94b47d1b34be47c1aaca38c5737a74f0c9c53518334aacedd5d8c563dc7L26-L27), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-6e8fb94b47d1b34be47c1aaca38c5737a74f0c9c53518334aacedd5d8c563dc7L65-R63), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-6e8fb94b47d1b34be47c1aaca38c5737a74f0c9c53518334aacedd5d8c563dc7L145-L151), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-6e8fb94b47d1b34be47c1aaca38c5737a74f0c9c53518334aacedd5d8c563dc7L161-R149), [link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-6e8fb94b47d1b34be47c1aaca38c5737a74f0c9c53518334aacedd5d8c563dc7L192-L197))
*  Update the `WorkloadRenderer` type alias in the `oam` package to use the `Component` type ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-69aa8ab01d4884613353464548a9b6c5797580a117ff1d06a1d9c96a71fa7c88L56-R56))
*  Update the `fakeWorkloadRenderer` function in the `terraform` test to use the `Component` type ([link](https://github.com/kubevela/kubevela/pull/6250/files?diff=unified&w=0#diff-15dfd492994993d254da29924502ce3222972f6e8413e9126f9c13c897579aa9L36-R43))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->