### PR TITLE
Fix: corrects validating webhook behaviour with cuex compilers

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/validating_handler.go
@@ -65,7 +65,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 		// validate cueTemplate
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
-			err = webhookutils.ValidateCueTemplate(obj.Spec.Schematic.CUE.Template)
+			err = webhookutils.ValidateCuexTemplate(ctx, obj.Spec.Schematic.CUE.Template)
 			if err != nil {
 				return admission.Denied(err.Error())
 			}

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validating_handler.go
@@ -91,7 +91,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 		// validate cueTemplate
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
-			err = webhookutils.ValidateCueTemplate(obj.Spec.Schematic.CUE.Template)
+			err = webhookutils.ValidateCuexTemplate(ctx, obj.Spec.Schematic.CUE.Template)
 			if err != nil {
 				return admission.Denied(err.Error())
 			}

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubevela/pkg/cue/cuex"
+
 	"cuelang.org/go/cue/cuecontext"
 	cueErrors "cuelang.org/go/cue/errors"
 	"github.com/pkg/errors"
@@ -70,6 +72,19 @@ func ValidateCueTemplate(cueTemplate string) error {
 	}
 
 	err := val.Validate()
+	return checkError(err)
+}
+
+// ValidateCuexTemplate validate cueTemplate with CueX for types utilising it
+func ValidateCuexTemplate(ctx context.Context, cueTemplate string) error {
+	val, err := cuex.DefaultCompiler.Get().CompileStringWithOptions(ctx, cueTemplate)
+	if err != nil {
+		return err
+	}
+	if e := checkError(val.Err()); e != nil {
+		return e
+	}
+	err = val.Validate()
 	return checkError(err)
 }
 


### PR DESCRIPTION
### Description of your changes

copilot:all

Fixes the validating webhooks for CueX enabled resource definitions by adding new CueX validation. Longer term it would be nice to swap all compilation to CueX and then merge the validation logic. 

Fixes #6786

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. **(N/A)**
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary. **(N/A)**

### How has this code been tested

Unit testing for CueX validation. 


### Special notes for your reviewer

