### PR TITLE
Fix: vela up command to behave similarly with kubectl

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -49,6 +49,31 @@ func GetNamespace(_ Factory, cmd *cobra.Command) string {
 	return envMeta.Namespace
 }
 
+// GetNamespaceAndSource get namespace from command flags and env and also returns source of the namespace
+func GetNamespaceAndSource(_ Factory, cmd *cobra.Command) (string, string) {
+	namespace, err := cmd.Flags().GetString(flagNamespace)
+	cmdutil.CheckErr(err)
+	if namespace != "" {
+		return namespace, "namespaceflag"
+	}
+	// find namespace from env
+	envName, err := cmd.Flags().GetString(flagEnv)
+	if err != nil {
+		// ignore env if the command does not use the flag
+		return "", "defaulted"
+	}
+	var envMeta *types.EnvMeta
+	if envName != "" {
+		envMeta, err = env.GetEnvByName(envName)
+	} else {
+		envMeta, err = env.GetCurrentEnv()
+	}
+	if err != nil {
+		return "", "defaulted"
+	}
+	return envMeta.Namespace, "env"
+}
+
 // GetGroup get group from command flags
 func GetGroup(cmd *cobra.Command) string {
 	group, err := cmd.Flags().GetString(flagGroup)

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -49,8 +49,8 @@ func GetNamespace(_ Factory, cmd *cobra.Command) string {
 	return envMeta.Namespace
 }
 
-// GetNamespaceAndSource get namespace from command flags and env and also returns source of the namespace
-func GetNamespaceAndSource(_ Factory, cmd *cobra.Command) (string, string) {
+// GetNamespaceAndSource gets namespace from command flags and env and also returns source of the namespace
+func GetNamespaceAndSource(cmd *cobra.Command) (string, string) {
 	namespace, err := cmd.Flags().GetString(flagNamespace)
 	cmdutil.CheckErr(err)
 	if namespace != "" {

--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -46,15 +46,16 @@ import (
 
 // UpCommandOptions command args for vela up
 type UpCommandOptions struct {
-	AppName        string
-	Namespace      string
-	File           string
-	PublishVersion string
-	RevisionName   string
-	ShardID        string
-	Debug          bool
-	Wait           bool
-	WaitTimeout    string
+	AppName         string
+	Namespace       string
+	File            string
+	PublishVersion  string
+	RevisionName    string
+	ShardID         string
+	Debug           bool
+	Wait            bool
+	WaitTimeout     string
+	NamespaceSource string
 }
 
 // Complete fill the args for vela up
@@ -62,7 +63,7 @@ func (opt *UpCommandOptions) Complete(f velacmd.Factory, cmd *cobra.Command, arg
 	if len(args) > 0 {
 		opt.AppName = args[0]
 	}
-	opt.Namespace = velacmd.GetNamespace(f, cmd)
+	opt.Namespace, opt.NamespaceSource = velacmd.GetNamespaceAndSource(f, cmd)
 }
 
 // Validate if vela up args is valid, interrupt the command
@@ -184,7 +185,12 @@ func (opt *UpCommandOptions) deployApplicationFromFile(f velacmd.Factory, cmd *c
 
 		// Override namespace if namespace flag is set. We should check if namespace is `default` or not
 		// since GetFlagNamespaceOrEnv returns default namespace when failed to get current env.
-		if opt.Namespace != "" && opt.Namespace != types.DefaultAppNamespace {
+
+		if app.Namespace != "" && opt.Namespace != "" && opt.NamespaceSource == "namespaceflag" && app.Namespace != opt.Namespace {
+			return errors.Errorf("application namespace %s is different from the namespace %s specified by flag", app.Namespace, opt.Namespace)
+		}
+
+		if opt.Namespace != "" && opt.Namespace != types.DefaultAppNamespace && app.Namespace == "" {
 			app.SetNamespace(opt.Namespace)
 		}
 		if opt.PublishVersion != "" {

--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -63,7 +63,7 @@ func (opt *UpCommandOptions) Complete(f velacmd.Factory, cmd *cobra.Command, arg
 	if len(args) > 0 {
 		opt.AppName = args[0]
 	}
-	opt.Namespace, opt.NamespaceSource = velacmd.GetNamespaceAndSource(f, cmd)
+	opt.Namespace, opt.NamespaceSource = velacmd.GetNamespaceAndSource(cmd)
 }
 
 // Validate if vela up args is valid, interrupt the command
@@ -185,6 +185,8 @@ func (opt *UpCommandOptions) deployApplicationFromFile(f velacmd.Factory, cmd *c
 
 		// Override namespace if namespace flag is set. We should check if namespace is `default` or not
 		// since GetFlagNamespaceOrEnv returns default namespace when failed to get current env.
+		// If the Namespace mentioned in the flag and the file are different, returns an error.
+		// Precedence is as follows: flag/file > env
 
 		if app.Namespace != "" && opt.Namespace != "" && opt.NamespaceSource == "namespaceflag" && app.Namespace != opt.Namespace {
 			return errors.Errorf("application namespace %s is different from the namespace %s specified by flag", app.Namespace, opt.Namespace)


### PR DESCRIPTION
### Description of your changes

Modified the `vela up -f` command behaviour to align with the kubectl command by throwing the error when there are conflicting namespace in the `-n` flag and the application file.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Written the relevant test cases and tested the behavior by building the CLI.

### Special notes for your reviewer

The behavior of the `vela up -f <app-file.yaml> -n <namespace>` command has been modified to throw an error when there are conflicting namespaces specified in the `-n` flag and the application file. Previously, the `-n` flag would be overriden by the namespace defined in the application file.

![image](https://github.com/user-attachments/assets/e60e6b75-5760-430a-b68b-adadadd2d2b8)
