### PR TITLE
Fix: fix the error when create the same secret twice

### DIFF
--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -618,7 +618,7 @@ func (k *kubeConfigFactory) CreateOrUpdateConfig(ctx context.Context, i *Config,
 		if secret.Labels[types.LabelConfigType] != i.Template.Name {
 			return ErrChangeTemplate
 		}
-		if secret.Type != i.Secret.Type {
+		if i.Secret.Type != "" && secret.Type != i.Secret.Type {
 			return ErrChangeSecretType
 		}
 	}


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d71004d</samp>

### Summary
🐛🔒🚸

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🔒 - This emoji represents a security-related change, which is relevant for any change involving secrets or encryption.
3.  🚸 - This emoji represents an improvement to the user experience or usability, which is applicable for any change that avoids unnecessary errors or confusion for the user.
-->
Fix a bug in `factory.go` that caused an error when secret type was not specified. Allow empty secret type for some secret sources in application configuration.

> _`secret type` check_
> _avoids error when empty_
> _a bug fix in fall_

### Walkthrough
* Fix a bug related to secret sources in the application configuration ([link](https://github.com/kubevela/kubevela/pull/6290/files?diff=unified&w=0#diff-a7bb21919ecd95689199a6a4f1b1d013c8dbe734306be14b2a916f2a21e1b1e2L621-R621))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #5654

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->