### PR TITLE
Feat: optimize component-pod template to display podStatus

### DIFF
--- a/charts/vela-core/templates/velaql/component-pod.yaml
+++ b/charts/vela-core/templates/velaql/component-pod.yaml
@@ -53,6 +53,10 @@ data:
             }
             status: {
               phase: pod.object.status.phase
+              if pod.additionalInfo != _|_ {
+              // similar to the STATUS shown in the `kubectl get pod`
+              podStatus: pod.additionalInfo.Status
+              }
               // refer to https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
               if phase != "Pending" && phase != "Unknown" {
                 if pod.object.status.podIP != _|_ {

--- a/pkg/utils/types/ql_type.go
+++ b/pkg/utils/types/ql_type.go
@@ -155,6 +155,7 @@ type ResourceItem struct {
 	Object         *unstructured.Unstructured `json:"object"`
 	PublishVersion string                     `json:"publishVersion"`
 	DeployVersion  string                     `json:"deployVersion"`
+	AdditionalInfo map[string]interface{}     `json:"additionalInfo,omitempty"`
 }
 
 // Workload workload resource base info

--- a/pkg/workflow/providers/legacy/query/handler.go
+++ b/pkg/workflow/providers/legacy/query/handler.go
@@ -162,12 +162,16 @@ func CollectResources(ctx context.Context, params *ListParams) (*ListResult[quer
 			object.SetAPIVersion(opt.Filter.APIVersion)
 			object.SetKind(opt.Filter.Kind)
 			if err := cli.Get(ctx, apimachinerytypes.NamespacedName{Namespace: res.Namespace, Name: res.Name}, object); err == nil {
+				addInfo, err := additionalInfo(*object)
+				if err != nil {
+					klog.Errorf("check additionalInfo for resource apiVersion=%s kind=%s namespace=%s name=%s failure %s, skip this resource", res.APIVersion, res.Kind, res.Namespace, res.Name, err.Error())
+				}
 				resources = append(resources, buildResourceItem(res, querytypes.Workload{
 					APIVersion: app.APIVersion,
 					Kind:       app.Kind,
 					Name:       app.Name,
 					Namespace:  app.Namespace,
-				}, object))
+				}, object, addInfo))
 			} else {
 				klog.Errorf("failed to get the service:%s", err.Error())
 			}

--- a/pkg/workflow/providers/legacy/query/utils.go
+++ b/pkg/workflow/providers/legacy/query/utils.go
@@ -34,12 +34,12 @@ func buildResourceArray(res querytypes.AppliedResource, parent, node *querytypes
 			Kind:       parent.Kind,
 			Name:       parent.Name,
 			Namespace:  parent.Namespace,
-		}, node.Object))
+		}, node.Object, node.AdditionalInfo))
 	}
 	return
 }
 
-func buildResourceItem(res querytypes.AppliedResource, workload querytypes.Workload, object *unstructured.Unstructured) querytypes.ResourceItem {
+func buildResourceItem(res querytypes.AppliedResource, workload querytypes.Workload, object *unstructured.Unstructured, addInfo map[string]interface{}) querytypes.ResourceItem {
 	return querytypes.ResourceItem{
 		Cluster:   res.Cluster,
 		Workload:  workload,
@@ -57,5 +57,6 @@ func buildResourceItem(res querytypes.AppliedResource, workload querytypes.Workl
 			}
 			return res.DeployVersion
 		}(),
+		AdditionalInfo: addInfo,
 	}
 }


### PR DESCRIPTION
### Description of your changes

Add the podStatus field in the velaql template `component-pod` to display the aggregated status of pod containers.

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6611

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->