### PR TITLE
fix: extract the desired resources from existing by using last-applied-configuration to skip the generated fields

### DIFF
--- a/pkg/utils/apply/apply.go
+++ b/pkg/utils/apply/apply.go
@@ -503,11 +503,7 @@ func SharedByApp(app *v1beta1.Application) ApplyOption {
 		}
 		// the application that controls the resource allows sharing, then only mutate the shared-by annotation
 		act.isShared = true
-		bs, err := json.Marshal(existing)
-		if err != nil {
-			return err
-		}
-		if err = json.Unmarshal(bs, desired); err != nil {
+		if err := json.Unmarshal([]byte(existing.GetAnnotations()[oam.AnnotationLastAppliedConfig]), desired); err != nil {
 			return err
 		}
 		util.AddAnnotations(desired, map[string]string{oam.AnnotationAppSharedBy: sharedBy})


### PR DESCRIPTION
Fixes: #6863 6863


### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->