### PR TITLE
Chore: switches to new oapi type field type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/fluxcd/source-controller/api v0.30.0
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/gdamore/tcell/v2 v2.6.0
-	github.com/getkin/kin-openapi v0.118.0
+	github.com/getkin/kin-openapi v0.131.0
 	github.com/go-git/go-git/v5 v5.16.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-resty/resty/v2 v2.8.0
@@ -197,7 +197,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jellydator/ttlcache/v3 v3.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -231,10 +230,12 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
+	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/openshift/library-go v0.0.0-20230327085348-8477ec72b725 // indirect
-	github.com/perimeterx/marshmallow v1.1.4 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
 github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
-github.com/getkin/kin-openapi v0.118.0 h1:z43njxPmJ7TaPpMSCQb7PN0dEYno4tyBPQcrFdHoLuM=
-github.com/getkin/kin-openapi v0.118.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
+github.com/getkin/kin-openapi v0.131.0 h1:NO2UeHnFKRYhZ8wg6Nyh5Cq7dHk4suQQr72a4pMrDxE=
+github.com/getkin/kin-openapi v0.131.0/go.mod h1:3OlG51PCYNsPByuiMB0t4fjnNlIDnaEDsjiKUV8nL58=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -504,7 +504,6 @@ github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97Dwqy
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -582,8 +581,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
-github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
@@ -780,6 +777,10 @@ github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28 h
 github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28/go.mod h1:Mu8i0/DdplvnjwRbAYPsc8+LRR27n/mp8VWdkN10GzE=
 github.com/oam-dev/terraform-controller v0.8.0 h1:/881bAELCsceSj+Zh3Nsu8Ym5N7D5Ho0HsWzO+TDc1w=
 github.com/oam-dev/terraform-controller v0.8.0/go.mod h1:ydc9iHjgLzwuWB+MlE2vRA8gOZsif0T4E2FL34K8CZ4=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -828,8 +829,8 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=
-github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
+github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
@@ -986,8 +987,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
-github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
-github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
@@ -1535,7 +1534,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/pkg/cue/cuex/providers/config/config_test.go
+++ b/pkg/cue/cuex/providers/config/config_test.go
@@ -95,7 +95,7 @@ func TestHelmRepository(t *testing.T) {
 			name: "Should authenticate with correct credential",
 			validationParams: &HelmRepositoryParams{
 				Params: HelmRepositoryVars{
-					URL: "https://charts.kubevela.net/core",
+					URL: "https://kubevela.github.io/charts",
 				},
 			},
 			expectResult: true,

--- a/pkg/cue/script/template.go
+++ b/pkg/cue/script/template.go
@@ -355,17 +355,18 @@ func (c CUE) ParsePropertiesToSchemaWithCueX(ctx context.Context, templateFieldP
 // FixOpenAPISchema fixes tainted `description` filed, missing of title `field`.
 func FixOpenAPISchema(name string, schema *openapi3.Schema) {
 	t := schema.Type
-	switch t {
-	case "object":
+
+	if t.Is("object") {
 		for k, v := range schema.Properties {
 			s := v.Value
 			FixOpenAPISchema(k, s)
 		}
-	case "array":
+	} else if t.Is("array") {
 		if schema.Items != nil {
 			FixOpenAPISchema("", schema.Items.Value)
 		}
 	}
+
 	if name != "" {
 		schema.Title = name
 	}

--- a/pkg/definition/gen_sdk/gen_sdk.go
+++ b/pkg/definition/gen_sdk/gen_sdk.go
@@ -565,7 +565,7 @@ func completeFreeFormSchema(schema *openapi3.SchemaRef) {
 // 1. move properties in the root schema to sub schema in OneOf. See https://github.com/OpenAPITools/openapi-generator/issues/14250
 // 2. move default value to sub schema in OneOf.
 // 3. remove duplicated type in OneOf.
-func fixSchemaWithOneOf(schema *openapi3.SchemaRef) (error) {
+func fixSchemaWithOneOf(schema *openapi3.SchemaRef) error {
 	var schemaNeedFix []*openapi3.Schema
 
 	oneOf := schema.Value.OneOf
@@ -591,7 +591,7 @@ func fixSchemaWithOneOf(schema *openapi3.SchemaRef) (error) {
 	}
 
 	if schemaNeedFix == nil {
-		return nil// no non-ref schema found
+		return nil // no non-ref schema found
 	}
 	for _, s := range schemaNeedFix {
 		if s.Properties == nil {

--- a/pkg/definition/gen_sdk/gen_sdk.go
+++ b/pkg/definition/gen_sdk/gen_sdk.go
@@ -544,17 +544,17 @@ func (g *Generator) GenerateCode() (err error) {
 func completeFreeFormSchema(schema *openapi3.SchemaRef) {
 	v := schema.Value
 	if v.OneOf == nil && v.AnyOf == nil && v.AllOf == nil && v.Properties == nil {
-		if v.Type == openapi3.TypeObject {
+		if v.Type.Is(openapi3.TypeObject) {
 			schema.Value.AdditionalProperties = openapi3.AdditionalProperties{Schema: &openapi3.SchemaRef{
 				Value: &openapi3.Schema{
-					Type:     openapi3.TypeObject,
+					Type:     &openapi3.Types{openapi3.TypeObject},
 					Nullable: true,
 				},
 			}}
-		} else if v.Type == "string" {
+		} else if v.Type.Is("string") {
 			schema.Value.AdditionalProperties = openapi3.AdditionalProperties{Schema: &openapi3.SchemaRef{
 				Value: &openapi3.Schema{
-					Type: "string",
+					Type: &openapi3.Types{"string"},
 				},
 			}}
 		}
@@ -585,7 +585,7 @@ func fixSchemaWithOneOf(schema *openapi3.SchemaRef) {
 		// 1. A non-ref sub-schema maybe have no properties and the needed properties is in the root schema.
 		// 2. A sub-schema maybe have no type and the needed type is in the root schema.
 		// In both cases, we need to complete the sub-schema with the properties or type in the root schema if any of them is missing.
-		if s.Value.Properties == nil || s.Value.Type == "" {
+		if s.Value.Properties == nil || s.Value.Type.Is("") {
 			schemaNeedFix = append(schemaNeedFix, s.Value)
 		}
 	}
@@ -597,7 +597,7 @@ func fixSchemaWithOneOf(schema *openapi3.SchemaRef) {
 		if s.Properties == nil {
 			s.Properties = schema.Value.Properties
 		}
-		if s.Type == "" {
+		if s.Type.Is("") {
 			s.Type = schema.Value.Type
 		}
 	}
@@ -605,7 +605,7 @@ func fixSchemaWithOneOf(schema *openapi3.SchemaRef) {
 
 	// remove duplicated type
 	for i, s := range oneOf {
-		if s.Value.Type == "" {
+		if s.Value.Type.Is("") {
 			continue
 		}
 		if _, ok := typeSet[s.Value.Type]; ok && s.Value.Type != openapi3.TypeObject {
@@ -704,15 +704,15 @@ func (t CUEType) fit(schema *openapi3.Schema) bool {
 	openapiType := schema.Type
 	switch t {
 	case "string":
-		return openapiType == "string"
+		return openapiType.Is("string")
 	case "integer":
-		return openapiType == "integer" || openapiType == "number"
+		return openapiType.Is("integer") || openapiType.Is("number")
 	case "number":
-		return openapiType == "number"
+		return openapiType.Is("number")
 	case "boolean":
-		return openapiType == "boolean"
+		return openapiType.Is("boolean")
 	case "array":
-		return openapiType == "array"
+		return openapiType.Is("array")
 	default:
 		return false
 	}

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -151,18 +151,19 @@ var _ = Describe("FixSchemaWithOneAnyAllOf", func() {
 				OneOf: openapi3.SchemaRefs{
 					{
 						Value: &openapi3.Schema{
-							Type: "number",
+							Type: &openapi3.Types{"number"},
 						},
 					},
 					{
 						Value: &openapi3.Schema{
-							Type: "string",
+							Type: &openapi3.Types{"string"},
 						},
 					},
 				},
 			},
 		}
-		fixSchemaWithOneOf(schema)
+		err := fixSchemaWithOneOf(schema)
+		Expect(err).To(BeNil())
 
 		Expect(schema.Value.OneOf[0].Value.Default).To(Equal(1))
 		Expect(schema.Value.OneOf[1].Value.Default).To(BeNil())
@@ -174,24 +175,25 @@ var _ = Describe("FixSchemaWithOneAnyAllOf", func() {
 		By(`image: language | string`)
 		schema = &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
-				Type:  "string",
+				Type:  &openapi3.Types{"string"},
 				Title: "image",
 				OneOf: openapi3.SchemaRefs{
 					{
 						Value: &openapi3.Schema{
-							Type: "string",
+							Type: &openapi3.Types{"string"},
 							Enum: []interface{}{"go", "java", "python", "node", "ruby"},
 						},
 					},
 					{
 						Value: &openapi3.Schema{
-							Type: "string",
+							Type: &openapi3.Types{"string"},
 						},
 					},
 				},
 			},
 		}
-		fixSchemaWithOneOf(schema)
+		err := fixSchemaWithOneOf(schema)
+		Expect(err).To(BeNil())
 
 		Expect(schema.Value.OneOf).To(HaveLen(1))
 		Expect(schema.Value.OneOf[0].Value.Type).To(Equal("string"))
@@ -201,7 +203,7 @@ var _ = Describe("FixSchemaWithOneAnyAllOf", func() {
 	It("should both move type and remove duplicated type in oneOf", func() {
 		schema = &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
-				Type:  "string",
+				Type:  &openapi3.Types{"string"},
 				Title: "image",
 				OneOf: openapi3.SchemaRefs{
 					{
@@ -211,14 +213,15 @@ var _ = Describe("FixSchemaWithOneAnyAllOf", func() {
 					},
 					{
 						Value: &openapi3.Schema{
-							Type: "string",
+							Type: &openapi3.Types{"string"},
 						},
 					},
 				},
 			},
 		}
 
-		fixSchemaWithOneOf(schema)
+		err := fixSchemaWithOneOf(schema)
+		Expect(err).To(BeNil())
 		Expect(schema.Value.OneOf).To(HaveLen(1))
 		Expect(schema.Value.OneOf[0].Value.Type).To(Equal("string"))
 		Expect(schema.Value.OneOf[0].Value.Enum).To(Equal([]interface{}{"go", "java", "python", "node", "ruby"}))
@@ -311,7 +314,7 @@ var _ = Describe("type fit", func() {
 	var schema *openapi3.Schema
 
 	BeforeEach(func() {
-		schema = &openapi3.Schema{Type: "string"}
+		schema = &openapi3.Schema{Type: &openapi3.Types{"string"}}
 	})
 
 	var testCases = []struct {
@@ -333,7 +336,7 @@ var _ = Describe("type fit", func() {
 
 	It("should return whether the CUEType fits the schema type or not", func() {
 		for _, tc := range testCases {
-			schema.Type = tc.schemaType
+			schema.Type = &openapi3.Types{tc.schemaType}
 			result := tc.cueType.fit(schema)
 			Expect(result).To(Equal(tc.expectedFit), tc.name)
 		}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -93,17 +93,18 @@ func ConvertOpenAPISchema2SwaggerObject(data []byte) (*openapi3.Schema, error) {
 // FixOpenAPISchema fixes tainted `description` filed, missing of title `field`.
 func FixOpenAPISchema(name string, schema *openapi3.Schema) {
 	t := schema.Type
-	switch t {
-	case "object":
+
+	if t.Is("object") {
 		for k, v := range schema.Properties {
 			s := v.Value
 			FixOpenAPISchema(k, s)
 		}
-	case "array":
+	} else if t.Is("array") {
 		if schema.Items != nil {
 			FixOpenAPISchema("", schema.Items.Value)
 		}
 	}
+
 	if name != "" {
 		schema.Title = name
 	}

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Test helm helper", func() {
 	It("Test validate helm repo", func() {
 		helper := NewHelper()
 		helmRepo := &Repository{
-			URL: "https://charts.kubevela.net/core",
+			URL: "https://kubevela.github.io/charts",
 		}
 		ok, err := helper.ValidateRepo(ctx, helmRepo)
 		Expect(err).Should(BeNil())

--- a/pkg/utils/helm/repo_index_test.go
+++ b/pkg/utils/helm/repo_index_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestLoadRepo(t *testing.T) {
 
-	u := "https://charts.kubevela.net/core"
+	u := "https://kubevela.github.io/charts"
 
 	ctx := context.Background()
 	index, err := LoadRepoIndex(ctx, u, &RepoCredential{})

--- a/pkg/utils/helm/testdata/index.yaml
+++ b/pkg/utils/helm/testdata/index.yaml
@@ -9,7 +9,7 @@ entries:
     name: autoscalertrait
     type: application
     urls:
-    - https://charts.kubevela.net/example/autoscalertrait-0.1.0.tgz
+    - https://kubevela.github.io/charts/example/autoscalertrait-0.1.0.tgz
     version: 0.1.0
   - apiVersion: v2
     appVersion: 1.16.0
@@ -19,7 +19,7 @@ entries:
     name: autoscalertrait
     type: application
     urls:
-    - https://charts.kubevela.net/example/autoscalertrait-0.1.0.tgz
+    - autoscalertrait-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 1.16.0

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -913,7 +913,8 @@ func printSchema(ref *openapi3.Schema, currentParams map[string]interface{}, ind
 
 		// Object type param, we will get inside the object.
 		// To show what's inside nested objects.
-		if propValue.Value.Type == "object" {
+		// if propValue.Value.Type == "object" {
+		if propValue.Value.Type.Is("object") {
 			nestedParam := make(map[string]interface{})
 			if hasParam {
 				nestedParam = currentParams[propKey].(map[string]interface{})

--- a/references/docgen/openapi.go
+++ b/references/docgen/openapi.go
@@ -45,9 +45,15 @@ func GenerateConsoleDocument(title string, schema *openapi3.Schema) (string, err
 			for _, enum := range subSchema.Value.Enum {
 				options += fmt.Sprintf("%v", enum)
 			}
+
+			jsonType, err := subSchema.Value.Type.MarshalJSON()
+			if err != nil {
+				return "", err
+			}
+
 			propertiesTable.Append([]string{
 				name,
-				subSchema.Value.Type,
+				string(jsonType),
 				subSchema.Value.Description,
 				fmt.Sprintf("%t", strings.Contains(strings.Join(schema.Required, "/"), subSchema.Value.Title)),
 				options,

--- a/references/docgen/parser.go
+++ b/references/docgen/parser.go
@@ -636,7 +636,7 @@ func ParseLocalFile(localFilePath string, c common.Args) (*types.Capability, err
 }
 
 // WalkParameterSchema will extract properties from *openapi3.Schema
-func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) (error) {
+func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) error {
 	if parameters == nil {
 		return nil
 	}

--- a/references/docgen/parser.go
+++ b/references/docgen/parser.go
@@ -636,21 +636,26 @@ func ParseLocalFile(localFilePath string, c common.Args) (*types.Capability, err
 }
 
 // WalkParameterSchema will extract properties from *openapi3.Schema
-func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) {
+func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) (error) {
 	if parameters == nil {
-		return
+		return nil
 	}
 	var schemas []CommonSchema
 	var commonParameters []ReferenceParameter
 	for k, v := range parameters.Properties {
+		jsonType, err := v.Value.Type.MarshalJSON()
+		if err != nil {
+			return err
+		}
+
 		p := ReferenceParameter{
 			Parameter: types.Parameter{
 				Name:     k,
 				Default:  v.Value.Default,
 				Usage:    v.Value.Description,
-				JSONType: v.Value.Type,
+				JSONType: string(jsonType),
 			},
-			PrintableType: v.Value.Type,
+			PrintableType: string(jsonType),
 		}
 		required := false
 		for _, requiredType := range parameters.Required {
@@ -660,7 +665,7 @@ func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) {
 			}
 		}
 		p.Required = required
-		if v.Value.Type == "object" {
+		if v.Value.Type.Is("object") {
 			if v.Value.Properties != nil {
 				schemas = append(schemas, CommonSchema{
 					Name:    k,
@@ -679,8 +684,13 @@ func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) {
 	})
 
 	for _, schema := range schemas {
-		WalkParameterSchema(schema.Schemas, schema.Name, depth+1)
+		err := WalkParameterSchema(schema.Schemas, schema.Name, depth+1)
+		if err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // GetBaseResourceKinds helps get resource.group string of components' base resource

--- a/references/docgen/parser.go
+++ b/references/docgen/parser.go
@@ -645,7 +645,7 @@ func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) (e
 	for k, v := range parameters.Properties {
 		jsonType, err := v.Value.Type.MarshalJSON()
 		if err != nil {
-			return err
+			return fmt.Errorf("error while marshalling openapi schema type:%v", err)
 		}
 
 		p := ReferenceParameter{

--- a/references/docgen/parser_test.go
+++ b/references/docgen/parser_test.go
@@ -248,7 +248,9 @@ func TestWalkParameterSchema(t *testing.T) {
 		swagger, err := openapi3.NewLoader().LoadFromData(json.RawMessage(parameterJSON))
 		assert.Equal(t, nil, err)
 		parameters := swagger.Components.Schemas["parameter"].Value
-		WalkParameterSchema(parameters, Specification, 0)
+		err = WalkParameterSchema(parameters, Specification, 0)
+		assert.Nil(t, err)
+
 		refs := make(map[string]map[string]ReferenceParameter)
 		for _, items := range commonRefs {
 			refs[items.Name] = make(map[string]ReferenceParameter)


### PR DESCRIPTION
### Description of your changes

copilot:all

Upgrades kin-openapi dependency to v0.131.0

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

