### PR TITLE
Feat(#6505): Add support for Cue Required field feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oam-dev/kubevela
 go 1.22
 
 require (
-	cuelang.org/go v0.5.0
+	cuelang.org/go v0.6.0
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/FogDong/uitable v0.0.5
 	github.com/Masterminds/semver/v3 v3.2.1
@@ -126,7 +126,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
-	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
+	github.com/cockroachdb/apd/v3 v3.2.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
@@ -169,7 +169,6 @@ require (
 	github.com/gobuffalo/flect v0.3.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -236,7 +235,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
-	github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b // indirect
+	github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rubenv/sql-migrate v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
-cuelang.org/go v0.5.0 h1:D6N0UgTGJCOxFKU8RU+qYvavKNsVc/+ZobmifStVJzU=
-cuelang.org/go v0.5.0/go.mod h1:okjJBHFQFer+a41sAe2SaGm1glWS8oEb6CmJvn5Zdws=
+cuelang.org/go v0.6.0 h1:dJhgKCog+FEZt7OwAYV1R+o/RZPmE8aqFoptmxSWyr8=
+cuelang.org/go v0.6.0/go.mod h1:9CxOX8aawrr3BgSdqPj7V0RYoXo7XIb+yDFC6uESrOQ=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -171,8 +171,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cockroachdb/apd/v2 v2.0.2 h1:weh8u7Cneje73dDh+2tEVLUvyBc89iwepWCD8b8034E=
-github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
+github.com/cockroachdb/apd/v3 v3.2.0 h1:79kHCn4tO0VGu3W0WujYrMjBDk8a2H4KEUYcXf7whcg=
+github.com/cockroachdb/apd/v3 v3.2.0/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
@@ -365,6 +365,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-quicktest/qt v1.100.0 h1:I7iSLgIwNp0E0UnSvKJzs7ig0jg/Iq83zsZjtQNW7jY=
 github.com/go-resty/resty/v2 v2.8.0 h1:J29d0JFWwSWrDCysnOK/YjsPMLQTx0TvgJEHVGvf2L8=
 github.com/go-resty/resty/v2 v2.8.0/go.mod h1:UCui0cMHekLrSntoMyofdSTaPpinlRHFtPpizuyDW2w=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
@@ -888,8 +889,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b h1:zd/2RNzIRkoGGMjE+YIsZ85CnDIz672JK2F3Zl4vux4=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b/go.mod h1:KjY0wibdYKc4DYkerHSbguaf3JeIPGhNJBp2BNiFH78=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0 h1:sadMIsgmHpEOGbUs6VtHBXRR1OHevnj7hLx9ZcdNGW4=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/rivo/tview v0.0.0-20221128165837-db36428c92d9 h1:ccTgRxA37ypj3q8zB8G4k3xGPfBbIaMwrf3Yw6k50NY=
 github.com/rivo/tview v0.0.0-20221128165837-db36428c92d9/go.mod h1:YX2wUZOcJGOIycErz2s9KvDaP0jnWwRCirQMPLPpQ+Y=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cue/definition/template.go
+++ b/pkg/cue/definition/template.go
@@ -124,6 +124,10 @@ func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, pa
 	if err != nil {
 		return err
 	}
+	paramCue := val.LookupPath(value.FieldPath(velaprocess.ParameterFieldName))
+	if err := paramCue.Validate(cue.Concrete(true)); err != nil {
+		return errors.WithMessagef(err, "parameter error for %s", wd.name)
+	}
 
 	if err := val.Validate(); err != nil {
 		return errors.WithMessagef(err, "invalid cue template of workload %s after merge parameter and context", wd.name)

--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -1566,3 +1566,270 @@ parameter: {
 		assert.Contains(t, err.Error(), v.err)
 	}
 }
+
+func TestWorkloadParamsValidations(t *testing.T) {
+	testCases := map[string]struct {
+		workloadTemplate string
+		params           map[string]interface{}
+		expectObj        runtime.Object
+		expAssObjs       map[string]runtime.Object
+		category         types.CapabilityCategory
+		hasCompileErr    bool
+		errorString      string
+	}{
+		"Missing Required Param that is used in template": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+		host: parameter.requiredParam
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	requiredParam!: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas": 2,
+				"type":     "ClusterIP",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: true,
+			errorString:   "parameter error for testWorkload: parameter.requiredParam: field is required but not present",
+		},
+		// Missing Required Param that is not used in template
+		"Missing Required Param that is not used in template": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	requiredParam!: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas": 2,
+				"type":     "ClusterIP",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: true,
+			errorString:   "parameter error for testWorkload: parameter.requiredParam: field is required but not present",
+		},
+		//required param that is nested
+		"required param that is nested": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	host: requiredParam!: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas": 2,
+				"type":     "ClusterIP",
+				"host":     map[string]string{},
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: true,
+			errorString:   "parameter error for testWorkload: parameter.host.requiredParam: field is required but not present",
+		},
+		//required params that are provided
+		"required params that are provided": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+		host: parameter.host.requiredParam
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	host: requiredParam!: string
+	param1!: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas": 2,
+				"type":     "ClusterIP",
+				"host":     map[string]interface{}{"requiredParam": "example.com"},
+				"param1":   "newparam",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2), "host": "example.com"},
+			}},
+			hasCompileErr: false,
+			errorString:   "",
+		},
+		//optional and regular param with default value should not give error
+		"optional and regular param with default value should not give error": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	requiredParam!: string
+	optionalParam?: string
+	regularParam: string | *""
+}
+`,
+			params: map[string]interface{}{
+				"replicas":      2,
+				"type":          "ClusterIP",
+				"requiredParam": "example.com",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: false,
+			errorString:   "",
+		},
+		// regular param should give error
+		"regular param should give error": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	requiredParam!: string
+	regularParam: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas":      2,
+				"type":          "ClusterIP",
+				"requiredParam": "example.com",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: true,
+			errorString:   "parameter error for testWorkload: parameter.regularParam: incomplete value string",
+		},
+
+		// multiple errors
+		"multiple errors": {
+			workloadTemplate: `
+output:{
+	apiVersion: "apps/v1"
+    kind: "Deployment"
+	metadata: name: context.name
+    spec: {
+		replicas: parameter.replicas
+	}
+}
+parameter: {
+	replicas: *1 | int
+	type: string
+	requiredParam!: string
+	regularParam: string
+}
+`,
+			params: map[string]interface{}{
+				"replicas": 2,
+				"type":     "ClusterIP",
+			},
+			expectObj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "test"},
+				"spec":       map[string]interface{}{"replicas": int64(2)},
+			}},
+			hasCompileErr: true,
+			errorString:   "parameter error for testWorkload: parameter.requiredParam: field is required but not present (and 1 more errors)",
+		},
+	}
+
+	for _, v := range testCases {
+		ctx := process.NewContext(process.ContextData{
+			AppName:         "myapp",
+			CompName:        "test",
+			Namespace:       "default",
+			AppRevisionName: "myapp-v1",
+			ClusterVersion:  types.ClusterVersion{Minor: "19+"},
+		})
+		wt := NewWorkloadAbstractEngine("testWorkload", &packages.PackageDiscover{})
+		err := wt.Complete(ctx, v.workloadTemplate, v.params)
+		hasError := err != nil
+		assert.Equal(t, v.hasCompileErr, hasError)
+		if v.hasCompileErr {
+			if err != nil {
+				assert.Equal(t, err.Error(), v.errorString)
+			}
+			continue
+		}
+		base, assists := ctx.Output()
+		assert.Equal(t, len(v.expAssObjs), len(assists))
+		assert.NotNil(t, base)
+		baseObj, err := base.Unstructured()
+		assert.Equal(t, nil, err)
+		assert.Equal(t, v.expectObj, baseObj)
+		for _, ss := range assists {
+			assert.Equal(t, AuxiliaryWorkload, ss.Type)
+			got, err := ss.Ins.Unstructured()
+			assert.NoError(t, err)
+			assert.Equal(t, got, v.expAssObjs[ss.Name])
+		}
+	}
+}


### PR DESCRIPTION
Added support for the use of "required" parameter feature of Cuelang that was added in Cue 0.6.

Added validation for workload Parameters, detecting errors such as "Required parameter not passed" and giving more user-friendly messages in application status.

Fixes #6505


Note: waiting for the cuex PR to get merged, so that we can update the Cue version to latest.