### PR TITLE
feat: Allow loading of Kubevela Configs in Components and Traits

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/oam-dev/kubevela/apis/types"
+	v1 "k8s.io/api/core/v1"
+	pkgtypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SaveInputPropertiesKey define the key name for saving the input properties in the secret.
+const SaveInputPropertiesKey = "input-properties"
+
+// ErrSensitiveConfig means this config can not be read directly.
+var ErrSensitiveConfig = errors.New("the config is sensitive")
+
+// TemplateConfigMapNamePrefix the prefix of the configmap name.
+const TemplateConfigMapNamePrefix = "config-template-"
+
+// SaveObjectReferenceKey define the key name for saving the outputs objects reference metadata in the secret.
+const SaveObjectReferenceKey = "objects-reference"
+
+// SaveExpandedWriterKey define the key name for saving the expanded writer config
+const SaveExpandedWriterKey = "expanded-writer"
+
+// SaveSchemaKey define the key name for saving the API schema
+const SaveSchemaKey = "schema"
+
+// SaveTemplateKey define the key name for saving the config-template
+const SaveTemplateKey = "template"
+
+// TemplateValidationReturns define the key name for the config-template validation returns
+const TemplateValidationReturns = SaveTemplateKey + ".validation.$returns"
+
+// TemplateOutput define the key name for the config-template output
+const TemplateOutput = SaveTemplateKey + ".output"
+
+// TemplateOutputs define the key name for the config-template outputs
+const TemplateOutputs = SaveTemplateKey + ".outputs"
+
+// ErrNoConfigOrTarget means the config or the target is empty.
+var ErrNoConfigOrTarget = errors.New("you must specify the config name and destination to distribute")
+
+// ErrNotFoundDistribution means the app of the distribution does not exist.
+var ErrNotFoundDistribution = errors.New("the distribution does not found")
+
+// ErrConfigExist means the config does exist.
+var ErrConfigExist = errors.New("the config does exist")
+
+// ErrConfigNotFound means the config does not exist
+var ErrConfigNotFound = errors.New("the config does not exist")
+
+// ErrTemplateNotFound means the template does not exist
+var ErrTemplateNotFound = errors.New("the template does not exist")
+
+// ErrChangeTemplate means the template of the config can not be changed
+var ErrChangeTemplate = errors.New("the template of the config can not be changed")
+
+// ErrChangeSecretType means the secret type of the config can not be changed
+var ErrChangeSecretType = errors.New("the secret type of the config can not be changed")
+
+func ReadConfig(ctx context.Context, client client.Client, namespace string, name string) (map[string]interface{}, error) {
+	var secret v1.Secret
+	if err := client.Get(ctx, pkgtypes.NamespacedName{Namespace: namespace, Name: name}, &secret); err != nil {
+		return nil, err
+	}
+	if secret.Annotations[types.AnnotationConfigSensitive] == "true" {
+		return nil, ErrSensitiveConfig
+	}
+	properties := secret.Data[SaveInputPropertiesKey]
+	var input = map[string]interface{}{}
+	if err := json.Unmarshal(properties, &input); err != nil {
+		return nil, err
+	}
+	return input, nil
+}

--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	. "github.com/oam-dev/kubevela/pkg/config/common"
 	"strings"
 	"time"
 
@@ -51,57 +52,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 )
-
-// SaveInputPropertiesKey define the key name for saving the input properties in the secret.
-const SaveInputPropertiesKey = "input-properties"
-
-// SaveObjectReferenceKey define the key name for saving the outputs objects reference metadata in the secret.
-const SaveObjectReferenceKey = "objects-reference"
-
-// SaveExpandedWriterKey define the key name for saving the expanded writer config
-const SaveExpandedWriterKey = "expanded-writer"
-
-// SaveSchemaKey define the key name for saving the API schema
-const SaveSchemaKey = "schema"
-
-// SaveTemplateKey define the key name for saving the config-template
-const SaveTemplateKey = "template"
-
-// TemplateConfigMapNamePrefix the prefix of the configmap name.
-const TemplateConfigMapNamePrefix = "config-template-"
-
-// TemplateValidationReturns define the key name for the config-template validation returns
-const TemplateValidationReturns = SaveTemplateKey + ".validation.$returns"
-
-// TemplateOutput define the key name for the config-template output
-const TemplateOutput = SaveTemplateKey + ".output"
-
-// TemplateOutputs define the key name for the config-template outputs
-const TemplateOutputs = SaveTemplateKey + ".outputs"
-
-// ErrSensitiveConfig means this config can not be read directly.
-var ErrSensitiveConfig = errors.New("the config is sensitive")
-
-// ErrNoConfigOrTarget means the config or the target is empty.
-var ErrNoConfigOrTarget = errors.New("you must specify the config name and destination to distribute")
-
-// ErrNotFoundDistribution means the app of the distribution does not exist.
-var ErrNotFoundDistribution = errors.New("the distribution does not found")
-
-// ErrConfigExist means the config does exist.
-var ErrConfigExist = errors.New("the config does exist")
-
-// ErrConfigNotFound means the config does not exist
-var ErrConfigNotFound = errors.New("the config does not exist")
-
-// ErrTemplateNotFound means the template does not exist
-var ErrTemplateNotFound = errors.New("the template does not exist")
-
-// ErrChangeTemplate means the template of the config can not be changed
-var ErrChangeTemplate = errors.New("the template of the config can not be changed")
-
-// ErrChangeSecretType means the secret type of the config can not be changed
-var ErrChangeSecretType = errors.New("the secret type of the config can not be changed")
 
 // NamespacedName the namespace and name model
 type NamespacedName struct {
@@ -572,19 +522,7 @@ func (k *kubeConfigFactory) ParseConfig(ctx context.Context,
 
 // ReadConfig read the config secret
 func (k *kubeConfigFactory) ReadConfig(ctx context.Context, namespace, name string) (map[string]interface{}, error) {
-	var secret v1.Secret
-	if err := k.cli.Get(ctx, pkgtypes.NamespacedName{Namespace: namespace, Name: name}, &secret); err != nil {
-		return nil, err
-	}
-	if secret.Annotations[types.AnnotationConfigSensitive] == "true" {
-		return nil, ErrSensitiveConfig
-	}
-	properties := secret.Data[SaveInputPropertiesKey]
-	var input = map[string]interface{}{}
-	if err := json.Unmarshal(properties, &input); err != nil {
-		return nil, err
-	}
-	return input, nil
+	return ReadConfig(ctx, k.cli, namespace, name)
 }
 
 func (k *kubeConfigFactory) GetConfig(ctx context.Context, namespace, name string, withStatus bool) (*Config, error) {

--- a/pkg/config/factory_test.go
+++ b/pkg/config/factory_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"github.com/oam-dev/kubevela/pkg/config/common"
 	"os"
 	"testing"
 
@@ -66,7 +67,7 @@ var _ = Describe("test config factory", func() {
 			}},
 		}})
 		Expect(err).Should(BeNil())
-		Expect(len(nacos.Secret.Data[SaveInputPropertiesKey]) > 0).Should(BeTrue())
+		Expect(len(nacos.Secret.Data[common.SaveInputPropertiesKey]) > 0).Should(BeTrue())
 		Expect(fac.CreateOrUpdateConfig(context.Background(), nacos, "default")).Should(BeNil())
 
 		config, err := fac.ReadConfig(context.TODO(), "default", "nacos")

--- a/pkg/cue/definition/template.go
+++ b/pkg/cue/definition/template.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kubevela/pkg/util/singleton"
+	"github.com/oam-dev/kubevela/pkg/config/common"
+	"k8s.io/klog/v2"
 	"strings"
 
 	"github.com/kubevela/pkg/cue/cuex"
@@ -109,9 +112,15 @@ func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, pa
 		return err
 	}
 
-	val, err := cuex.DefaultCompiler.Get().CompileString(ctx.GetCtx(), strings.Join([]string{
+	template := strings.Join([]string{
 		renderTemplate(abstractTemplate), paramFile, c,
-	}, "\n"))
+	}, "\n")
+
+	val, err := cuex.DefaultCompiler.Get().CompileStringWithOptions(
+		ctx.GetCtx(),
+		template,
+		cuex.WithIntraResolveMutation("config", readConfigMutator(ctx)),
+	)
 
 	if err != nil {
 		return errors.WithMessagef(err, "failed to compile workload %s after merge parameter and context", wd.name)
@@ -312,7 +321,11 @@ func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, param
 	}
 	buff += c
 
-	val, err := cuex.DefaultCompiler.Get().CompileString(ctx.GetCtx(), buff)
+	val, err := cuex.DefaultCompiler.Get().CompileStringWithOptions(
+		ctx.GetCtx(),
+		buff,
+		cuex.WithIntraResolveMutation("config", readConfigMutator(ctx)),
+	)
 
 	if err != nil {
 		return errors.WithMessagef(err, "failed to compile trait %s after merge parameter and context", td.name)
@@ -510,4 +523,63 @@ func getResourceFromObj(ctx context.Context, pctx process.Context, obj *unstruct
 		}
 	}
 	return nil, errors.Errorf("no resources found gvk(%v) labels(%v)", obj.GroupVersionKind(), labels)
+}
+
+func readConfigMutator(pCtx process.Context) func(context.Context, cue.Value) (cue.Value, error) {
+	return func(_ context.Context, val cue.Value) (cue.Value, error) {
+		configField := val.LookupPath(value.FieldPath("$config"))
+		if !configField.Exists() {
+			return val, nil
+		}
+
+		iter, _ := configField.Fields()
+		for iter.Next() {
+			configKey := iter.Label()
+			configEntryVal := iter.Value()
+
+			configVal, err := getConfigFromCueVal(pCtx, configKey, configEntryVal)
+			if err != nil {
+				return val, errors.WithMessagef(err, "failed to read $config from `%s.%s`", "$config", configKey)
+			}
+			val = val.FillPath(value.FieldPath("$config."+configKey+".output"), configVal)
+		}
+		return val, nil
+	}
+}
+
+func getConfigFromCueVal(ctx process.Context, key string, config cue.Value) (map[string]interface{}, error) {
+	cfgName := config.LookupPath(value.FieldPath("name"))
+	if !cfgName.Exists() {
+		return nil, errors.New(
+			fmt.Sprintf("Invalid $config provided in field `%s.%s`. Must specify `name` field.", "$config", key))
+	}
+	cfgNameStr, err := cfgName.String()
+	if err != nil {
+		klog.Errorf("error reading $config at `$config.%s.name`\n%v", key, err)
+		return nil, err
+	}
+	cfgNamespace := config.LookupPath(value.FieldPath("namespace"))
+	cfgNamespaceStr := ctx.GetData(velaprocess.ContextNamespace).(string)
+	if cfgNamespace.Exists() {
+		ns, err := cfgNamespace.String()
+		if err != nil {
+			klog.Errorf("invalid string value supplied for `$config.%s.namespace`\n%v", key, err)
+			return nil, err
+		}
+		if len(ns) > 0 {
+			cfgNamespaceStr = ns
+			// handle any interpreted values, e.g. $vela-system, $current
+			switch ns {
+			case "$vela-system":
+				cfgNamespaceStr = oam.SystemDefinitionNamespace
+			case "$current":
+				cfgNamespaceStr = ctx.GetData(velaprocess.ContextNamespace).(string)
+			}
+		}
+	}
+	cfg, err := common.ReadConfig(ctx.GetCtx(), singleton.KubeClient.Get(), cfgNamespaceStr, cfgNameStr)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "could not retrieve $config `%s` in namespace `%s`", cfgNameStr, cfgNamespaceStr)
+	}
+	return cfg, nil
 }

--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -17,7 +17,21 @@ limitations under the License.
 package definition
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/kubevela/pkg/cue/cuex"
+	"github.com/kubevela/pkg/util/singleton"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1564,4 +1578,550 @@ parameter: {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), v.err)
 	}
+}
+
+func TestConfigFieldInWorkload(t *testing.T) {
+	testCases := map[string]struct {
+		createConfig       bool
+		configValues       map[string]interface{}
+		configNamespace    string
+		configName         string
+		namespaceRequired  bool
+		lookupNamespace    string
+		lookupName         string
+		expectedCompileErr string
+		expected           *unstructured.Unstructured
+	}{
+		"happy path": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:   "vela-system",
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupNamespace:   "vela-system",
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "a-cluster-type",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"happy path with defaulted value not in config": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+			},
+			configNamespace:   "vela-system",
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupNamespace:   "vela-system",
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "default",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"no name provided for config": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:    "vela-system",
+			configName:         "test-config",
+			namespaceRequired:  false,
+			lookupNamespace:    "vela-system",
+			expectedCompileErr: "Invalid $config provided in field `$config.cluster`. Must specify `name` field.",
+		},
+		"namespace is blank and uses oam default": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:   "default",
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupNamespace:   "",
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "a-cluster-type",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"namespace is empty but marked required": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:    "",
+			configName:         "test-config",
+			namespaceRequired:  true,
+			lookupNamespace:    "",
+			lookupName:         "test-config",
+			expectedCompileErr: "$config.cluster.namespace: non-concrete value string",
+		},
+		"namespace is null but marked required": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:    "default",
+			configName:         "test-config",
+			namespaceRequired:  true,
+			lookupNamespace:    "",
+			lookupName:         "test-config",
+			expectedCompileErr: "$config.cluster.namespace: non-concrete value string",
+		},
+		"namespace is null and uses apps namespace": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:   "default",
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "a-cluster-type",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"namespace set to $current uses apps namespace": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:   "default",
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupNamespace:   "$current",
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "a-cluster-type",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"namespace is set to $vela-system default": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"name": "a-test-cluster",
+				"type": "a-cluster-type",
+			},
+			configNamespace:   oam.SystemDefinitionNamespace,
+			configName:        "test-config",
+			namespaceRequired: false,
+			lookupNamespace:   "$vela-system",
+			lookupName:        "test-config",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deployment",
+						"labels": map[string]interface{}{
+							"name": "a-test-cluster",
+							"type": "a-cluster-type",
+						},
+					},
+					"spec": map[string]interface{}{"replicas": int64(1)},
+				},
+			},
+		},
+		"referenced parameter names do not exist in config": {
+			createConfig: true,
+			configValues: map[string]interface{}{
+				"not-used": "an-unused-value",
+			},
+			configNamespace:    "vela-system",
+			configName:         "test-config",
+			namespaceRequired:  false,
+			lookupName:         "test-config",
+			lookupNamespace:    "vela-system",
+			expectedCompileErr: "",
+			expected:           nil,
+		},
+		"missing config": {
+			createConfig:       false,
+			namespaceRequired:  true,
+			lookupNamespace:    "vela-system",
+			lookupName:         "test-config",
+			expectedCompileErr: "secrets \"test-config\" not found",
+		},
+	}
+
+	for testId, testCase := range testCases {
+		t.Run(testId, func(t *testing.T) {
+			if testCase.createConfig {
+				secret, err := createSecret(testCase.configName, testCase.configNamespace, testCase.configValues)
+				require.NoError(t, err)
+
+				cl := fake.NewClientBuilder().WithObjects(secret).Build()
+				singleton.KubeClient.Set(cl)
+				defer singleton.KubeClient.Reload()
+			}
+
+			ctx := process.NewContext(process.ContextData{
+				AppName:         "myapp",
+				CompName:        "test",
+				Namespace:       "default",
+				AppRevisionName: "myapp-v1",
+				ClusterVersion:  types.ClusterVersion{Minor: "19+"},
+			})
+
+			wt := NewWorkloadAbstractEngine("testWorkload")
+			params := map[string]interface{}{
+				"config": testCase.lookupName,
+			}
+
+			data := struct {
+				Namespace         string
+				Name              string
+				NamespaceRequired bool
+				NameRequired      bool
+			}{
+				Namespace:         testCase.lookupNamespace,
+				Name:              testCase.lookupName,
+				NamespaceRequired: testCase.namespaceRequired,
+				NameRequired:      len(testCase.lookupName) > 0,
+			}
+
+			tmpl := strings.TrimSpace(`
+				parameter: {
+					config: string
+				}
+		
+				$config: {
+					cluster: {
+						namespace{{ if not .NamespaceRequired }}?{{ end }}: string
+						name?: string
+						output: {
+							type: string | *"default"
+							name?: string
+						}
+					}
+				}
+		
+				$config: {
+					cluster: {
+						{{ if .Namespace }}
+						namespace: "{{ .Namespace }}"
+						{{ end }}
+						{{ if .NameRequired }}name: parameter.config{{ end }}
+					}
+				}
+		
+				output: {
+					apiVersion: "apps/v1"
+					kind: "Deployment"
+					metadata: {
+						name: "deployment"
+						labels: {
+							"name": $config.cluster.output.name,
+							"type": $config.cluster.output.type,
+						}
+					}
+					spec: replicas: 1
+				}
+		
+				parameter: {
+					hello: string
+				}
+			`)
+			defTmpl, err := template.New("definition").Parse(tmpl)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			err = defTmpl.Execute(&buf, data)
+			require.NoError(t, err)
+
+			err = wt.Complete(ctx, buf.String(), params)
+			if len(testCase.expectedCompileErr) > 0 {
+				require.Contains(t, err.Error(), testCase.expectedCompileErr)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			if testCase.createConfig {
+				require.NoError(t, err)
+			} else {
+				require.Errorf(t, err, "secrets %s not found", testCase.configName)
+				return
+			}
+
+			base, _ := ctx.Output()
+
+			baseObj, err := base.Unstructured()
+			assert.Equal(t, testCase.expected, baseObj)
+		})
+	}
+}
+
+func TestConfigFieldWithinCuexParameter(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(fmt.Sprintf("{\"name\": \"test\"}")))
+		if err != nil {
+			return
+		}
+	}))
+	defer mockServer.Close()
+
+	packagePath := "test/ext"
+	packageObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cue.oam.dev/v1alpha1",
+			"kind":       "Package",
+			"metadata": map[string]interface{}{
+				"name":      "test-package",
+				"namespace": "vela-system",
+			},
+			"spec": map[string]interface{}{
+				"path": packagePath,
+				"provider": map[string]interface{}{
+					"endpoint": mockServer.URL,
+					"protocol": "http",
+				},
+				"templates": map[string]interface{}{
+					"test/ext": strings.TrimSpace(`
+                        package ext
+                        #TestFunction: {
+                            #do: "test",
+                            #provider: "test-package",
+                            $params: {
+                                name: string
+                            },
+                            $returns: {
+                                name: string
+                            }
+                        }
+                    `),
+				},
+			},
+		},
+	}
+
+	secret, err := createSecret("test-config", "vela-system", map[string]interface{}{
+		"name": "test-value",
+	})
+	require.NoError(t, err)
+
+	cl := fake.NewClientBuilder().WithObjects(secret).Build()
+	dcl := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), packageObj)
+	singleton.KubeClient.Set(cl)
+	singleton.DynamicClient.Set(dcl)
+	cuex.DefaultCompiler.Reload()
+	defer singleton.ReloadClients()
+	defer cuex.DefaultCompiler.Reload()
+
+	ctx := process.NewContext(process.ContextData{
+		AppName:         "myapp",
+		CompName:        "test",
+		Namespace:       "default",
+		AppRevisionName: "myapp-v1",
+		ClusterVersion:  types.ClusterVersion{Minor: "19+"},
+	})
+
+	wt := NewWorkloadAbstractEngine("testWorkload")
+	params := map[string]interface{}{}
+
+	tmpl := strings.TrimSpace(`
+		import (
+			"test/ext"
+		)
+		$config: {
+			cluster: {
+				namespace: string
+				name?: string
+				output: {
+					type: string | *"default"
+					name: string
+				}
+			}
+		}
+		$config: {
+			cluster: {
+				name: "test-config"
+				namespace: "vela-system"
+			}
+		}
+		aValue: ext.#TestFunction & {
+			$params: {
+				name: $config.cluster.output.name
+			}
+		}
+		output: {
+			apiVersion: "apps/v1"
+			kind: "Deployment"
+			metadata: {
+				name: aValue.$returns.name
+			}
+		}
+	`)
+	require.NoError(t, err)
+
+	err = wt.Complete(ctx, tmpl, params)
+	require.NoError(t, err)
+
+	base, _ := ctx.Output()
+
+	expected := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name": "test",
+		},
+	}}
+	baseObj, err := base.Unstructured()
+	assert.Equal(t, expected, baseObj)
+}
+
+func TestConfigFieldInTrait(t *testing.T) {
+	secret, err := createSecret("test-config", "vela-system", map[string]interface{}{
+		"name": "test-value",
+	})
+	require.NoError(t, err)
+
+	cl := fake.NewClientBuilder().WithObjects(secret).Build()
+	singleton.KubeClient.Set(cl)
+	defer singleton.KubeClient.Reload()
+
+	baseTemplate := strings.TrimSpace(`
+		parameter: {}		
+		output: {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			spec: selector: matchLabels: "app.oam.dev/component": context.name
+		}
+	`)
+	traitTemplate := strings.TrimSpace(`
+		parameter: {}
+		$config: {
+			test: {
+				name: "test-config"
+				namespace: "vela-system"
+			}
+		}
+		outputs: test: {
+			apiVersion: "apps/v1"
+			kind: "Deployment"
+			metadata: {
+				name: "deployment"
+				labels: {
+					"name": $config.test.output.name
+				}
+			}
+			spec: replicas: 1
+		}
+	`)
+	ctx := process.NewContext(process.ContextData{
+		AppName:         "myapp",
+		CompName:        "test",
+		Namespace:       "default",
+		AppRevisionName: "myapp-v1",
+	})
+
+	wt := NewWorkloadAbstractEngine("-")
+	if err := wt.Complete(ctx, baseTemplate, map[string]interface{}{}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	td := NewTraitAbstractEngine("test")
+	err = td.Complete(ctx, traitTemplate, map[string]string{})
+	require.NoError(t, err)
+	base, assists := ctx.Output()
+	require.NotNil(t, base)
+
+	traitOutput, err := assists[0].Ins.Unstructured()
+	assert.NoError(t, err)
+
+	assert.Equal(t, &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name": "deployment",
+			"labels": map[string]interface{}{
+				"name": "test-value",
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": int64(1),
+		},
+	}}, traitOutput)
+}
+
+func createSecret(name string, namespace string, value map[string]interface{}) (*corev1.Secret, error) {
+	config, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	data := map[string][]byte{
+		"input-properties": config,
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+	return secret, nil
 }

--- a/references/cli/config.go
+++ b/references/cli/config.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/oam-dev/kubevela/pkg/config/common"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -614,7 +615,7 @@ func NewDeleteConfigCommand(f velacmd.Factory, streams util.IOStreams) *cobra.Co
 			}
 
 			if !options.NotRecall {
-				if err := inf.DeleteDistribution(context.Background(), options.Namespace, config.DefaultDistributionName(options.Name)); err != nil && !errors.Is(err, config.ErrNotFoundDistribution) {
+				if err := inf.DeleteDistribution(context.Background(), options.Namespace, config.DefaultDistributionName(options.Name)); err != nil && !errors.Is(err, common.ErrNotFoundDistribution) {
 					return err
 				}
 			}


### PR DESCRIPTION
### Description of your changes

copilot:all

Adds functionality to allow Kubevela defined configurations (ConfigTemplate/Config) to be used within Components and Traits to enable shared configurations across components/apps. Config is specified in the `$config` parameter ($ used to avoid collisions) of component/trait templates and can then be referenced via `$config.{alias}.output.{field}`. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Unit tests added
- Manual testing and internal demo'ing


### Special notes for your reviewer

!!! This PR relies on https://github.com/kubevela/pkg/pull/118 which was added to prevent issues with usage of $config fields inside of provider function $inputs. 