### PR TITLE
Fix: re-installing kubevela failure due to trait webhook

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/resource.yaml
+++ b/charts/vela-core/templates/defwithtemplate/resource.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     definition.oam.dev/description: Add resource requests and limits on K8s pod for your workload which follows the pod spec in path 'spec.template.'
   name: resource
-  namespace: vela-system
+  namespace: {{ include "systemDefinitionNamespace" . }}
 spec:
   appliesToWorkloads:
     - deployments.apps

--- a/charts/vela-core/templates/defwithtemplate/resource.yaml
+++ b/charts/vela-core/templates/defwithtemplate/resource.yaml
@@ -61,14 +61,19 @@ spec:
         // spec.template.spec.containers and spec.jobTemplate...
         patch: {
         	// for Pod/Deployment/StatefulSet/DaemonSet
-        	spec: template: spec: {
-        		// +patchKey=name
-        		containers: [resourceContent]
+        	if context.output.spec != _|_ if context.output.spec.template != _|_ {
+        		spec: template: spec: {
+        			// +patchKey=name
+        			containers: [resourceContent]
+        		}
         	}
+
         	// for Job/CronJob
-        	spec: jobTemplate: spec: template: spec: {
-        		// +patchKey=name
-        		containers: [resourceContent]
+        	if context.output.spec != _|_ if context.output.spec.jobTemplate != _|_ {
+        		spec: jobTemplate: spec: template: spec: {
+        			// +patchKey=name
+        			containers: [resourceContent]
+        		}
         	}
         }
 

--- a/charts/vela-core/templates/defwithtemplate/resource.yaml
+++ b/charts/vela-core/templates/defwithtemplate/resource.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     definition.oam.dev/description: Add resource requests and limits on K8s pod for your workload which follows the pod spec in path 'spec.template.'
   name: resource
-  namespace: {{ include "systemDefinitionNamespace" . }}
+  namespace: vela-system
 spec:
   appliesToWorkloads:
     - deployments.apps
@@ -17,70 +17,75 @@ spec:
   podDisruptive: true
   schematic:
     cue:
-      template: |2
+      template: |
+        // +patchStrategy=jsonMergePatch
+
+        // Define just the resources block once
         let resourceContent = {
         	resources: {
-        		if parameter.cpu != _|_ if parameter.memory != _|_ if parameter.requests == _|_ if parameter.limits == _|_ {
+        		// if cpu or memory at root → set both requests+limits
+        		if parameter.cpu != _|_ || parameter.memory != _|_ {
         			// +patchStrategy=retainKeys
         			requests: {
-        				cpu:    parameter.cpu
-        				memory: parameter.memory
+        				if parameter.cpu != _|_ {cpu: parameter.cpu}
+        				if parameter.memory != _|_ {memory: parameter.memory}
         			}
         			// +patchStrategy=retainKeys
         			limits: {
-        				cpu:    parameter.cpu
-        				memory: parameter.memory
+        				if parameter.cpu != _|_ {cpu: parameter.cpu}
+        				if parameter.memory != _|_ {memory: parameter.memory}
         			}
         		}
 
+        		// if separate requests block provided
         		if parameter.requests != _|_ {
         			// +patchStrategy=retainKeys
         			requests: {
-        				cpu:    parameter.requests.cpu
-        				memory: parameter.requests.memory
+        				if parameter.requests.cpu != _|_ {cpu: parameter.requests.cpu}
+        				if parameter.requests.memory != _|_ {memory: parameter.requests.memory}
         			}
         		}
+
+        		// if separate limits block provided
         		if parameter.limits != _|_ {
         			// +patchStrategy=retainKeys
         			limits: {
-        				cpu:    parameter.limits.cpu
-        				memory: parameter.limits.memory
+        				if parameter.limits.cpu != _|_ {cpu: parameter.limits.cpu}
+        				if parameter.limits.memory != _|_ {memory: parameter.limits.memory}
         			}
         		}
         	}
         }
 
-        if context.output.spec != _|_ if context.output.spec.template != _|_ {
-        	patch: spec: template: spec: {
+        // Top-level patch that applies resourceContent into both
+        // spec.template.spec.containers and spec.jobTemplate...
+        patch: {
+        	// for Pod/Deployment/StatefulSet/DaemonSet
+        	spec: template: spec: {
         		// +patchKey=name
         		containers: [resourceContent]
         	}
-        }
-        if context.output.spec != _|_ if context.output.spec.jobTemplate != _|_ {
-        	patch: spec: jobTemplate: spec: template: spec: {
+        	// for Job/CronJob
+        	spec: jobTemplate: spec: template: spec: {
         		// +patchKey=name
         		containers: [resourceContent]
         	}
         }
 
         parameter: {
-        	// +usage=Specify the amount of cpu for requests and limits
+        	// +usage=Specify the amount of cpu for both requests and limits
         	cpu?: *1 | number | string
-        	// +usage=Specify the amount of memory for requests and limits
+        	// +usage=Specify the amount of memory for both requests and limits
         	memory?: *"2048Mi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
-        	// +usage=Specify the resources in requests
+        	// +usage=Specify custom requests
         	requests?: {
-        		// +usage=Specify the amount of cpu for requests
-        		cpu: *1 | number | string
-        		// +usage=Specify the amount of memory for requests
-        		memory: *"2048Mi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
+        		cpu?:    *1 | number | string
+        		memory?: *"2048Mi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
         	}
-        	// +usage=Specify the resources in limits
+        	// +usage=Specify custom limits
         	limits?: {
-        		// +usage=Specify the amount of cpu for limits
-        		cpu: *1 | number | string
-        		// +usage=Specify the amount of memory for limits
-        		memory: *"2048Mi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
+        		cpu?:    *1 | number | string
+        		memory?: *"2048Mi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
         	}
         }
 

--- a/vela-templates/definitions/internal/trait/resource.cue
+++ b/vela-templates/definitions/internal/trait/resource.cue
@@ -51,14 +51,18 @@ template: {
 	// spec.template.spec.containers and spec.jobTemplate...
 	patch: {
 		// for Pod/Deployment/StatefulSet/DaemonSet
-		spec: template: spec: {
-			// +patchKey=name
-			containers: [ resourceContent]
+		if context.output.spec != _|_ if context.output.spec.template != _|_ {
+			spec: template: spec: {
+				// +patchKey=name
+				containers: [ resourceContent]
+			}
 		}
 		// for Job/CronJob
-		spec: jobTemplate: spec: template: spec: {
-			// +patchKey=name
-			containers: [ resourceContent]
+		if context.output.spec != _|_ if context.output.spec.jobTemplate != _|_ {
+			spec: jobTemplate: spec: template: spec: {
+				// +patchKey=name
+				containers: [ resourceContent]
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of your changes

"Fixes #6784":
Modified the resource.cue file keeping the logic same to make sure it is not denied by the webhook

Fixes #6784

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

Tested the trait with all the workloads on which it can be applied.