### PR TITLE
Fix: hpa trait corresponding to cpu parameters when try to use memory

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/hpa.yaml
+++ b/charts/vela-core/templates/defwithtemplate/hpa.yaml
@@ -55,11 +55,11 @@ spec:
         						name: "memory"
         						target: {
         							type: parameter.mem.type
-        							if parameter.cpu.type == "Utilization" {
-        								averageUtilization: parameter.cpu.value
+        							if parameter.mem.type == "Utilization" {
+        								averageUtilization: parameter.mem.value
         							}
-        							if parameter.cpu.type == "AverageValue" {
-        								averageValue: parameter.cpu.value
+        							if parameter.mem.type == "AverageValue" {
+        								averageValue: parameter.mem.value
         							}
         						}
         					}

--- a/vela-templates/definitions/internal/trait/hpa.cue
+++ b/vela-templates/definitions/internal/trait/hpa.cue
@@ -49,11 +49,11 @@ template: {
 							name: "memory"
 							target: {
 								type: parameter.mem.type
-								if parameter.cpu.type == "Utilization" {
-									averageUtilization: parameter.cpu.value
+								if parameter.mem.type == "Utilization" {
+									averageUtilization: parameter.mem.value
 								}
-								if parameter.cpu.type == "AverageValue" {
-									averageValue: parameter.cpu.value
+								if parameter.mem.type == "AverageValue" {
+									averageValue: parameter.mem.value
 								}
 							}
 						}


### PR DESCRIPTION
### Description of your changes

I fixed build-in hpa trait which is using cpu parameters when try to use memory.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

e2e test


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->