### PR TITLE
Fix: update apps with topology policy during cluster join

### DIFF
--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -29,8 +29,6 @@ import (
 	"github.com/kubevela/pkg/util/slices"
 	clustergatewayapi "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 	"github.com/oam-dev/cluster-gateway/pkg/config"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,6 +37,9 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	velacmd "github.com/oam-dev/kubevela/pkg/cmd"

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -221,11 +221,10 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 				return err
 			}
 			cmd.Printf("Successfully add cluster %s, endpoint: %s.\n", clusterName, clusterConfig.Cluster.Server)
-
+			updateAppsWithTopologyPolicy(ctx, client)
 			if len(labels) > 0 {
 				return addClusterLabels(cmd, c, clusterName, labels)
 			}
-			go updateAppsWithTopologyPolicy(ctx, client)
 			return nil
 		},
 	}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/fatih/color"
 	"github.com/kubevela/pkg/util/runtime"
@@ -34,6 +32,7 @@ import (
 	clustergatewayapi "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 	"github.com/oam-dev/cluster-gateway/pkg/config"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/labels"
@@ -67,7 +66,7 @@ const (
 
 	// CreateLabel specifies the labels need to create in managedCluster
 	CreateLabel = "labels"
-	// ClusterUpdateTime specifies the time app is undated in cluster.
+	// ClusterUpdateTime specifies the time app is updated in cluster.
 	ClusterUpdateTime = "clusterUpdateTime"
 )
 
@@ -242,7 +241,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 }
 
 // updateAppsWithTopologyPolicy iterates through all Application resources in the cluster,
-// and updates those that have a cluster-level label selector defined in their policies.
+// and updates those that have a cluster-level label selector defined in topology policy.
 // For each matching application, it sets or updates an annotation with the current Unix timestamp.
 func updateAppsWithTopologyPolicy(ctx context.Context, k8sClient client.Client) error {
 	// List every Application once, update only those with a cluster label selector.

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -66,8 +66,6 @@ const (
 
 	// CreateLabel specifies the labels need to create in managedCluster
 	CreateLabel = "labels"
-	// ClusterUpdateTime specifies the time app is updated in cluster.
-	ClusterUpdateTime = "app.oam.dev/publishVersion"
 )
 
 // ClusterCommandGroup create a group of cluster command
@@ -246,7 +244,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 
 // updateAppsWithTopologyPolicy iterates through all Application resources in the cluster,
 // and updates those that have a cluster-level label selector defined in topology policy.
-// For each matching application, it sets or updates an annotation with the current Unix timestamp.
+// For each matching application, it sets or updates publish version annotation.
 func updateAppsWithTopologyPolicy(ctx context.Context, k8sClient client.Client) error {
 	// List every Application once, update only those with a cluster label selector.
 	applicationList := &v1beta1.ApplicationList{}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -262,7 +262,7 @@ func updateAppsWithTopologyPolicy(ctx context.Context, cmd *cobra.Command, k8sCl
 
 		matched, err := hasClusterLabelSelector(app.Spec.Policies)
 		if err != nil {
-			return fmt.Errorf("failed to check clusterlabelselector for application %s: %w", app.Name, err)
+			return fmt.Errorf("failed to check clusterlabelselector for application %s in namespace %s: %w", app.Name, app.Namespace, err)
 		}
 		if !matched {
 			continue
@@ -276,7 +276,7 @@ func updateAppsWithTopologyPolicy(ctx context.Context, cmd *cobra.Command, k8sCl
 			if attempt > 0 {
 				key := apitypes.NamespacedName{Namespace: app.Namespace, Name: app.Name}
 				if err := k8sClient.Get(ctx, key, app); err != nil {
-					return fmt.Errorf("failed to refetch app %s: %w", app.Name, err)
+					return fmt.Errorf("failed to refetch app %s in namespace %s: %w", app.Name, app.Namespace, err)
 				}
 				retries++
 			}
@@ -287,16 +287,16 @@ func updateAppsWithTopologyPolicy(ctx context.Context, cmd *cobra.Command, k8sCl
 			if err := k8sClient.Update(ctx, app); err != nil {
 				if apierrors.IsConflict(err) {
 					// Retry if there's a conflict
-					cmd.Printf("Conflict updating app %s, retrying (%d/%d)...\n", app.Name, attempt+1, maxRetries)
+					cmd.Printf("Conflict updating app %s in namespace %s, retrying (%d/%d)...\n", app.Name, app.Namespace, attempt+1, maxRetries)
 					time.Sleep(500 * time.Millisecond)
 					continue
 				}
 				// Non-conflict error, return it
-				return fmt.Errorf("error updating app %s: %w", app.Name, err)
+				return fmt.Errorf("error updating app %s in namespace %s: %w", app.Name, app.Namespace, err)
 			}
 
 			if retries > 0 {
-				cmd.Printf("Successfully updated app %s after %d retries\n", app.Name, retries)
+				cmd.Printf("Successfully updated app %s in namespace %s after %d retries.\n", app.Name, app.Namespace, retries)
 			}
 			// Successful update
 			break

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -226,7 +226,9 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 					return fmt.Errorf("error in adding cluster labels: %w", err)
 				}
 			}
-			updateAppsWithTopologyPolicy(ctx, client)
+			if err := updateAppsWithTopologyPolicy(ctx, client); err != nil {
+			  return fmt.Errorf("error in updating apps with topology policy: %w", err)
+			}
 			return nil
 		},
 	}
@@ -254,12 +256,12 @@ func updateAppsWithTopologyPolicy(ctx context.Context, k8sClient client.Client) 
 		app := &applicationList.Items[i]
 		matched, err := hasClusterLabelSelector(app.Spec.Policies)
 		if err != nil {
-			return fmt.Errorf("failed to check clusterlabelselector for application %v: %w", *app, err)
+			return fmt.Errorf("failed to check clusterlabelselector for application %s: %w", app.Name, err)
 		}
 		if matched {
 			oam.SetPublishVersion(app, util.GenerateVersion("clusterjoin"))
 			if err := k8sClient.Update(ctx, app); err != nil {
-				return fmt.Errorf("error in updating app %v: %w", *app, err)
+				return fmt.Errorf("error in updating app %s: %w", app.Name, err)
 			}
 		}
 	}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -226,9 +226,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 					return fmt.Errorf("error in adding cluster labels: %w", err)
 				}
 			}
-			if err := updateAppsWithTopologyPolicy(ctx, client); err != nil {
-				return fmt.Errorf("error in updating apps with topology policy: %w", err)
-			}
+			updateAppsWithTopologyPolicy(ctx, client)
 			return nil
 		},
 	}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -227,7 +227,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 				}
 			}
 			if err := updateAppsWithTopologyPolicy(ctx, client); err != nil {
-			  return fmt.Errorf("error in updating apps with topology policy: %w", err)
+				return fmt.Errorf("error in updating apps with topology policy: %w", err)
 			}
 			return nil
 		},

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -230,7 +230,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 					return fmt.Errorf("error in adding cluster labels: %w", err)
 				}
 			}
-			if err := updateAppsWithTopologyPolicy(cmd, ctx, client); err != nil {
+			if err := updateAppsWithTopologyPolicy(ctx, cmd, client); err != nil {
 				return fmt.Errorf("error in updating apps with topology policy: %w", err)
 			}
 			return nil
@@ -250,7 +250,7 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 // updateAppsWithTopologyPolicy iterates through all Application resources in the cluster,
 // and updates those that have a cluster-level label selector defined in topology policy.
 // For each matching application, it sets or updates publish version annotation.
-func updateAppsWithTopologyPolicy(cmd *cobra.Command, ctx context.Context, k8sClient client.Client) error {
+func updateAppsWithTopologyPolicy(ctx context.Context, cmd *cobra.Command, k8sClient client.Client) error {
 	// List every Application once, update only those with a cluster label selector.
 	applicationList := &v1beta1.ApplicationList{}
 	if err := k8sClient.List(ctx, applicationList); err != nil {

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cli
 
 import (

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -171,7 +171,7 @@ func createApplication(appYaml string) error {
 		return fmt.Errorf("unmarshal error for yaml %s: %w", appYaml, err)
 	}
 	if err := k8sClient.Create(context.Background(), &app); err != nil {
-		return fmt.Errorf("error in creating app %v: %w", app, err)
+		return fmt.Errorf("error in creating app %s in namespace %s: %w", app.Name, app.Namespace, err)
 	}
 	return nil
 }

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -92,9 +92,9 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
-			err, result := hasUpdateTimeAnnotation("app-without-policies", "vela-system")
+			matched, err := hasUpdateTimeAnnotation("app-without-policies", "vela-system")
 			Expect(err).Should(BeNil())
-			Expect(result).Should(BeFalse())
+			Expect(matched).Should(BeFalse())
 		})
 	})
 
@@ -106,9 +106,9 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
-			err, result := hasUpdateTimeAnnotation("basic-topology", "default")
+			matched, err := hasUpdateTimeAnnotation("basic-topology", "default")
 			Expect(err).Should(BeNil())
-			Expect(result).Should(BeFalse())
+			Expect(matched).Should(BeFalse())
 		})
 	})
 
@@ -120,9 +120,9 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
-			err, result := hasUpdateTimeAnnotation("region-selector", "vela-system")
+			matched, err := hasUpdateTimeAnnotation("region-selector", "vela-system")
 			Expect(err).Should(BeNil())
-			Expect(result).Should(BeTrue())
+			Expect(matched).Should(BeTrue())
 		})
 	})
 
@@ -134,9 +134,9 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
-			err, result := hasUpdateTimeAnnotation("empty-cluster-selector", "default")
+			matched, err := hasUpdateTimeAnnotation("empty-cluster-selector", "default")
 			Expect(err).Should(BeNil())
-			Expect(result).Should(BeTrue())
+			Expect(matched).Should(BeTrue())
 		})
 	})
 
@@ -153,14 +153,14 @@ func createApplication(appYaml string) error {
 	return nil
 }
 
-func hasUpdateTimeAnnotation(name, namespace string) (error, bool) {
+func hasUpdateTimeAnnotation(name, namespace string) (bool, error) {
 	app := &v1beta1.Application{}
 	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, app); err != nil {
-		return fmt.Errorf("error in getting application %s in namespace %s: %w", name, namespace, err), false
+		return false, fmt.Errorf("error in getting application %s in namespace %s: %w", name, namespace, err)
 	}
 	annotations := app.GetAnnotations()
 	if annotations != nil && annotations[ClusterUpdateTime] != "" {
-		return nil, true
+		return true, nil
 	}
-	return nil, false
+	return false, nil
 }

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -107,7 +108,8 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err := createApplication(appWithoutTopologyPolicyYaml)
 			Expect(err).Should(BeNil())
 
-			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			cmd := &cobra.Command{}
+			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("app-without-policies", "vela-system")
@@ -121,7 +123,8 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err := createApplication(appWithTopologyClustersYaml)
 			Expect(err).Should(BeNil())
 
-			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			cmd := &cobra.Command{}
+			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("basic-topology", "default")
@@ -135,7 +138,8 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err := createApplication(appWithTopologyClusterLabelSelectorYaml)
 			Expect(err).Should(BeNil())
 
-			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			cmd := &cobra.Command{}
+			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("region-selector", "vela-system")
@@ -149,7 +153,8 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			err := createApplication(appWithEmptyTopologyClusterLabelSelectorYaml)
 			Expect(err).Should(BeNil())
 
-			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			cmd := &cobra.Command{}
+			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("empty-cluster-selector", "default")

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			Expect(err).Should(BeNil())
 
 			cmd := &cobra.Command{}
-			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
+			err = updateAppsWithTopologyPolicy(context.Background(), cmd, k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("app-without-policies", "vela-system")
@@ -124,7 +124,7 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			Expect(err).Should(BeNil())
 
 			cmd := &cobra.Command{}
-			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
+			err = updateAppsWithTopologyPolicy(context.Background(), cmd, k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("basic-topology", "default")
@@ -139,7 +139,7 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			Expect(err).Should(BeNil())
 
 			cmd := &cobra.Command{}
-			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
+			err = updateAppsWithTopologyPolicy(context.Background(), cmd, k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("region-selector", "vela-system")
@@ -154,7 +154,7 @@ var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
 			Expect(err).Should(BeNil())
 
 			cmd := &cobra.Command{}
-			err = updateAppsWithTopologyPolicy(cmd, context.Background(), k8sClient)
+			err = updateAppsWithTopologyPolicy(context.Background(), cmd, k8sClient)
 			Expect(err).Should(BeNil())
 
 			matched, err := hasPublishVersionAnnotation("empty-cluster-selector", "default")

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	appWithoutTopologyPolicyYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-without-policies
+  namespace: vela-system
+spec:
+  components:
+    - name: nginx-basic
+      type: webservice
+      properties:
+        image: nginx
+`
+	appWithTopologyClustersYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: basic-topology
+  namespace: default
+spec:
+  components:
+    - name: nginx-basic
+      type: webservice
+      properties:
+        image: nginx
+  policies:
+    - name: topology-hangzhou-clusters
+      type: topology
+      properties:
+        clusters: ["hangzhou-1", "hangzhou-2"]
+`
+	appWithTopologyClusterLabelSelectorYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: region-selector
+  namespace: vela-system
+spec:
+  components:
+    - name: nginx-basic
+      type: webservice
+      properties:
+        image: nginx
+  policies:
+    - name: topology-hangzhou-clusters
+      type: topology
+      properties:
+        clusterLabelSelector:
+          region: hangzhou
+`
+	appWithEmptyTopologyClusterLabelSelectorYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: empty-cluster-selector
+  namespace: default
+spec:
+  components:
+    - name: nginx-basic
+      type: webservice
+      properties:
+        image: nginx
+  policies:
+    - name: topology-hangzhou-clusters
+      type: topology
+      properties:
+        clusterLabelSelector: {}
+`
+)
+
+var _ = Describe("Test updateAppsWithTopologyPolicy", func() {
+
+	var _ = When("app does not have topology policy", func() {
+		It("app should not have update app annotation set", func() {
+			err := createApplication(appWithoutTopologyPolicyYaml)
+			Expect(err).Should(BeNil())
+
+			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			Expect(err).Should(BeNil())
+
+			err, result := hasUpdateTimeAnnotation("app-without-policies", "vela-system")
+			Expect(err).Should(BeNil())
+			Expect(result).Should(BeFalse())
+		})
+	})
+
+	var _ = When("app has topology policy without clusterLabelSelector", func() {
+		It("app should not have update app annotation set", func() {
+			err := createApplication(appWithTopologyClustersYaml)
+			Expect(err).Should(BeNil())
+
+			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			Expect(err).Should(BeNil())
+
+			err, result := hasUpdateTimeAnnotation("basic-topology", "default")
+			Expect(err).Should(BeNil())
+			Expect(result).Should(BeFalse())
+		})
+	})
+
+	var _ = When("app has topology policy with clusterLabelSelector", func() {
+		It("app should have update app annotation set", func() {
+			err := createApplication(appWithTopologyClusterLabelSelectorYaml)
+			Expect(err).Should(BeNil())
+
+			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			Expect(err).Should(BeNil())
+
+			err, result := hasUpdateTimeAnnotation("region-selector", "vela-system")
+			Expect(err).Should(BeNil())
+			Expect(result).Should(BeTrue())
+		})
+	})
+
+	var _ = When("app has topology policy with empty clusterLabelSelector", func() {
+		It("app should have update app annotation set", func() {
+			err := createApplication(appWithEmptyTopologyClusterLabelSelectorYaml)
+			Expect(err).Should(BeNil())
+
+			err = updateAppsWithTopologyPolicy(context.Background(), k8sClient)
+			Expect(err).Should(BeNil())
+
+			err, result := hasUpdateTimeAnnotation("empty-cluster-selector", "default")
+			Expect(err).Should(BeNil())
+			Expect(result).Should(BeTrue())
+		})
+	})
+
+})
+
+func createApplication(appYaml string) error {
+	app := v1beta1.Application{}
+	if err := yaml.Unmarshal([]byte(appYaml), &app); err != nil {
+		return fmt.Errorf("unmarshal error for yaml %s: %w", appYaml, err)
+	}
+	if err := k8sClient.Create(context.Background(), &app); err != nil {
+		return fmt.Errorf("error in creating app %v: %w", app, err)
+	}
+	return nil
+}
+
+func hasUpdateTimeAnnotation(name, namespace string) (error, bool) {
+	app := &v1beta1.Application{}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, app); err != nil {
+		return fmt.Errorf("error in getting application %s in namespace %s: %w", name, namespace, err), false
+	}
+	annotations := app.GetAnnotations()
+	if annotations != nil && annotations[ClusterUpdateTime] != "" {
+		return nil, true
+	}
+	return nil, false
+}

--- a/references/cli/cluster_test.go
+++ b/references/cli/cluster_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/oam"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 var (


### PR DESCRIPTION
### Description of your changes

When user runs vela cluster join command, we iterate through all Application resources in the cluster and updates those that have a cluster-level label selector defined in topology policy. For each matching application, it sets or updates publish version annotation. This makes sure the workflow in the application gets retrigerred which makes sure the app resources gets deployed to the newly joined cluster.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes [#6765](https://github.com/kubevela/kubevela/issues/6765)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested locally by applying applications with topology policy and enabling fluxcd addon. Verified that on joining the new cluster, the resources are deployed in the newly created cluster.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->