### PR TITLE
Feat: Enable CueX compiler in component & trait templating

### DIFF
--- a/cmd/core/app/options/options.go
+++ b/cmd/core/app/options/options.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"time"
 
+	cueOptions "github.com/oam-dev/kubevela/pkg/cue/options"
+
 	pkgclient "github.com/kubevela/pkg/controller/client"
 	ctrlrec "github.com/kubevela/pkg/controller/reconciler"
 	"github.com/kubevela/pkg/controller/sharding"
@@ -35,7 +37,6 @@ import (
 	oamcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
-	"github.com/oam-dev/kubevela/pkg/workflow/providers"
 )
 
 // CoreOptions contains everything necessary to create and run vela-core
@@ -129,8 +130,9 @@ func (s *CoreOptions) Flags() cliflag.NamedFlagSets {
 	gfs.BoolVar(&s.EnableClusterGateway, "enable-cluster-gateway", s.EnableClusterGateway, "Enable cluster-gateway to use multicluster, disabled by default.")
 	gfs.BoolVar(&s.EnableClusterMetrics, "enable-cluster-metrics", s.EnableClusterMetrics, "Enable cluster-metrics-management to collect metrics from clusters with cluster-gateway, disabled by default. When this param is enabled, enable-cluster-gateway should be enabled")
 	gfs.DurationVar(&s.ClusterMetricsInterval, "cluster-metrics-interval", s.ClusterMetricsInterval, "The interval that ClusterMetricsMgr will collect metrics from clusters, default value is 15 seconds.")
-	gfs.BoolVar(&providers.EnableExternalPackageForDefaultCompiler, "enable-external-package-for-default-compiler", providers.EnableExternalPackageForDefaultCompiler, "Enable external package for default compiler")
-	gfs.BoolVar(&providers.EnableExternalPackageWatchForDefaultCompiler, "enable-external-package-watch-for-default-compiler", providers.EnableExternalPackageWatchForDefaultCompiler, "Enable external package watch for default compiler")
+	gfs.BoolVar(&cueOptions.EnableExternalPackageForDefaultCompiler, "enable-external-package-for-default-compiler", cueOptions.EnableExternalPackageForDefaultCompiler, "Enable external package for default compiler")
+	gfs.BoolVar(&cueOptions.EnableExternalPackageWatchForDefaultCompiler, "enable-external-package-watch-for-default-compiler", cueOptions.EnableExternalPackageWatchForDefaultCompiler, "Enable external package watch for default compiler")
+	gfs.BoolVar(&cueOptions.EnableExternalPackagesForWorkloadsAndTraits, "enable-external-cue-packages-in-workloads", cueOptions.EnableExternalPackagesForWorkloadsAndTraits, "experimental - enable external packages for workloads and traits")
 
 	s.ControllerArgs.AddFlags(fss.FlagSet("controllerArgs"), s.ControllerArgs)
 

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -20,6 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/pkg/cue/options"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
 
@@ -95,4 +99,30 @@ func TestCoreOptions_Flags(t *testing.T) {
 	if !cmp.Equal(opt, expected, cmp.AllowUnexported(CoreOptions{})) {
 		t.Errorf("Flags() diff: %v", cmp.Diff(opt, expected, cmp.AllowUnexported(CoreOptions{})))
 	}
+}
+
+func TestCuexOptions_Flags(t *testing.T) {
+	pflag.NewFlagSet("test", pflag.ContinueOnError)
+	options.EnableExternalPackageForDefaultCompiler = false
+	options.EnableExternalPackageWatchForDefaultCompiler = false
+	options.EnableExternalPackagesForWorkloadsAndTraits = false
+
+	opts := &CoreOptions{
+		ControllerArgs: &oamcontroller.Args{},
+	}
+	fss := opts.Flags()
+
+	args := []string{
+		"--enable-external-package-for-default-compiler=true",
+		"--enable-external-package-watch-for-default-compiler=true",
+		"--enable-external-cue-packages-in-workloads=true",
+	}
+	err := fss.FlagSet("generic").Parse(args)
+	if err != nil {
+		return
+	}
+
+	assert.True(t, options.EnableExternalPackageForDefaultCompiler, "The --enable-external-package-for-default-compiler flag should be enabled")
+	assert.True(t, options.EnableExternalPackageWatchForDefaultCompiler, "The --enable-external-package-watch-for-default-compiler flag should be enabled")
+	assert.True(t, options.EnableExternalPackagesForWorkloadsAndTraits, "The --enable-external-cue-packages-in-workloads flag should be enabled")
 }

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -36,6 +36,7 @@ var ConfigCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compile
 	return compiler
 })
 
+// WorkloadCompiler ...
 var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
 	compiler := cuex.NewCompilerWithInternalPackages(
 		config.Package,

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -17,10 +17,15 @@ limitations under the License.
 package cuex
 
 import (
+	"context"
+
 	"github.com/kubevela/pkg/cue/cuex"
 	"github.com/kubevela/pkg/util/singleton"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/config"
+	"github.com/oam-dev/kubevela/pkg/cue/options"
 )
 
 // ConfigCompiler ...
@@ -28,5 +33,20 @@ var ConfigCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compile
 	compiler := cuex.NewCompilerWithInternalPackages(
 		config.Package,
 	)
+	return compiler
+})
+
+var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
+	compiler := cuex.NewCompilerWithInternalPackages(
+		config.Package,
+	)
+	if options.EnableExternalPackageForDefaultCompiler && options.EnableExternalPackagesForWorkloadsAndTraits {
+		if err := compiler.LoadExternalPackages(context.Background()); err != nil && !kerrors.IsNotFound(err) {
+			klog.Errorf("failed to load external packages for cuex default compiler: %s", err.Error())
+		}
+	}
+	if options.EnableExternalPackageWatchForDefaultCompiler && options.EnableExternalPackagesForWorkloadsAndTraits {
+		go compiler.ListenExternalPackages(nil)
+	}
 	return compiler
 })

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -1,9 +1,24 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cuex_test
 
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kubevela/pkg/util/singleton"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,6 +88,10 @@ func TestMain(m *testing.M) {
 	}
 
 	testCtx.K8sClient, err = createK8sClient(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create k8s Client: %v\n", err)
+		os.Exit(1)
+	}
 
 	mockServer := createMockServer()
 	defer mockServer.Close()
@@ -258,6 +279,9 @@ func deleteTestPackage() error {
 	testPkg.SetNamespace(testCtx.Namespace)
 
 	err := testCtx.K8sClient.Delete(ctx, testPkg)
+	if err != nil {
+		return fmt.Errorf("failed to delete test package: %w", err)
+	}
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
 		err := testCtx.K8sClient.Get(ctx, client.ObjectKey{
 			Name:      testCtx.CueXTestPackage,

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -1,0 +1,329 @@
+package cuex_test
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubevela/pkg/util/singleton"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/cue/cuex"
+	"github.com/oam-dev/kubevela/pkg/cue/definition"
+	"github.com/oam-dev/kubevela/pkg/cue/options"
+	"github.com/oam-dev/kubevela/pkg/cue/process"
+)
+
+type testContext struct {
+	K8sClient       client.Client
+	ReturnVal       string
+	CueXTestPackage string
+	Namespace       string
+	CueXPath        string
+	ExternalFnName  string
+	InputParamName  string
+	OutputParamName string
+}
+
+var testCtx = &testContext{
+	ReturnVal:       "external",
+	CueXTestPackage: "cuex-test-package",
+	Namespace:       "default",
+	CueXPath:        "cuex/ext",
+	ExternalFnName:  "external",
+	InputParamName:  "input",
+	OutputParamName: "output",
+}
+
+func TestMain(m *testing.M) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "charts", "vela-core", "crds"),
+		},
+	}
+
+	var err error
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to start envtest: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintf(os.Stderr, "envtest config is nil")
+		os.Exit(1)
+	}
+
+	testCtx.K8sClient, err = createK8sClient(cfg)
+
+	mockServer := createMockServer()
+	defer mockServer.Close()
+
+	singleton.KubeConfig.Set(cfg)
+
+	if err = createTestPackage(mockServer.URL); err != nil {
+		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err = deleteTestPackage(); err != nil {
+			fmt.Fprintf(os.Stderr, "Teardown failed: %v\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	code := m.Run()
+
+	singleton.KubeConfig.Reload()
+
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to stop envtest: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+func TestWorkloadCompiler(t *testing.T) {
+	testCases := map[string]struct {
+		cuexEnabled            bool
+		workloadTemplate       string
+		params                 map[string]interface{}
+		expectedObj            runtime.Object
+		expectedAdditionalObjs map[string]runtime.Object
+		hasCompileErr          bool
+		errorString            string
+	}{
+		"cuex disabled with no external packages": {
+			cuexEnabled:            false,
+			workloadTemplate:       getWorkloadTemplate(false),
+			params:                 make(map[string]interface{}),
+			expectedObj:            getExpectedObj(false),
+			expectedAdditionalObjs: make(map[string]runtime.Object),
+			hasCompileErr:          false,
+			errorString:            "",
+		},
+		"cuex enabled with no external packages": {
+			cuexEnabled:            true,
+			workloadTemplate:       getWorkloadTemplate(false),
+			params:                 make(map[string]interface{}),
+			expectedObj:            getExpectedObj(false),
+			expectedAdditionalObjs: make(map[string]runtime.Object),
+			hasCompileErr:          false,
+			errorString:            "",
+		},
+		"cuex disabled with external packages": {
+			cuexEnabled:            false,
+			workloadTemplate:       getWorkloadTemplate(true),
+			params:                 make(map[string]interface{}),
+			expectedObj:            getExpectedObj(true),
+			expectedAdditionalObjs: make(map[string]runtime.Object),
+			hasCompileErr:          true,
+			errorString:            "builtin package \"cuex/ext\" undefined",
+		},
+		"cuex enabled with external packages": {
+			cuexEnabled:            true,
+			workloadTemplate:       getWorkloadTemplate(true),
+			params:                 make(map[string]interface{}),
+			expectedObj:            getExpectedObj(true),
+			expectedAdditionalObjs: make(map[string]runtime.Object),
+			hasCompileErr:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		options.EnableExternalPackagesForWorkloadsAndTraits = tc.cuexEnabled
+		cuex.WorkloadCompiler.Reload()
+
+		ctx := process.NewContext(process.ContextData{
+			AppName:         "test-app",
+			CompName:        "test-component",
+			Namespace:       testCtx.Namespace,
+			AppRevisionName: "test-app-v1",
+			ClusterVersion:  types.ClusterVersion{Minor: "19+"},
+		})
+
+		wt := definition.NewWorkloadAbstractEngine("test-workload")
+		err := wt.Complete(ctx, tc.workloadTemplate, tc.params)
+		assert.Equal(t, tc.hasCompileErr, err != nil)
+		if tc.hasCompileErr {
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), tc.errorString)
+		} else {
+			output, _ := ctx.Output()
+			assert.Nil(t, err)
+			assert.NotNil(t, output)
+			outputObj, _ := output.Unstructured()
+			assert.Equal(t, tc.expectedObj, outputObj)
+		}
+	}
+}
+
+func createMockServer() *httptest.Server {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+testCtx.ExternalFnName {
+			http.Error(w, fmt.Sprintf("unexpected path: %s, expected: /%s", r.URL.Path, testCtx.ExternalFnName), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(fmt.Sprintf("{\"%s\": \"%s\"}", testCtx.OutputParamName, testCtx.ReturnVal)))
+		if err != nil {
+			return
+		}
+	}))
+	return mockServer
+}
+
+func createTestPackage(url string) error {
+	ctx := context.Background()
+
+	packageObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cue.oam.dev/v1alpha1",
+			"kind":       "Package",
+			"metadata": map[string]interface{}{
+				"name":      testCtx.CueXTestPackage,
+				"namespace": testCtx.Namespace,
+			},
+			"spec": map[string]interface{}{
+				"path": testCtx.CueXPath,
+				"provider": map[string]interface{}{
+					"endpoint": url,
+					"protocol": "http",
+				},
+				"templates": map[string]interface{}{
+					"ext/cue": strings.TrimSpace(fmt.Sprintf(`
+                        package ext
+
+                        #ExternalFunction: {
+                            #do: "%s",
+                            #provider: "%s",
+                            $params: {
+                                %s: string
+                            },
+                            $returns: {
+                                %s: string
+                            }
+                        }
+                    `, testCtx.ExternalFnName, testCtx.CueXTestPackage, testCtx.InputParamName, testCtx.OutputParamName)),
+				},
+			},
+		},
+	}
+
+	err := testCtx.K8sClient.Create(ctx, packageObj)
+
+	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+		err = testCtx.K8sClient.Get(ctx, client.ObjectKey{
+			Name:      testCtx.CueXTestPackage,
+			Namespace: testCtx.Namespace,
+		}, packageObj)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create test package: %w", err)
+	}
+	return nil
+}
+
+func deleteTestPackage() error {
+	ctx := context.Background()
+
+	testPkg := &unstructured.Unstructured{}
+	testPkg.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cue.oam.dev",
+		Version: "v1alpha1",
+		Kind:    "Package",
+	})
+	testPkg.SetName(testCtx.CueXTestPackage)
+	testPkg.SetNamespace(testCtx.Namespace)
+
+	err := testCtx.K8sClient.Delete(ctx, testPkg)
+	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+		err := testCtx.K8sClient.Get(ctx, client.ObjectKey{
+			Name:      testCtx.CueXTestPackage,
+			Namespace: testCtx.Namespace,
+		}, testPkg)
+		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete test package: %w", err)
+	}
+	return nil
+}
+
+func getWorkloadTemplate(includeExt bool) string {
+	tmpl := ""
+	name := "test-deployment"
+	if includeExt {
+		name = "test-deployment-\\(external.$returns.output)"
+		tmpl = tmpl + strings.TrimSpace(fmt.Sprintf(`
+			import (
+				"%s"
+			)
+
+			external: ext.#ExternalFunction & {
+				$params: {
+					%s: "external"
+				}
+			}
+		`, testCtx.CueXPath, testCtx.InputParamName)) + "\n"
+
+	}
+
+	tmpl = tmpl + strings.TrimSpace(fmt.Sprintf(`
+		output: {
+			apiVersion: "apps/v1"
+			kind: "Deployment"
+			metadata: name: "%s"
+			spec: replicas: 1
+		}
+	`, name))
+	return tmpl
+}
+
+func getExpectedObj(includeExt bool) *unstructured.Unstructured {
+	name := "test-deployment"
+	if includeExt {
+		name = fmt.Sprintf("test-deployment-%s", testCtx.ReturnVal)
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": name},
+		"spec":       map[string]interface{}{"replicas": int64(1)},
+	}}
+}
+
+func createK8sClient(config *rest.Config) (client.Client, error) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add corev1 to scheme: %w", err)
+	}
+	return client.New(config, client.Options{Scheme: scheme})
+}

--- a/pkg/cue/options/options.go
+++ b/pkg/cue/options/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package options
 
 var (
@@ -7,5 +23,6 @@ var (
 	// EnableExternalPackageWatchForDefaultCompiler .
 	EnableExternalPackageWatchForDefaultCompiler = false
 
+	// EnableExternalPackagesForWorkloadsAndTraits .
 	EnableExternalPackagesForWorkloadsAndTraits = false
 )

--- a/pkg/cue/options/options.go
+++ b/pkg/cue/options/options.go
@@ -1,0 +1,11 @@
+package options
+
+var (
+	// EnableExternalPackageForDefaultCompiler .
+	EnableExternalPackageForDefaultCompiler = true
+
+	// EnableExternalPackageWatchForDefaultCompiler .
+	EnableExternalPackageWatchForDefaultCompiler = false
+
+	EnableExternalPackagesForWorkloadsAndTraits = false
+)

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -19,6 +19,8 @@ package providers
 import (
 	"context"
 
+	"github.com/oam-dev/kubevela/pkg/cue/options"
+
 	"github.com/kubevela/pkg/cue/cuex"
 	cuexruntime "github.com/kubevela/pkg/cue/cuex/runtime"
 	"github.com/kubevela/pkg/util/runtime"
@@ -49,13 +51,6 @@ const (
 	QLProviderName = "ql"
 )
 
-var (
-	// EnableExternalPackageForDefaultCompiler .
-	EnableExternalPackageForDefaultCompiler = true
-	// EnableExternalPackageWatchForDefaultCompiler .
-	EnableExternalPackageWatchForDefaultCompiler = false
-)
-
 // compiler is the workflow default compiler
 var compiler = singleton.NewSingletonE[*cuex.Compiler](func() (*cuex.Compiler, error) {
 	return cuex.NewCompilerWithInternalPackages(
@@ -84,12 +79,12 @@ var compiler = singleton.NewSingletonE[*cuex.Compiler](func() (*cuex.Compiler, e
 // DefaultCompiler compiler for cuex to compile
 var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
 	c := compiler.Get()
-	if EnableExternalPackageForDefaultCompiler {
+	if options.EnableExternalPackageForDefaultCompiler {
 		if err := c.LoadExternalPackages(context.Background()); err != nil {
 			klog.Errorf("failed to load external packages for cuex default compiler: %v", err.Error())
 		}
 	}
-	if EnableExternalPackageWatchForDefaultCompiler {
+	if options.EnableExternalPackageWatchForDefaultCompiler {
 		go c.ListenExternalPackages(nil)
 	}
 	return c


### PR DESCRIPTION
### Description of your changes

copilot:all

- Updates components and trait templating to use CueX (via a new Workload compiler).
- Adds a new flag to enable/disable external CueX packages in the new Workload compiler. 
- Moves some CUE compiler related flags to a new package to prevent circular dependencies. 

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. **(N/A)**

### How has this code been tested

- Unit tests to verify templating with and without external packages
- Manual verification of component & trait creation
- Manual verification of data with `vela debug` 


### Special notes for your reviewer

This feature was discussed with @FogDong during her presentation @ Guidewire HQ. 