### PR TITLE
Fix: Debug Logging

### DIFF
--- a/cmd/core/app/options/options.go
+++ b/cmd/core/app/options/options.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/kubevela/pkg/cue/cuex"
@@ -162,16 +161,6 @@ func (s *CoreOptions) Flags() cliflag.NamedFlagSets {
 	pkgclient.AddTimeoutControllerClientFlags(fss.FlagSet("controllerclient"))
 	utillog.AddFlags(kfs)
 	profiling.AddFlags(fss.FlagSet("profiling"))
-
-	if s.LogDebug {
-		_ = kfs.Set("v", strconv.Itoa(int(commonconfig.LogDebug)))
-	}
-
-	if s.LogFilePath != "" {
-		_ = kfs.Set("logtostderr", "false")
-		_ = kfs.Set("log_file", s.LogFilePath)
-		_ = kfs.Set("log_file_max_size", strconv.FormatUint(s.LogFileMaxSize, 10))
-	}
 
 	return fss
 }

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -1,5 +1,4 @@
 /*
-/*
 Copyright 2022 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Description of your changes

copilot:all

- The `--log-debug` flag now properly sets klog verbosity level to 1 (LogDebug)
- Debug logs at klog.V(1) level will be displayed when this flag is used
- When users try the `--log-file-path` flag, they get a warning message
- The warning directs them to use the correct klog flags: `--logtostderr=false --log_file=<path>`
- This is due to a the technical limitation that klog initialises too early and can't be updated

Fixes #:
- https://github.com/kubevela/kubevela/issues/6467

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Verified debug logs can be seen