### PR TITLE
Feat: Added configurable env specific arbitrary render context

### DIFF
--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -48,6 +48,7 @@ type ContextData struct {
 
 	AppLabels      map[string]string
 	AppAnnotations map[string]string
+	EnvConfig      map[string]string
 
 	ClusterVersion types.ClusterVersion
 }
@@ -75,6 +76,9 @@ func NewContext(data ContextData) process.Context {
 	ctx.PushData(ContextAppRevisionNum, revNum)
 	ctx.PushData(ContextCluster, data.Cluster)
 	ctx.PushData(ContextClusterVersion, parseClusterVersion(data.ClusterVersion))
+	for k, v := range data.EnvConfig {
+		ctx.PushData(k, v)
+	}
 	return ctx
 }
 


### PR DESCRIPTION
This is just a POC, to get feedback if this is a feasible idea to continue. 

We have a Kubevela setup with a lot of environments for different tenants. Every tenant has own settings, that we would like to use in our own custom components and traits when we render them. 

The idea is to have a configmap per vela env, that is added to the cue context and then can be used to render components and traits.

Any opinion if we can continue with that idea and make a proper PR our of it?
