### PR TITLE
Fix: modified webservice componenet definition to define resource req and …

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -208,15 +208,19 @@ spec:
 
         					if parameter["cpu"] != _|_ {
         						resources: {
-        							limits: cpu:   parameter.cpu
-        							requests: cpu: parameter.cpu
+                                    if parameter.cpu.limit != _|_ {
+        							    limits: cpu:   parameter.cpu.limit
+                                    }
+        							requests: cpu: parameter.cpu.req
         						}
         					}
 
         					if parameter["memory"] != _|_ {
         						resources: {
-        							limits: memory:   parameter.memory
-        							requests: memory: parameter.memory
+                                    if parameter.memory.limit != _|_ {
+        							    limits: memory:   parameter.memory.limit
+                                    }
+        							requests: memory: parameter.memory.req
         						}
         					}
 
@@ -416,10 +420,14 @@ spec:
         	}]
 
         	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-        	cpu?: string
+        	cpu?:
+                req: string
+                limit?: string
 
         	// +usage=Specifies the attributes of the memory resource required for the container.
-        	memory?: string
+        	memory?:
+                req: string
+                limit?: string
 
         	volumeMounts?: {
         		// +usage=Mount PVC type volume

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -207,33 +207,33 @@ spec:
         					}
 
         					if parameter["cpu"] != _|_ {
-                                if(parameter.limit.cpu != _|_) {
-                                    resources: {
-                                        requests: cpu: parameter.cpu
-        							    limits: cpu:   parameter.limit.cpu
-        						    }
-                                }
-                                if(parameter.limit.cpu == _|_) {
-                                    resources: {
-        							    limits: cpu:   parameter.cpu
-        							    requests: cpu: parameter.cpu
-        						    }
-                                }
+        						if (parameter.limit.cpu != _|_) {
+        							resources: {
+        								requests: cpu: parameter.cpu
+        								limits: cpu:   parameter.limit.cpu
+        							}
+        						}
+        						if (parameter.limit.cpu == _|_) {
+        							resources: {
+        								limits: cpu:   parameter.cpu
+        								requests: cpu: parameter.cpu
+        							}
+        						}
         					}
 
         					if parameter["memory"] != _|_ {
-                                if(parameter.limit.memory != _|_) {
-                                    resources: {
-        							    limits: memory:   parameter.limit.memory
-                                        requests: memory: parameter.memory
-        						    }
-                                }
-                                if(parameter.limit.memory == _|_) {
-                                    resources: {
-        							    limits: memory:   parameter.memory
-        							    requests: memory: parameter.memory
-        						    }
-                                }
+        						if (parameter.limit.memory != _|_) {
+        							resources: {
+        								limits: memory:   parameter.limit.memory
+        								requests: memory: parameter.memory
+        							}
+        						}
+        						if (parameter.limit.memory == _|_) {
+        							resources: {
+        								limits: memory:   parameter.memory
+        								requests: memory: parameter.memory
+        							}
+        						}
         					}
 
         					if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
@@ -437,9 +437,10 @@ spec:
         	// +usage=Specifies the attributes of the memory resource required for the container.
         	memory?: string
 
-            limit?:
-                cpu?: string
-                memory?: string
+        	limit?: {
+        		cpu?:    string
+        		memory?: string
+        	}
 
         	volumeMounts?: {
         		// +usage=Mount PVC type volume

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -207,21 +207,33 @@ spec:
         					}
 
         					if parameter["cpu"] != _|_ {
-        						resources: {
-                                    if parameter.cpu.limit != _|_ {
-        							    limits: cpu:   parameter.cpu.limit
-                                    }
-        							requests: cpu: parameter.cpu.req
-        						}
+                                if(parameter.limit.cpu != _|_) {
+                                    resources: {
+                                        requests: cpu: parameter.cpu
+        							    limits: cpu:   parameter.limit.cpu
+        						    }
+                                }
+                                if(parameter.limit.cpu == _|_) {
+                                    resources: {
+        							    limits: cpu:   parameter.cpu
+        							    requests: cpu: parameter.cpu
+        						    }
+                                }
         					}
 
         					if parameter["memory"] != _|_ {
-        						resources: {
-                                    if parameter.memory.limit != _|_ {
-        							    limits: memory:   parameter.memory.limit
-                                    }
-        							requests: memory: parameter.memory.req
-        						}
+                                if(parameter.limit.memory != _|_) {
+                                    resources: {
+        							    limits: memory:   parameter.limit.memory
+                                        requests: memory: parameter.memory
+        						    }
+                                }
+                                if(parameter.limit.memory == _|_) {
+                                    resources: {
+        							    limits: memory:   parameter.memory
+        							    requests: memory: parameter.memory
+        						    }
+                                }
         					}
 
         					if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
@@ -420,14 +432,14 @@ spec:
         	}]
 
         	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-        	cpu?:
-                req: string
-                limit?: string
+        	cpu?: string
 
         	// +usage=Specifies the attributes of the memory resource required for the container.
-        	memory?:
-                req: string
-                limit?: string
+        	memory?: string
+
+            limit?:
+                cpu?: string
+                memory?: string
 
         	volumeMounts?: {
         		// +usage=Mount PVC type volume

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -254,16 +254,32 @@ template: {
 						}
 
 						if parameter["cpu"] != _|_ {
-							resources: {
-								limits: cpu:   parameter.cpu
-								requests: cpu: parameter.cpu
+							if (parameter.limit.cpu != _|_) {
+								resources: {
+									requests: cpu: parameter.cpu
+									limits: cpu:   parameter.limit.cpu
+								}
+							}
+							if (parameter.limit.cpu == _|_) {
+								resources: {
+									limits: cpu:   parameter.cpu
+									requests: cpu: parameter.cpu
+								}
 							}
 						}
 
 						if parameter["memory"] != _|_ {
-							resources: {
-								limits: memory:   parameter.memory
-								requests: memory: parameter.memory
+							if (parameter.limit.memory != _|_) {
+								resources: {
+									limits: memory:   parameter.limit.memory
+									requests: memory: parameter.memory
+								}
+							}
+							if (parameter.limit.memory == _|_) {
+								resources: {
+									limits: memory:   parameter.memory
+									requests: memory: parameter.memory
+								}
 							}
 						}
 
@@ -467,6 +483,11 @@ template: {
 
 		// +usage=Specifies the attributes of the memory resource required for the container.
 		memory?: string
+
+		limit?: {
+			cpu?:    string
+			memory?: string
+		}
 
 		volumeMounts?: {
 			// +usage=Mount PVC type volume


### PR DESCRIPTION
### Description of your changes

Add Configurable Resource Requests and Limits for Web Service Components

## Problem
The current KubeVela web service component configuration applies the same CPU and memory values to both resource `requests` and `limits`. While this aligns with Kubernetes best practices, it limits flexibility in non-production environments where separate control over resource allocation is often desirable.

## Solution
Modified the component definition to allow **independent configuration** of resources `requests` and `limits` for CPU/memory. Users can now define these parameters separately to better align with specific environment needs.

## Changes Made
- Updated component schema to support nested resource specifications:
  ```yaml
        cpu: "2m"
        memory: "500Mi"
        limit:
          cpu: "3m"
          memory: "800Mi"

Fixes #[6704](https://github.com/kubevela/kubevela/issues/6704):

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually tested by applying the changed manifest in k3d cluster and applying sample webservice component with given parameters


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->