### PR TITLE
Test: Improving the checks in the application controller unit test

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller_test.go
@@ -692,6 +692,19 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(appRevision.Status.Workflow.EndTime.IsZero()).ShouldNot(BeTrue())
 		Expect(appRevision.Status.Workflow.Phase).Should(Equal(workflowv1alpha1.WorkflowStateSuspending))
 
+		// Fetching the status of the app after modification and ensuring latest revision is incremented
+		Expect(k8sClient.Get(ctx, appKey, curApp)).Should(BeNil())
+		Expect(curApp.Status.Phase).Should(Equal(common.ApplicationRunningWorkflow))
+		Expect(curApp.Status.LatestRevision).ShouldNot(BeNil())
+		Expect(curApp.Status.LatestRevision.Revision).Should(BeEquivalentTo(2))
+
+		// Fetching latest application revision and validating workflow status is nil
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: app.Namespace,
+			Name:      curApp.Status.LatestRevision.Name,
+		}, appRevision)).Should(BeNil())
+		Expect(appRevision.Status.Workflow).Should(BeNil())
+
 		By("Delete Application, clean the resource")
 		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
 	})


### PR DESCRIPTION
### Description of your changes
Improves the checks on the test `revision should be updated if the workflow is restarted` in application controller tests. Improvements:
- Verifying that applications revision got incremented to 2
- Verifying the latest revision's workflow status is nil.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ X] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ X] Run `make reviewable` to ensure this PR is ready for review.
- [ NA] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Not applicable as this is an improvement to existing tests.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->