### PR TITLE
Fix(CUE): fix variable error bug in startup-probe

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/startup-probe.yaml
+++ b/charts/vela-core/templates/defwithtemplate/startup-probe.yaml
@@ -65,7 +65,7 @@ spec:
         	// +usage=Instructions for assessing container startup status by probing a TCP socket. Either this attribute or the exec attribute or the tcpSocket attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with the exec attribute and the httpGet attribute and the gRPC attribute.
         	tcpSocket?: {
         		// +usage=Number or name of the port to access on the container.
-        		port: string
+        		port: int
         		// +usage=Host name to connect to, defaults to the pod IP.
         		host?: string
         	}
@@ -144,7 +144,7 @@ spec:
         					grpc: parameter.grpc
         				}
         				if parameter.tcpSocket != _|_ {
-        					tcpSocket: parameter.grtcpSocketpc
+        					tcpSocket: parameter.tcpSocket
         				}
         			}}
         		}]

--- a/vela-templates/definitions/internal/trait/startup-probe.cue
+++ b/vela-templates/definitions/internal/trait/startup-probe.cue
@@ -56,7 +56,7 @@ template: {
 		// +usage=Instructions for assessing container startup status by probing a TCP socket. Either this attribute or the exec attribute or the tcpSocket attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with the exec attribute and the httpGet attribute and the gRPC attribute.
 		tcpSocket?: {
 			// +usage=Number or name of the port to access on the container.
-			port: string
+			port: int
 			// +usage=Host name to connect to, defaults to the pod IP.
 			host?: string
 		}
@@ -135,7 +135,7 @@ template: {
 						grpc: parameter.grpc
 					}
 					if parameter.tcpSocket != _|_ {
-						tcpSocket: parameter.grtcpSocketpc
+						tcpSocket: parameter.tcpSocket
 					}
 				}}
 			}]


### PR DESCRIPTION
The original variable is "grtcpSocketpc", but this variable does not exist in the file. According to the context, it should be "tcpSocket". In addition, its type needs to be int to work properly.


### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->