### PR TITLE
Fix: identity addon from helm chart structure

### DIFF
--- a/pkg/addon/cache.go
+++ b/pkg/addon/cache.go
@@ -337,6 +337,11 @@ func (u *Cache) listVersionRegistryUIDataAndCache(r Registry) ([]*UIData, error)
 			klog.Errorf("fail to get addon from versioned registry %s, addon %s version %s for cache updating, %v", r.Name, addon.Name, addon.Version, err)
 			continue
 		}
+		// identity an addon from helm chart structure
+		if uiData.Name == "" {
+			addon.Name = ""
+			continue
+		}
 		u.putVersionedUIData2Cache(r.Name, addon.Name, addon.Version, uiData)
 		// we also no version key, if use get addonUIData without version will return this vale as latest data.
 		u.putVersionedUIData2Cache(r.Name, addon.Name, "latest", uiData)


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6c727f6</samp>

### Summary
🛑🚫➡️

<!--
1.  🛑 - This emoji represents the condition that stops the loop from processing an invalid helm chart and prevents it from being cached and displayed.
2.  🚫 - This emoji represents the assignment of an empty string to the `addon.Name` field, which effectively removes the invalid helm chart from the list of addons.
3.  ➡️ - This emoji represents the continuation of the loop to the next helm chart, which skips the invalid one and moves on to the next valid one.
-->
Prevent caching and displaying invalid addons from helm charts. Skip helm charts with empty `uiData.Name` field in `pkg/addon/cache.go`.

> _`uiData.Name` blank_
> _skip invalid helm chart - kireji_
> _spring cleaning cache_

### Walkthrough
* Add a condition to skip invalid addons without a name ([link](https://github.com/kubevela/kubevela/pull/6288/files?diff=unified&w=0#diff-30f651121b79dea3b83a2e6b84ac3faa3083f8406dd24cefc4611dd714faac9aR340-R344))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6289 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->