### PR TITLE
Fix: initilization for trait in output section

### DIFF
--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -133,12 +133,14 @@ func buildTemplateFromYAML(templateYAML string, def *pkgdef.Definition) error {
 		process.OutputsFieldName:   map[string]interface{}{},
 		process.ParameterFieldName: map[string]interface{}{},
 	}
+	kind := def.GetKind()
 	for index, yamlString := range yamlStrings {
 		var yamlObject map[string]interface{}
 		if err = yaml.Unmarshal([]byte(yamlString), &yamlObject); err != nil {
 			return errors.Wrapf(err, "failed to unmarshal template yaml file")
 		}
-		if index == 0 {
+
+		if index == 0 && kind != v1beta1.TraitDefinitionKind {
 			templateObject[process.OutputFieldName] = yamlObject
 		} else {
 			name, _, _ := unstructured.NestedString(yamlObject, "metadata", "name")


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We fixed the Vela CLI init command for trait definition initialization to generate a cue template with outputs, instead of output.

Fixes #6751

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
We built the vela cli init command for definition initilization and verified that the it generated cue template with outputs.

`bin/vela def init sample -t trait  --template-yaml config.yaml > sample.cue`

Output

```
sample: {
	alias: ""
	annotations: {}
	attributes: {
		appliesToWorkloads: []
		conflictsWith: []
		definitionRef: {}
		podDisruptive:   false
		workloadRefPath: ""
	}
	description: ""
	labels: {}
	type: "trait"
}

template: {
	output: {}
	outputs: {
		config1: {
			apiVersion: "v1"
			data: key1: "value1"
			kind: "ConfigMap"
			metadata: name: "config1"
		}
		config2: {
			apiVersion: "v1"
			data: key2: "value2"
			kind: "ConfigMap"
			metadata: name: "config2"
		}
	}
	parameter: {}
}

```



### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->


cc @shivin 