### PR TITLE
Fix: Correct spelling of "application" in deletion message (#6626)

### DIFF
--- a/references/cli/delete.go
+++ b/references/cli/delete.go
@@ -127,11 +127,11 @@ func (opt *DeleteOptions) DeleteApp(f velacmd.Factory, cmd *cobra.Command, app *
 
 	if !opt.AssumeYes {
 		if !NewUserInput().AskBool(fmt.Sprintf("Are you sure to delete the application %s/%s", app.Namespace, app.Name), &UserInputOptions{opt.AssumeYes}) {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "skip deleting appplication %s/%s\n", app.Namespace, app.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "skip deleting application %s/%s\n", app.Namespace, app.Name)
 			return nil
 		}
 	}
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Start deleting appplication %s/%s\n", app.Namespace, app.Name)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Start deleting application %s/%s\n", app.Namespace, app.Name)
 
 	// orphan app
 	if opt.Orphan {
@@ -164,7 +164,7 @@ func (opt *DeleteOptions) DeleteApp(f velacmd.Factory, cmd *cobra.Command, app *
 		}
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Delete appplication %s/%s succeeded\n", app.Namespace, app.Name)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Delete application %s/%s succeeded\n", app.Namespace, app.Name)
 	return nil
 }
 


### PR DESCRIPTION
### Description of your changes

Previously, the deletion message for applications contained a typo where "application" was misspelled as "appplication". This commit corrects the spelling to "application" in the message:

- Before: "Start deleting appplication %s/%s\n"
- After: "Start deleting application %s/%s\n"

This change improves the clarity of the output message when deleting applications.

Fixes #6626

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
This code has been tested by running the following steps:

- Applied a sample application using the KubeVela CLI.

- Attempted to delete the application using the vela delete command.

- Verified that the deletion message correctly displays "Start deleting application" instead of the previous typo "Start deleting appplication".


### Special notes for your reviewer

This is a minor fix for a typo in the deletion message. No additional testing beyond the standard application lifecycle operations is required. The change is straightforward and should not impact any other functionality.

