### PR TITLE
Chore: updates the make fmt command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ fmt: goimports installcue
 	$(CUE) fmt ./vela-templates/definitions/registry/*
 	$(CUE) fmt ./pkg/stdlib/pkgs/*
 	$(CUE) fmt ./pkg/stdlib/op.cue
-	$(CUE) fmt ./pkg/workflow/tasks/template/static/*
+	$(CUE) fmt ./pkg/workflow/template/static/*
 
 ## sdk_fmt: Run go fmt against code
 sdk_fmt:


### PR DESCRIPTION
### Updates the make fmt command

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.