### PR TITLE
Chore: update homebrew bump action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Update kubectl plugin version in krew-index
         uses: rajatjindal/krew-release-bot@df3eb197549e3568be8b4767eec31c5e8e8e6ad8 # v0.0.46
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3428a0601bba3173ec0bdcc945be23fa27aa4c31 #v5
+        uses: dawidd6/action-homebrew-bump-formula@3428a0601bba3173ec0bdcc945be23fa27aa4c31 #v5
         with:
           token: ${{ secrets.HOMEBREW_TOKEN }}
           formula: kubevela

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,6 @@ jobs:
 
       - name: Update kubectl plugin version in krew-index
         uses: rajatjindal/krew-release-bot@df3eb197549e3568be8b4767eec31c5e8e8e6ad8 # v0.0.46
-      - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@3428a0601bba3173ec0bdcc945be23fa27aa4c31 #v5
-        with:
-          token: ${{ secrets.HOMEBREW_TOKEN }}
-          formula: kubevela
-          tag: ${{ github.ref }}
-          revision: ${{ github.sha }}
-          force: false
 
   provenance-vela-bins:
     name: generate provenance for binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
       - name: Update kubectl plugin version in krew-index
         uses: rajatjindal/krew-release-bot@df3eb197549e3568be8b4767eec31c5e8e8e6ad8 # v0.0.46
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@d3667e5ae14df19579e4414897498e3e88f2f458 # v3.10.0
+        uses: dawidd6/action-homebrew-bump-formula@v3428a0601bba3173ec0bdcc945be23fa27aa4c31 #v5
         with:
           token: ${{ secrets.HOMEBREW_TOKEN }}
           formula: kubevela


### PR DESCRIPTION
### Description of your changes

This fixes the failure in the release workflow —
[`Error: Tapping homebrew/core is no longer typically necessary.`](https://github.com/kubevela/kubevela/actions/runs/18149681613/job/51659048948) —
by updating the `dawidd6/action-homebrew-bump-formula` action version to `v5`.

While addressing this, another Homebrew check surfaced:
the `kubevela` formula in `homebrew-core` is already auto-bumped by **BrewTestBot** every few hours. This caused manual bump attempts to fail with:

> “Whoops, the kubevela formula has its version update pull requests automatically opened by BrewTestBot.”

To handle this cleanly, the redundant **manual Homebrew bump step** has been **removed** from the release workflow.
BrewTestBot will continue to automatically open formula update PRs within a few hours of each release tag, [reference](https://github.com/Homebrew/homebrew-core/blob/master/Formula/k/kubevela.rb)

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Validated that the updated workflow no longer attempts a manual bump.
Confirmed that BrewTestBot independently handles formula updates after tagging, keeping the release flow simpler and conflict-free.