### PR TITLE
Feat: Add command to list all workflows in vela-cli

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -63,6 +63,8 @@ import (
 	terraformapiv1 "github.com/oam-dev/terraform-controller/api/v1beta1"
 	terraformapi "github.com/oam-dev/terraform-controller/api/v1beta2"
 
+	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
+
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev"
 	"github.com/oam-dev/kubevela/apis/types"
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
@@ -93,6 +95,7 @@ func init() {
 	_ = metricsV1beta1api.AddToScheme(Scheme)
 	_ = kruisev1alpha1.AddToScheme(Scheme)
 	_ = gatewayv1beta1.AddToScheme(Scheme)
+	_ = workflowv1alpha1.AddToScheme(Scheme)
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
### Description of your changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6fd4667</samp>

### Summary
🚀🌊📜

<!--
1.  🚀 - This emoji represents the addition of a bash script to install the vela CLI from the GitHub releases, as it is a useful and convenient feature that can speed up the installation process and make it more user-friendly.
2.  🌊 - This emoji represents the support for the workflow API in the vela CLI, as it is a new and experimental feature that can enable more complex and flexible workflows for the users.
3.  📜 - This emoji represents the new unit test and subcommand for listing the workflows, as they are related to documentation and visibility of the workflows.
-->
This pull request adds support for the workflow API to the vela CLI. It implements a new `workflow list` subcommand, a unit test for it, and a script to install the CLI from GitHub. It also updates the common scheme with the workflowv1alpha1 package.

> _To install vela CLI with ease_
> _There's a bash script for fetching releases_
> _It also supports workflow list_
> _With flags and tests that assist_
> _And imports the workflowv1alpha1 APIs_

### Walkthrough
*  Add a bash script to install the vela CLI from the GitHub releases ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-33472366a5ea56418c8e7f7b1dcbd090d290ff1128a23326686c66e6e5701175R1-R204))
*  Import the workflowv1alpha1 package and add it to the common scheme to enable the vela CLI to interact with the workflow CRDs ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-34b55c11ab5300d3a9d50547854bd984e45aa35cacc4b1289221bddb717502c6R66), [link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-34b55c11ab5300d3a9d50547854bd984e45aa35cacc4b1289221bddb717502c6R97))
*  Add a new list subcommand to the workflow command in `workflow.go` to allow the user to list the running workflows in a given namespace or across all namespaces ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-8a75fc4bcf97cde32992a872fcd7a5afaea22b85633c94f66bda5e5c365fc5bdR70), [link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-8a75fc4bcf97cde32992a872fcd7a5afaea22b85633c94f66bda5e5c365fc5bdR252-R335))
*  Use the gosuri/uitable package to create a table for displaying the workflow list and the k8s.io/apimachinery/pkg/api/errors package to check for the NotFound error ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-8a75fc4bcf97cde32992a872fcd7a5afaea22b85633c94f66bda5e5c365fc5bdL26-R29), [link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-8a75fc4bcf97cde32992a872fcd7a5afaea22b85633c94f66bda5e5c365fc5bdR252-R335))
*  Add a test function for the list command in `workflow_test.go` to cover different workflows, flags, and expected results ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-432e7c7f5e5f95dcde95531d7de37273070e47d4d0299fd66bbcb757429ed059R824-R978))
*  Use the bytes, strings, and time packages to create a buffer, parse the output lines, and format the start and end times in the test function ([link](https://github.com/kubevela/kubevela/pull/6326/files?diff=unified&w=0#diff-432e7c7f5e5f95dcde95531d7de37273070e47d4d0299fd66bbcb757429ed059L20-R26))





Fixes #6301 

I have:

- [ x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added tests

