### PR TITLE
Fix: Omit component revision in additionalLabel to add to k8s object

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble.go
@@ -41,9 +41,12 @@ func PrepareBeforeApply(comp *types.ComponentManifest, appRev *v1beta1.Applicati
 	compRevisionName := comp.RevisionName
 	compName := comp.Name
 	additionalLabel := map[string]string{
-		oam.LabelAppComponentRevision: compRevisionName,
 		oam.LabelAppRevisionHash:      appRev.Labels[oam.LabelAppRevisionHash],
 	}
+	if !DisableAllComponentRevision  {
+		additionalLabel[oam.LabelAppComponentRevision] = compRevisionName
+	}
+	
 	wl := assembleWorkload(compName, comp.ComponentOutput, additionalLabel)
 
 	assembledTraits := make([]*unstructured.Unstructured, len(comp.ComponentOutputsAndTraits))


### PR DESCRIPTION
### Description of your changes

copilot:all

I use Kubevela to orchestrate my applications, and I have installed the apisix-ingress component. I have also customized a trait to manage apisixroute resources. However, due to the empty value of app.oam.dev/revision in the ingress-controller sync label, I am experiencing errors like "failed to sync due to illegal label". I am considering whether disabling the "DisableAllComponentRevision" feature will allow me to hide the label.

For example, when DisableAllComponentRevision is set to true, the value of key "app.oam.dev/revision" returns null string like app.oam.dev/revision":"". This means that in the final PrepareBeforeApply, instead of directly defining two key values, we can check if DisableAllComponentRevision is true and if it is true, the app.oam.dev/revision tag will not be added by default.

Fixes #

I have:

- [✅] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [✅] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [✅] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I completed the update in the vela-core that we deployed ourselves in our company and have been providing services normally since the deployment, as well as executing unit test files in relevant folders within the code.

### Special notes for your reviewer
Please kindly review it for me, thank you very much.