### PR TITLE
Fix: helm template adding namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,7 @@ lint: golangci
 	@$(GOLANGCILINT) run --fix --verbose --skip-dirs 'scaffold'
 
 ## reviewable: Run the reviewable
-#reviewable: manifests fmt vet lint staticcheck helm-doc-gen sdk_fmt
-reviewable: manifests fmt vet staticcheck helm-doc-gen sdk_fmt
+reviewable: manifests fmt vet lint staticcheck helm-doc-gen sdk_fmt
 	go mod tidy
 
 # check-diff: Execute auto-gen code commands and ensure branch is clean.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ lint: golangci
 	@$(GOLANGCILINT) run --fix --verbose --skip-dirs 'scaffold'
 
 ## reviewable: Run the reviewable
-reviewable: manifests fmt vet lint staticcheck helm-doc-gen sdk_fmt
+#reviewable: manifests fmt vet lint staticcheck helm-doc-gen sdk_fmt
+reviewable: manifests fmt vet staticcheck helm-doc-gen sdk_fmt
 	go mod tidy
 
 # check-diff: Execute auto-gen code commands and ensure branch is clean.

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubevela.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubevela.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -121,6 +122,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubevela.fullname" . }}:leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -154,6 +156,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubevela.fullname" . }}:leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -168,6 +171,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubevela.fullname" . }}:template-reader-role
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -188,6 +192,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubevela.fullname" . }}:template-reader-binding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -46,12 +46,13 @@ else
 GOIMPORTS=$(shell which goimports)
 endif
 
+CUE_VERSION ?= v0.6.0
 .PHONY: installcue
 installcue:
 ifeq (, $(shell which cue))
 	@{ \
 	set -e ;\
-	go install cuelang.org/go/cmd/cue@latest ;\
+	go install cuelang.org/go/cmd/cue@$(CUE_VERSION) ;\
 	}
 CUE=$(GOBIN)/cue
 else


### PR DESCRIPTION
### Description of your changes
This PR adds the target namespace to the Helm Chart. For use cases where `helm template` is being used to obtain the rendered YAML entities, some of the entities did not contain the expected namespace that is being generated.

Additionally, this PR also adds a new makefile constant `CUE_VERSION` as the `latest` was updated two weeks ago and it is not compatible with the underlying golang version. Previous reported error was:

```bash
# cuelang.org/go/cue
/go/pkg/mod/cuelang.org/go@v0.7.0/cue/decode.go:74:5: x.SetZero undefined (type reflect.Value has no field or method SetZero)
/go/pkg/mod/cuelang.org/go@v0.7.0/cue/decode.go:381:12: mapElem.SetZero undefined (type reflect.Value has no field or method SetZero)
/go/pkg/mod/cuelang.org/go@v0.7.0/cue/types.go:1340:16: undefined: bytes.Clone
note: module requires Go 1.20
```

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

* Make reviewable now works with the new CUE dependency.
* Tested new Helm chart generation with:

```bash
helm template kubevela vela-core --set=authentication.enabled=true --set=authentication.withUser=true --create-namespace --skip-tests --namespace vela-system
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->