### PR TITLE
Fix: fix for skipping deletion of orphan resources

### DIFF
--- a/apis/core.oam.dev/v1alpha1/garbagecollect_policy_types.go
+++ b/apis/core.oam.dev/v1alpha1/garbagecollect_policy_types.go
@@ -102,16 +102,16 @@ func (in *GarbageCollectPolicySpec) FindStrategy(manifest *unstructured.Unstruct
 }
 
 // FindDeleteOption find delete option for target resource
-func (in *GarbageCollectPolicySpec) FindDeleteOption(manifest *unstructured.Unstructured) []client.DeleteOption {
+func (in *GarbageCollectPolicySpec) FindDeleteOption(manifest *unstructured.Unstructured) (bool, []client.DeleteOption) {
 	for _, rule := range in.Rules {
 		if rule.Selector.Match(manifest) && rule.Propagation != nil {
 			switch *rule.Propagation {
 			case GarbageCollectPropagationOrphan:
-				return []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationOrphan)}
+				return true, []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationOrphan)}
 			case GarbageCollectPropagationCascading:
-				return []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationBackground)}
+				return false, []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationBackground)}
 			}
 		}
 	}
-	return nil
+	return false, nil
 }

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -414,7 +414,7 @@ func DeleteManagedResourceInApplication(ctx context.Context, cli client.Client, 
 		}
 		return errors.Wrapf(cli.Update(_ctx, obj), "skipping deletion for resource")
 	}
-	
+
 	if err := cli.Delete(_ctx, obj, opts...); err != nil && !kerrors.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to delete resource %s", mr.ResourceKey())
 	}

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -398,18 +398,23 @@ func DeleteManagedResourceInApplication(ctx context.Context, cli client.Client, 
 		}
 		util.RemoveAnnotations(obj, []string{oam.AnnotationAppSharedBy})
 	}
-	if mr.SkipGC || hasOrphanFinalizer(app) {
+
+	var opts []client.DeleteOption
+	var isOrphan bool
+
+	if garbageCollectPolicy, _ := policy.ParsePolicy[v1alpha1.GarbageCollectPolicySpec](app); garbageCollectPolicy != nil {
+		isOrphan, opts = garbageCollectPolicy.FindDeleteOption(obj)
+	}
+
+	if mr.SkipGC || hasOrphanFinalizer(app) || isOrphan {
 		if labels := obj.GetLabels(); labels != nil {
 			delete(labels, oam.LabelAppName)
 			delete(labels, oam.LabelAppNamespace)
 			obj.SetLabels(labels)
 		}
-		return errors.Wrapf(cli.Update(_ctx, obj), "failed to remove owner labels for resource while skipping gc")
+		return errors.Wrapf(cli.Update(_ctx, obj), "skipping deletion for resource")
 	}
-	var opts []client.DeleteOption
-	if garbageCollectPolicy, _ := policy.ParsePolicy[v1alpha1.GarbageCollectPolicySpec](app); garbageCollectPolicy != nil {
-		opts = garbageCollectPolicy.FindDeleteOption(obj)
-	}
+	
 	if err := cli.Delete(_ctx, obj, opts...); err != nil && !kerrors.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to delete resource %s", mr.ResourceKey())
 	}


### PR DESCRIPTION
### Description of your changes

When specifying orphan propagation for garbage collect policy for a component it still deletes the workload associated with the component. This PR fixes this issue by skipping deletion for orphan propagated resources.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500": 

-->

Fixes [#6703](https://github.com/kubevela/kubevela/issues/6703)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
 
Manual Testing

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->