### PR TITLE
Fix(traitdefinition):  Make localhostProfile optional for other types and provide it only for Localhost

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/podsecuritycontext.yaml
+++ b/charts/vela-core/templates/defwithtemplate/podsecuritycontext.yaml
@@ -39,8 +39,9 @@ spec:
         parameter: {
         	// +usage=Specify the AppArmor profile for the pod
         	appArmorProfile?: {
-        		type:             "RuntimeDefault" | "Unconfined" | "Localhost"
-        		localhostProfile: string
+        		type: "RuntimeDefault" | "Unconfined" | "Localhost"
+        		// +usage:  localhostProfile is required when type is 'Localhost'
+        		localhostProfile?: string
         	}
         	fsGroup?:    int
         	runAsGroup?: int
@@ -50,8 +51,9 @@ spec:
         	runAsNonRoot: *true | bool
         	// +usage=Specify the seccomp profile for the pod
         	seccompProfile?: {
-        		type:             "RuntimeDefault" | "Unconfined" | "Localhost"
-        		localhostProfile: string
+        		type: "RuntimeDefault" | "Unconfined" | "Localhost"
+        		// +usage:  localhostProfile is required when type is 'Localhost'
+        		localhostProfile?: string
         	}
         }
 

--- a/vela-templates/definitions/internal/trait/podsecuritycontext.cue
+++ b/vela-templates/definitions/internal/trait/podsecuritycontext.cue
@@ -33,8 +33,9 @@ template: {
 	parameter: {
 		// +usage=Specify the AppArmor profile for the pod
 		appArmorProfile?: {
-			type:             "RuntimeDefault" | "Unconfined" | "Localhost"
-			localhostProfile: string
+			type: "RuntimeDefault" | "Unconfined" | "Localhost"
+			// +usage:  localhostProfile is required when type is 'Localhost'
+			localhostProfile?: string
 		}
 		fsGroup?:    int
 		runAsGroup?: int
@@ -44,8 +45,9 @@ template: {
 		runAsNonRoot: *true | bool
 		// +usage=Specify the seccomp profile for the pod
 		seccompProfile?: {
-			type:             "RuntimeDefault" | "Unconfined" | "Localhost"
-			localhostProfile: string
+			type: "RuntimeDefault" | "Unconfined" | "Localhost"
+			// +usage:  localhostProfile is required when type is 'Localhost'
+			localhostProfile?: string
 		}
 	}
 }


### PR DESCRIPTION
 Make localhostProfile optional for other types and provide it only for Localhost. Fixes #6772


### Description of your changes

copilot:all

The localhostProfile attribute is currently required or improperly validated when the type field is set to RuntimeDefault in both seccompProfile and appArmorProfile. According to expected behavior, localhostProfile should be optional and ignored when the type is RuntimeDefault, as the runtime’s default profile does not require a custom local profile. This change will make localhostProfile optional and allow providing it when the type is set to Localhost.

Fixes #6772

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Made localhostProfile optional in pod security context so it is only required when type is set to Localhost. This prevents validation errors when using RuntimeDefault or Unconfined types.

<!-- End of auto-generated description by mrge. -->

