### PR TITLE
Feat(addon): Store addon registry tokens in Secrets

### DIFF
--- a/pkg/addon/registry_test.go
+++ b/pkg/addon/registry_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	velatypes "github.com/oam-dev/kubevela/apis/types"
+)
+
+func TestAddonRegistry(t *testing.T) {
+	ctx := context.Background()
+	testRegistry := Registry{
+		Name: "test-registry",
+		Git: &GitAddonSource{
+			URL:   "http://github.com/test/repo",
+			Token: "test-token",
+		},
+	}
+	scheme := runtime.NewScheme()
+	v1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ds := NewRegistryDataStore(client)
+
+	t.Run("add registry", func(t *testing.T) {
+		err := ds.AddRegistry(ctx, testRegistry)
+		assert.NoError(t, err)
+
+		var cm v1.ConfigMap
+		err = client.Get(ctx, types.NamespacedName{Name: registryConfigMapName, Namespace: velatypes.DefaultKubeVelaNS}, &cm)
+		assert.NoError(t, err)
+		var registries map[string]Registry
+		err = json.Unmarshal([]byte(cm.Data[registriesKey]), &registries)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(registries))
+		gotRegistry := registries["test-registry"]
+		assert.Equal(t, "", gotRegistry.Git.Token)
+		assert.Equal(t, "addon-registry-test-registry", gotRegistry.Git.TokenSecretRef)
+
+		var secret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &secret)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token", string(secret.Data["token"]))
+	})
+
+	t.Run("update registry", func(t *testing.T) {
+		updatedRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:   "http://github.com/test/repo-updated",
+				Token: "test-token-updated",
+			},
+		}
+		err := ds.UpdateRegistry(ctx, updatedRegistry)
+		assert.NoError(t, err)
+
+		var secret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &secret)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token-updated", string(secret.Data["token"]))
+	})
+
+	t.Run("list and get registry", func(t *testing.T) {
+		registries, err := ds.ListRegistries(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(registries))
+		assert.Equal(t, "test-token-updated", registries[0].Git.Token)
+
+		reg, err := ds.GetRegistry(ctx, "test-registry")
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token-updated", reg.Git.Token)
+	})
+
+	t.Run("delete registry", func(t *testing.T) {
+		err := ds.DeleteRegistry(ctx, "test-registry")
+		assert.NoError(t, err)
+
+		var cm v1.ConfigMap
+		err = client.Get(ctx, types.NamespacedName{Name: registryConfigMapName, Namespace: velatypes.DefaultKubeVelaNS}, &cm)
+		assert.NoError(t, err)
+		var registries map[string]Registry
+		err = json.Unmarshal([]byte(cm.Data[registriesKey]), &registries)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(registries))
+
+		var secret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &secret)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+	})
+}
+
+func TestAddRegistry(t *testing.T) {
+	t.Run("Test adding a registry", func(t *testing.T) {
+		ctx := context.Background()
+		testRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:   "http://github.com/test/repo",
+				Token: "test-token",
+			},
+		}
+		scheme := runtime.NewScheme()
+		v1.AddToScheme(scheme)
+		client := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ds := NewRegistryDataStore(client)
+
+		err := ds.AddRegistry(ctx, testRegistry)
+		assert.NoError(t, err)
+
+		var cm v1.ConfigMap
+		err = client.Get(ctx, types.NamespacedName{Name: registryConfigMapName, Namespace: velatypes.DefaultKubeVelaNS}, &cm)
+		assert.NoError(t, err)
+		var registries map[string]Registry
+		err = json.Unmarshal([]byte(cm.Data[registriesKey]), &registries)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(registries))
+		gotRegistry := registries["test-registry"]
+		assert.Equal(t, "", gotRegistry.Git.Token)
+		assert.Equal(t, "addon-registry-test-registry", gotRegistry.Git.TokenSecretRef)
+
+		var secret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &secret)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token", string(secret.Data["token"]))
+	})
+}
+
+func TestUpdateRegistry(t *testing.T) {
+	t.Run("Test updating a registry", func(t *testing.T) {
+		ctx := context.Background()
+		updatedRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:   "http://github.com/test/repo-updated",
+				Token: "test-token-updated",
+			},
+		}
+		// Pre-existing state
+		existingRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:            "http://github.com/test/repo",
+				TokenSecretRef: "addon-registry-test-registry",
+			},
+		}
+		registries := map[string]Registry{"test-registry": existingRegistry}
+		registriesBytes, err := json.Marshal(registries)
+		assert.NoError(t, err)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registryConfigMapName,
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string]string{
+				registriesKey: string(registriesBytes),
+			},
+		}
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-registry-test-registry",
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		v1.AddToScheme(scheme)
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
+		ds := NewRegistryDataStore(client)
+
+		err = ds.UpdateRegistry(ctx, updatedRegistry)
+		assert.NoError(t, err)
+
+		var updatedSecret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &updatedSecret)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token-updated", string(updatedSecret.Data["token"]))
+
+		var updatedCm v1.ConfigMap
+		err = client.Get(ctx, types.NamespacedName{Name: registryConfigMapName, Namespace: velatypes.DefaultKubeVelaNS}, &updatedCm)
+		assert.NoError(t, err)
+		var updatedRegistries map[string]Registry
+		err = json.Unmarshal([]byte(updatedCm.Data[registriesKey]), &updatedRegistries)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://github.com/test/repo-updated", updatedRegistries["test-registry"].Git.URL)
+	})
+}
+
+func TestListRegistry(t *testing.T) {
+	t.Run("Test listing registries", func(t *testing.T) {
+		ctx := context.Background()
+		// Pre-existing state
+		existingRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:            "http://github.com/test/repo",
+				TokenSecretRef: "addon-registry-test-registry",
+			},
+		}
+		registries := map[string]Registry{"test-registry": existingRegistry}
+		registriesBytes, err := json.Marshal(registries)
+		assert.NoError(t, err)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registryConfigMapName,
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string]string{
+				registriesKey: string(registriesBytes),
+			},
+		}
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-registry-test-registry",
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		v1.AddToScheme(scheme)
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
+		ds := NewRegistryDataStore(client)
+
+		// Test List
+		listedRegistries, err := ds.ListRegistries(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(listedRegistries))
+		assert.Equal(t, "test-token", listedRegistries[0].Git.Token)
+		assert.Equal(t, "http://github.com/test/repo", listedRegistries[0].Git.URL)
+	})
+}
+
+func TestGetRegistry(t *testing.T) {
+	t.Run("Test getting a single registry", func(t *testing.T) {
+		ctx := context.Background()
+		// Pre-existing state
+		existingRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:            "http://github.com/test/repo",
+				TokenSecretRef: "addon-registry-test-registry",
+			},
+		}
+		registries := map[string]Registry{"test-registry": existingRegistry}
+		registriesBytes, err := json.Marshal(registries)
+		assert.NoError(t, err)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registryConfigMapName,
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string]string{
+				registriesKey: string(registriesBytes),
+			},
+		}
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-registry-test-registry",
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		v1.AddToScheme(scheme)
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
+		ds := NewRegistryDataStore(client)
+
+		// Test Get
+		reg, err := ds.GetRegistry(ctx, "test-registry")
+		assert.NoError(t, err)
+		assert.Equal(t, "test-token", reg.Git.Token)
+		assert.Equal(t, "http://github.com/test/repo", reg.Git.URL)
+	})
+}
+
+func TestDeleteRegistry(t *testing.T) {
+	t.Run("Test deleting a registry", func(t *testing.T) {
+		ctx := context.Background()
+		// Pre-existing state
+		existingRegistry := Registry{
+			Name: "test-registry",
+			Git: &GitAddonSource{
+				URL:            "http://github.com/test/repo",
+				TokenSecretRef: "addon-registry-test-registry",
+			},
+		}
+		registries := map[string]Registry{"test-registry": existingRegistry}
+		registriesBytes, err := json.Marshal(registries)
+		assert.NoError(t, err)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registryConfigMapName,
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string]string{
+				registriesKey: string(registriesBytes),
+			},
+		}
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-registry-test-registry",
+				Namespace: velatypes.DefaultKubeVelaNS,
+			},
+			Data: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		v1.AddToScheme(scheme)
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
+		ds := NewRegistryDataStore(client)
+
+		err = ds.DeleteRegistry(ctx, "test-registry")
+		assert.NoError(t, err)
+
+		var updatedCm v1.ConfigMap
+		err = client.Get(ctx, types.NamespacedName{Name: registryConfigMapName, Namespace: velatypes.DefaultKubeVelaNS}, &updatedCm)
+		assert.NoError(t, err)
+		var updatedRegistries map[string]Registry
+		err = json.Unmarshal([]byte(updatedCm.Data[registriesKey]), &updatedRegistries)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(updatedRegistries))
+
+		var deletedSecret v1.Secret
+		err = client.Get(ctx, types.NamespacedName{Name: "addon-registry-test-registry", Namespace: velatypes.DefaultKubeVelaNS}, &deletedSecret)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+	})
+}

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -56,37 +56,31 @@ type Source interface {
 
 // GitAddonSource defines the information about the Git as addon source
 type GitAddonSource struct {
-	URL   string `json:"url,omitempty" validate:"required"`
-	Path  string `json:"path,omitempty"`
-	Token string `json:"token,omitempty"`
+	URL            string `json:"url,omitempty" validate:"required"`
+	Path           string `json:"path,omitempty"`
+	Token          string `json:"token,omitempty"`
+	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
 }
 
-// GiteeAddonSource defines the information about the Gitee as addon source
-type GiteeAddonSource struct {
-	URL   string `json:"url,omitempty" validate:"required"`
-	Path  string `json:"path,omitempty"`
-	Token string `json:"token,omitempty"`
+// GetToken return the token of the source
+func (g *GitAddonSource) GetToken() string {
+	return g.Token
 }
 
-// GitlabAddonSource defines the information about the Gitlab as addon source
-type GitlabAddonSource struct {
-	URL   string `json:"url,omitempty" validate:"required"`
-	Repo  string `json:"repo,omitempty" validate:"required"`
-	Path  string `json:"path,omitempty"`
-	Token string `json:"token,omitempty"`
+// SetToken set the token of the source
+func (g *GitAddonSource) SetToken(token string) {
+	g.Token = token
 }
 
-// HelmSource  defines the information about the helm repo addon source
-type HelmSource struct {
-	URL             string `json:"url,omitempty" validate:"required"`
-	InsecureSkipTLS bool   `json:"insecureSkipTLS,omitempty"`
-	Username        string `json:"username,omitempty"`
-	Password        string `json:"password,omitempty"`
+// SetTokenSecretRef set the token secret ref to the source
+func (g *GitAddonSource) SetTokenSecretRef(secretName string) {
+	g.Token = ""
+	g.TokenSecretRef = secretName
 }
 
-// SafeCopier is an interface to copy Struct without sensitive fields, such as Token, Username, Password
-type SafeCopier interface {
-	SafeCopy() interface{}
+// GetTokenSecretRef return the token secret ref of the source
+func (g *GitAddonSource) GetTokenSecretRef() string {
+	return g.TokenSecretRef
 }
 
 // SafeCopy hides field Token
@@ -100,6 +94,35 @@ func (g *GitAddonSource) SafeCopy() *GitAddonSource {
 	}
 }
 
+// GiteeAddonSource defines the information about the Gitee as addon source
+type GiteeAddonSource struct {
+	URL            string `json:"url,omitempty" validate:"required"`
+	Path           string `json:"path,omitempty"`
+	Token          string `json:"token,omitempty"`
+	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
+}
+
+// GetToken return the token of the source
+func (g *GiteeAddonSource) GetToken() string {
+	return g.Token
+}
+
+// SetToken set the token of the source
+func (g *GiteeAddonSource) SetToken(token string) {
+	g.Token = token
+}
+
+// SetTokenSecretRef set the token secret ref to the source
+func (g *GiteeAddonSource) SetTokenSecretRef(secretName string) {
+	g.Token = ""
+	g.TokenSecretRef = secretName
+}
+
+// GetTokenSecretRef return the token secret ref of the source
+func (g *GiteeAddonSource) GetTokenSecretRef() string {
+	return g.TokenSecretRef
+}
+
 // SafeCopy hides field Token
 func (g *GiteeAddonSource) SafeCopy() *GiteeAddonSource {
 	if g == nil {
@@ -109,6 +132,36 @@ func (g *GiteeAddonSource) SafeCopy() *GiteeAddonSource {
 		URL:  g.URL,
 		Path: g.Path,
 	}
+}
+
+// GitlabAddonSource defines the information about the Gitlab as addon source
+type GitlabAddonSource struct {
+	URL            string `json:"url,omitempty" validate:"required"`
+	Repo           string `json:"repo,omitempty" validate:"required"`
+	Path           string `json:"path,omitempty"`
+	Token          string `json:"token,omitempty"`
+	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
+}
+
+// GetToken return the token of the source
+func (g *GitlabAddonSource) GetToken() string {
+	return g.Token
+}
+
+// SetToken set the token of the source
+func (g *GitlabAddonSource) SetToken(token string) {
+	g.Token = token
+}
+
+// SetTokenSecretRef set the token secret ref to the source
+func (g *GitlabAddonSource) SetTokenSecretRef(secretName string) {
+	g.Token = ""
+	g.TokenSecretRef = secretName
+}
+
+// GetTokenSecretRef return the token secret ref of the source
+func (g *GitlabAddonSource) GetTokenSecretRef() string {
+	return g.TokenSecretRef
 }
 
 // SafeCopy hides field Token
@@ -121,6 +174,19 @@ func (g *GitlabAddonSource) SafeCopy() *GitlabAddonSource {
 		Repo: g.Repo,
 		Path: g.Path,
 	}
+}
+
+// HelmSource  defines the information about the helm repo addon source
+type HelmSource struct {
+	URL             string `json:"url,omitempty" validate:"required"`
+	InsecureSkipTLS bool   `json:"insecureSkipTLS,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
+}
+
+// SafeCopier is an interface to copy Struct without sensitive fields, such as Token, Username, Password
+type SafeCopier interface {
+	SafeCopy() interface{}
 }
 
 // SafeCopy hides field Username, Password


### PR DESCRIPTION
### Description

This pull request addresses the security concern of storing sensitive addon registry tokens in plaintext. It refactors the addon registry functionality to store tokens in Kubernetes Secrets, aligning with security best practices.

The implementation modifies the registry to no longer store the token directly in the `vela-addon-registry` ConfigMap. Instead, it creates a dedicated Secret for each token and stores only a reference to this Secret in the ConfigMap. The full lifecycle (create, update, read, delete) of the registry is updated to manage the corresponding Secret.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Related Issue
- Fixes #6836

### How has this code been tested

This change is thoroughly tested with a new test suite in `pkg/addon/registry_test.go`. The testing strategy includes:

- **Unit Tests:** Each function involved in the CRUD lifecycle (Add, Update, List, Get, Delete) has been given its own isolated unit test to verify the secret handling logic.
- **Integration Test:** A full, stateful integration test is included to simulate the entire user workflow, from adding a registry to deleting it, ensuring the token is managed securely at every step.

### Special notes for your reviewer

None.
