### PR TITLE
Fix: addon dependency package retrieving is not compatible to v-prefixed version

### DIFF
--- a/pkg/addon/versioned_registry.go
+++ b/pkg/addon/versioned_registry.go
@@ -161,7 +161,7 @@ func (i versionedRegistry) loadAddon(ctx context.Context, name, version string) 
 	sort.Sort(sort.Reverse(versions))
 	addonVersion, availableVersions := chooseVersion(version, versions)
 	if addonVersion == nil {
-		return nil, errors.Errorf("specified version %s not exist", utils.Sanitize(version))
+		return nil, errors.Errorf("specified version %s for addon %s not exist", utils.Sanitize(version), name)
 	}
 	for _, chartURL := range addonVersion.URLs {
 		if !utils.IsValidURL(chartURL) {
@@ -231,6 +231,7 @@ func loadAddonPackage(addonName string, files []*loader.BufferedFile) (*WholeAdd
 }
 
 // chooseVersion will return the target version and all available versions
+// This function is not sensitive to v-prefix, which means if specifiedVersion=0.3.0, v0.3.0 can be chosen.
 func chooseVersion(specifiedVersion string, versions []*repo.ChartVersion) (*repo.ChartVersion, []string) {
 	var addonVersion *repo.ChartVersion
 	var availableVersions []string
@@ -241,7 +242,7 @@ func chooseVersion(specifiedVersion string, versions []*repo.ChartVersion) (*rep
 			continue
 		}
 		if len(specifiedVersion) != 0 {
-			if v.Version == specifiedVersion {
+			if utils.IgnoreVPrefix(v.Version) == utils.IgnoreVPrefix(specifiedVersion) {
 				addonVersion = versions[i]
 			}
 		} else {

--- a/pkg/addon/versioned_registry_test.go
+++ b/pkg/addon/versioned_registry_test.go
@@ -51,13 +51,36 @@ func TestChooseAddonVersion(t *testing.T) {
 			},
 		},
 	}
-	targetVersion, availableVersion := chooseVersion("v1.2.0", versions)
-	assert.Equal(t, availableVersion, []string{"v1.4.0-beta1", "v1.3.6", "v1.2.0"})
-	assert.Equal(t, targetVersion.Version, "v1.2.0")
-
-	targetVersion, availableVersion = chooseVersion("", versions)
-	assert.Equal(t, availableVersion, []string{"v1.4.0-beta1", "v1.3.6", "v1.2.0"})
-	assert.Equal(t, targetVersion.Version, "v1.3.6")
+	avs := []string{"v1.4.0-beta1", "v1.3.6", "v1.2.0"}
+	for _, tc := range []struct {
+		name             string
+		specifiedVersion string
+		wantVersion      string
+		wantAVersions    []string
+	}{
+		{
+			name:             "choose specified",
+			specifiedVersion: "v1.2.0",
+			wantVersion:      "v1.2.0",
+			wantAVersions:    avs,
+		},
+		{
+			name:             "choose specified, ignore v prefix",
+			specifiedVersion: "1.2.0",
+			wantVersion:      "v1.2.0",
+			wantAVersions:    avs,
+		},
+		{
+			name:             "not specifying version, choose non-prerelease && highest version",
+			specifiedVersion: "",
+			wantVersion:      "v1.3.6",
+			wantAVersions:    avs,
+		},
+	} {
+		targetVersion, availableVersion := chooseVersion(tc.specifiedVersion, versions)
+		assert.Equal(t, availableVersion, tc.wantAVersions)
+		assert.Equal(t, targetVersion.Version, tc.wantVersion)
+	}
 }
 
 var versionedHandler http.HandlerFunc = func(writer http.ResponseWriter, request *http.Request) {

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -80,3 +80,7 @@ func Sanitize(s string) string {
 	s = strings.ReplaceAll(s, "\r", "")
 	return s
 }
+
+func IgnoreVPrefix(s string) string {
+	return strings.TrimPrefix(s, "v")
+}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -81,6 +81,7 @@ func Sanitize(s string) string {
 	return s
 }
 
+// IgnoreVPrefix removes the leading "v" from a string
 func IgnoreVPrefix(s string) string {
 	return strings.TrimPrefix(s, "v")
 }

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -26,3 +26,8 @@ func TestSanitize(t *testing.T) {
 	s := "abc\ndef\rgh"
 	require.Equal(t, "abcdefgh", Sanitize(s))
 }
+
+func TestIgnoreVPrefix(t *testing.T) {
+	require.Equal(t, "1.2.0", IgnoreVPrefix("v1.2.0"))
+	require.Equal(t, "1.2.0", IgnoreVPrefix("1.2.0"))
+}


### PR DESCRIPTION
### Description of your changes


Fixes: https://github.com/kubevela/kubevela/issues/6295

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 198f1f3</samp>

### Summary
🧪🛠️➕

<!--
1.  🧪 This emoji represents testing, and can be used for the changes related to the `TestChooseAddonVersion` and `TestIgnoreVPrefix` functions.
2.  🛠️ This emoji represents fixing or improving, and can be used for the changes related to the error handling and version matching logic for addons.
3.  ➕ This emoji represents adding or creating, and can be used for the changes related to the `utils.IgnoreVPrefix` function.
-->
This pull request enhances the addon versioning and error handling features. It adds a `utils.IgnoreVPrefix` function to remove the v-prefix from versions, and uses it in `pkg/addon/versioned_registry.go` and its test file. It also improves the error messages and the test cases for choosing addon versions.

> _`IgnoreVPrefix` helps_
> _compare addon versions well_
> _autumn of errors_

### Walkthrough
*  Refactor `TestChooseAddonVersion` function to use table-driven test with multiple cases ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-063fdb37ad03f33c987fc5375440658da60e736358588a1305c4db2cea5c1c75L54-R83))
*  Add addon name to error message when specified version does not exist ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-26be8587c8d145547594a37dcbeee70c0cac6de8616038a07b2e9637acc73085L164-R164))
*  Add comment to `chooseVersion` function to explain v-prefix insensitivity ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-26be8587c8d145547594a37dcbeee70c0cac6de8616038a07b2e9637acc73085R234))
*  Modify `chooseVersion` function to use `utils.IgnoreVPrefix` function to compare versions ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-26be8587c8d145547594a37dcbeee70c0cac6de8616038a07b2e9637acc73085L244-R245))
*  Add `TestIgnoreVPrefix` function to test `utils.IgnoreVPrefix` function with different inputs and outputs ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-9f0595779a258e5ab53b924c8d89d93f9fae98dd0f32c2cc1163551178bc414dR29-R33))
*  Add `utils.IgnoreVPrefix` function to remove v-prefix from version string if it exists ([link](https://github.com/kubevela/kubevela/pull/6316/files?diff=unified&w=0#diff-9128bfe925e886e4891edaa9667c047ea3cc83b9b1e2968e0c01c9bec19201d6R83-R86))



<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->