### PR TITLE
Fix: vela cli namespace behaviour

### DIFF
--- a/references/cli/common.go
+++ b/references/cli/common.go
@@ -67,7 +67,7 @@ func addNamespaceAndEnvArg(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("env", "e", "", "specify environment name for application")
 }
 
-// GetFlagNamespaceOrEnv will get env and namespace flag, namespace flag takes the priority
+// GetFlagNamespace will get the namespace from the flag and returns empty string if namepspace if not provided
 func GetFlagNamespace(cmd *cobra.Command, args common.Args) (string, error) {
 	namespace, err := cmd.Flags().GetString(Namespace)
 	if err != nil {
@@ -80,6 +80,7 @@ func GetFlagNamespace(cmd *cobra.Command, args common.Args) (string, error) {
 	return namespace, nil
 }
 
+// GetNamespaceFromEnv will get the namespace from the env provided or defaults to vela env
 func GetNamespaceFromEnv(cmd *cobra.Command, args common.Args) (string, error) {
 	velaEnv, err := GetFlagEnvOrCurrent(cmd, args)
 	if err != nil {

--- a/references/cli/common.go
+++ b/references/cli/common.go
@@ -68,7 +68,7 @@ func addNamespaceAndEnvArg(cmd *cobra.Command) {
 }
 
 // GetFlagNamespaceOrEnv will get env and namespace flag, namespace flag takes the priority
-func GetFlagNamespaceOrEnv(cmd *cobra.Command, args common.Args) (string, error) {
+func GetFlagNamespace(cmd *cobra.Command, args common.Args) (string, error) {
 	namespace, err := cmd.Flags().GetString(Namespace)
 	if err != nil {
 		return "", err
@@ -76,10 +76,14 @@ func GetFlagNamespaceOrEnv(cmd *cobra.Command, args common.Args) (string, error)
 	if namespace != "" {
 		return namespace, nil
 	}
+
+	return namespace, nil
+}
+
+func GetNamespaceFromEnv(cmd *cobra.Command, args common.Args) (string, error) {
 	velaEnv, err := GetFlagEnvOrCurrent(cmd, args)
 	if err != nil {
 		return "", err
 	}
 	return velaEnv.Namespace, nil
-
 }

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -179,18 +179,19 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 
 	app, err := readApplicationFromFiles(cmdOption, &buff)
 
-	if namespace == "" && app.Namespace == "" {
-		ctx = oamutil.SetNamespaceInCtx(ctx, namespaceEnv)
-	} else if namespace != "" && app.Namespace == "" {
-		ctx = oamutil.SetNamespaceInCtx(ctx, namespace)
-	} else if namespace == "" && app.Namespace != "" {
-		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
-	} else {
-		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
-	}
-
 	if app.Namespace != "" && namespace != "" && app.Namespace != namespace {
 		return buff, errors.WithMessage(fmt.Errorf("Error: Conflicting namespace found in file and flag %s doesn't match with namespace %s ", namespace, app.Namespace), "The namespace must be unique")
+	}
+
+	switch {
+	case namespace == "" && app.Namespace == "":
+		ctx = oamutil.SetNamespaceInCtx(ctx, namespaceEnv)
+	case namespace != "" && app.Namespace == "":
+		ctx = oamutil.SetNamespaceInCtx(ctx, namespace)
+	case namespace == "" && app.Namespace != "":
+		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
+	default:
+		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
 	}
 
 	if err != nil {

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -178,9 +178,12 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 	}
 
 	app, err := readApplicationFromFiles(cmdOption, &buff)
+	if err != nil {
+		return buff, errors.WithMessagef(err, "read application files: %s", cmdOption.ApplicationFiles)
+	}
 
 	if app.Namespace != "" && namespace != "" && app.Namespace != namespace {
-		return buff, errors.WithMessage(fmt.Errorf("Error: Conflicting namespace found in file and flag %s doesn't match with namespace %s ", namespace, app.Namespace), "The namespace must be unique")
+		return buff, errors.WithMessage(fmt.Errorf("error: conflicting namespace found in file and flag %s doesn't match with namespace %s ", namespace, app.Namespace), "The namespace must be unique")
 	}
 
 	switch {
@@ -194,9 +197,6 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
 	}
 
-	if err != nil {
-		return buff, errors.WithMessagef(err, "read application files: %s", cmdOption.ApplicationFiles)
-	}
 	err = dryRunOpt.ExecuteDryRunWithPolicies(ctx, app, &buff)
 	if err != nil {
 		return buff, err

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -96,18 +96,23 @@ vela dry-run -f app.yaml -f policy.yaml -f workflow.yaml
 			types.TagCommandOrder: order,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				// We need to return an error only if not in offline mode
 				if !o.OfflineMode {
 					return err
 				}
-
-				// Set the namespace to default to match behavior of `GetFlagNamespaceOrEnv`
-				namespace = types.DefaultAppNamespace
 			}
 
-			buff, err := DryRunApplication(o, c, namespace)
+			namespaceEnv, err := GetNamespaceFromEnv(cmd, c)
+			if err != nil {
+				// We need to return an error only if not in offline mode
+				if !o.OfflineMode {
+					return err
+				}
+			}
+
+			buff, err := DryRunApplication(o, c, namespace, namespaceEnv)
 			if err != nil {
 				return err
 			}
@@ -127,9 +132,9 @@ vela dry-run -f app.yaml -f policy.yaml -f workflow.yaml
 }
 
 // DryRunApplication will dry-run an application and return the render result
-func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace string) (bytes.Buffer, error) {
+func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace string, namespaceEnv string) (bytes.Buffer, error) {
 	var err error
-	var buff = bytes.Buffer{}
+	buff := bytes.Buffer{}
 
 	var objs []*unstructured.Unstructured
 	if cmdOption.DefinitionFile != "" {
@@ -173,6 +178,21 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 	}
 
 	app, err := readApplicationFromFiles(cmdOption, &buff)
+
+	if namespace == "" && app.Namespace == "" {
+		ctx = oamutil.SetNamespaceInCtx(ctx, namespaceEnv)
+	} else if namespace != "" && app.Namespace == "" {
+		ctx = oamutil.SetNamespaceInCtx(ctx, namespace)
+	} else if namespace == "" && app.Namespace != "" {
+		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
+	} else {
+		ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
+	}
+
+	if app.Namespace != "" && namespace != "" && app.Namespace != namespace {
+		return buff, errors.WithMessage(fmt.Errorf("Error: Conflicting namespace found in file and flag %s doesn't match with namespace %s ", namespace, app.Namespace), "The namespace must be unique")
+	}
+
 	if err != nil {
 		return buff, errors.WithMessagef(err, "read application files: %s", cmdOption.ApplicationFiles)
 	}
@@ -371,7 +391,6 @@ func readApplicationFromFiles(cmdOption *DryRunCmdOptions, buff *bytes.Buffer) (
 }
 
 func getPolicyNameFromWorkflow(wf *wfv1alpha1.Workflow, policyNameMap map[string]struct{}) error {
-
 	checkPolicy := func(wfsb wfv1alpha1.WorkflowStepBase, policyNameMap map[string]struct{}) error {
 		workflowStepSpec := &step.DeployWorkflowStepSpec{}
 		if err := utils.StrictUnmarshal(wfsb.Properties.Raw, workflowStepSpec); err != nil {
@@ -427,7 +446,8 @@ var deployDefinition = &corev1beta1.WorkflowStepDefinition{
 	},
 	Spec: corev1beta1.WorkflowStepDefinitionSpec{
 		Schematic: &apicommon.Schematic{
-			CUE: &apicommon.CUE{Template: `
+			CUE: &apicommon.CUE{
+				Template: `
 import (
 	"vela/op"
 )

--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-2.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "","")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-default)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -119,7 +119,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-4.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "","")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology deploy-somewhere)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))

--- a/references/cli/dryrun_test.go
+++ b/references/cli/dryrun_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
 		Expect(buff.String()).Should(ContainSubstring("kind: Deployment"))
@@ -77,7 +77,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-2.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "","")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-default)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -91,7 +91,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-3.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-default)"))
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-prod)"))
@@ -119,7 +119,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-4.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "","")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology deploy-somewhere)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -132,7 +132,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-policy.yaml"}, OfflineMode: false}
-		_, err := DryRunApplication(&opt, c, "")
+		_, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(ContainSubstring("no application provided"))
 
@@ -144,7 +144,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml", "test-data/dry-run/testing-dry-run-2.yaml"}, OfflineMode: false}
-		_, err := DryRunApplication(&opt, c, "")
+		_, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(ContainSubstring("more than one applications provided"))
 
@@ -156,7 +156,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml", "test-data/dry-run/testing-wf.yaml", "test-data/dry-run/testing-wf.yaml"}, OfflineMode: false}
-		_, err := DryRunApplication(&opt, c, "")
+		_, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(ContainSubstring("more than one external workflow provided"))
 
@@ -168,7 +168,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-trait.yaml"}, OfflineMode: false}
-		_, err := DryRunApplication(&opt, c, "")
+		_, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(ContainSubstring("is not application, policy or workflow"))
 
@@ -180,7 +180,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-trait.yaml"}, OfflineMode: false}
-		_, err := DryRunApplication(&opt, c, "")
+		_, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(ContainSubstring("is not application, policy or workflow"))
 
@@ -192,7 +192,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-5.yaml", "test-data/dry-run/testing-wf.yaml", "test-data/dry-run/testing-policy.yaml"}, OfflineMode: false, MergeStandaloneFiles: true}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology deploy-somewhere)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -205,7 +205,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-5.yaml", "test-data/dry-run/testing-policy.yaml"}, OfflineMode: false, MergeStandaloneFiles: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("WARNING: policy deploy-somewhere not referenced by application"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -218,7 +218,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-5.yaml", "test-data/dry-run/testing-wf.yaml"}, OfflineMode: false, MergeStandaloneFiles: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("WARNING: workflow testing-wf not referenced by application"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -228,7 +228,7 @@ var _ = Describe("Testing dry-run", func() {
 	It("Testing dry-run offline with definition file", func() {
 		c := common2.Args{}
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-6.yaml"}, DefinitionFile: "test-data/dry-run/definitions/testing-worker-def.yaml", OfflineMode: true}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -239,7 +239,7 @@ var _ = Describe("Testing dry-run", func() {
 	It("Testing dry-run offline with definition directory", func() {
 		c := common2.Args{}
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-6.yaml"}, DefinitionFile: "test-data/dry-run/definitions", OfflineMode: true}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app)"))
 		Expect(buff.String()).Should(ContainSubstring("name: testing-dryrun"))
@@ -250,7 +250,7 @@ var _ = Describe("Testing dry-run", func() {
 	It("Testing dry-run offline with deploy workflow step", func() {
 		c := common2.Args{}
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-7.yaml"}, DefinitionFile: "test-data/dry-run/definitions/testing-worker-def.yaml", OfflineMode: true}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-prod)"))
 		Expect(buff.String()).Should(ContainSubstring("# Application(testing-app with topology target-default)"))
@@ -264,7 +264,7 @@ var _ = Describe("Testing dry-run", func() {
 		c.SetConfig(cfg)
 		c.SetClient(k8sClient)
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, "")
+		buff, err := DryRunApplication(&opt, c, "", "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring("namespace: default"))
 	})
@@ -280,7 +280,7 @@ var _ = Describe("Testing dry-run", func() {
 		Expect(err).Should(BeNil())
 
 		opt := DryRunCmdOptions{ApplicationFiles: []string{"test-data/dry-run/testing-dry-run-1.yaml"}, OfflineMode: false}
-		buff, err := DryRunApplication(&opt, c, appNamespace)
+		buff, err := DryRunApplication(&opt, c, appNamespace, "")
 		Expect(err).Should(BeNil())
 		Expect(buff.String()).Should(ContainSubstring(fmt.Sprintf("namespace: %s", appNamespace)))
 	})

--- a/references/cli/env.go
+++ b/references/cli/env.go
@@ -151,7 +151,7 @@ func NewEnvSetCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 func ListEnvs(args []string, ioStreams cmdutil.IOStreams) error {
 	table := newUITable()
 	table.AddRow("NAME", "NAMESPACE", "CURRENT")
-	var envName = ""
+	envName := ""
 	if len(args) > 0 {
 		envName = args[0]
 	}

--- a/references/cli/exec.go
+++ b/references/cli/exec.go
@@ -108,10 +108,19 @@ func NewExecCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 				return nil
 			}
 			var err error
-			o.namespace, err = GetFlagNamespaceOrEnv(cmd, c)
+
+			o.namespace, err = GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
 			}
+
+			if o.namespace == "" {
+				o.namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
+			}
+
 			if err := o.Init(context.Background(), cmd, args); err != nil {
 				return err
 			}
@@ -191,7 +200,7 @@ func (o *VelaExecOptions) Init(ctx context.Context, c *cobra.Command, argsIn []s
 	}
 
 	cf := genericclioptions.NewConfigFlags(true)
-	var namespace = selectPod.Metadata.Namespace
+	namespace := selectPod.Metadata.Namespace
 	cf.Namespace = &namespace
 	cf.WrapConfigFn = func(cfg *rest.Config) *rest.Config {
 		cfg.Wrap(pkgmulticluster.NewTransportWrapper(pkgmulticluster.ForCluster(selectPod.Cluster)))

--- a/references/cli/export.go
+++ b/references/cli/export.go
@@ -37,10 +37,19 @@ func NewExportCommand(c common2.Args, ioStream cmdutil.IOStreams) *cobra.Command
 			types.TagCommandType: types.TypeLegacy,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
 			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+			}
+
+			if err != nil {
+				return err
+			}
+
 			o := &common.AppfileOptions{
 				IO: ioStream,
 			}

--- a/references/cli/init.go
+++ b/references/cli/init.go
@@ -67,7 +67,11 @@ func NewInitCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *
 		Example:               "vela init",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			o.Namespace, err = GetFlagNamespaceOrEnv(cmd, c)
+			o.Namespace, err = GetFlagNamespace(cmd, c)
+
+			if o.Namespace == "" {
+				o.Namespace, err = GetNamespaceFromEnv(cmd, c)
+			}
 			if err != nil {
 				return err
 			}

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -69,10 +69,15 @@ func NewLiveDiffCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 		},
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			o.Namespace, err = GetFlagNamespaceOrEnv(cmd, c)
+			o.Namespace, err = GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
 			}
+
+			if o.Namespace == "" {
+				o.Namespace, err = GetNamespaceFromEnv(cmd, c)
+			}
+
 			if err = o.loadAndValidate(args); err != nil {
 				return err
 			}
@@ -95,7 +100,7 @@ func NewLiveDiffCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 
 // LiveDiffApplication can return user what would change if upgrade an application.
 func LiveDiffApplication(cmdOption *LiveDiffCmdOptions, c common.Args) (bytes.Buffer, error) {
-	var buff = bytes.Buffer{}
+	buff := bytes.Buffer{}
 
 	newClient, err := c.GetClient()
 	if err != nil {

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -76,6 +76,9 @@ func NewLiveDiffCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 
 			if o.Namespace == "" {
 				o.Namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err = o.loadAndValidate(args); err != nil {

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -54,6 +54,9 @@ func NewLogsCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 
 			if largs.Namespace == "" {
 				largs.Namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 
 			largs.Name = args[0]

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -47,10 +47,15 @@ func NewLogsCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			largs.Namespace, err = GetFlagNamespaceOrEnv(cmd, c)
+			largs.Namespace, err = GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
 			}
+
+			if largs.Namespace == "" {
+				largs.Namespace, err = GetNamespaceFromEnv(cmd, c)
+			}
+
 			largs.Name = args[0]
 			ctx := context.Background()
 			app, err := appfile.LoadApplication(largs.Namespace, args[0], c)

--- a/references/cli/ls.go
+++ b/references/cli/ls.go
@@ -61,9 +61,15 @@ func NewListCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *c
 			if err != nil {
 				return err
 			}
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			if AllNamespace {
 				namespace = ""
@@ -144,7 +150,7 @@ func buildApplicationListTable(ctx context.Context, c client.Reader, namespace s
 		}
 
 		for idx, cmp := range a.Spec.Components {
-			var appName = a.Name
+			appName := a.Name
 			if idx > 0 {
 				appName = "├─"
 				if idx == len(a.Spec.Components)-1 {

--- a/references/cli/portforward.go
+++ b/references/cli/portforward.go
@@ -105,9 +105,16 @@ func NewPortForwardCommand(c common.Args, order string, ioStreams util.IOStreams
 				return errors.New("not port specified for port-forward")
 			}
 			var err error
-			o.namespace, err = GetFlagNamespaceOrEnv(cmd, c)
+			o.namespace, err = GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+
+			if o.namespace == "" {
+				o.namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 
 			newClient, err := o.VelaC.GetClient()
@@ -296,7 +303,7 @@ func (o *VelaPortForwardOptions) Run() error {
 		<-o.kcPortForwardOptions.ReadyChannel
 		o.ioStreams.Info("\nForward successfully! Opening browser ...")
 		local, _ := splitPort(o.Args[1])
-		var url = "http://127.0.0.1:" + local
+		url := "http://127.0.0.1:" + local
 		if err := OpenBrowser(url); err != nil {
 			o.ioStreams.Errorf("\nFailed to open browser: %v", err)
 		}

--- a/references/cli/revision.go
+++ b/references/cli/revision.go
@@ -67,9 +67,16 @@ func NewRevisionListCommand(c common.Args) *cobra.Command {
 		Long:    "list Kubevela application revisions",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			cli, err := c.GetClient()
 			if err != nil {
@@ -105,10 +112,18 @@ func NewRevisionGetCommand(c common.Args) *cobra.Command {
 		Long:    "get specific revision of application",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
 			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
+			}
+
 			name := args[0]
 			def, err := cmd.Flags().GetString("definition")
 			if err != nil {
@@ -125,7 +140,6 @@ func NewRevisionGetCommand(c common.Args) *cobra.Command {
 }
 
 func getRevision(ctx context.Context, c common.Args, format string, out io.Writer, name string, namespace string, def string) error {
-
 	kubeConfig, err := c.GetConfig()
 	if err != nil {
 		return err

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -58,9 +58,11 @@ const (
 	Port = ":18081"
 )
 
-var webSite bool
-var generateDocOnly bool
-var showFormat string
+var (
+	webSite         bool
+	generateDocOnly bool
+	showFormat      string
+)
 
 // NewCapabilityShowCommand shows the reference doc for a component type or trait
 func NewCapabilityShowCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
@@ -97,9 +99,16 @@ func NewCapabilityShowCommand(c common.Args, order string, ioStreams cmdutil.IOS
 				cmd.Println("generating all capability docs into folder '~/.vela/reference/docs/', use '--web' to start a server for browser.")
 				generateDocOnly = true
 			}
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			var ver int
 			if revision != "" {
@@ -217,7 +226,7 @@ func startReferenceDocsSite(ctx context.Context, ns string, c common.Args, ioStr
 		capabilityType != types.TypeComponentDefinition && capabilityType != types.TypeWorkflowStep && capabilityType != "" {
 		return fmt.Errorf("unsupported type: %v", capabilityType)
 	}
-	var suffix = capabilityName
+	suffix := capabilityName
 	if suffix != "" {
 		suffix = "/" + suffix
 	}

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -108,9 +108,16 @@ func NewAppStatusCommand(c common.Args, order string, ioStreams cmdutil.IOStream
 			}
 			appName := args[0]
 			// get namespace
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			if printTree, err := cmd.Flags().GetBool("tree"); err == nil && printTree {
 				return printApplicationTree(c, cmd, appName, namespace)

--- a/references/cli/top.go
+++ b/references/cli/top.go
@@ -49,9 +49,16 @@ func NewTopCommand(c common.Args, order string, _ cmdutil.IOStreams) *cobra.Comm
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runewidth.DefaultCondition.EastAsianWidth = false // https://github.com/rivo/tview/issues/118
 
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			if AllNamespace {
 				namespace = ""

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -256,9 +256,15 @@ func NewWorkflowListCommand(c common.Args, ioStream cmdutil.IOStreams, _ *Workfl
 			if err != nil {
 				return err
 			}
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			if AllNamespace {
 				namespace = ""
@@ -350,9 +356,15 @@ func (w *WorkflowArgs) getWorkflowInstance(ctx context.Context, cmd *cobra.Comma
 		return fmt.Errorf("please specify the name of application/workflow")
 	}
 	name := args[0]
-	namespace, err := GetFlagNamespaceOrEnv(cmd, w.Args)
+	namespace, err := GetFlagNamespace(cmd, w.Args)
 	if err != nil {
 		return err
+	}
+	if namespace == "" {
+		namespace, err = GetNamespaceFromEnv(cmd, w.Args)
+		if err != nil {
+			return err
+		}
 	}
 	cli, err := w.Args.GetClient()
 	if err != nil {

--- a/references/cli/workloads.go
+++ b/references/cli/workloads.go
@@ -36,9 +36,15 @@ func NewWorkloadsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Com
 		Example:               `vela workloads`,
 		Hidden:                true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
+			namespace, err := GetFlagNamespace(cmd, c)
 			if err != nil {
 				return err
+			}
+			if namespace == "" {
+				namespace, err = GetNamespaceFromEnv(cmd, c)
+				if err != nil {
+					return err
+				}
 			}
 			return printWorkloadList(namespace, c, ioStreams)
 		},


### PR DESCRIPTION
### Description of your changes

Fixes the behaviour of `vela dry-run` command to consider the namespaces provided in flags, namespace filed in the yaml file and the vela env

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested the code by building the cli locally.