### PR TITLE
Fix: allow different service and container port

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -21,22 +21,28 @@ spec:
         	if parameter.name != _|_ {"-" + parameter.name}
         	if parameter.name == _|_ {""}
         }
-        let serviceOutputName = "service" + nameSuffix
-        let serviceMetaName = context.name + nameSuffix
 
-        outputs: (serviceOutputName): {
-        	apiVersion: "v1"
-        	kind:       "Service"
-        	metadata: name: "\(serviceMetaName)"
-        	spec: {
-        		selector: "app.oam.dev/component": context.name
-        		ports: [
-        			for k, v in parameter.http {
-        				name:       "port-" + strconv.FormatInt(v, 10)
-        				port:       v
-        				targetPort: v
-        			},
-        		]
+        let serviceMetaName = {
+        	if (parameter.existingServiceName != _|_) {parameter.existingServiceName}
+        	if (parameter.existingServiceName == _|_) {context.name + nameSuffix}
+        }
+
+        if (parameter.existingServiceName == _|_) {
+        	let serviceOutputName = "service" + nameSuffix
+        	outputs: (serviceOutputName): {
+        		apiVersion: "v1"
+        		kind:       "Service"
+        		metadata: name: "\(serviceMetaName)"
+        		spec: {
+        			selector: "app.oam.dev/component": context.name
+        			ports: [
+        				for k, v in parameter.http {
+        					name:       "port-" + strconv.FormatInt(v, 10)
+        					port:       v
+        					targetPort: v
+        				},
+        			]
+        		}
         	}
         }
 
@@ -143,6 +149,9 @@ spec:
 
         	// +usage=Specify the labels to be added to the ingress
         	labels?: [string]: string
+
+        	// +usage=If specified, use an existing Service rather than creating one
+        	existingServiceName?: string
         }
   status:
     customStatus: |-

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -165,14 +165,20 @@ spec:
         					if parameter["ports"] != _|_ {
         						ports: [ for v in parameter.ports {
         							{
-        								containerPort: v.port
-        								protocol:      v.protocol
+        								containerPort: {
+        									if v.containerPort != _|_ {v.containerPort}
+        									if v.containerPort == _|_ {v.port}
+        								}
+        								protocol: v.protocol
         								if v.name != _|_ {
         									name: v.name
         								}
         								if v.name == _|_ {
-        									_name: "port-" + strconv.FormatInt(v.port, 10)
-        									name:  *_name | string
+        									_name: {
+        										if v.containerPort != _|_ {"port-" + strconv.FormatInt(v.containerPort, 10)}
+        										if v.containerPort == _|_ {"port-" + strconv.FormatInt(v.port, 10)}
+        									}
+        									name: *_name | string
         									if v.protocol != "TCP" {
         										name: _name + "-" + strings.ToLower(v.protocol)
         									}
@@ -290,14 +296,20 @@ spec:
 
         exposePorts: [
         	if parameter.ports != _|_ for v in parameter.ports if v.expose == true {
-        		port:       v.port
-        		targetPort: v.port
-        		if v.name != _|_ {
-        			name: v.name
-        		}
+        		port: v.port
+        		if v.containerPort != _|_ {targetPort: v.containerPort}
+        		if v.containerPort == _|_ {targetPort: v.port}
+        		if v.name != _|_ {name: v.name}
         		if v.name == _|_ {
-        			_name: "port-" + strconv.FormatInt(v.port, 10)
-        			name:  *_name | string
+        			_name: {
+        				if v.containerPort != _|_ {
+        					"port-" + strconv.FormatInt(v.containerPort, 10)
+        				}
+        				if v.containerPort == _|_ {
+        					"port-" + strconv.FormatInt(v.port, 10)
+        				}
+        			}
+        			name: *_name | string
         			if v.protocol != "TCP" {
         				name: _name + "-" + strings.ToLower(v.protocol)
         			}
@@ -352,6 +364,8 @@ spec:
         	ports?: [...{
         		// +usage=Number of port to expose on the pod's IP address
         		port: int
+        		// +usage=Number of container port to connect to, defaults to port
+        		containerPort?: int
         		// +usage=Name of the port
         		name?: string
         		// +usage=Protocol for port. Must be UDP, TCP, or SCTP

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -64,22 +64,28 @@ template: {
 		if parameter.name != _|_ {"-" + parameter.name}
 		if parameter.name == _|_ {""}
 	}
-	let serviceOutputName = "service" + nameSuffix
-	let serviceMetaName = context.name + nameSuffix
 
-	outputs: (serviceOutputName): {
-		apiVersion: "v1"
-		kind:       "Service"
-		metadata: name: "\(serviceMetaName)"
-		spec: {
-			selector: "app.oam.dev/component": context.name
-			ports: [
-				for k, v in parameter.http {
-					name:       "port-" + strconv.FormatInt(v, 10)
-					port:       v
-					targetPort: v
-				},
-			]
+	let serviceMetaName = {
+		if (parameter.existingServiceName != _|_) {parameter.existingServiceName}
+		if (parameter.existingServiceName == _|_) {context.name + nameSuffix}
+	}
+
+	if (parameter.existingServiceName == _|_) {
+		let serviceOutputName = "service" + nameSuffix
+		outputs: (serviceOutputName): {
+			apiVersion: "v1"
+			kind:       "Service"
+			metadata: name: "\(serviceMetaName)"
+			spec: {
+				selector: "app.oam.dev/component": context.name
+				ports: [
+					for k, v in parameter.http {
+						name:       "port-" + strconv.FormatInt(v, 10)
+						port:       v
+						targetPort: v
+					},
+				]
+			}
 		}
 	}
 
@@ -186,5 +192,8 @@ template: {
 
 		// +usage=Specify the labels to be added to the ingress
 		labels?: [string]: string
+
+		// +usage=If specified, use an existing Service rather than creating one
+		existingServiceName?: string
 	}
 }


### PR DESCRIPTION
### Description of your changes

copilot:all

This PR allows specifying a different port and containerPort to be used by the service created by a webservice component.

It also allows the gateway trait to use an existing service (in the usecase, the one created by the webservice) rather than creating one.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I've used this locally, and have taken care that this is a non-breaking change is new properties are not used.

### Special notes for your reviewer

An example usecase is a dotnet workload in the webservice container where dotnet serves on port 5000, but the service is to be exposed for port 80 requests.  Currently there is no way to achieve this with the standard component/traits.