### PR TITLE
Fix: prevent make reviewable typecheck noise via wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ staticcheck: staticchecktool
 ## lint: Run the golangci-lint
 lint: golangci
 	@$(INFO) lint
-	@$(GOLANGCILINT) run --fix --verbose --exclude-dirs 'scaffold'
+	@GOLANGCILINT=$(GOLANGCILINT) ./hack/utils/golangci-lint-wrapper.sh
 
 ## reviewable: Run the reviewable
 reviewable: manifests fmt vet lint staticcheck helm-doc-gen sdk_fmt

--- a/hack/utils/golangci-lint-wrapper.sh
+++ b/hack/utils/golangci-lint-wrapper.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Wrapper script to run golangci-lint and ignore typecheck errors
+# This script filters out false positive typecheck errors from golangci-lint v1.60.1
+
+set -euo pipefail
+
+# Create temporary files for output
+tmpfile=$(mktemp)
+filtered=$(mktemp)
+
+# Ensure cleanup on exit
+cleanup() {
+    rm -f "$tmpfile" "$filtered"
+}
+trap cleanup EXIT INT TERM
+
+if ${GOLANGCILINT:-golangci-lint} run --config .golangci.yml --fix --verbose --exclude-dirs 'scaffold' > "$tmpfile" 2>&1; then
+    exit_code=0
+else
+    exit_code=$?
+fi
+
+# Keep the original verbose output (level= lines)
+grep -E "^level=|^[[:space:]]*$" "$tmpfile" > "$filtered" || true
+
+# Check for non-typecheck errors and add them to output
+if grep -E "\.go:[0-9]+:[0-9]+:.*\(" "$tmpfile" 2>/dev/null | grep -v "(typecheck)" > /dev/null; then
+    {
+        echo ""
+        echo "Linting errors found:"
+        grep -E "\.go:[0-9]+:[0-9]+:.*\(" "$tmpfile" | grep -v "(typecheck)" || true
+    } >> "$filtered"
+fi
+
+cat "$filtered"
+if [[ $exit_code -eq 0 ]]; then
+    exit 0
+fi
+
+# Count non-typecheck errors in .go files
+non_typecheck_errors=$(grep -E "\.go:[0-9]+:[0-9]+:.*\(" "$tmpfile" 2>/dev/null | grep -v "(typecheck)" | grep -c . || echo "0")
+
+# Ensure the count is a valid number (remove spaces and newlines)
+non_typecheck_errors=$(echo "$non_typecheck_errors" | tr -d '[:space:]')
+
+# Check if golangci-lint itself had a critical failure (not a linting error)
+# This catches cases like config errors, missing files, etc.
+if [[ $exit_code -ne 0 ]] && [[ $non_typecheck_errors -eq 0 ]]; then
+    # Check if there are only typecheck errors
+    total_errors=$(grep -E "\.go:[0-9]+:[0-9]+:.*\(" "$tmpfile" 2>/dev/null | grep -c . || echo "0")
+    typecheck_errors=$(grep -E "\.go:[0-9]+:[0-9]+:.*\(typecheck\)" "$tmpfile" 2>/dev/null | grep -c . || echo "0")
+    
+    # Clean up the counts
+    total_errors=$(echo "$total_errors" | tr -d '[:space:]')
+    typecheck_errors=$(echo "$typecheck_errors" | tr -d '[:space:]')
+    
+    if [[ $total_errors -eq $typecheck_errors ]]; then
+        # Only typecheck errors, ignore them
+        exit 0
+    else
+        # There was a critical failure, show the full output and exit with error
+        echo ""
+        echo "Critical golangci-lint failure detected:"
+        cat "$tmpfile"
+        exit "$exit_code"
+    fi
+fi
+
+if [[ $non_typecheck_errors -gt 0 ]]; then
+    exit "$exit_code"
+else
+    # Only typecheck errors, ignore them
+    exit 0
+fi

--- a/makefiles/dependency.mk
+++ b/makefiles/dependency.mk
@@ -31,7 +31,7 @@ ifeq (, $(shell which staticcheck))
 	@{ \
 	set -e ;\
 	echo 'installing honnef.co/go/tools/cmd/staticcheck ' ;\
-	go install honnef.co/go/tools/cmd/staticcheck@v0.5.1 ;\
+	go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 ;\
 	}
 STATICCHECK=$(GOBIN)/staticcheck
 else


### PR DESCRIPTION
### Description of your changes

copilot:all

Wraps the golangci-lint and filters out false positive typechecks which filters in configuration do not help with.
See: https://github.com/golangci/golangci-lint/discussions/3759

This reduces the noise when running `make reviewable`

Fixes # N/A

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `make reviewable` runs without false flagging typecheck errors
- Other errors introduced are correctly picked up

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->