### PR TITLE
Fix: add KinD setup step to sync-sdk workflow

### DIFF
--- a/.github/workflows/sync-sdk.yaml
+++ b/.github/workflows/sync-sdk.yaml
@@ -28,9 +28,14 @@ jobs:
       - name: Install Go tools
         run: |
           make goimports
-          
+
       - name: Build CLI
         run: make vela-cli
+
+      - name: Setup KinD
+        uses: ./.github/actions/setup-kind-cluster
+        with:
+          name: sync-sdk
 
       - name: Get the version
         id: get_version


### PR DESCRIPTION
## Fix: Sync SDK Workflow Kubernetes Configuration Issue

### Problem
The `sync-sdk.yaml` workflow was failing with the error:

`Error: failed to get client: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable`

This occurred when running `bash ./hack/sdk/sync.sh` because the `bin/vela def gen-api` command requires access to a Kubernetes cluster to generate API definitions.

### Changes Made
- Fixed the Kubernetes cluster access issue in the sync SDK workflow

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.