### PR TITLE
Feat: enable unknown flags

### DIFF
--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -75,6 +75,10 @@ func NewCoreCommand() *cobra.Command {
 			return run(signals.SetupSignalHandler(), s)
 		},
 		SilenceUsage: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags for backward-compatibility.
+			UnknownFlags: true,
+		},
 	}
 
 	fs := cmd.Flags()

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -60,6 +60,10 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags for backward-compatibility.
+			UnknownFlags: true,
+		},
 	}
 
 	scheme := common.Scheme


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ee68df</samp>

### Summary
🚩🆕🔙

<!--
1.  🚩 - This emoji represents the concept of flags or options that can be passed to a command. It also conveys the idea of ignoring or whitelisting some flags that may be unknown or deprecated.
2.  🆕 - This emoji represents the concept of adding or introducing a new feature or functionality. It also conveys the idea of innovation or improvement.
3.  🔙 - This emoji represents the concept of backward-compatibility or supporting older versions or formats. It also conveys the idea of preservation or legacy.
-->
This pull request adds a new field to the `cobra.Command` structs that are used to create the root commands for the `vela-core` and `vela` binaries. This field enables the commands to ignore unknown flags for backward-compatibility reasons.

> _`cobra.Command` has_
> _`FParseErrWhitelist` now_
> _ignoring unknown flags_

### Walkthrough
*  Add `FParseErrWhitelist` field to `cobra.Command` structs to ignore unknown flags for backward-compatibility ([link](https://github.com/kubevela/kubevela/pull/6303/files?diff=unified&w=0#diff-a57ee75b273fb895d1187cd441b0ad88c832a42c02121b246d6ce6d55f58cf5eR78-R81), [link](https://github.com/kubevela/kubevela/pull/6303/files?diff=unified&w=0#diff-004b35966c6dda784fba0fe64ddc863a10d0bab72fbedf97929daebc8d18d93dR63-R66))
*  Update `cmd/core/app/server.go` to create the root command for the `vela-core` binary with the new field ([link](https://github.com/kubevela/kubevela/pull/6303/files?diff=unified&w=0#diff-a57ee75b273fb895d1187cd441b0ad88c832a42c02121b246d6ce6d55f58cf5eR78-R81))
*  Update `references/cli/cli.go` to create the root command for the `vela` binary with the new field ([link](https://github.com/kubevela/kubevela/pull/6303/files?diff=unified&w=0#diff-004b35966c6dda784fba0fe64ddc863a10d0bab72fbedf97929daebc8d18d93dR63-R66))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->