### PR TITLE
Feat: support token retrieval via AuthInfo.Exec command

### DIFF
--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -19,7 +19,10 @@ package multicluster
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -125,10 +128,20 @@ func (clusterConfig *KubeClusterConfig) createOrUpdateClusterSecret(ctx context.
 			data["ca.crt"] = clusterConfig.Cluster.CertificateAuthorityData
 		}
 	}
-	if len(clusterConfig.AuthInfo.Token) > 0 {
+	switch {
+	case len(clusterConfig.AuthInfo.Token) > 0:
 		credentialType = clusterv1alpha1.CredentialTypeServiceAccountToken
 		data["token"] = []byte(clusterConfig.AuthInfo.Token)
-	} else {
+
+	case clusterConfig.AuthInfo.Exec != nil:
+		token, err := getTokenFromExec(clusterConfig.AuthInfo.Exec)
+		if err != nil {
+			return err
+		}
+		credentialType = clusterv1alpha1.CredentialTypeServiceAccountToken
+		data["token"] = []byte(token)
+
+	default:
 		credentialType = clusterv1alpha1.CredentialTypeX509Certificate
 		data["tls.crt"] = clusterConfig.AuthInfo.ClientCertificateData
 		data["tls.key"] = clusterConfig.AuthInfo.ClientKeyData
@@ -597,4 +610,55 @@ func getMutableClusterSecret(ctx context.Context, c client.Client, clusterName s
 		return nil, fmt.Errorf("invalid cluster secret %s: cluster credential type label %s is not set", clusterName, clustercommon.LabelKeyClusterCredentialType)
 	}
 	return clusterSecret, nil
+}
+
+func getTokenFromExec(execConfig *clientcmdapi.ExecConfig) (string, error) {
+	// #nosec G204 -- This is intentionally running an exec command with user-provided input
+	// The execConfig comes from the kubeconfig which should be trusted in this context
+
+	cmdPath := execConfig.Command
+	if strings.Contains(cmdPath, "..") {
+		return "", fmt.Errorf("command path must not contain '..'")
+	}
+
+	if strings.ContainsAny(cmdPath, "$;&|<>\"'\\") {
+		return "", fmt.Errorf("command must not contain shell metacharacters")
+	}
+
+	for _, arg := range execConfig.Args {
+		if strings.ContainsAny(arg, "$;&|<>\\") {
+			return "", fmt.Errorf("arguments must not contain shell metacharacters")
+		}
+	}
+
+	cmd := exec.Command(cmdPath, execConfig.Args...) // #nosec G204
+
+	env := os.Environ()
+	for _, e := range execConfig.Env {
+		if strings.ContainsAny(e.Name, "=$;\n") || strings.ContainsAny(e.Value, "\n") {
+			return "", fmt.Errorf("environment variable names and values must not contain control characters")
+		}
+		env = append(env, fmt.Sprintf("%s=%s", e.Name, e.Value))
+	}
+	cmd.Env = env
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute auth command: %w", err)
+	}
+
+	var execCredential struct {
+		Status struct {
+			Token string `json:"token"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(output, &execCredential); err != nil {
+		return "", fmt.Errorf("failed to parse exec command output: %w", err)
+	}
+
+	if execCredential.Status.Token == "" {
+		return "", fmt.Errorf("token not found in exec command output")
+	}
+
+	return execCredential.Status.Token, nil
 }


### PR DESCRIPTION
copilot:all

Add a elseif condition in createOrUpdateClusterSecret to check for a non-nil AuthInfo.Exec.
If provided, execute the external command with its specified arguments and environment variables,
parse the JSON output to extract the token from status.token, and use it as the service account token.
Fallback to the existing token or certificate-based authentication logic when AuthInfo.Exec is absent.

Fixes #6658 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

https://github.com/kubevela/kubevela/pull/6716