### PR TITLE
Fix: container-ports trait reserve port name

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/container-ports.yaml
+++ b/charts/vela-core/templates/defwithtemplate/container-ports.yaml
@@ -70,6 +70,7 @@ spec:
         			ports: [ for portVar in _basePorts {
         				containerPort: portVar.containerPort
         				protocol:      portVar.protocol
+        				name:          portVar.name
         				_uniqueKey:    strings.ToLower(portVar.protocol) + strconv.FormatInt(portVar.containerPort, 10)
         				if _portsMap[_uniqueKey] != _|_ {
         					if _portsMap[_uniqueKey].hostPort != _|_ {
@@ -77,11 +78,6 @@ spec:
         					}
         					if _portsMap[_uniqueKey].hostIP != _|_ {
         						hostIP: _portsMap[_uniqueKey].hostIP
-        					}
-        				}
-        				if _portsMap[_uniqueKey] == _|_ {
-        					if portVar.name != _|_ {
-        						name: portVar.name
         					}
         				}
         			}] + [ for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {

--- a/vela-templates/definitions/internal/trait/container-ports.cue
+++ b/vela-templates/definitions/internal/trait/container-ports.cue
@@ -63,6 +63,7 @@ template: {
 				ports: [ for portVar in _basePorts {
 					containerPort: portVar.containerPort
 					protocol:      portVar.protocol
+					name:          portVar.name
 					_uniqueKey:    strings.ToLower(portVar.protocol) + strconv.FormatInt(portVar.containerPort, 10)
 					if _portsMap[_uniqueKey] != _|_ {
 						if _portsMap[_uniqueKey].hostPort != _|_ {
@@ -70,11 +71,6 @@ template: {
 						}
 						if _portsMap[_uniqueKey].hostIP != _|_ {
 							hostIP: _portsMap[_uniqueKey].hostIP
-						}
-					}
-					if _portsMap[_uniqueKey] == _|_ {
-						if portVar.name != _|_ {
-							name: portVar.name
 						}
 					}
 				}] + [ for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {


### PR DESCRIPTION
Signed-off-by: wuzhongjian wuzhongjian_yewu@cmss.chinamobile.com

### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ae8270</samp>

### Summary
🔄🌐🛠️

<!--
1.  🔄 - This emoji represents a refactoring or restructuring of existing code or logic, without changing its functionality or behavior. It can also be used for renaming or moving files or folders.
2. 🌐 - This emoji represents a change related to networking, ports, protocols, or communication between services or components. It can also be used for web development or web-related features.
3. 🛠️ - This emoji represents a change related to fixing, improving, or optimizing something, such as a bug, a performance issue, a dependency, or a configuration. It can also be used for general maintenance or quality assurance tasks.
-->
Refactor container port spec to use name field in `vela-core` template and `container-ports` trait definition. This enhances port identification and consistency across vela components.

> _Sing, O Muse, of the port spec refactor, a noble deed_
> _That brought more clarity and order to the vela-core template_
> _And to the `container-ports` trait, whose logic was refined_
> _By using names instead of maps, as the vela-templates defined_

### Walkthrough
*  Add optional name field to container port spec in both vela-core template and vela-templates definition to simplify port logic and avoid conflicts ([link](https://github.com/kubevela/kubevela/pull/6274/files?diff=unified&w=0#diff-461739c6d8bdf824b34b3587fd7feeaca980e0019e8f1180c9d4398b8f0bddbaR73), [link](https://github.com/kubevela/kubevela/pull/6274/files?diff=unified&w=0#diff-e691818ea219599bb165cb6b231e5a8d8e3a09212c4df30451819ef3a96b3bc7R66))
* Remove unnecessary conditional logic that checked for port name in map from both `charts/vela-core/templates/defwithtemplate/container-ports.yaml` and `vela-templates/definitions/internal/trait/container-ports.cue` as map is no longer used ([link](https://github.com/kubevela/kubevela/pull/6274/files?diff=unified&w=0#diff-461739c6d8bdf824b34b3587fd7feeaca980e0019e8f1180c9d4398b8f0bddbaL82-L86), [link](https://github.com/kubevela/kubevela/pull/6274/files?diff=unified&w=0#diff-e691818ea219599bb165cb6b231e5a8d8e3a09212c4df30451819ef3a96b3bc7L75-L79))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->