### PR TITLE
Fix: removing detached clusters from resource trackers

### DIFF
--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -378,7 +378,8 @@ func TestGetAddonStatus(t *testing.T) {
 	})
 
 	cli := test.MockClient{
-		MockGet: getFunc,
+		MockGet:  getFunc,
+		MockList: listFunc,
 	}
 
 	cases := []struct {
@@ -408,6 +409,10 @@ func TestGetAddonStatus(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, addonStatus.AddonPhase, s.expectStatus)
 	}
+}
+
+func listFunc(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
 }
 
 func TestGetAddonVersionMeetSystemRequirement(t *testing.T) {

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -690,4 +690,3 @@ func getTokenFromExec(execConfig *clientcmdapi.ExecConfig) (string, error) {
 
 	return execCredential.Status.Token, nil
 }
-

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -44,6 +44,7 @@ import (
 	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/utils"
 	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
 )
@@ -486,6 +487,9 @@ func (op DetachClusterManagedClusterKubeConfigPathOption) ApplyToArgs(args *Deta
 
 // DetachCluster detach cluster by name, if cluster is using by application, it will return error
 func DetachCluster(ctx context.Context, cli client.Client, clusterName string, options ...DetachClusterOption) error {
+	if err := removeClusterFromResourceTrackers(ctx, cli, clusterName); err != nil {
+		return fmt.Errorf("error in removing cluster references from resourcetrackers: %w", err)
+	}
 	args := newDetachClusterArgs(options...)
 	if clusterName == ClusterLocalName {
 		return ErrReservedLocalClusterName
@@ -661,4 +665,28 @@ func getTokenFromExec(execConfig *clientcmdapi.ExecConfig) (string, error) {
 	}
 
 	return execCredential.Status.Token, nil
+}
+
+// removeClusterFromResourceTrackers removes cluster refereneces from all resource trackers.
+func removeClusterFromResourceTrackers(ctx context.Context, cli client.Client, clusterName string) error {
+	rts := v1beta1.ResourceTrackerList{}
+	if err := cli.List(ctx, &rts); err != nil {
+		return fmt.Errorf("unable to list resourcetrackers due to error: %w", err)
+	}
+	for i := range rts.Items {
+		managedResources := rts.Items[i].Spec.ManagedResources
+		var result []v1beta1.ManagedResource
+		for _, mr := range managedResources {
+			if mr.ClusterObjectReference.Cluster != clusterName {
+				result = append(result, mr)
+			}
+		}
+		if len(rts.Items[i].Spec.ManagedResources) != len(result) {
+			rts.Items[i].Spec.ManagedResources = result
+			if err := cli.Update(ctx, &rts.Items[i]); err != nil {
+				return fmt.Errorf("error in updating resourcetracker %s: %w", rts.Items[i].Name, err)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### Description of your changes


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR does these changes:
1. When user detaches the cluster using `vela cluster detach` command then we remove references for that cluster from all resource trackers.
2. Modified GetAddonStatus to skip those clusters if it is not registered in KubeVela.
Fixes [#6727](https://github.com/kubevela/kubevela/issues/6727)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
This is tested locally by building the vela cli from the modified code and testing the scenario described in the issue.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->