### PR TITLE
Fix: hide msg when no cluster uninstall

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -1247,6 +1247,9 @@ func checkUninstallFromClusters(ctx context.Context, k8sClient client.Client, ad
 		}
 		installedClusters = append(installedClusters, c)
 	}
+	if len(disableClusters) == 0 {
+		return nil
+	}
 	fmt.Println(color.New(color.FgRed).Sprintf("'%s' addon was currently installed on clusters %s, but this operation will uninstall from these clusters: %s \n", addonName, generateClustersInfo(installedClusters), generateClustersInfo(disableClusters)))
 	input := NewUserInput()
 	if !input.AskBool("Do you want to continue?", &UserInputOptions{AssumeYes: false}) {


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8b920a5</samp>

### Summary
🚫🚀🔧

<!--
1.  🚫 - This emoji conveys the idea of avoiding or preventing something, which matches the goal of the check to avoid unnecessary operations.
2.  🚀 - This emoji suggests speed or efficiency, which relates to the benefit of the change in improving the addon uninstall logic and performance.
3.  🔧 - This emoji implies fixing or tweaking something, which reflects the fact that this change is part of a larger refactor to fix some issues with the addon uninstall logic.
-->
Refactor addon uninstall logic and fix issues. Add a check in `addon.go` to skip disabling addon if no clusters are found.

> _`clusters` are empty_
> _no need to disable `addon`_
> _autumn leaves fall fast_

### Walkthrough
* Refactor the addon uninstall logic to avoid unnecessary operations and fix some issues ([link](https://github.com/kubevela/kubevela/pull/6294/files?diff=unified&w=0#diff-5c1ce01bb88762ec6a5abb96531e8ac946cff33a1fa7ff2e033131f8dcf0e2b8R1250-R1252))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->