### PR TITLE
docs(references): velacp is now velaux

### DIFF
--- a/references/README.md
+++ b/references/README.md
@@ -4,4 +4,4 @@ This folder contains all reference implementation of vela cli, apiserver and das
 It provides a PoC of how to integrate KubeVela with your own system,
 you can refer to these implementations and build your own.
 
-The formal KubeVela APIServer is a standalone project called [velacp](https://github.com/oam-dev/velacp).
+The formal KubeVela APIServer is a standalone project called [velaux](https://github.com/kubevela/velaux).


### PR DESCRIPTION
This was outdated on the README for the references folder, `velacp`'s repo seems to redirect to `velaux` now.


### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->