### PR TITLE
Fix: support task component to be one-time run to completion

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -14,6 +14,7 @@ spec:
         output: {
         	apiVersion: "batch/v1"
         	kind:       "Job"
+        	metadata: name: "\(context.appName)-\(context.name)"
         	spec: {
         		parallelism: parameter.count
         		completions: parameter.count

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -44,6 +44,9 @@ template: {
 	output: {
 		apiVersion: "batch/v1"
 		kind:       "Job"
+		metadata: {
+			name: "\(context.appName)-\(context.name)"
+		}
 		spec: {
 			parallelism: parameter.count
 			completions: parameter.count


### PR DESCRIPTION
…nt name


### Description of your changes

In KubeVela, we have a task component that creates a Kubernetes Job internally. However, when we modify properties of the task, the KubeVela controller attempts to update the existing job, which fails since updating a Job is not allowed in Kubernetes. The purpose of the Task component is to trigger a one-time run to completion. Therefore, whenever an application containing this component is deployed, we always want a new job to be triggered, even if no changes have been made to the spec.

To address this, I've implemented a solution to ensure that each time the application is applied, a unique job name is generated, and the task component creates a new Job instead of modifying the existing one. Here's a summary of the changes:

Custom Component Definition:
Modify the ComponentDefinition of the task to generate the metadata.name for the Job resource using a unique combination of the application name and component name. This guarantees that the Job name will be unique for every application deployment, based on the application and component names.

Application Definition:
Use the metadata.generateName property in the application YAML instead of metadata.name to ensure that a unique name is generated automatically for each deployment.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6732

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Followed https://kubevela.net/docs/v1.4/contributor/code-contribute and installed KubeVela. Applied below application multiple times and verified it creates new Job every time without any errors:

```
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  generateName: app-worker
spec:
  components:
    - name: mytask
      type: task
      properties:
        image: ubuntu:22.04
        count: 2
        cmd: [ "sleep", "30" ]
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->