### PR TITLE
Chore: Remove unused parameter 'addonName' from 'vela-cli' workflow s…

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
@@ -126,8 +126,6 @@ spec:
         }
 
         parameter: {
-        	// +usage=Specify the name of the addon.
-        	addonName: string
         	// +usage=Specify the vela command
         	command: [...string]
         	// +usage=Specify the image

--- a/vela-templates/definitions/internal/workflowstep/vela-cli.cue
+++ b/vela-templates/definitions/internal/workflowstep/vela-cli.cue
@@ -133,8 +133,6 @@ template: {
 	}
 
 	parameter: {
-		// +usage=Specify the name of the addon.
-		addonName: string
 		// +usage=Specify the vela command
 		command: [...string]
 		// +usage=Specify the image


### PR DESCRIPTION
### Description of your changes
Removes the "addonName" parameter from the "vela-cli" workflow step.

"addonName" is not connected to anything (does nothing) and it's not apparent what it should do on this step. Best choice is to remove it, I believe.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. -- see: https://github.com/kubevela/kubevela.github.io/pull/1385
- [ ] Run `make reviewable` to ensure this PR is ready for review. -- it failed for me: `[./vela-templates/gen_definitions.sh] (0/3) Generating internal definitions from definitions/internal to ../charts/vela-core/templates/defwithtemplate ... make: *** [manifests] Error 1`
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. -- I don't think this is necessary

### How has this code been tested
I ran `make test`; there were some errors but they did not appear related.
I tried making an `Application` with a workflow that used a `vela-cli` step and it still worked.

### Special notes for your reviewer
This change removes `addonName`, but I don't think it creates an incompatibility issue if someone does specify `addonName`: the workflow still seems to run, no validation error.