### PR TITLE
Fix(addon): Correct path calculation and test location for GitLab reader

### DIFF
--- a/pkg/addon/reader_gitlab.go
+++ b/pkg/addon/reader_gitlab.go
@@ -52,6 +52,9 @@ func (g GitLabItem) GetType() string {
 
 // GetPath get addon's sub item path
 func (g GitLabItem) GetPath() string {
+	if g.basePath == "" {
+		return g.path
+	}
 	return g.path[len(g.basePath)+1:]
 }
 

--- a/pkg/addon/reader_gitlab_test.go
+++ b/pkg/addon/reader_gitlab_test.go
@@ -111,3 +111,39 @@ func TestGitlabReader(t *testing.T) {
 	_, err := r.ReadFile("example/metadata.yaml")
 	assert.NoError(t, err)
 }
+
+func TestGitLabItem(t *testing.T) {
+	t.Run("Getters", func(t *testing.T) {
+		item := GitLabItem{
+			tp:   "blob",
+			name: "metadata.yaml",
+		}
+		assert.Equal(t, "blob", item.GetType())
+		assert.Equal(t, "metadata.yaml", item.GetName())
+	})
+
+	t.Run("GetPath", func(t *testing.T) {
+		testCases := map[string]struct {
+			basePath string
+			fullPath string
+			expected string
+		}{
+			"no base path": {
+				basePath: "",
+				fullPath: "fluxcd/metadata.yaml",
+				expected: "fluxcd/metadata.yaml",
+			},
+			"with base path": {
+				basePath: "addons",
+				fullPath: "addons/fluxcd/metadata.yaml",
+				expected: "fluxcd/metadata.yaml",
+			},
+		}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				item := GitLabItem{basePath: tc.basePath, path: tc.fullPath}
+				assert.Equal(t, tc.expected, item.GetPath())
+			})
+		}
+	})
+}


### PR DESCRIPTION
### Description

This PR fixes a bug in the GitLab addon reader where file paths were calculated incorrectly for addons located at the repository root. This was caused by an off-by-one error that truncated the first character of the path.

Additionally, this PR moves the `TestGitLabItem` unit test function from `pkg/addon/reader_local_test.go` to its correct location in `pkg/addon/reader_gitlab_test.go`.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Related Issue
- Fixes #6899

### How has this code been tested

The fix is validated by the `TestGitLabItem` unit test, which now passes. This test specifically covers the case of an empty base path that was causing the bug. All other existing tests continue to pass.

### Special notes for your reviewer

This PR includes two distinct changes: the bug fix itself and a minor test file cleanup (moving `TestGitLabItem` from `reader_local_test.go` to `reader_gitlab_test.go`).