### PR TITLE
Fix(parser) - The app.Spec.Policies[idx].Name must be a valid string

### DIFF
--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -128,8 +128,18 @@ var ApplicationExecContext = func(context string, appName string) bool {
 
 var ApplicationPortForwardContext = func(context string, appName string) bool {
 	return ginkgo.It(context+": should get output of port-forward successfully", func() {
+		ginkgo.By("waiting for the application to reach the desired status")
+		gomega.Eventually(func() bool {
+			cli := fmt.Sprintf("vela status %s", appName)
+			output, err := e2e.Exec(cli)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(output, "Running") // Adjust this condition as needed
+		}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(), "Application did not reach the desired status in time")
+
+		ginkgo.By("executing port-forward")
 		cli := fmt.Sprintf("vela port-forward %s 8080:80 ", appName)
-		time.Sleep(10 * time.Second) // Prevent port-forward to run when Current status=Pending, desired status=Running
 		output, err := e2e.ExecAndTerminate(cli)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(output).To(gomega.ContainSubstring("Forward successfully"))

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -128,15 +128,13 @@ var ApplicationExecContext = func(context string, appName string) bool {
 
 var ApplicationPortForwardContext = func(context string, appName string) bool {
 	return ginkgo.It(context+": should get output of port-forward successfully", func() {
-		ginkgo.By("waiting for the application to reach the desired status")
-		gomega.Eventually(func() bool {
+		ginkgo.By(fmt.Sprintf("waiting for the application [%s] to reach the desired status", appName))
+		gomega.Eventually(func() string {
 			cli := fmt.Sprintf("vela status %s", appName)
 			output, err := e2e.Exec(cli)
-			if err != nil {
-				return false
-			}
-			return strings.Contains(output, "Running") // Adjust this condition as needed
-		}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(), "Application did not reach the desired status in time")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			return output
+		}, 90*time.Second, 1*time.Second).Should(gomega.ContainSubstring("running"))
 
 		ginkgo.By("executing port-forward")
 		cli := fmt.Sprintf("vela port-forward %s 8080:80 ", appName)

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -129,6 +129,7 @@ var ApplicationExecContext = func(context string, appName string) bool {
 var ApplicationPortForwardContext = func(context string, appName string) bool {
 	return ginkgo.It(context+": should get output of port-forward successfully", func() {
 		cli := fmt.Sprintf("vela port-forward %s 8080:80 ", appName)
+		time.Sleep(60 * time.Second) // Prevent port-forward to run when Current status=Pending, desired status=Running
 		output, err := e2e.ExecAndTerminate(cli)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(output).To(gomega.ContainSubstring("Forward successfully"))

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -129,7 +129,7 @@ var ApplicationExecContext = func(context string, appName string) bool {
 var ApplicationPortForwardContext = func(context string, appName string) bool {
 	return ginkgo.It(context+": should get output of port-forward successfully", func() {
 		cli := fmt.Sprintf("vela port-forward %s 8080:80 ", appName)
-		time.Sleep(60 * time.Second) // Prevent port-forward to run when Current status=Pending, desired status=Running
+		time.Sleep(10 * time.Second) // Prevent port-forward to run when Current status=Pending, desired status=Running
 		output, err := e2e.ExecAndTerminate(cli)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(output).To(gomega.ContainSubstring("Forward successfully"))

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -104,7 +104,7 @@ func (p *Parser) GenerateAppFileFromApp(ctx context.Context, app *v1beta1.Applic
 
 	for idx := range app.Spec.Policies {
 		if app.Spec.Policies[idx].Name == "" {
-			app.Spec.Policies[idx].Name = fmt.Sprintf("%s:auto-gen:%d", app.Spec.Policies[idx].Type, idx)
+			app.Spec.Policies[idx].Name = fmt.Sprintf("%s-auto-gen-%d", app.Spec.Policies[idx].Type, idx)
 		}
 	}
 


### PR DESCRIPTION
### Description of your changes

copilot:all


The value is being used as labels and labels must be an empty string or consist of alphanumeric characters, '-', '' or '.', and must start and end with an alphanumeric character. In other words `:` is not a valid character. 


Error description:
```
one or more objects failed to apply, reason:

DestinationRule.networking.istio.io "service" is invalid: metadata.labels: Invalid value: "dependencies:auto-gen:0": a valid label must be an empty string or consist of alphanumeric characters, '-', '' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9.])?[A-Za-z0-9])?'),

ServiceEntry.networking.istio.io "service" is invalid: metadata.labels: Invalid value: "dependencies:auto-gen:0": a valid label must be an empty string or consist of alphanumeric characters, '-', '' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9.])?[A-Za-z0-9])?'),

Sidecar.networking.istio.io "service" is invalid: metadata.labels: Invalid value: "dependencies:auto-gen:0": a valid label must be an empty string or consist of alphanumeric characters, '-', '' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?') (retried 5 times).
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
