### PR TITLE
Fix webhook TLS caBundle breakage during failed Helm upgrades

### DIFF
--- a/charts/vela-core/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name:  {{ template "kubevela.fullname" . }}-admission
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission

--- a/charts/vela-core/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name:  {{ template "kubevela.fullname" . }}-admission
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission

--- a/charts/vela-core/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "kubevela.fullname" . }}-admission-patch
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission-patch

--- a/charts/vela-core/templates/admission-webhooks/job-patch/role.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "kubevela.fullname" . }}-admission
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission

--- a/charts/vela-core/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "kubevela.fullname" . }}-admission
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission

--- a/charts/vela-core/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "kubevela.fullname" . }}-admission
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "kubevela.name" . }}-admission

--- a/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -1,4 +1,14 @@
 {{- if .Values.admissionWebhooks.enabled -}}
+{{- /* Preserve existing caBundle on upgrade to avoid breaking admission if hooks fail. */}}
+{{- $mName := printf "%s-admission" (include "kubevela.fullname" .) -}}
+{{- $existing := (lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" "" $mName) -}}
+{{- $vals := dict "apps" "" "comps" "" -}}
+{{- if $existing -}}
+{{- range $existing.webhooks -}}
+{{- if eq .name "mutating.core.oam.dev.v1beta1.applications" -}}{{- $_ := set $vals "apps" .clientConfig.caBundle -}}{{- end -}}
+{{- if eq .name "mutating.core.oam-dev.v1beta1.componentdefinitions" -}}{{- $_ := set $vals "comps" .clientConfig.caBundle -}}{{- end -}}
+{{- end -}}
+{{- end -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -10,7 +20,7 @@ metadata:
   {{- end }}
 webhooks:
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "apps") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
@@ -36,7 +46,7 @@ webhooks:
         resources:
           - applications
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "comps") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}

--- a/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -1,4 +1,16 @@
 {{- if .Values.admissionWebhooks.enabled -}}
+{{- /* Preserve existing caBundle on upgrade to avoid breaking admission if hooks fail. */}}
+{{- $vName := printf "%s-admission" (include "kubevela.fullname" .) -}}
+{{- $existing := (lookup "admissionregistration.k8s.io/v1" "ValidatingWebhookConfiguration" "" $vName) -}}
+{{- $vals := dict "traits" "" "apps" "" "comps" "" "policies" "" -}}
+{{- if $existing -}}
+{{- range $existing.webhooks -}}
+{{- if eq .name "validating.core.oam.dev.v1beta1.traitdefinitions" -}}{{- $_ := set $vals "traits" .clientConfig.caBundle -}}{{- end -}}
+{{- if eq .name "validating.core.oam.dev.v1beta1.applications" -}}{{- $_ := set $vals "apps" .clientConfig.caBundle -}}{{- end -}}
+{{- if eq .name "validating.core.oam-dev.v1beta1.componentdefinitions" -}}{{- $_ := set $vals "comps" .clientConfig.caBundle -}}{{- end -}}
+{{- if eq .name "validating.core.oam-dev.v1beta1.policydefinitions" -}}{{- $_ := set $vals "policies" .clientConfig.caBundle -}}{{- end -}}
+{{- end -}}
+{{- end -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -10,7 +22,7 @@ metadata:
   {{- end }}
 webhooks:
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "traits") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
@@ -37,7 +49,7 @@ webhooks:
           - traitdefinitions
     timeoutSeconds: 5
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "apps") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
@@ -63,7 +75,7 @@ webhooks:
         resources:
           - applications
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "comps") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
@@ -89,7 +101,7 @@ webhooks:
         resources:
           - componentdefinitions
   - clientConfig:
-      caBundle: Cg==
+      caBundle: {{ default "Cg==" (get $vals "policies") }}
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## **Overview**

> **Solution Summary**  
> Fixes webhook TLS caBundle breakage during failed Helm upgrades by **preserving existing caBundle** and **ensuring the patch job runs on rollback**. Keeps the existing Job-based certificate management intact and idempotent.

---

## **Problem**

### **Root Cause**
The Helm deployment process creates webhook configurations with placeholder certificate bundles (`caBundle: Cg==`) and relies on post-install/post-upgrade jobs to populate the actual base64-encoded certificates. If the Helm operation fails before these jobs complete, the webhook configurations persist with invalid/empty certificate bundles.

### **Impact**
- **Webhook calls are disabled:** Any operations that should trigger the admission webhooks will fail or be ignored
- **Silent failures:** Depending on failurePolicy settings, requests may silently bypass validation/mutation  
- **Broken cluster state:** The cluster remains in a partially configured state until manual intervention

### **Current Workflow Issues**
1. **Template Creation:** Helm creates ValidatingWebhookConfiguration and MutatingWebhookConfiguration with empty `caBundle: Cg==`
2. **Certificate Generation:** A pre-install,pre-upgrade job (kubevela-admission-create) generates certificates and creates a secret  
3. **Configuration Patching:** A post-install,post-upgrade job (kubevela-admission-patch) updates the webhook configurations with the actual certificate bundle

> **Critical Issue:** If step 3 fails, the webhook configurations remain with invalid certificates.

### **Additional Observation**
During successful helm upgrades, the secret job runs but doesn't update the secret. The `oamdev/kube-webhook-certgen` create mode typically no-ops if the secret already exists - it's designed to generate on first install, not rotate on upgrade. With caBundle preservation in templates, some patchers only update when they see the placeholder. So on a successful upgrade, if the caBundle already exists, it may not be overwritten.

---

## **Solution**

### **Key Changes**

#### **1. Preserve caBundle with Helm lookup**
*Templates never overwrite a good caBundle on upgrade:*

```yaml
# Modified files:
charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
```

- Each webhook stanza looks up the existing resource and reuses the matching webhook's `.clientConfig.caBundle`
- Falls back to `Cg==` only when not found (fresh install)

#### **2. Ensure patch job runs after rollbacks**
*By adding post-rollback to `helm.sh/hook`:*

```yaml
# Modified files:
charts/vela-core/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
charts/vela-core/templates/admission-webhooks/job-patch/clusterrole.yaml
charts/vela-core/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
charts/vela-core/templates/admission-webhooks/job-patch/role.yaml
charts/vela-core/templates/admission-webhooks/job-patch/rolebinding.yaml
charts/vela-core/templates/admission-webhooks/job-patch/serviceaccount.yaml
```

#### **3. Maintained hook policies**
- Kept `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`
- Failed jobs remain for debugging; succeeded jobs are cleaned up before re-creation

---

### **Behavior Changes**

| | **Before** | **After** |
|---|---|---|
| **Upgrade Behavior** | Upgrade renders webhook configs with `caBundle: Cg==` | Upgrade renders webhook configs preserving the current caBundle (via lookup) |
| **Failure Handling** | If upgrade fails before post-upgrade Job runs, webhooks remain with invalid caBundle until manual recovery | Admission continues to work even if hooks do not run |
| **Job Execution** | Patch job runs on install and upgrade only | Patch job runs on install, upgrade, **and rollback** |

---

### **Compatibility**

<details>
<summary><strong>Cert-manager Integration</strong></summary>

- **Path remains unchanged:** When `admissionWebhooks.certManager.enabled=true`, templates keep `cert-manager.io/inject-ca-from` and cert-manager injects the CA automatically
- **No adverse effects:** The lookup preservation works seamlessly in cert-manager mode

</details>

<details>
<summary><strong>Helm Version Requirements</strong></summary>

- **Minimum version:** Requires Helm 3.2+ for lookup support
- **Template/dry-run behavior:** On `helm template` or `--dry-run`, lookup returns nothing; templates fall back to `Cg==` (expected behavior)
- **Runtime patching:** The job patches CA during actual apply

</details>

---

<div align="center">

**This PR ensures webhook reliability during Helm operations**

![Helm](https://img.shields.io/badge/Helm-3.2%2B-0F1689?style=flat-square&logo=helm)
![Kubernetes](https://img.shields.io/badge/Kubernetes-Compatible-326CE5?style=flat-square&logo=kubernetes)
![Status](https://img.shields.io/badge/Status-Ready%20for%20Review-28a745?style=flat-square)

</div>