### PR TITLE
Feat: support token retrieval via AuthInfo.Exec command

### DIFF
--- a/pkg/workflow/providers/legacy/multicluster/multicluster.cue
+++ b/pkg/workflow/providers/legacy/multicluster/multicluster.cue
@@ -25,7 +25,7 @@
 	policies: [...string]
 	parallelism:              int
 	ignoreTerraformComponent: bool
-	inlinePolicies: *[] | [...{...}]
+	inlinePolicies:           *[] | [...{...}]
 }
 
 // deprecated
@@ -102,7 +102,7 @@
 	policy_:      string
 	envBindingPolicies: []
 	if inputs.policy == "" && loadPolicies.value != _|_ {
-		envBindingPolicies: [for k, v in loadPolicies.value if v.type == "env-binding" {k}]
+		envBindingPolicies: [ for k, v in loadPolicies.value if v.type == "env-binding" {k}]
 		policy_: envBindingPolicies[0]
 	}
 	if inputs.policy != "" {

--- a/pkg/workflow/providers/legacy/oam/oam.cue
+++ b/pkg/workflow/providers/legacy/oam/oam.cue
@@ -61,7 +61,7 @@
 #LoadInOrder: #LoadComponetsInOrder
 
 #ApplyApplication: #Steps & {
-	load: #LoadComponetsInOrder
+	load:       #LoadComponetsInOrder
 	components: #Steps & {
 		for name, c in load.value {
 			"\(name)": #ApplyComponent & {
@@ -75,7 +75,7 @@
 // Currently it works for Addon Observability to speed up the installation. It can also works for other applications, which
 // needs to skip health check for components.
 #ApplyApplicationInParallel: #Steps & {
-	load: #LoadComponetsInOrder
+	load:       #LoadComponetsInOrder
 	components: #Steps & {
 		for name, c in load.value {
 			"\(name)": #ApplyComponent & {
@@ -92,7 +92,7 @@
 	exceptions_: {for c in exceptions {"\(c)": true}}
 	component: string
 
-	load: #LoadComponets
+	load:   #LoadComponets
 	render: #Steps & {
 		rendered: #RenderComponent & {
 			value: load.value[component]
@@ -115,7 +115,7 @@
 	exceptions: [...string]
 	exceptions_: {for c in exceptions {"\(c)": true}}
 
-	load: #LoadComponets
+	load:       #LoadComponets
 	components: #Steps & {
 		for name, c in load.value {
 			if exceptions_[name] == _|_ {

--- a/pkg/workflow/providers/legacy/terraform/terraform.cue
+++ b/pkg/workflow/providers/legacy/terraform/terraform.cue
@@ -43,7 +43,7 @@
 		}
 		...
 	}
-	components_: [for comp in prepare.outputs.components if terraformComponentMap[(comp.name)] != _|_ {comp}]
+	components_: [ for comp in prepare.outputs.components if terraformComponentMap[(comp.name)] != _|_ {comp}]
 	outputs: {
 		components: components_
 		decisions:  prepare.outputs.decisions
@@ -132,8 +132,8 @@
 	policy:    string
 	namespace: string
 
-	env_:    env
-	policy_: policy
+	env_:          env
+	policy_:       policy
 	prepareDeploy: #PrepareTerraformEnvBinding & {
 		inputs: {
 			env:    env_
@@ -178,7 +178,7 @@
 				}
 
 				comp_: comp
-				bind: #bindTerraformComponentToCluster & {
+				bind:  #bindTerraformComponentToCluster & {
 					comp:      comp_
 					secret:    secretMeta
 					env:       env_
@@ -233,8 +233,8 @@
 	namespace_: namespace
 	placements: [...#PlacementDecision]
 
-	env_:    env
-	policy_: policy
+	env_:        env
+	policy_:     policy
 	prepareBind: #PrepareTerraformEnvBinding & {
 		inputs: {
 			env:    env_
@@ -242,7 +242,7 @@
 		}
 	}
 
-	decisions_: [for placement in placements {
+	decisions_: [ for placement in placements {
 		namespace: *"" | string
 		if placement.namespace != _|_ {
 			namespace: placement.namespace
@@ -265,7 +265,7 @@
 					appNamespace: namespace
 				}
 				comp_: comp
-				bind: #bindTerraformComponentToCluster & {
+				bind:  #bindTerraformComponentToCluster & {
 					comp:      comp_
 					secret:    secretMeta
 					env:       env_

--- a/pkg/workflow/providers/multicluster/multicluster.cue
+++ b/pkg/workflow/providers/multicluster/multicluster.cue
@@ -34,7 +34,7 @@
 		policies: [...string]
 		parallelism:              int
 		ignoreTerraformComponent: bool
-		inlinePolicies: *[] | [...{...}]
+		inlinePolicies:           *[] | [...{...}]
 	}
 	$returns?: {...}
 }

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -20,7 +20,7 @@ template: {
 		] | []
 
 		configMap: *[
-			for v in parameter.volumeMounts.configMap {
+				for v in parameter.volumeMounts.configMap {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -44,7 +44,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-			for v in parameter.volumeMounts.emptyDir {
+				for v in parameter.volumeMounts.emptyDir {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -56,7 +56,7 @@ template: {
 		] | []
 
 		hostPath: *[
-			for v in parameter.volumeMounts.hostPath {
+				for v in parameter.volumeMounts.hostPath {
 				{
 					mountPath: v.mountPath
 					if v.subPath != _|_ {
@@ -78,7 +78,7 @@ template: {
 		] | []
 
 		configMap: *[
-			for v in parameter.volumeMounts.configMap {
+				for v in parameter.volumeMounts.configMap {
 				{
 					name: v.name
 					configMap: {
@@ -108,7 +108,7 @@ template: {
 		] | []
 
 		emptyDir: *[
-			for v in parameter.volumeMounts.emptyDir {
+				for v in parameter.volumeMounts.emptyDir {
 				{
 					name: v.name
 					emptyDir: medium: v.medium
@@ -117,7 +117,7 @@ template: {
 		] | []
 
 		hostPath: *[
-			for v in parameter.volumeMounts.hostPath {
+				for v in parameter.volumeMounts.hostPath {
 				{
 					name: v.name
 					hostPath: path: v.path
@@ -218,7 +218,7 @@ template: {
 									}
 								}
 								if parameter["volumes"] != _|_ if parameter["volumeMounts"] == _|_ {
-									volumeMounts: [for v in parameter.volumes {
+									volumeMounts: [ for v in parameter.volumes {
 										{
 											mountPath: v.mountPath
 											name:      v.name
@@ -229,7 +229,7 @@ template: {
 								}
 							}]
 							if parameter["volumes"] != _|_ if parameter["volumeMounts"] == _|_ {
-								volumes: [for v in parameter.volumes {
+								volumes: [ for v in parameter.volumes {
 									{
 										name: v.name
 										if v.type == "pvc" {
@@ -262,13 +262,13 @@ template: {
 								volumes: deDupVolumesArray
 							}
 							if parameter["imagePullSecrets"] != _|_ {
-								imagePullSecrets: [for v in parameter.imagePullSecrets {
+								imagePullSecrets: [ for v in parameter.imagePullSecrets {
 									name: v
 								},
 								]
 							}
 							if parameter.hostAliases != _|_ {
-								hostAliases: [for v in parameter.hostAliases {
+								hostAliases: [ for v in parameter.hostAliases {
 									ip:        v.ip
 									hostnames: v.hostnames
 								},

--- a/vela-templates/definitions/internal/component/daemon.cue
+++ b/vela-templates/definitions/internal/component/daemon.cue
@@ -227,7 +227,7 @@ template: {
 							}]
 						}
 						if parameter["ports"] != _|_ {
-							ports: [for v in parameter.ports {
+							ports: [ for v in parameter.ports {
 								{
 									containerPort: v.port
 									protocol:      v.protocol
@@ -271,7 +271,7 @@ template: {
 						}
 
 						if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-							volumeMounts: [for v in parameter.volumes {
+							volumeMounts: [ for v in parameter.volumes {
 								{
 									mountPath: v.mountPath
 									name:      v.name
@@ -298,14 +298,14 @@ template: {
 					}
 
 					if parameter["imagePullSecrets"] != _|_ {
-						imagePullSecrets: [for v in parameter.imagePullSecrets {
+						imagePullSecrets: [ for v in parameter.imagePullSecrets {
 							name: v
 						},
 						]
 					}
 
 					if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-						volumes: [for v in parameter.volumes {
+						volumes: [ for v in parameter.volumes {
 							{
 								name: v.name
 								if v.type == "pvc" {

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -93,7 +93,7 @@ template: {
 						}
 
 						if parameter["volumes"] != _|_ {
-							volumeMounts: [for v in parameter.volumes {
+							volumeMounts: [ for v in parameter.volumes {
 								{
 									mountPath: v.mountPath
 									name:      v.name
@@ -102,7 +102,7 @@ template: {
 					}]
 
 					if parameter["volumes"] != _|_ {
-						volumes: [for v in parameter.volumes {
+						volumes: [ for v in parameter.volumes {
 							{
 								name: v.name
 								if v.type == "pvc" {
@@ -133,7 +133,7 @@ template: {
 					}
 
 					if parameter["imagePullSecrets"] != _|_ {
-						imagePullSecrets: [for v in parameter.imagePullSecrets {
+						imagePullSecrets: [ for v in parameter.imagePullSecrets {
 							name: v
 						},
 						]

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -210,7 +210,7 @@ template: {
 							}]
 						}
 						if parameter["ports"] != _|_ {
-							ports: [for v in parameter.ports {
+							ports: [ for v in parameter.ports {
 								{
 									containerPort: {
 										if v.containerPort != _|_ {v.containerPort}
@@ -268,7 +268,7 @@ template: {
 						}
 
 						if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-							volumeMounts: [for v in parameter.volumes {
+							volumeMounts: [ for v in parameter.volumes {
 								{
 									mountPath: v.mountPath
 									name:      v.name
@@ -295,14 +295,14 @@ template: {
 					}
 
 					if parameter["imagePullSecrets"] != _|_ {
-						imagePullSecrets: [for v in parameter.imagePullSecrets {
+						imagePullSecrets: [ for v in parameter.imagePullSecrets {
 							name: v
 						},
 						]
 					}
 
 					if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-						volumes: [for v in parameter.volumes {
+						volumes: [ for v in parameter.volumes {
 							{
 								name: v.name
 								if v.type == "pvc" {

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -212,7 +212,7 @@ template: {
 						}
 
 						if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-							volumeMounts: [for v in parameter.volumes {
+							volumeMounts: [ for v in parameter.volumes {
 								{
 									mountPath: v.mountPath
 									name:      v.name
@@ -234,14 +234,14 @@ template: {
 					}]
 
 					if parameter["imagePullSecrets"] != _|_ {
-						imagePullSecrets: [for v in parameter.imagePullSecrets {
+						imagePullSecrets: [ for v in parameter.imagePullSecrets {
 							name: v
 						},
 						]
 					}
 
 					if parameter["volumes"] != _|_ && parameter["volumeMounts"] == _|_ {
-						volumes: [for v in parameter.volumes {
+						volumes: [ for v in parameter.volumes {
 							{
 								name: v.name
 								if v.type == "pvc" {

--- a/vela-templates/definitions/internal/trait/command.cue
+++ b/vela-templates/definitions/internal/trait/command.cue
@@ -23,7 +23,7 @@ template: {
 		_params:         #PatchParams
 		name:            _params.containerName
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		_baseContainer: *_|_ | {...}
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
@@ -64,7 +64,7 @@ template: {
 			}
 
 			// +patchStrategy=replace
-			args: [for a in _args if _delArgs[a] == _|_ {a}] + [for a in _addArgs if _delArgs[a] == _|_ && _argsMap[a] == _|_ {a}]
+			args: [ for a in _args if _delArgs[a] == _|_ {a}] + [ for a in _addArgs if _delArgs[a] == _|_ && _argsMap[a] == _|_ {a}]
 		}
 	}
 	// +patchStrategy=open
@@ -88,7 +88,7 @@ template: {
 		}
 		if parameter.containers != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.containers {
+			containers: [ for c in parameter.containers {
 				if c.containerName == "" {
 					err: "container name must be set for containers"
 				}
@@ -104,5 +104,5 @@ template: {
 		containers: [...#PatchParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 }

--- a/vela-templates/definitions/internal/trait/container-image.cue
+++ b/vela-templates/definitions/internal/trait/container-image.cue
@@ -20,7 +20,7 @@ template: {
 		_params:         #PatchParams
 		name:            _params.containerName
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		_baseContainer: *_|_ | {...}
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
@@ -53,7 +53,7 @@ template: {
 		}
 		if parameter.containers != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.containers {
+			containers: [ for c in parameter.containers {
 				if c.containerName == "" {
 					err: "containerName must be set for containers"
 				}
@@ -69,5 +69,5 @@ template: {
 		containers: [...#PatchParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 }

--- a/vela-templates/definitions/internal/trait/container-ports.cue
+++ b/vela-templates/definitions/internal/trait/container-ports.cue
@@ -35,7 +35,7 @@ template: {
 		_params:         #PatchParams
 		name:            _params.containerName
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		_baseContainer: *_|_ | {...}
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
@@ -45,7 +45,7 @@ template: {
 			_basePorts:     _baseContainer.ports
 			if _basePorts == _|_ {
 				// +patchStrategy=replace
-				ports: [for port in _params.ports {
+				ports: [ for port in _params.ports {
 					containerPort: port.containerPort
 					protocol:      port.protocol
 					if port.hostPort != _|_ {
@@ -60,7 +60,7 @@ template: {
 				_basePortsMap: {for _basePort in _basePorts {(strings.ToLower(_basePort.protocol) + strconv.FormatInt(_basePort.containerPort, 10)): _basePort}}
 				_portsMap: {for port in _params.ports {(strings.ToLower(port.protocol) + strconv.FormatInt(port.containerPort, 10)): port}}
 				// +patchStrategy=replace
-				ports: [for portVar in _basePorts {
+				ports: [ for portVar in _basePorts {
 					containerPort: portVar.containerPort
 					protocol:      portVar.protocol
 					name:          portVar.name
@@ -73,7 +73,7 @@ template: {
 							hostIP: _portsMap[_uniqueKey].hostIP
 						}
 					}
-				}] + [for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {
+				}] + [ for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {
 					if port.containerPort != _|_ {
 						containerPort: port.containerPort
 					}
@@ -108,7 +108,7 @@ template: {
 		}
 		if parameter.containers != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.containers {
+			containers: [ for c in parameter.containers {
 				if c.containerName == "" {
 					err: "container name must be set for containers"
 				}
@@ -124,5 +124,5 @@ template: {
 		containers: [...#PatchParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 }

--- a/vela-templates/definitions/internal/trait/env.cue
+++ b/vela-templates/definitions/internal/trait/env.cue
@@ -22,7 +22,7 @@ template: {
 		name:    _params.containerName
 		_delKeys: {for k in _params.unset {(k): ""}}
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		_baseContainer: *_|_ | {...}
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
@@ -32,7 +32,7 @@ template: {
 			_baseEnv:       _baseContainer.env
 			if _baseEnv == _|_ {
 				// +patchStrategy=replace
-				env: [for k, v in _params.env if _delKeys[k] == _|_ {
+				env: [ for k, v in _params.env if _delKeys[k] == _|_ {
 					name:  k
 					value: v
 				}]
@@ -40,7 +40,7 @@ template: {
 			if _baseEnv != _|_ {
 				_baseEnvMap: {for envVar in _baseEnv {(envVar.name): envVar}}
 				// +patchStrategy=replace
-				env: [for envVar in _baseEnv if _delKeys[envVar.name] == _|_ && !_params.replace {
+				env: [ for envVar in _baseEnv if _delKeys[envVar.name] == _|_ && !_params.replace {
 					name: envVar.name
 					if _params.env[envVar.name] != _|_ {
 						value: _params.env[envVar.name]
@@ -53,7 +53,7 @@ template: {
 							valueFrom: envVar.valueFrom
 						}
 					}
-				}] + [for k, v in _params.env if _delKeys[k] == _|_ && (_params.replace || _baseEnvMap[k] == _|_) {
+				}] + [ for k, v in _params.env if _delKeys[k] == _|_ && (_params.replace || _baseEnvMap[k] == _|_) {
 					name:  k
 					value: v
 				}]
@@ -79,7 +79,7 @@ template: {
 		}
 		if parameter.containers != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.containers {
+			containers: [ for c in parameter.containers {
 				if c.containerName == "" {
 					err: "containerName must be set for containers"
 				}
@@ -95,5 +95,5 @@ template: {
 		containers: [...#PatchParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 }

--- a/vela-templates/definitions/internal/trait/expose.cue
+++ b/vela-templates/definitions/internal/trait/expose.cue
@@ -73,7 +73,7 @@ template: {
 				]
 			}
 			if parameter["ports"] != _|_ {
-				ports: [for v in parameter.ports {
+				ports: [ for v in parameter.ports {
 					port:       v.port
 					targetPort: v.port
 					if v.name != _|_ {

--- a/vela-templates/definitions/internal/trait/nocalhost.cue
+++ b/vela-templates/definitions/internal/trait/nocalhost.cue
@@ -38,7 +38,7 @@ template: {
 		metadata: annotations: {
 			"dev.nocalhost/application-name":      context.appName
 			"dev.nocalhost/application-namespace": context.namespace
-			"dev.nocalhost": json.Marshal({
+			"dev.nocalhost":                       json.Marshal({
 				name:        context.name
 				serviceType: parameter.serviceType
 				"containers": [
@@ -123,7 +123,7 @@ template: {
 		workDir:       *"/home/nocalhost-dev" | string
 		storageClass?: string
 		command: {
-			run: *["sh", "run.sh"] | [...string]
+			run:   *["sh", "run.sh"] | [...string]
 			debug: *["sh", "debug.sh"] | [...string]
 		}
 		debug?: {
@@ -131,8 +131,8 @@ template: {
 		}
 		hotReload: *true | bool
 		sync: {
-			type: *"send" | string
-			filePattern: *["./"] | [...string]
+			type:              *"send" | string
+			filePattern:       *["./"] | [...string]
 			ignoreFilePattern: *[".git", ".vscode", ".idea", ".gradle", "build"] | [...string]
 		}
 		env?: [...{

--- a/vela-templates/definitions/internal/trait/securitycontext.cue
+++ b/vela-templates/definitions/internal/trait/securitycontext.cue
@@ -26,7 +26,7 @@ template: {
 		_params:         #PatchParams
 		name:            _params.containerName
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		_baseContainer: *_|_ | {...}
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
@@ -79,7 +79,7 @@ template: {
 
 		if parameter.containers != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.containers {
+			containers: [ for c in parameter.containers {
 				if c.containerName == "" {
 					err: "containerName must be set for containers"
 				}
@@ -95,5 +95,5 @@ template: {
 		containers: [...#PatchParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 }

--- a/vela-templates/definitions/internal/trait/service-account.cue
+++ b/vela-templates/definitions/internal/trait/service-account.cue
@@ -34,8 +34,8 @@ template: {
 	// +patchStrategy=retainKeys
 	patch: spec: template: spec: serviceAccountName: parameter.name
 
-	_clusterPrivileges: [if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "cluster" {p}]
-	_namespacePrivileges: [if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "namespace" {p}]
+	_clusterPrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "cluster" {p}]
+	_namespacePrivileges: [ if parameter.privileges != _|_ for p in parameter.privileges if p.scope == "namespace" {p}]
 	outputs: {
 		if parameter.create {
 			"service-account": {
@@ -50,7 +50,7 @@ template: {
 					apiVersion: "rbac.authorization.k8s.io/v1"
 					kind:       "ClusterRole"
 					metadata: name: "\(context.namespace):\(parameter.name)"
-					rules: [for p in _clusterPrivileges {
+					rules: [ for p in _clusterPrivileges {
 						verbs: p.verbs
 						if p.apiGroups != _|_ {
 							apiGroups: p.apiGroups
@@ -87,7 +87,7 @@ template: {
 					apiVersion: "rbac.authorization.k8s.io/v1"
 					kind:       "Role"
 					metadata: name: parameter.name
-					rules: [for p in _namespacePrivileges {
+					rules: [ for p in _namespacePrivileges {
 						verbs: p.verbs
 						if p.apiGroups != _|_ {
 							apiGroups: p.apiGroups

--- a/vela-templates/definitions/internal/trait/sidecar.cue
+++ b/vela-templates/definitions/internal/trait/sidecar.cue
@@ -23,7 +23,7 @@ template: {
 				env: parameter.env
 			}
 			if parameter["volumes"] != _|_ {
-				volumeMounts: [for v in parameter.volumes {
+				volumeMounts: [ for v in parameter.volumes {
 					{
 						mountPath: v.path
 						name:      v.name

--- a/vela-templates/definitions/internal/trait/startup-probe.cue
+++ b/vela-templates/definitions/internal/trait/startup-probe.cue
@@ -65,7 +65,7 @@ template: {
 		_params:         #StartupProbeParams
 		name:            _params.containerName
 		_baseContainers: context.output.spec.template.spec.containers
-		_matchContainers_: [for _container_ in _baseContainers if _container_.name == name {_container_}]
+		_matchContainers_: [ for _container_ in _baseContainers if _container_.name == name {_container_}]
 		if len(_matchContainers_) == 0 {
 			err: "container \(name) not found"
 		}
@@ -142,7 +142,7 @@ template: {
 		}
 		if parameter.probes != _|_ {
 			// +patchKey=name
-			containers: [for c in parameter.probes {
+			containers: [ for c in parameter.probes {
 				if c.name == "" {
 					err: "containerName must be set when specifying startup probe for multiple containers"
 				}
@@ -158,6 +158,6 @@ template: {
 		probes: [...#StartupProbeParams]
 	})
 
-	errs: [for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
+	errs: [ for c in patch.spec.template.spec.containers if c.err != _|_ {c.err}]
 
 }

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -143,7 +143,7 @@ template: {
 	]
 
 	volumeDevicesList: *[
-		for v in parameter.pvc if v.volumeMode == "Block" {
+				for v in parameter.pvc if v.volumeMode == "Block" {
 			{
 				name:       "pvc-" + v.name
 				devicePath: v.mountPath
@@ -258,13 +258,13 @@ template: {
 	parameter: {
 		// +usage=Declare pvc type storage
 		pvc?: [...{
-			name:        string
-			mountOnly:   *false | bool
-			mountPath:   string
-			subPath?:    string
-			volumeMode:  *"Filesystem" | string
-			volumeName?: string
-			accessModes: *["ReadWriteOnce"] | [...string]
+			name:              string
+			mountOnly:         *false | bool
+			mountPath:         string
+			subPath?:          string
+			volumeMode:        *"Filesystem" | string
+			volumeName?:       string
+			accessModes:       *["ReadWriteOnce"] | [...string]
 			storageClassName?: string
 			resources?: {
 				requests: storage: =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"

--- a/vela-templates/definitions/internal/workflowstep/collect-service-endpoints.cue
+++ b/vela-templates/definitions/internal/workflowstep/collect-service-endpoints.cue
@@ -34,7 +34,7 @@ template: {
 			eps_port_name_filtered: collect.$returns.list
 		}
 		if parameter.portName != _|_ {
-			eps_port_name_filtered: [for ep in collect.$returns.list if parameter.portName == ep.endpoint.portName {ep}]
+			eps_port_name_filtered: [ for ep in collect.$returns.list if parameter.portName == ep.endpoint.portName {ep}]
 		}
 
 		eps_port_filtered: *[] | [...]
@@ -42,12 +42,12 @@ template: {
 			eps_port_filtered: eps_port_name_filtered
 		}
 		if parameter.port != _|_ {
-			eps_port_filtered: [for ep in eps_port_name_filtered if parameter.port == ep.endpoint.port {ep}]
+			eps_port_filtered: [ for ep in eps_port_name_filtered if parameter.port == ep.endpoint.port {ep}]
 		}
-		eps: eps_port_filtered
+		eps:       eps_port_filtered
 		endpoints: *[] | [...]
 		if parameter.outer != _|_ {
-			tmps: [for ep in eps {
+			tmps: [ for ep in eps {
 				ep
 				if ep.endpoint.inner == _|_ {
 					outer: true
@@ -56,7 +56,7 @@ template: {
 					outer: !ep.endpoint.inner
 				}
 			}]
-			endpoints: [for ep in tmps if (!parameter.outer || ep.outer) {ep}]
+			endpoints: [ for ep in tmps if (!parameter.outer || ep.outer) {ep}]
 		}
 		if parameter.outer == _|_ {
 			endpoints: eps_port_filtered

--- a/vela-templates/definitions/internal/workflowstep/depends-on-app.cue
+++ b/vela-templates/definitions/internal/workflowstep/depends-on-app.cue
@@ -41,7 +41,7 @@ template: {
 				}
 			}
 			template: configMap.$returns.value.data["application"]
-			apply: kube.#Apply & {
+			apply:    kube.#Apply & {
 				$params: value: yaml.Unmarshal(template)
 			}
 			wait: builtin.#ConditionalWait & {

--- a/vela-templates/definitions/internal/workflowstep/generate-jdbc-connection.cue
+++ b/vela-templates/definitions/internal/workflowstep/generate-jdbc-connection.cue
@@ -26,14 +26,14 @@ template: {
 			}
 		}
 	}
-	dbHost: util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_HOST"])}
-	dbPort: util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_PORT"])}
-	dbName: util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_NAME"])}
+	dbHost:   util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_HOST"])}
+	dbPort:   util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_PORT"])}
+	dbName:   util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_NAME"])}
 	username: util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_USER"])}
 	password: util.#ConvertString & {$params: bt: base64.Decode(null, output.$returns.value.data["DB_PASSWORD"])}
 
 	env: [
-		{name: "url", value: "jdbc://" + dbHost.$returns.str + ":" + dbPort.$returns.str + "/" + dbName.$returns.str + "?characterEncoding=utf8&useSSL=false"},
+		{name: "url", value:      "jdbc://" + dbHost.$returns.str + ":" + dbPort.$returns.str + "/" + dbName.$returns.str + "?characterEncoding=utf8&useSSL=false"},
 		{name: "username", value: username.$returns.str},
 		{name: "password", value: password.$returns.str},
 	]

--- a/vela-templates/definitions/internal/workflowstep/notification.cue
+++ b/vela-templates/definitions/internal/workflowstep/notification.cue
@@ -69,7 +69,7 @@ template: {
 					picUrl?:     string
 				}
 
-				link?: #link
+				link?:     #link
 				markdown?: close({
 					text:  string
 					title: string
@@ -240,7 +240,7 @@ template: {
 				}
 
 				stringValue: util.#ConvertString & {$params: bt: base64.Decode(null, read.$returns.value.data[parameter.dingding.url.secretRef.key])}
-				ding2: http.#Do & {
+				ding2:       http.#Do & {
 					$params: {
 						method: "POST"
 						url:    stringValue.$returns.str
@@ -283,7 +283,7 @@ template: {
 				}
 
 				stringValue: util.#ConvertString & {$params: bt: base64.Decode(null, read.$returns.value.data[parameter.lark.url.secretRef.key])}
-				lark2: http.#Do & {
+				lark2:       http.#Do & {
 					$params: {
 						method: "POST"
 						url:    stringValue.$returns.str
@@ -327,7 +327,7 @@ template: {
 				}
 
 				stringValue: util.#ConvertString & {$params: bt: base64.Decode(null, read.$returns.value.data[parameter.slack.url.secretRef.key])}
-				slack2: http.#Do & {
+				slack2:      http.#Do & {
 					$params: {
 						method: "POST"
 						url:    stringValue.$returns.str
@@ -376,7 +376,7 @@ template: {
 				}
 
 				stringValue: util.#ConvertString & {$params: bt: base64.Decode(null, read.$returns.value.data[parameter.email.from.password.secretRef.key])}
-				email2: email.#SendEmail & {
+				email2:      email.#SendEmail & {
 					$params: {
 						from: {
 							address: parameter.email.from.address

--- a/vela-templates/definitions/internal/workflowstep/webhook.cue
+++ b/vela-templates/definitions/internal/workflowstep/webhook.cue
@@ -62,7 +62,7 @@ template: {
 			}
 
 			stringValue: util.#ConvertString & {$params: bt: base64.Decode(null, read.$returns.value.data[parameter.url.secretRef.key])}
-			req: http.#HTTPPost & {
+			req:         http.#HTTPPost & {
 				$params: {
 					url: stringValue.$returns.str
 					request: {


### PR DESCRIPTION
copilot:all

Add a elseif condition in createOrUpdateClusterSecret to check for a non-nil AuthInfo.Exec.
If provided, execute the external command with its specified arguments and environment variables,
parse the JSON output to extract the token from status.token, and use it as the service account token.
Fallback to the existing token or certificate-based authentication logic when AuthInfo.Exec is absent.

Fixes #6658 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
