### PR TITLE
Fix: switches to new helm repo url

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -195,11 +195,11 @@ func NewVersionListCommand(ioStream util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all available versions",
-		Long:  "Query all available versions from remote server.",
+		Long:  "Query all available versions from remote server, compared to your current installed version.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			helmHelper := helm.NewHelper()
-			versions, err := helmHelper.ListVersions(LegacyKubeVelaInstallerHelmRepoURL, kubeVelaChartName, true, nil)
+			versions, err := helmHelper.ListVersions(KubeVelaInstallerHelmRepoURL, kubeVelaChartName, true, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description of your changes

copilot:all

Fixes #6693

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This change only updates helm repo url for the `vela version list` command to work as expected.
