### PR TITLE
Fix: include the build labels and annotation metadata

### DIFF
--- a/pkg/definition/gen_sdk/_scaffold/go/pkg/apis/common/application.go
+++ b/pkg/definition/gen_sdk/_scaffold/go/pkg/apis/common/application.go
@@ -228,6 +228,8 @@ func (a *ApplicationBuilder) Build() v1beta1.Application {
 			Name:            a.name,
 			Namespace:       a.namespace,
 			ResourceVersion: a.resourceVersion,
+			Labels:          a.labels,
+			Annotations:     a.annotations,
 		},
 		Spec: v1beta1.ApplicationSpec{
 			Components: components,


### PR DESCRIPTION
### Description of your changes

copilot:all

This PR adds the missing labels and annotations to ObjectMeta when the Build method is called.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The code was tested using Go code that generates the OAM YAML file from an in-house specification file.


```go
func (a *ApplicationBuilder) GetLabels() map[string]string {
func (a *ApplicationBuilder) Labels(labels map[string]string) TypedApplication
func (a *ApplicationBuilder) Build() v1beta1.Application {
```

### Special notes for your reviewer

The change is quite straight forward, and simple. 