### PR TITLE
Fix: prevent kube client lookup in GetFakeClient

### DIFF
--- a/pkg/utils/common/args.go
+++ b/pkg/utils/common/args.go
@@ -128,7 +128,7 @@ func (a *Args) GetFakeClient(defs []*unstructured.Unstructured) (client.Client, 
 		return a.client, nil
 	}
 	if a.config == nil {
-		if err := a.SetConfig(nil); err != nil {
+		if err := a.SetConfig(&rest.Config{}); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Description of your changes

Fixes issue where `vela dry-run --offline` fails when the `KUBECONFIG` environment variable is unset.

The fix passes a default rest client to avoid calling `config.GetConfig()`.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Prior to fix:
```bash
❯ unset KUBECONFIG
❯ vela dry-run -f ./app.yaml --offline -d definitions/internal
Error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```
With the fix, the Application resources are rendered properly.

### Special notes for your reviewer
N/A