### PR TITLE
Feat: Enhance unit test coverage for `references/appfile` package

### DIFF
--- a/references/appfile/addon_test.go
+++ b/references/appfile/addon_test.go
@@ -19,9 +19,9 @@ package appfile
 import (
 	"fmt"
 	"os"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -31,7 +31,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
-var _ = It("Test ApplyTerraform", func() {
+func TestApplyTerraform(t *testing.T) {
 	app := &v1beta1.Application{
 		ObjectMeta: v1.ObjectMeta{Name: "test-terraform-app"},
 		Spec: v1beta1.ApplicationSpec{Components: []commontype.ApplicationComponent{{
@@ -46,27 +46,29 @@ var _ = It("Test ApplyTerraform", func() {
 		Schema: scheme,
 	}
 	err := arg.SetConfig(cfg)
-	Expect(err).Should(BeNil())
+	assert.NoError(t, err)
 	_, err = ApplyTerraform(app, k8sClient, ioStream, addonNamespace, arg)
-	Expect(err).Should(BeNil())
-})
+	assert.NoError(t, err)
+}
 
-var _ = Describe("Test generateSecretFromTerraformOutput", func() {
+func TestGenerateSecretFromTerraformOutput(t *testing.T) {
 	var name = "test-addon-secret"
-	It("namespace doesn't exist", func() {
+
+	t.Run("namespace doesn't exist", func(t *testing.T) {
 		badNamespace := "a-not-existed-namespace"
 		err := generateSecretFromTerraformOutput(k8sClient, nil, name, badNamespace)
-		Expect(err).Should(Equal(fmt.Errorf("namespace %s doesn't exist", badNamespace)))
-	})
-	It("valid output list", func() {
-		outputList := []string{"name=aaa", "age=1"}
-		err := generateSecretFromTerraformOutput(k8sClient, outputList, name, addonNamespace)
-		Expect(err).Should(BeNil())
+		assert.EqualError(t, err, fmt.Sprintf("namespace %s doesn't exist", badNamespace))
 	})
 
-	It("invalid output list", func() {
+	t.Run("valid output list", func(t *testing.T) {
+		outputList := []string{"name=aaa", "age=1"}
+		err := generateSecretFromTerraformOutput(k8sClient, outputList, name, addonNamespace)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid output list", func(t *testing.T) {
 		outputList := []string{"name"}
 		err := generateSecretFromTerraformOutput(k8sClient, outputList, name, addonNamespace)
-		Expect(err).Should(Equal(fmt.Errorf("terraform output isn't in the right format")))
+		assert.EqualError(t, err, "terraform output isn't in the right format")
 	})
-})
+}

--- a/references/appfile/api/appfile_test.go
+++ b/references/appfile/api/appfile_test.go
@@ -34,6 +34,58 @@ import (
 	"github.com/oam-dev/kubevela/references/appfile/template"
 )
 
+func TestNewAppFile(t *testing.T) {
+	appFile := NewAppFile()
+	assert.NotNil(t, appFile)
+	assert.NotNil(t, appFile.Services)
+	assert.NotNil(t, appFile.Secrets)
+	assert.Empty(t, appFile.Name)
+}
+
+func TestJSONToYaml(t *testing.T) {
+	t.Run("valid json", func(t *testing.T) {
+		jsonData := `{"name":"test-app","services":{"my-svc":{"image":"nginx"}}}`
+		appFile := NewAppFile()
+		_, err := JSONToYaml([]byte(jsonData), appFile)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-app", appFile.Name)
+		assert.Contains(t, appFile.Services, "my-svc")
+		assert.Equal(t, "nginx", appFile.Services["my-svc"]["image"])
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		jsonData := `{"name":"test-app"` // Malformed JSON
+		appFile := NewAppFile()
+		_, err := JSONToYaml([]byte(jsonData), appFile)
+		assert.Error(t, err)
+	})
+}
+
+func TestLoadFromBytes(t *testing.T) {
+	t.Run("valid yaml", func(t *testing.T) {
+		yamlData := `
+name: test-yaml-app
+services:
+  main:
+    image: httpd
+`
+		appFile, err := LoadFromBytes([]byte(yamlData))
+		assert.NoError(t, err)
+		assert.Equal(t, "test-yaml-app", appFile.Name)
+		assert.Len(t, appFile.Services, 1)
+		assert.Equal(t, "httpd", appFile.Services["main"]["image"])
+	})
+
+	t.Run("valid json", func(t *testing.T) {
+		jsonData := `{"name":"test-json-app","services":{"sidecar":{"image":"redis"}}}`
+		appFile, err := LoadFromBytes([]byte(jsonData))
+		assert.NoError(t, err)
+		assert.Equal(t, "test-json-app", appFile.Name)
+		assert.Len(t, appFile.Services, 1)
+		assert.Equal(t, "redis", appFile.Services["sidecar"]["image"])
+	})
+}
+
 func TestBuildOAMApplication2(t *testing.T) {
 	expectNs := "test-ns"
 

--- a/references/appfile/api/service_test.go
+++ b/references/appfile/api/service_test.go
@@ -36,3 +36,85 @@ func TestGetType(t *testing.T) {
 	got = svc2.GetType()
 	assert.Equal(t, workload2, got)
 }
+
+func TestGetUserConfigName(t *testing.T) {
+	t.Run("config name exists", func(t *testing.T) {
+		svc := Service{"config": "my-config"}
+		assert.Equal(t, "my-config", svc.GetUserConfigName())
+	})
+
+	t.Run("config name does not exist", func(t *testing.T) {
+		svc := Service{"image": "nginx"}
+		assert.Equal(t, "", svc.GetUserConfigName())
+	})
+}
+
+func TestGetApplicationConfig(t *testing.T) {
+	svc := Service{
+		"image":  "nginx",
+		"port":   80,
+		"type":   "webservice",
+		"build":  "./",
+		"config": "my-config",
+	}
+
+	config := svc.GetApplicationConfig()
+
+	assert.Contains(t, config, "image")
+	assert.Contains(t, config, "port")
+	assert.NotContains(t, config, "type")
+	assert.NotContains(t, config, "build")
+	assert.NotContains(t, config, "config")
+	assert.Len(t, config, 2)
+}
+
+func TestToStringSlice(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    interface{}
+		expected []string
+	}{
+		{
+			name:     "string",
+			input:    "one",
+			expected: []string{"one"},
+		},
+		{
+			name:     "[]string",
+			input:    []string{"one", "two"},
+			expected: []string{"one", "two"},
+		},
+		{
+			name:     "[]interface{} of strings",
+			input:    []interface{}{"one", "two"},
+			expected: []string{"one", "two"},
+		},
+		{
+			name:     "[]interface{} of mixed types",
+			input:    []interface{}{"one", 2, "three"},
+			expected: []string{"one", "three"},
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty []string",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "other type (int)",
+			input:    123,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := toStringSlice(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/references/appfile/app_test.go
+++ b/references/appfile/app_test.go
@@ -22,14 +22,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/references/appfile/api"
 	"github.com/oam-dev/kubevela/references/appfile/template"
 )
 
-func TestApplication(t *testing.T) {
-	yamlNormal := `name: myapp
+const (
+	yamlNormal = `name: myapp
 services:
   frontend:
     image: inanimate/echo-server
@@ -45,55 +49,207 @@ services:
     type: cloneset
     image: "back:v1"
 `
-	yamlNoService := `name: myapp`
-	yamlNoName := `services:
+	yamlNoService = `name: myapp`
+	yamlNoName    = `services:
   frontend:
     image: inanimate/echo-server
     env:
       PORT: 8080`
-	yamlTraitNotMap := `name: myapp
+	yamlTraitNotMap = `name: myapp
 services:
   frontend:
     image: inanimate/echo-server
     env:
       PORT: 8080
     autoscaling: 10`
+)
 
-	cases := map[string]struct {
-		raw             string
-		InValid         bool
-		InvalidReason   error
-		ExpName         string
-		ExpComponents   []string
-		WantWorkload    string
-		ExpWorkload     map[string]interface{}
-		ExpWorkloadType string
-		ExpTraits       map[string]map[string]interface{}
+func TestNewApplication(t *testing.T) {
+	tm := template.NewFakeTemplateManager()
+	app := NewApplication(nil, tm)
+	assert.NotNil(t, app)
+	assert.Equal(t, tm, app.Tm)
+	assert.NotNil(t, app.AppFile)
+
+	appfile := api.NewAppFile()
+	appfile.Name = "test-app"
+	app = NewApplication(appfile, tm)
+	assert.NotNil(t, app)
+	assert.Equal(t, "test-app", app.Name)
+}
+
+func TestValidate(t *testing.T) {
+	testCases := map[string]struct {
+		raw     string
+		expErr  error
+		addFake bool
 	}{
-		"normal case backend": {
-			raw:           yamlNormal,
-			ExpName:       "myapp",
-			ExpComponents: []string{"backend", "frontend"},
-			WantWorkload:  "backend",
-			ExpWorkload: map[string]interface{}{
-				"image": "back:v1",
-			},
-			ExpWorkloadType: "cloneset",
-			ExpTraits:       map[string]map[string]interface{}{},
+		"normal": {
+			raw:    yamlNormal,
+			expErr: nil,
 		},
-		"normal case frontend": {
-			raw:           yamlNormal,
-			ExpName:       "myapp",
-			ExpComponents: []string{"backend", "frontend"},
-			WantWorkload:  "frontend",
-			ExpWorkload: map[string]interface{}{
+		"no service": {
+			raw:    yamlNoService,
+			expErr: errors.New("at least one service is required"),
+		},
+		"no name": {
+			raw:    yamlNoName,
+			expErr: errors.New("name is required"),
+		},
+		"trait not map": {
+			raw:     yamlTraitNotMap,
+			expErr:  fmt.Errorf("trait autoscaling in 'frontend' must be map"),
+			addFake: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tm := template.NewFakeTemplateManager()
+			if tc.addFake {
+				tm.Templates["autoscaling"] = &template.Template{
+					Captype: types.TypeTrait,
+				}
+			}
+			app := NewApplication(nil, tm)
+			err := yaml.Unmarshal([]byte(tc.raw), &app)
+			assert.NoError(t, err)
+			err = Validate(app)
+			assert.Equal(t, tc.expErr, err)
+		})
+	}
+}
+
+func TestGetComponents(t *testing.T) {
+	app := &v1beta1.Application{
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{Name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+			},
+		},
+	}
+	comps := GetComponents(app)
+	assert.Equal(t, []string{"a", "b", "c"}, comps)
+}
+
+func TestGetServiceConfig(t *testing.T) {
+	tm := template.NewFakeTemplateManager()
+	app := NewApplication(nil, tm)
+	err := yaml.Unmarshal([]byte(yamlNormal), &app)
+	assert.NoError(t, err)
+
+	tp, cfg := GetServiceConfig(app, "frontend")
+	assert.Equal(t, "webservice", tp)
+	assert.NotEmpty(t, cfg)
+	assert.Contains(t, cfg, "image")
+
+	tp, cfg = GetServiceConfig(app, "backend")
+	assert.Equal(t, "cloneset", tp)
+	assert.NotEmpty(t, cfg)
+	assert.Contains(t, cfg, "image")
+
+	tp, cfg = GetServiceConfig(app, "non-existent")
+	assert.Equal(t, "", tp)
+	assert.Empty(t, cfg)
+}
+
+func TestGetApplicationSettings(t *testing.T) {
+	app := &v1beta1.Application{
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{
+					Name: "comp-1",
+					Type: "worker",
+					Properties: &runtime.RawExtension{
+						Raw: []byte(`{"image":"my-image"}`),
+					},
+				},
+			},
+		},
+	}
+
+	tp, settings := GetApplicationSettings(app, "comp-1")
+	assert.Equal(t, "worker", tp)
+	assert.Equal(t, map[string]interface{}{"image": "my-image"}, settings)
+
+	tp, settings = GetApplicationSettings(app, "non-existent")
+	assert.Equal(t, "", tp)
+	assert.Empty(t, settings)
+}
+
+func TestGetWorkload(t *testing.T) {
+	tm := template.NewFakeTemplateManager()
+	tm.Templates["autoscaling"] = &template.Template{Captype: types.TypeTrait}
+	tm.Templates["rollout"] = &template.Template{Captype: types.TypeTrait}
+
+	app := NewApplication(nil, tm)
+	err := yaml.Unmarshal([]byte(yamlNormal), &app)
+	assert.NoError(t, err)
+
+	testCases := map[string]struct {
+		componentName   string
+		expWorkloadType string
+		expWorkload     map[string]interface{}
+	}{
+		"frontend": {
+			componentName:   "frontend",
+			expWorkloadType: "webservice",
+			expWorkload: map[string]interface{}{
 				"image": "inanimate/echo-server",
 				"env": map[string]interface{}{
 					"PORT": float64(8080),
 				},
 			},
-			ExpWorkloadType: "webservice",
-			ExpTraits: map[string]map[string]interface{}{
+		},
+		"backend": {
+			componentName:   "backend",
+			expWorkloadType: "cloneset",
+			expWorkload: map[string]interface{}{
+				"image": "back:v1",
+			},
+		},
+		"non-existent": {
+			componentName:   "non-existent",
+			expWorkloadType: "",
+			expWorkload:     map[string]interface{}{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			workloadType, workload := GetWorkload(app, tc.componentName)
+			assert.Equal(t, tc.expWorkloadType, workloadType)
+			assert.Equal(t, tc.expWorkload, workload)
+		})
+	}
+}
+
+func TestGetTraits(t *testing.T) {
+	tm := template.NewFakeTemplateManager()
+	tm.Templates["autoscaling"] = &template.Template{Captype: types.TypeTrait}
+	tm.Templates["rollout"] = &template.Template{Captype: types.TypeTrait}
+
+	app := NewApplication(nil, tm)
+	err := yaml.Unmarshal([]byte(yamlNormal), &app)
+	assert.NoError(t, err)
+
+	// Test case with invalid trait format
+	invalidTraitApp := NewApplication(nil, tm)
+	err = yaml.Unmarshal([]byte(yamlTraitNotMap), &invalidTraitApp)
+	assert.NoError(t, err)
+
+	testCases := map[string]struct {
+		app      *api.Application
+		compName string
+		exp      map[string]map[string]interface{}
+		expErr   string
+	}{
+		"frontend traits": {
+			app:      app,
+			compName: "frontend",
+			exp: map[string]map[string]interface{}{
 				"autoscaling": {
 					"max": float64(10),
 					"min": float64(1),
@@ -104,50 +260,33 @@ services:
 				},
 			},
 		},
-		"no component": {
-			raw:           yamlNoService,
-			ExpName:       "myapp",
-			InValid:       true,
-			InvalidReason: errors.New("at least one service is required"),
+		"backend traits (none)": {
+			app:      app,
+			compName: "backend",
+			exp:      map[string]map[string]interface{}{},
 		},
-		"no name": {
-			raw:           yamlNoName,
-			ExpName:       "",
-			InValid:       true,
-			InvalidReason: errors.New("name is required"),
+		"non-existent component": {
+			app:      app,
+			compName: "non-existent",
+			exp:      map[string]map[string]interface{}{},
 		},
-		"trait must be map": {
-			raw: yamlTraitNotMap,
-			ExpTraits: map[string]map[string]interface{}{
-				"autoscaling": {},
-			},
-			ExpName:       "myapp",
-			InValid:       true,
-			InvalidReason: fmt.Errorf("trait autoscaling in 'frontend' must be map"),
+		"invalid trait format": {
+			app:      invalidTraitApp,
+			compName: "frontend",
+			exp:      nil,
+			expErr:   "autoscaling is trait, but with invalid format float64, should be map[string]interface{}",
 		},
 	}
 
-	for caseName, c := range cases {
-		tm := template.NewFakeTemplateManager()
-		for k := range c.ExpTraits {
-			tm.Templates[k] = &template.Template{
-				Captype: types.TypeTrait,
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			traits, err := GetTraits(tc.app, tc.compName)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.exp, traits)
 			}
-		}
-		app := NewApplication(nil, tm)
-		err := yaml.Unmarshal([]byte(c.raw), &app)
-		assert.NoError(t, err, caseName)
-		err = Validate(app)
-		if c.InValid {
-			assert.Equal(t, c.InvalidReason, err)
-			continue
-		}
-		assert.Equal(t, c.ExpName, app.Name, caseName)
-		workloadType, workload := GetWorkload(app, c.WantWorkload)
-		assert.Equal(t, c.ExpWorkload, workload, caseName)
-		assert.Equal(t, c.ExpWorkloadType, workloadType, caseName)
-		traits, err := GetTraits(app, c.WantWorkload)
-		assert.NoError(t, err, caseName)
-		assert.Equal(t, c.ExpTraits, traits, caseName)
+		})
 	}
 }

--- a/references/appfile/modify_test.go
+++ b/references/appfile/modify_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/references/appfile/api"
+	"github.com/oam-dev/kubevela/references/appfile/template"
+)
+
+func TestSetWorkload(t *testing.T) {
+	tm := template.NewFakeTemplateManager()
+
+	t.Run("app is nil", func(t *testing.T) {
+		err := SetWorkload(nil, "comp", "worker", nil)
+		assert.EqualError(t, err, errorAppNilPointer.Error())
+	})
+
+	t.Run("add new component", func(t *testing.T) {
+		app := NewApplication(nil, tm)
+		app.Name = "test-app"
+		workloadData := map[string]interface{}{"image": "test-image", "cmd": []string{"sleep", "1000"}}
+		err := SetWorkload(app, "my-comp", "worker", workloadData)
+		assert.NoError(t, err)
+
+		assert.Len(t, app.Services, 1)
+		svc, ok := app.Services["my-comp"]
+		assert.True(t, ok)
+		assert.NotNil(t, svc)
+		assert.Equal(t, "worker", svc["type"])
+		assert.Equal(t, "test-image", svc["image"])
+		assert.Equal(t, []string{"sleep", "1000"}, svc["cmd"])
+	})
+
+	t.Run("update existing component", func(t *testing.T) {
+		app := NewApplication(nil, tm)
+		app.Name = "test-app"
+		app.Services["my-comp"] = api.Service{
+			"type":  "worker",
+			"image": "initial-image",
+		}
+
+		updatedWorkloadData := map[string]interface{}{"image": "updated-image", "port": 8080}
+		err := SetWorkload(app, "my-comp", "webservice", updatedWorkloadData)
+		assert.NoError(t, err)
+
+		assert.Len(t, app.Services, 1)
+		svc, ok := app.Services["my-comp"]
+		assert.True(t, ok)
+		assert.NotNil(t, svc)
+		assert.Equal(t, "webservice", svc["type"])
+		assert.Equal(t, "updated-image", svc["image"])
+		assert.Equal(t, 8080, svc["port"])
+	})
+
+	t.Run("add to existing services", func(t *testing.T) {
+		app := NewApplication(nil, tm)
+		app.Name = "test-app"
+		app.Services["comp-1"] = api.Service{
+			"type": "worker",
+		}
+
+		workloadData := map[string]interface{}{"image": "test-image"}
+		err := SetWorkload(app, "comp-2", "task", workloadData)
+		assert.NoError(t, err)
+
+		assert.Len(t, app.Services, 2)
+		assert.Contains(t, app.Services, "comp-1")
+		assert.Contains(t, app.Services, "comp-2")
+		svc2, _ := app.Services["comp-2"]
+		assert.Equal(t, "task", svc2["type"])
+		assert.Equal(t, "test-image", svc2["image"])
+	})
+}

--- a/references/appfile/run_test.go
+++ b/references/appfile/run_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appfile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestCreateOrUpdateApplication(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, v1beta1.AddToScheme(scheme))
+
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("create application", func(t *testing.T) {
+		builder := fake.NewClientBuilder().WithScheme(scheme)
+		fakeClient := builder.Build()
+		err := CreateOrUpdateApplication(context.Background(), fakeClient, app)
+		assert.NoError(t, err)
+
+		var created v1beta1.Application
+		err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(app), &created)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-app", created.Name)
+	})
+
+	t.Run("update application", func(t *testing.T) {
+		appToUpdate := app.DeepCopy()
+		appToUpdate.SetAnnotations(map[string]string{"key": "val"})
+
+		builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app)
+		fakeClient := builder.Build()
+
+		err := CreateOrUpdateApplication(context.Background(), fakeClient, appToUpdate)
+		assert.NoError(t, err)
+
+		var updated v1beta1.Application
+		err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(app), &updated)
+		assert.NoError(t, err)
+		assert.Equal(t, "val", updated.Annotations["key"])
+	})
+}
+
+func TestCreateOrUpdateObjects(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"initial": "true",
+		},
+	}
+
+	t.Run("create object", func(t *testing.T) {
+		builder := fake.NewClientBuilder().WithScheme(scheme)
+		fakeClient := builder.Build()
+		objects := []oam.Object{cm}
+
+		err := CreateOrUpdateObjects(context.Background(), fakeClient, objects)
+		assert.NoError(t, err)
+
+		var created corev1.ConfigMap
+		err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(cm), &created)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", created.Data["initial"])
+	})
+
+	t.Run("update object", func(t *testing.T) {
+		cmToUpdate := cm.DeepCopy()
+		cmToUpdate.Data["initial"] = "false"
+
+		builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm)
+		fakeClient := builder.Build()
+		objects := []oam.Object{cmToUpdate}
+
+		err := CreateOrUpdateObjects(context.Background(), fakeClient, objects)
+		assert.NoError(t, err)
+
+		var updated corev1.ConfigMap
+		err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(cm), &updated)
+		assert.NoError(t, err)
+		assert.Equal(t, "false", updated.Data["initial"])
+	})
+}
+
+func TestRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, v1beta1.AddToScheme(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app-run",
+			Namespace: "default",
+		},
+	}
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm-run",
+			Namespace: "default",
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	fakeClient := builder.Build()
+
+	err := Run(context.Background(), fakeClient, app, []oam.Object{cm})
+	assert.NoError(t, err)
+
+	var createdApp v1beta1.Application
+	err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(app), &createdApp)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-app-run", createdApp.Name)
+
+	var createdCM corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(cm), &createdCM)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-cm-run", createdCM.Name)
+}


### PR DESCRIPTION
### Description

This PR enhances the test coverage for the `references/appfile` package to improve the overall quality, stability, and maintainability of the KubeVela codebase. This addresses gaps in test coverage and inconsistencies in the testing framework, which is essential for preventing regressions and enabling confident refactoring and feature development.

Key contributions of this PR include:

*   **New Test Cases for `references/appfile/api/appfile.go`**: Added tests for `NewAppFile`, `JSONToYaml`, and `LoadFromBytes` to ensure correct application file initialization, parsing, and loading.
*   **New Test Cases for `references/appfile/api/service.go`**: Introduced tests for `GetUserConfigName`, `GetApplicationConfig`, and `ToStringSlice` to validate service configuration extraction and type conversions.
*   **Expanded Test Coverage for `references/appfile/app.go`**: Added new tests for `NewApplication`, `Validate`, `GetComponents`, `GetServiceConfig`, `GetApplicationSettings`, `GetWorkload`, and `GetTraits`, ensuring the robustness of application-level operations.
*   **Dedicated Test Files for `modify.go` and `run.go`**: Created `modify_test.go` and `run_test.go` to provide specific unit tests for `SetWorkload`, `CreateOrUpdateApplication`, `CreateOrUpdateObjects`, and `Run` functions.
*   **Test Framework Migration**: Refactored `addon_suit_test.go` to `main_test.go` and `addon_test.go` to use standard Go `testing` and `testify/assert`, improving consistency and maintainability.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Related Issue
- Fixes #6912

### How has this code been tested

The changes have been tested by adding comprehensive unit tests for the `references/appfile` package. The new tests cover initialization, parsing, loading, and application-level operations. Existing tests were refactored to use standard Go testing frameworks for better consistency.

### Special notes for your reviewer

This PR significantly increases the test coverage for the `references/appfile` package, which previously had limited testing. The refactoring of existing tests to use `testify/assert` improves the consistency of the test suite.
