### PR TITLE
Fix(cli): return non-zero exit code on `vela def render` error

### DIFF
--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -837,12 +837,16 @@ func NewDefinitionRenderCommand(c common.Args) *cobra.Command {
 					return errors.Wrapf(err, "failed to read directory %s", args[0])
 				}
 			}
+			var renderErrs []error
 			for i, inputFilename := range inputFilenames {
-				if err = render(inputFilename, outputFilenames[i]); err != nil {
-					if _, err = fmt.Fprintf(cmd.ErrOrStderr(), "failed to render %s, reason: %v", inputFilename, err); err != nil {
-						return errors.Wrapf(err, "failed to write err")
-					}
+				err := render(inputFilename, outputFilenames[i])
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "failed to render %s, reason: %v\n", inputFilename, err)
+					renderErrs = append(renderErrs, err)
 				}
+			}
+			if len(renderErrs) > 0 {
+				return fmt.Errorf("rendering failed for %d file(s)", len(renderErrs))
 			}
 			return nil
 		},

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -839,10 +839,10 @@ func NewDefinitionRenderCommand(c common.Args) *cobra.Command {
 			}
 			var renderErrs []error
 			for i, inputFilename := range inputFilenames {
-				err := render(inputFilename, outputFilenames[i])
-				if err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "failed to render %s, reason: %v\n", inputFilename, err)
-					renderErrs = append(renderErrs, err)
+				if err = render(inputFilename, outputFilenames[i]); err != nil {
+					if _, err = fmt.Fprintf(cmd.ErrOrStderr(), "failed to render %s, reason: %v", inputFilename, err); err != nil {
+						renderErrs = append(renderErrs, err)
+					}
 				}
 			}
 			if len(renderErrs) > 0 {

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -839,10 +839,13 @@ func NewDefinitionRenderCommand(c common.Args) *cobra.Command {
 			}
 			var renderErrs []error
 			for i, inputFilename := range inputFilenames {
-				if err = render(inputFilename, outputFilenames[i]); err != nil {
-					if _, err = fmt.Fprintf(cmd.ErrOrStderr(), "failed to render %s, reason: %v", inputFilename, err); err != nil {
-						renderErrs = append(renderErrs, err)
+				renderErr := render(inputFilename, outputFilenames[i])
+				if renderErr != nil {
+					wrappedRenderErr := errors.Wrapf(renderErr, "failed to render %s", inputFilename)
+					if _, writeErr := fmt.Fprintln(cmd.ErrOrStderr(), wrappedRenderErr); writeErr != nil {
+						renderErrs = append(renderErrs, errors.Wrapf(writeErr, "failed to write to stderr for %s", inputFilename))
 					}
+					renderErrs = append(renderErrs, wrappedRenderErr)
 				}
 			}
 			if len(renderErrs) > 0 {

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -561,9 +561,9 @@ func TestNewDefinitionRenderCommand(t *testing.T) {
 		t.Fatalf("unexpected error when executing render command on valid directory: %v", err)
 	}
 	// directory read/print test
-	_ = os.WriteFile(filepath.Join(dirname, "temp.json"), []byte("hello"), 0600) // ignored
+	require.NoError(t, os.WriteFile(filepath.Join(dirname, "temp.json"), []byte("hello"), 0600)) // ignored
 	badCueFile := filepath.Join(dirname, "temp.cue")
-	_ = os.WriteFile(badCueFile, []byte("hello"), 0600)
+	require.NoError(t, os.WriteFile(badCueFile, []byte("hello"), 0600))
 
 	cmd = NewDefinitionRenderCommand(c)
 	initCommand(cmd)


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6651 

This PR ensures that when rendering a .cue file fails due to invalid CUE syntax or missing metadata, vela def render returns a non-zero exit code.
I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manual testing done:
The fix was verified manually by running:
``` bash
echo "1234" > /tmp/test.cue
./vela def render /tmp/test.cue
echo $?
```
