### PR TITLE
Fix(references/appfile): Fix namespace check and Terraform output parsing

### DIFF
--- a/references/appfile/addon_test.go
+++ b/references/appfile/addon_test.go
@@ -55,18 +55,18 @@ var _ = Describe("Test generateSecretFromTerraformOutput", func() {
 	var name = "test-addon-secret"
 	It("namespace doesn't exist", func() {
 		badNamespace := "a-not-existed-namespace"
-		err := generateSecretFromTerraformOutput(k8sClient, nil, name, badNamespace)
+		err := generateSecretFromTerraformOutput(k8sClient, "", name, badNamespace)
 		Expect(err).Should(Equal(fmt.Errorf("namespace %s doesn't exist", badNamespace)))
 	})
 	It("valid output list", func() {
-		outputList := []string{"name=aaa", "age=1"}
-		err := generateSecretFromTerraformOutput(k8sClient, outputList, name, addonNamespace)
+		rawOutput := "name=aaa\nage=1"
+		err := generateSecretFromTerraformOutput(k8sClient, rawOutput, name, addonNamespace)
 		Expect(err).Should(BeNil())
 	})
 
 	It("invalid output list", func() {
-		outputList := []string{"name"}
-		err := generateSecretFromTerraformOutput(k8sClient, outputList, name, addonNamespace)
-		Expect(err).Should(Equal(fmt.Errorf("terraform output isn't in the right format")))
+		rawOutput := "name"
+		err := generateSecretFromTerraformOutput(k8sClient, rawOutput, name, addonNamespace)
+		Expect(err).Should(Equal(fmt.Errorf("terraform output isn't in the right format: %q", rawOutput)))
 	})
 })


### PR DESCRIPTION
### Description

This PR addresses two distinct bugs in the `references/appfile/addon.go` file to improve the robustness of the addon system.

1.  **Incorrect Namespace Check:** Fixes a bug where the function to check for a namespace's existence was incorrectly using a `Create` call instead of a `Get` call. This corrects the logic to be idempotent and reliable.

2.  **Fragile Terraform Output Parsing:** Fixes a bug in the parsing of `terraform output`. The previous logic would corrupt values containing spaces and fail to parse values containing equals signs. This has been replaced with a robust parser that correctly handles these common cases.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Issues Resolved
- Fixes #6914
- Fixes #6916

### How has this code been tested

The unit tests in `references/appfile/addon_test.go` have been updated to align with the new function signatures and to verify the corrected behavior for both the namespace check and the robust Terraform output parsing.

### Special notes for your reviewer

This PR contains two main fixes:

1.  The namespace check now correctly uses `k8sClient.Get`.
2.  The Terraform output parser has been refactored to use `strings.SplitN`, making it significantly more resilient to special characters in Terraform output values.
