### PR TITLE
[WIP] Fix : Block the DefinitonRevision creation once the specified limit is passed 

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/validating_handler.go
@@ -92,6 +92,12 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		if err != nil {
 			return admission.Denied(err.Error())
 		}
+
+		err = webhookutils.ValidateDefinitionRevisionCleanUp(ctx, h.Client, req)
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+
 	}
 	return admission.ValidationResponse(true, "")
 }

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -159,11 +159,11 @@ func ValidateDefinitionRevisionCleanUp(ctx context.Context, cli client.Client, r
 	}
 
 	// Determine how many revisions exceed the limit.
+	// Additional 1 subtracted to take care of the current revision in use.
 	needKill := len(defRevList.Items) - revisionLimit - 1
 	if needKill < 0 {
 		return nil
 	}
-	klog.InfoS("cleanup old definitionRevision", "needKillNum", needKill)
 
 	// Sort the revisions by revision history.
 	sortedRevision := defRevList.Items

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -19,7 +19,13 @@ package utils
 import (
 	"context"
 	"fmt"
+	_ "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	"k8s.io/klog/v2"
+	"os"
 	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -110,4 +116,102 @@ func ValidateMultipleDefVersionsNotPresent(version, revisionName, objectType str
 		return fmt.Errorf("%s has both spec.version and revision name annotation. Only one can be present", objectType)
 	}
 	return nil
+}
+
+func ValidateDefinitionRevisionCleanUp(ctx context.Context, cli client.Client, req admission.Request) error {
+	var listOpts []client.ListOption
+
+	// Set list options based on the definition kind using the appropriate label key.
+	switch req.AdmissionRequest.Kind.Kind {
+	case "ComponentDefinition":
+		listOpts = []client.ListOption{
+			client.InNamespace(req.AdmissionRequest.Namespace),
+			client.MatchingLabels{oam.LabelComponentDefinitionName: req.AdmissionRequest.Name},
+		}
+	case "TraitDefinition":
+		listOpts = []client.ListOption{
+			client.InNamespace(req.AdmissionRequest.Namespace),
+			client.MatchingLabels{oam.LabelTraitDefinitionName: req.AdmissionRequest.Name},
+		}
+	case "PolicyDefinition":
+		listOpts = []client.ListOption{
+			client.InNamespace(req.AdmissionRequest.Namespace),
+			client.MatchingLabels{oam.LabelPolicyDefinitionName: req.AdmissionRequest.Name},
+		}
+	case "WorkFlowDefinition":
+		listOpts = []client.ListOption{
+			client.InNamespace(req.AdmissionRequest.Namespace),
+			client.MatchingLabels{oam.LabelWorkflowStepDefinitionName: req.AdmissionRequest.Name},
+		}
+	default:
+		return fmt.Errorf("unsupported kind %s", req.AdmissionRequest.Kind.Kind)
+	}
+
+	// List DefinitionRevisions matching the criteria.
+	defRevList := new(v1beta1.DefinitionRevisionList)
+	if err := cli.List(ctx, defRevList, listOpts...); err != nil {
+		return fmt.Errorf("failed to list definition revisions: %w", err)
+	}
+
+	revisionLimit, err := getDefLimitFromArgs()
+	if err != nil {
+		return fmt.Errorf("failed to get revision limit: %w", err)
+	}
+
+	// Determine how many revisions exceed the limit.
+	needKill := len(defRevList.Items) - revisionLimit - 1
+	if needKill < 0 {
+		return nil
+	}
+	klog.InfoS("cleanup old definitionRevision", "needKillNum", needKill)
+
+	// Sort the revisions by revision history.
+	sortedRevision := defRevList.Items
+	sort.Sort(historiesByRevision(sortedRevision))
+
+	// List applications across all namespaces.
+	applicationList := new(v1beta1.ApplicationList)
+	if err := cli.List(ctx, applicationList, []client.ListOption{}...); err != nil {
+		return fmt.Errorf("failed to list applications: %w", err)
+	}
+
+	// Construct the component type name to be deleted.
+	// Example format: "configmap-component@v11"
+	compTypeRevToBeDeleted := sortedRevision[0].Spec.Revision
+	compTypeNameToBeDeleted := fmt.Sprintf("%s@v%d", sortedRevision[0].Spec.ComponentDefinition.ObjectMeta.Name, compTypeRevToBeDeleted)
+
+	// Ensure no application is using the revision that's scheduled for deletion.
+	for _, app := range applicationList.Items {
+		for _, comp := range app.Spec.Components {
+			if comp.Type == compTypeNameToBeDeleted {
+				err := fmt.Errorf("could not apply new definition as application %s is already using the old revision %s", app.Name, comp.Type)
+				klog.Error(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getDefLimitFromArgs() (int, error) {
+	const prefix = "--definition-revision-limit="
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, prefix) {
+			valStr := strings.TrimPrefix(arg, prefix)
+			limit, err := strconv.Atoi(valStr)
+			if err != nil {
+				return 0, fmt.Errorf("invalid %s value: %w", prefix, err)
+			}
+			return limit, nil
+		}
+	}
+	return 0, fmt.Errorf("argument %s not found in os arguments", prefix)
+}
+
+type historiesByRevision []v1beta1.DefinitionRevision
+
+func (h historiesByRevision) Len() int      { return len(h) }
+func (h historiesByRevision) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h historiesByRevision) Less(i, j int) bool {
+	return h[i].Spec.Revision < h[j].Spec.Revision
 }


### PR DESCRIPTION
### Description of your changes

* Added the validation for component definition webhook to restrict the configuration of already present component definition once the definition revision limit specified is passed and the old revision which is supposed to be deleted is still in use.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6689

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manual Testing 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer
N/A
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->