### PR TITLE
Fix: Print command output using stdout channel #6268

### DIFF
--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -87,6 +87,7 @@ func ClusterCommandGroup(f velacmd.Factory, order string, c common.Args, ioStrea
 			return nil
 		},
 	}
+	cmd.SetOut(ioStreams.Out)
 	cmd.AddCommand(
 		NewClusterListCommand(&c),
 		NewClusterJoinCommand(&c, ioStreams),

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -82,6 +82,7 @@ func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStream
 			types.TagCommandType:  types.TypeExtension,
 		},
 	}
+	cmd.SetOut(ioStreams.Out)
 	cmd.AddCommand(
 		NewDefinitionGetCommand(c),
 		NewDefinitionListCommand(c),

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -56,6 +56,7 @@ func NewWorkflowCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 		Args:   c,
 		Writer: ioStreams.Out,
 	}
+	cmd.SetOut(ioStreams.Out)
 	cmd.AddCommand(
 		NewWorkflowSuspendCommand(c, ioStreams, wargs),
 		NewWorkflowResumeCommand(c, ioStreams, wargs),


### PR DESCRIPTION
### Description of your changes

Sets stdout channel to print the output. The Cobra cmd instance has `SetOut` method that takes IO out writer, setting this will ensure that the output always uses stdout to print the output.

Fixes #6268 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Run `vela def list` and pipe the output to grep it. The status code of the command execution should be zero.
