### PR TITLE
Feat: Delay Rendering for PostDispatch Traits

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -191,6 +191,7 @@ func (in ApplicationComponentStatus) Equal(r ApplicationComponentStatus) bool {
 type ApplicationTraitStatus struct {
 	Type    string            `json:"type"`
 	Healthy bool              `json:"healthy"`
+	Pending bool              `json:"pending,omitempty"`
 	Details map[string]string `json:"details,omitempty"`
 	Message string            `json:"message,omitempty"`
 }

--- a/apis/types/componentmanifest.go
+++ b/apis/types/componentmanifest.go
@@ -30,4 +30,7 @@ type ComponentManifest struct {
 	ComponentOutput *unstructured.Unstructured
 	// ComponentOutputsAndTraits contains both resources generated from "outputs" block of ComponentDefinition and resources generated from TraitDefinition
 	ComponentOutputsAndTraits []*unstructured.Unstructured
+	// DeferredTraits contains traits that should be rendered later (PostDispatch)
+	// This is []interface{} to avoid import cycles, but contains *appfile.Trait objects
+	DeferredTraits []interface{}
 }

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -632,6 +632,8 @@ spec:
                                     type: boolean
                                   message:
                                     type: string
+                                  pending:
+                                    type: boolean
                                   type:
                                     type: string
                                 required:

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -580,6 +580,8 @@ spec:
                             type: boolean
                           message:
                             type: string
+                          pending:
+                            type: boolean
                           type:
                             type: string
                         required:

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
@@ -517,6 +517,10 @@ func isHealthy(services []common.ApplicationComponentStatus) bool {
 			return false
 		}
 		for _, tr := range service.Traits {
+			// Skip pending traits when evaluating application health
+			if tr.Pending {
+				continue
+			}
 			if !tr.Healthy {
 				return false
 			}

--- a/pkg/controller/core.oam.dev/v1beta1/application/dispatcher_lazy_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/dispatcher_lazy_test.go
@@ -1,0 +1,839 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/appfile"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestLazyRenderingPostDispatchTraits(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MultiStageComponentApply, true)
+
+	tests := []struct {
+		name                   string
+		traits                 []appfile.Trait
+		traitDefinitions       map[string]*v1beta1.TraitDefinition
+		expectedImmediateCount int
+		expectedDeferredCount  int
+	}{
+		{
+			name: "separate PostDispatch traits",
+			traits: []appfile.Trait{
+				{Name: "normal-trait"},
+				{Name: "postdispatch-trait"},
+				{Name: "predispatch-trait"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"normal-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.DefaultDispatch,
+					},
+				},
+				"postdispatch-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+				"predispatch-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PreDispatch,
+					},
+				},
+			},
+			expectedImmediateCount: 2, // normal and predispatch
+			expectedDeferredCount:  1, // postdispatch
+		},
+		{
+			name: "all PostDispatch traits",
+			traits: []appfile.Trait{
+				{Name: "postdispatch-trait-1"},
+				{Name: "postdispatch-trait-2"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"postdispatch-trait-1": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+				"postdispatch-trait-2": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+			},
+			expectedImmediateCount: 0,
+			expectedDeferredCount:  2,
+		},
+		{
+			name: "no PostDispatch traits",
+			traits: []appfile.Trait{
+				{Name: "normal-trait-1"},
+				{Name: "normal-trait-2"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"normal-trait-1": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.DefaultDispatch,
+					},
+				},
+				"normal-trait-2": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PreDispatch,
+					},
+				},
+			},
+			expectedImmediateCount: 2,
+			expectedDeferredCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test trait separation logic
+			var immediateTraits []appfile.Trait
+			var deferredTraits []interface{}
+
+			for _, tr := range tt.traits {
+				// Simulate getTraitDispatchStage
+				traitDef, ok := tt.traitDefinitions[tr.Name]
+				var stage StageType
+				if ok && traitDef.Spec.Stage == v1beta1.PostDispatch {
+					stage = PostDispatch
+				} else if ok && traitDef.Spec.Stage == v1beta1.PreDispatch {
+					stage = PreDispatch
+				} else {
+					stage = DefaultDispatch
+				}
+
+				if stage == PostDispatch {
+					traitCopy := tr
+					deferredTraits = append(deferredTraits, &traitCopy)
+				} else {
+					immediateTraits = append(immediateTraits, tr)
+				}
+			}
+
+			assert.Equal(t, tt.expectedImmediateCount, len(immediateTraits), "immediate traits count mismatch")
+			assert.Equal(t, tt.expectedDeferredCount, len(deferredTraits), "deferred traits count mismatch")
+		})
+	}
+}
+
+func TestFetchComponentStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		workload       *unstructured.Unstructured
+		expectedStatus map[string]interface{}
+		expectError    bool
+	}{
+		{
+			name: "deployment with status",
+			workload: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "default",
+					},
+					"status": map[string]interface{}{
+						"replicas":          3,
+						"readyReplicas":     3,
+						"availableReplicas": 3,
+					},
+				},
+			},
+			expectedStatus: map[string]interface{}{
+				"replicas":          3,
+				"readyReplicas":     3,
+				"availableReplicas": 3,
+			},
+			expectError: false,
+		},
+		{
+			name: "workload without status",
+			workload: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test-cm",
+						"namespace": "default",
+					},
+				},
+			},
+			expectedStatus: map[string]interface{}{},
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, found, _ := unstructured.NestedFieldNoCopy(tt.workload.Object, "status")
+			if !found {
+				status = map[string]interface{}{}
+			}
+
+			statusMap, ok := status.(map[string]interface{})
+			if !ok {
+				statusMap = map[string]interface{}{}
+			}
+
+			assert.Equal(t, tt.expectedStatus, statusMap, "status mismatch")
+		})
+	}
+}
+
+func TestManifestWithDeferredTraits(t *testing.T) {
+	manifest := &types.ComponentManifest{
+		Name:      "test-component",
+		Namespace: "default",
+	}
+
+	deferredTraits := []interface{}{
+		&appfile.Trait{Name: "status-reader"},
+		&appfile.Trait{Name: "another-postdispatch"},
+	}
+
+	manifest.DeferredTraits = deferredTraits
+
+	assert.Equal(t, 2, len(manifest.DeferredTraits), "deferred traits not stored correctly")
+
+	for i, dt := range manifest.DeferredTraits {
+		trait, ok := dt.(*appfile.Trait)
+		assert.True(t, ok, "deferred trait type assertion failed")
+		if i == 0 {
+			assert.Equal(t, "status-reader", trait.Name)
+		} else {
+			assert.Equal(t, "another-postdispatch", trait.Name)
+		}
+	}
+}
+
+func TestPostDispatchWithOutputsStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	deployment := createDeploymentWithStatus("test-deployment", "default", 3)
+	service := createServiceWithLoadBalancer("test-service", "default", "192.168.1.1")
+	ingress := createIngressWithLoadBalancer("test-ingress", "default", "203.0.113.1")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deployment, service, ingress).
+		Build()
+
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+	}
+
+	appRev := &v1beta1.ApplicationRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app-v1",
+			Namespace: "default",
+		},
+	}
+
+	h := &AppHandler{
+		Client:        fakeClient,
+		app:           app,
+		currentAppRev: appRev,
+	}
+
+	comp := &appfile.Component{
+		Name: "test-comp",
+		Type: "webservice",
+	}
+
+	outputs := []string{"service", "ingress"}
+	_ = outputs
+
+	ctx := context.Background()
+
+	workloadStatus, err := h.fetchComponentStatus(ctx, deployment, "", "")
+	assert.NoError(t, err)
+	assert.NotNil(t, workloadStatus)
+	assert.Equal(t, int64(3), workloadStatus["replicas"])
+
+	t.Run("PostDispatch trait can access outputs status", func(t *testing.T) {
+		manifest := &types.ComponentManifest{
+			Name:            comp.Name,
+			Namespace:       "default",
+			ComponentOutput: deployment,
+			ComponentOutputsAndTraits: []*unstructured.Unstructured{
+				service,
+				ingress,
+			},
+			DeferredTraits: []interface{}{
+				&appfile.Trait{Name: "test-postdispatch"},
+			},
+		}
+
+		service.SetLabels(map[string]string{
+			oam.TraitResource: "service",
+		})
+		ingress.SetLabels(map[string]string{
+			oam.TraitResource: "ingress",
+		})
+
+		outputsStatus, err := h.fetchComponentOutputsStatus(ctx, manifest.ComponentOutputsAndTraits, "", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, outputsStatus)
+
+		assert.Contains(t, outputsStatus, "service")
+		assert.Contains(t, outputsStatus, "ingress")
+
+		verifyServiceStatus(t, outputsStatus["service"].(map[string]interface{}), "192.168.1.1")
+		verifyIngressStatus(t, outputsStatus["ingress"].(map[string]interface{}), "203.0.113.1")
+	})
+}
+
+// Helper functions for creating test resources
+
+func createDeploymentWithStatus(name, namespace string, replicas int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]interface{}{
+				"replicas":          replicas,
+				"readyReplicas":     replicas,
+				"availableReplicas": replicas,
+			},
+		},
+	}
+}
+
+func createServiceWithLoadBalancer(name, namespace, ip string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterIP": "10.0.0.1",
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port":       int64(80),
+						"targetPort": int64(8080),
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"loadBalancer": map[string]interface{}{
+					"ingress": []interface{}{
+						map[string]interface{}{
+							"ip": ip,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createIngressWithLoadBalancer(name, namespace, ip string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking.k8s.io/v1",
+			"kind":       "Ingress",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"rules": []interface{}{
+					map[string]interface{}{
+						"host": "example.com",
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"loadBalancer": map[string]interface{}{
+					"ingress": []interface{}{
+						map[string]interface{}{
+							"ip": ip,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func verifyServiceStatus(t *testing.T, serviceObj map[string]interface{}, expectedIP string) {
+	serviceStatus := serviceObj["status"].(map[string]interface{})
+	serviceLB := serviceStatus["loadBalancer"].(map[string]interface{})
+	serviceIngress := serviceLB["ingress"].([]interface{})
+	actualIP := serviceIngress[0].(map[string]interface{})["ip"]
+	assert.Equal(t, expectedIP, actualIP)
+}
+
+func verifyIngressStatus(t *testing.T, ingressObj map[string]interface{}, expectedIP string) {
+	ingressStatus := ingressObj["status"].(map[string]interface{})
+	ingressLB := ingressStatus["loadBalancer"].(map[string]interface{})
+	ingresses := ingressLB["ingress"].([]interface{})
+	actualIP := ingresses[0].(map[string]interface{})["ip"]
+	assert.Equal(t, expectedIP, actualIP)
+}
+
+func TestDispatcherWithPostDispatchStage(t *testing.T) {
+	dispatcher := &manifestDispatcher{
+		stage: PostDispatch,
+	}
+
+	assert.Equal(t, PostDispatch, dispatcher.stage, "dispatcher stage not set correctly")
+
+	stages := []StageType{PostDispatch, PreDispatch, DefaultDispatch}
+	expectedOrder := []StageType{PreDispatch, DefaultDispatch, PostDispatch}
+
+	options := SortDispatchOptions{
+		{Stage: stages[0]},
+		{Stage: stages[1]},
+		{Stage: stages[2]},
+	}
+
+	for i := 0; i < len(options); i++ {
+		for j := i + 1; j < len(options); j++ {
+			if options[i].Stage > options[j].Stage {
+				options[i], options[j] = options[j], options[i]
+			}
+		}
+	}
+
+	for i, opt := range options {
+		assert.Equal(t, expectedOrder[i], opt.Stage, "stage order mismatch at index %d", i)
+	}
+}
+
+func TestPostDispatchTraitHealthStatus(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MultiStageComponentApply, true)
+
+	tests := []struct {
+		name                string
+		stage               StageType
+		deferredTraits      []interface{}
+		renderedTraits      []*unstructured.Unstructured
+		existingResources   []client.Object
+		expectedTraitStatus []common.ApplicationTraitStatus
+		expectedHealthy     bool
+	}{
+		{
+			name:  "PostDispatch traits shown as waiting in DefaultDispatch stage",
+			stage: DefaultDispatch,
+			deferredTraits: []interface{}{
+				&appfile.Trait{Name: "my-trait"},
+			},
+			expectedTraitStatus: []common.ApplicationTraitStatus{
+				{
+					Type:    "my-trait",
+					Healthy: false,
+					Message: "PostDispatch: waiting for component to be healthy",
+				},
+			},
+			expectedHealthy: true, // Component itself is healthy
+		},
+		{
+			name:  "PostDispatch traits evaluated when deployed",
+			stage: PostDispatch,
+			renderedTraits: []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "my-component-configmap",
+							"namespace": "default",
+							"labels": map[string]interface{}{
+								oam.TraitTypeLabel: "my-trait",
+							},
+						},
+					},
+				},
+			},
+			existingResources: []client.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "my-component-configmap",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			expectedTraitStatus: []common.ApplicationTraitStatus{
+				{
+					Type:    "my-trait",
+					Healthy: true,
+					Message: "",
+				},
+			},
+			expectedHealthy: true,
+		},
+		{
+			name:  "PostDispatch trait unhealthy when not found",
+			stage: PostDispatch,
+			renderedTraits: []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "my-component-configmap",
+							"namespace": "default",
+							"labels": map[string]interface{}{
+								oam.TraitTypeLabel: "my-trait",
+							},
+						},
+					},
+				},
+			},
+			existingResources: []client.Object{}, // Resource doesn't exist
+			expectedTraitStatus: []common.ApplicationTraitStatus{
+				{
+					Type:    "my-trait",
+					Healthy: false,
+					Message: "Trait not found",
+				},
+			},
+			expectedHealthy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with existing resources
+			scheme := runtime.NewScheme()
+			_ = v1beta1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingResources...).Build()
+
+			// Create AppHandler
+			h := &AppHandler{
+				Client: fakeClient,
+				app: &v1beta1.Application{
+					Spec: v1beta1.ApplicationSpec{
+						Components: []common.ApplicationComponent{
+							{
+								Name: "my-component",
+							},
+						},
+					},
+				},
+			}
+
+			// Create component
+			comp := &appfile.Component{
+				Name:   "my-component",
+				Traits: []*appfile.Trait{},
+			}
+
+			// Create manifest with deferred traits
+			manifest := &types.ComponentManifest{
+				Name:           "my-component",
+				Namespace:      "default",
+				DeferredTraits: tt.deferredTraits,
+			}
+
+			// These variables are used but not needed for this test
+			_ = comp
+			_ = manifest
+
+			// Simulate health status collection
+			status := &common.ApplicationComponentStatus{
+				Name:      "my-component",
+				Namespace: "default",
+				Healthy:   true,
+				Traits:    []common.ApplicationTraitStatus{},
+			}
+
+			ctx := context.Background()
+
+			// Add PostDispatch trait status based on stage
+			if tt.stage != PostDispatch && len(tt.deferredTraits) > 0 {
+				// We're in an earlier stage - show deferred traits as waiting
+				for _, deferredTrait := range tt.deferredTraits {
+					if trait, ok := deferredTrait.(*appfile.Trait); ok && trait != nil {
+						traitStatus := common.ApplicationTraitStatus{
+							Type:    trait.Name,
+							Healthy: false,
+							Message: "PostDispatch: waiting for component to be healthy",
+						}
+						status.Traits = append(status.Traits, traitStatus)
+					}
+				}
+			} else if tt.stage == PostDispatch && len(tt.renderedTraits) > 0 {
+				// We're in PostDispatch stage - evaluate actual traits
+				isHealth := true
+				for _, trait := range tt.renderedTraits {
+					traitName := trait.GetLabels()[oam.TraitTypeLabel]
+					if traitName != "" {
+						traitHealthy := true
+						traitMessage := ""
+
+						// Get the trait from cluster to check its actual status
+						currentTrait := &unstructured.Unstructured{}
+						currentTrait.SetGroupVersionKind(trait.GroupVersionKind())
+						currentTrait.SetName(trait.GetName())
+						currentTrait.SetNamespace(trait.GetNamespace())
+
+						err := h.Client.Get(ctx, client.ObjectKey{
+							Name:      currentTrait.GetName(),
+							Namespace: currentTrait.GetNamespace(),
+						}, currentTrait)
+
+						if err != nil {
+							traitHealthy = false
+							if client.IgnoreNotFound(err) == nil {
+								traitMessage = "Trait not found"
+							} else {
+								traitMessage = "Failed to get trait"
+							}
+						}
+
+						traitStatus := common.ApplicationTraitStatus{
+							Type:    traitName,
+							Healthy: traitHealthy,
+							Message: traitMessage,
+						}
+						status.Traits = append(status.Traits, traitStatus)
+
+						if !traitHealthy {
+							isHealth = false
+						}
+					}
+				}
+				status.Healthy = isHealth
+			}
+
+			// Verify results
+			assert.Equal(t, len(tt.expectedTraitStatus), len(status.Traits), "trait count mismatch")
+			for i, expected := range tt.expectedTraitStatus {
+				if i < len(status.Traits) {
+					assert.Equal(t, expected.Type, status.Traits[i].Type, "trait type mismatch")
+					assert.Equal(t, expected.Healthy, status.Traits[i].Healthy, "trait health mismatch")
+					assert.Equal(t, expected.Message, status.Traits[i].Message, "trait message mismatch")
+				}
+			}
+			if tt.stage == PostDispatch {
+				assert.Equal(t, tt.expectedHealthy, status.Healthy, "overall health mismatch")
+			}
+		})
+	}
+}
+
+func TestGeneratorDeferPostDispatchTraits(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MultiStageComponentApply, true)
+
+	tests := []struct {
+		name                  string
+		inputTraits           []*appfile.Trait
+		traitDefinitions      map[string]*v1beta1.TraitDefinition
+		expectedRenderCount   int // Traits that should be rendered immediately
+		expectedDeferredCount int // Traits that should be deferred
+	}{
+		{
+			name: "defer PostDispatch traits during generation",
+			inputTraits: []*appfile.Trait{
+				{Name: "normal-trait"},
+				{Name: "postdispatch-trait"},
+				{Name: "predispatch-trait"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"normal-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.DefaultDispatch,
+					},
+				},
+				"postdispatch-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+				"predispatch-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PreDispatch,
+					},
+				},
+			},
+			expectedRenderCount:   2, // normal and predispatch should be rendered
+			expectedDeferredCount: 1, // postdispatch should be deferred
+		},
+		{
+			name: "all PostDispatch traits deferred",
+			inputTraits: []*appfile.Trait{
+				{Name: "postdispatch-1"},
+				{Name: "postdispatch-2"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"postdispatch-1": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+				"postdispatch-2": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PostDispatch,
+					},
+				},
+			},
+			expectedRenderCount:   0, // All should be deferred
+			expectedDeferredCount: 2,
+		},
+		{
+			name: "no PostDispatch traits",
+			inputTraits: []*appfile.Trait{
+				{Name: "normal-trait"},
+				{Name: "predispatch-trait"},
+			},
+			traitDefinitions: map[string]*v1beta1.TraitDefinition{
+				"normal-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.DefaultDispatch,
+					},
+				},
+				"predispatch-trait": {
+					Spec: v1beta1.TraitDefinitionSpec{
+						Stage: v1beta1.PreDispatch,
+					},
+				},
+			},
+			expectedRenderCount:   2, // All should be rendered
+			expectedDeferredCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the generator logic
+			var immediateTraits []*appfile.Trait
+			var deferredTraits []interface{}
+
+			// This simulates the logic in generator.go
+			for _, tr := range tt.inputTraits {
+				traitDef, ok := tt.traitDefinitions[tr.Name]
+				if ok && traitDef.Spec.Stage == v1beta1.PostDispatch {
+					// PostDispatch trait - defer it
+					deferredTraits = append(deferredTraits, tr)
+				} else {
+					// Other traits - render immediately
+					immediateTraits = append(immediateTraits, tr)
+				}
+			}
+
+			// Verify the separation
+			assert.Equal(t, tt.expectedRenderCount, len(immediateTraits), "immediate traits count mismatch")
+			assert.Equal(t, tt.expectedDeferredCount, len(deferredTraits), "deferred traits count mismatch")
+
+			// Verify trait names are preserved
+			for _, tr := range immediateTraits {
+				assert.NotEmpty(t, tr.Name, "immediate trait should have name")
+			}
+
+			for _, dt := range deferredTraits {
+				trait, ok := dt.(*appfile.Trait)
+				assert.True(t, ok, "deferred trait should be *appfile.Trait")
+				assert.NotEmpty(t, trait.Name, "deferred trait should have name")
+			}
+		})
+	}
+}
+
+func TestRenderPostDispatchTraitsWithStatus(t *testing.T) {
+	// Test that PostDispatch traits can be rendered with component status
+	tests := []struct {
+		name            string
+		componentStatus map[string]interface{}
+		deferredTraits  []interface{}
+		expectError     bool
+		expectedContext string // Expected substring in context
+	}{
+		{
+			name: "render trait with deployment status",
+			componentStatus: map[string]interface{}{
+				"replicas":          3,
+				"readyReplicas":     3,
+				"availableReplicas": 3,
+			},
+			deferredTraits: []interface{}{
+				&appfile.Trait{
+					Name: "status-reader",
+				},
+			},
+			expectError:     false,
+			expectedContext: `"readyReplicas":3`,
+		},
+		{
+			name:            "render trait with empty status",
+			componentStatus: map[string]interface{}{},
+			deferredTraits: []interface{}{
+				&appfile.Trait{
+					Name: "status-reader",
+				},
+			},
+			expectError:     false,
+			expectedContext: `"status":{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This is a simplified test - in reality, renderPostDispatchTraits
+			// would need a full CUE context and trait definitions
+			// Here we just verify the status injection logic
+
+			// Verify status can be marshaled to JSON
+			statusJSON, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&map[string]interface{}{
+				"status": tt.componentStatus,
+			})
+			assert.NoError(t, err)
+
+			// Check that status contains expected data
+			if tt.expectedContext != "" {
+				assert.NotNil(t, statusJSON["status"])
+			}
+		})
+	}
+}

--- a/pkg/controller/core.oam.dev/v1beta1/application/evalstatus_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/evalstatus_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	oamprovidertypes "github.com/oam-dev/kubevela/pkg/workflow/providers/types"
 )
 
 func Test_applyComponentHealthToServices(t *testing.T) {
@@ -168,9 +169,9 @@ func Test_applyComponentHealthToServices(t *testing.T) {
 				componentMap[component.Name] = component
 			}
 
-			mockHealthCheck := func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+			mockHealthCheck := func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (oamprovidertypes.ComponentHealthStatus, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 				status := tt.healthCheckFunc(comp.Name)
-				return false, status, nil, nil, nil
+				return oamprovidertypes.ComponentUnhealthy, status, nil, nil, nil
 			}
 
 			applyComponentHealthToServices(ctx, handler, componentMap, mockHealthCheck)

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,7 +54,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
-	"github.com/oam-dev/kubevela/pkg/oam/util"
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
 	oamprovidertypes "github.com/oam-dev/kubevela/pkg/workflow/providers/types"
@@ -99,7 +100,7 @@ func (h *AppHandler) GenerateApplicationSteps(ctx monitorContext.Context,
 		},
 		ConfigFactory: config.NewConfigFactoryWithDispatcher(h.Client, func(ctx context.Context, resources []*unstructured.Unstructured, applyOptions []apply.ApplyOption) error {
 			for _, res := range resources {
-				res.SetLabels(util.MergeMapOverrideWithDst(res.GetLabels(), appLabels))
+				res.SetLabels(oamutil.MergeMapOverrideWithDst(res.GetLabels(), appLabels))
 			}
 			return h.resourceKeeper.Dispatch(ctx, resources, applyOptions)
 		}),
@@ -281,7 +282,7 @@ func convertStepProperties(step *workflowv1alpha1.WorkflowStep, app *v1beta1.App
 			if o.Namespace != "" {
 				stepProperties["namespace"] = o.Namespace
 			}
-			step.Properties = util.Object2RawExtension(stepProperties)
+			step.Properties = oamutil.Object2RawExtension(stepProperties)
 			return nil
 		}
 	}
@@ -372,13 +373,13 @@ func (h *AppHandler) applyComponentFunc(appParser *appfile.Parser, af *appfile.A
 
 		isHealth := true
 		if utilfeature.DefaultMutableFeatureGate.Enabled(features.MultiStageComponentApply) {
-			manifestDispatchers, err := h.generateDispatcher(appRev, readyWorkload, readyTraits, overrideNamespace, af.AppAnnotations)
+			manifestDispatchers, err := h.generateDispatcher(appRev, readyWorkload, readyTraits, manifest, overrideNamespace, af.AppAnnotations)
 			if err != nil {
 				return nil, nil, false, errors.WithMessage(err, "generateDispatcher")
 			}
 
 			for _, dispatcher := range manifestDispatchers {
-				if isHealth, err := dispatcher.run(ctx, wl, appRev, clusterName); !isHealth || err != nil {
+				if isHealth, err := dispatcher.run(ctx, wl, manifest, appRev, clusterName); !isHealth || err != nil {
 					return nil, nil, false, err
 				}
 			}
@@ -429,7 +430,17 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "ParseWorkload")
 	}
+
 	wl.Patch = patcher
+
+	// Check if MultiStageComponentApply is enabled and separate PostDispatch traits
+	var deferredTraits []interface{}
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.MultiStageComponentApply) {
+		immediateTraits, deferredTr := h.separateTraitsByStage(wl.Traits, af.AppAnnotations)
+		wl.Traits = immediateTraits
+		deferredTraits = deferredTr
+	}
+
 	manifest, err := af.GenerateComponentManifest(wl, func(ctxData *velaprocess.ContextData) {
 		if ns := componentNamespaceFromContext(ctx); ns != "" {
 			ctxData.Namespace = ns
@@ -451,6 +462,12 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 	if err := af.SetOAMContract(manifest); err != nil {
 		return nil, nil, errors.WithMessage(err, "SetOAMContract")
 	}
+
+	// Attach deferred traits to manifest if any
+	if len(deferredTraits) > 0 {
+		manifest.DeferredTraits = deferredTraits
+	}
+
 	return wl, manifest, nil
 }
 
@@ -528,4 +545,109 @@ func generateContextDataFromApp(app *v1beta1.Application, appRev string) velapro
 		data.AppAnnotations = app.Annotations
 	}
 	return data
+}
+
+// separateTraitsByStage splits traits by dispatch stage
+func (h *AppHandler) separateTraitsByStage(traits []*appfile.Trait, annotations map[string]string) ([]*appfile.Trait, []interface{}) {
+	var immediateTraits []*appfile.Trait
+	var deferredTraits []interface{}
+
+	for _, tr := range traits {
+		// Check if this trait is PostDispatch
+		stage, err := getTraitDispatchStage(h.Client, tr.Name, h.currentAppRev, annotations)
+		if err == nil && stage == PostDispatch {
+			// Store this trait for later rendering
+			deferredTraits = append(deferredTraits, tr)
+		} else {
+			// Render this trait immediately
+			immediateTraits = append(immediateTraits, tr)
+		}
+	}
+
+	return immediateTraits, deferredTraits
+}
+
+// renderPostDispatchTraits renders deferred traits with status
+func (h *AppHandler) renderPostDispatchTraits(_ context.Context, comp *appfile.Component,
+	wlOutputStatus map[string]interface{}, wlOutputsStatus map[string]interface{}, deferredTraits []interface{}, appRev *v1beta1.ApplicationRevision, overrideNamespace string) ([]*unstructured.Unstructured, error) {
+
+	var renderedTraits []*unstructured.Unstructured
+
+	// Create Appfile for proper namespace resolution
+	namespace := h.app.Namespace
+	if overrideNamespace != "" {
+		namespace = overrideNamespace
+	}
+	af := &appfile.Appfile{
+		Name:            h.app.Name,
+		Namespace:       namespace,
+		AppRevisionName: appRev.Name,
+	}
+
+	for _, dt := range deferredTraits {
+		trait, ok := dt.(*appfile.Trait)
+		if !ok {
+			klog.Warningf("Expected *appfile.Trait but got %T", dt)
+			continue
+		}
+
+		ctxData := appfile.GenerateContextDataFromAppFile(af, comp.Name)
+
+		if overrideNamespace != "" {
+			ctxData.Namespace = overrideNamespace
+		}
+
+		pCtx := appfile.NewBasicContext(ctxData, comp.Params)
+
+		// Inject the component workload status - available as `context.output.status` in CUE
+		if wlOutputStatus != nil {
+			outputData := map[string]interface{}{
+				"status": wlOutputStatus,
+			}
+			pCtx.PushData("output", outputData)
+		}
+
+		// Inject outputs status - available as `context.outputs.<name>` in CUE
+		if len(wlOutputsStatus) > 0 {
+			pCtx.PushData("outputs", wlOutputsStatus)
+		}
+
+		pCtx.PushData(velaprocess.ContextComponentType, comp.Type)
+
+		if err := trait.EvalContext(pCtx); err != nil {
+			return nil, errors.Wrapf(err, "failed to evaluate PostDispatch trait %s with status", trait.Name)
+		}
+
+		_, assists := pCtx.Output()
+
+		for _, assist := range assists {
+			tr, err := assist.Ins.Unstructured()
+			if err != nil {
+				klog.Warningf("Failed to get unstructured for assist %s: %v", assist.Name, err)
+				continue
+			}
+
+			// Set namespace using same logic as Appfile.setNamespace
+			// Skip namespace resources
+			gvk := tr.GetObjectKind().GroupVersionKind()
+			if gvk.Kind != "Namespace" && tr.GetNamespace() == "" {
+				tr.SetNamespace(af.Namespace)
+			}
+
+			labels := map[string]string{
+				oam.LabelAppName:      h.app.Name,
+				oam.LabelAppNamespace: h.app.Namespace,
+				oam.LabelAppComponent: comp.Name,
+				oam.TraitTypeLabel:    trait.Name,
+			}
+			if assist.Name != "" {
+				labels[oam.TraitResource] = assist.Name
+			}
+			oamutil.AddLabels(tr, labels)
+
+			renderedTraits = append(renderedTraits, tr)
+		}
+	}
+
+	return renderedTraits, nil
 }

--- a/pkg/controller/core.oam.dev/v1beta1/application/testdata/app-with-postdispatch-status-trait.yaml
+++ b/pkg/controller/core.oam.dev/v1beta1/application/testdata/app-with-postdispatch-status-trait.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-with-postdispatch-status
+  namespace: default
+spec:
+  components:
+    - name: test-deployment
+      type: webservice
+      properties:
+        image: nginx:1.21
+        port: 80
+        cpu: "100m"
+        memory: "128Mi"
+      traits:
+        - type: status-reader-postdispatch
+          # This trait will be applied after the component is healthy
+          # and will have access to output.status

--- a/pkg/controller/core.oam.dev/v1beta1/application/testdata/definitions/status-reader-postdispatch.yaml
+++ b/pkg/controller/core.oam.dev/v1beta1/application/testdata/definitions/status-reader-postdispatch.yaml
@@ -1,0 +1,39 @@
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: "Read component status and create a ConfigMap with PostDispatch stage"
+  name: status-reader-postdispatch
+  namespace: vela-system
+spec:
+  appliesToWorkloads:
+    - "*"
+  podDisruptive: false
+  stage: PostDispatch
+  schematic:
+    cue:
+      template: |
+        outputs: statusconfig: {
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          metadata: {
+            name: context.name + "-status"
+            namespace: context.namespace
+          }
+          data: {
+            // This will work because output.status is available in PostDispatch
+            "component": context.name
+            if output.status != _|_ {
+              if output.status.ready != _|_ {
+                "ready": "\(output.status.ready)"
+              }
+              if output.status.replicas != _|_ {
+                "replicas": "\(output.status.replicas)"
+              }
+              if output.status.availableReplicas != _|_ {
+                "availableReplicas": "\(output.status.availableReplicas)"
+              }
+            }
+          }
+        }
+        parameter: {}

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -835,3 +835,11 @@ func (accessor *applicationResourceNamespaceAccessor) Namespace() string {
 func NewApplicationResourceNamespaceAccessor(appNs, overrideNs string) NamespaceAccessor {
 	return &applicationResourceNamespaceAccessor{applicationNamespace: appNs, overrideNamespace: overrideNs}
 }
+
+// ResolveNamespace returns override namespace if provided, otherwise returns original namespace
+func ResolveNamespace(original, override string) string {
+	if override != "" {
+		return override
+	}
+	return original
+}

--- a/pkg/utils/types/health_status.go
+++ b/pkg/utils/types/health_status.go
@@ -28,6 +28,8 @@ const (
 	HealthStatusProgressing HealthStatusCode = "Progressing"
 	// HealthStatusUnKnown health status is unknown
 	HealthStatusUnKnown HealthStatusCode = "UnKnown"
+	// HealthStatusWaitingPostDispatch component is healthy but waiting for PostDispatch traits
+	HealthStatusWaitingPostDispatch HealthStatusCode = "WaitingPostDispatch"
 )
 
 // HealthStatus the resource health status

--- a/pkg/workflow/providers/legacy/multicluster/deploy.go
+++ b/pkg/workflow/providers/legacy/multicluster/deploy.go
@@ -340,7 +340,9 @@ HealthCheck:
 			break HealthCheck
 		}
 		checkResults := slices.ParMap[*applyTask, *applyTaskResult](checkTasks, func(task *applyTask) *applyTaskResult {
-			healthy, _, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
+			healthStatus, _, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
+			// Convert ComponentHealthStatus to boolean - only ComponentHealthy means fully ready for workflow
+			healthy := healthStatus == oamprovidertypes.ComponentHealthy
 			task.healthy = ptr.To(healthy)
 			if healthy {
 				err = task.generateOutput(output, outputs, cache, makeValue)

--- a/pkg/workflow/providers/legacy/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/legacy/multicluster/deploy_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	oamprovidertypes "github.com/oam-dev/kubevela/pkg/workflow/providers/types"
 )
 
 func TestOverrideConfiguration(t *testing.T) {
@@ -119,9 +120,12 @@ func TestApplyComponentsDepends(t *testing.T) {
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
 		return nil, nil, true, nil
 	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (oamprovidertypes.ComponentHealthStatus, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
-		return found, nil, nil, nil, nil
+		if found {
+			return oamprovidertypes.ComponentHealthy, nil, nil, nil, nil
+		}
+		return oamprovidertypes.ComponentUnhealthy, nil, nil, nil, nil
 	}
 	parallelism := 10
 
@@ -163,9 +167,10 @@ func TestApplyComponentsIO(t *testing.T) {
 		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
 		return nil, nil, true, nil
 	}
-	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (oamprovidertypes.ComponentHealthStatus, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
-		return found, nil, &unstructured.Unstructured{Object: map[string]interface{}{
+		if found {
+			return oamprovidertypes.ComponentHealthy, nil, &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"path": fmt.Sprintf("%s/%s", clusterName, comp.Name),
 				},
@@ -183,6 +188,8 @@ func TestApplyComponentsIO(t *testing.T) {
 					},
 				},
 			}, nil
+		}
+		return oamprovidertypes.ComponentUnhealthy, nil, nil, nil, nil
 	}
 
 	resetStore := func() {
@@ -320,11 +327,14 @@ func TestApplyComponentsIO(t *testing.T) {
 			applyMap.Store(storeKey(clusterName, comp), result)
 			return nil, nil, true, nil
 		}
-		healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+		healthCheck := func(_ context.Context, comp apicommon.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (oamprovidertypes.ComponentHealthStatus, *apicommon.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
 			key := storeKey(clusterName, comp)
 			r, found := applyMap.Load(key)
 			result, _ := r.(applyResult)
-			return found, nil, result.output, result.outputs, nil
+			if found {
+				return oamprovidertypes.ComponentHealthy, nil, result.output, result.outputs, nil
+			}
+			return oamprovidertypes.ComponentUnhealthy, nil, result.output, result.outputs, nil
 		}
 
 		inputSlot := "input_slot"

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -340,7 +340,9 @@ HealthCheck:
 			break HealthCheck
 		}
 		checkResults := slices.ParMap[*applyTask, *applyTaskResult](checkTasks, func(task *applyTask) *applyTaskResult {
-			healthy, _, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
+			healthStatus, _, output, outputs, err := healthCheck(ctx, task.component, nil, task.placement.Cluster, task.placement.Namespace)
+			// Convert ComponentHealthStatus to boolean - only ComponentHealthy means fully ready for workflow
+			healthy := healthStatus == oamprovidertypes.ComponentHealthy
 			task.healthy = ptr.To(healthy)
 			if healthy {
 				err = task.generateOutput(output, outputs, cache, makeValue)

--- a/pkg/workflow/providers/multicluster/multicluster_test.go
+++ b/pkg/workflow/providers/multicluster/multicluster_test.go
@@ -97,8 +97,8 @@ func TestDeploy(t *testing.T) {
 	componentApply := func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
 		return nil, nil, true, nil
 	}
-	componentHealthCheck := func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
-		return true, nil, nil, nil, nil
+	componentHealthCheck := func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (oamprovidertypes.ComponentHealthStatus, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error) {
+		return oamprovidertypes.ComponentHealthy, nil, nil, nil, nil
 	}
 	workloadRender := func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Component, error) {
 		return &appfile.Component{}, nil

--- a/pkg/workflow/providers/types/types.go
+++ b/pkg/workflow/providers/types/types.go
@@ -35,6 +35,18 @@ import (
 	"github.com/oam-dev/kubevela/pkg/config"
 )
 
+// ComponentHealthStatus represents the health status of a component during deployment
+type ComponentHealthStatus string
+
+const (
+	// ComponentUnhealthy component is not ready yet
+	ComponentUnhealthy ComponentHealthStatus = "Unhealthy"
+	// ComponentDispatchHealthy component and immediate traits are healthy, ready for PostDispatch traits
+	ComponentDispatchHealthy ComponentHealthStatus = "DispatchHealthy" 
+	// ComponentHealthy component and all traits (including PostDispatch) are fully ready
+	ComponentHealthy ComponentHealthStatus = "Healthy"
+)
+
 // ComponentApply apply oam component.
 type ComponentApply func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error)
 
@@ -42,7 +54,7 @@ type ComponentApply func(ctx context.Context, comp common.ApplicationComponent, 
 type ComponentRender func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, error)
 
 // ComponentHealthCheck health check oam component.
-type ComponentHealthCheck func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (bool, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error)
+type ComponentHealthCheck func(ctx context.Context, comp common.ApplicationComponent, patcher *cue.Value, clusterName string, overrideNamespace string) (ComponentHealthStatus, *common.ApplicationComponentStatus, *unstructured.Unstructured, []*unstructured.Unstructured, error)
 
 // WorkloadRender render application component into workload
 type WorkloadRender func(ctx context.Context, comp common.ApplicationComponent) (*appfile.Component, error)

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -396,7 +396,9 @@ func loopCheckStatus(c client.Client, ioStreams cmdutil.IOStreams, appName strin
 		for _, tr := range comp.Traits {
 			ioStreams.Infof("      %s: %s\n", "Type", tr.Type)
 			var trHealthEmoji = emojiSucceed
-			if !tr.Healthy {
+			if tr.Pending {
+				trHealthEmoji = emojiExecuting
+			} else if !tr.Healthy {
 				trHealthEmoji = emojiFail
 			}
 			ioStreams.Infof("      %s: %s\n", "Health", trHealthEmoji)
@@ -488,6 +490,10 @@ func getAppHealth(app *v1beta1.Application) bool {
 			return false
 		}
 		for _, t := range s.Traits {
+			// Skip pending traits when evaluating application health
+			if t.Pending {
+				continue
+			}
 			if !t.Healthy {
 				return false
 			}

--- a/test/e2e-test/postdispatch_trait_test.go
+++ b/test/e2e-test/postdispatch_trait_test.go
@@ -1,0 +1,570 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+var _ = Describe("PostDispatch Trait tests", func() {
+	ctx := context.Background()
+	var namespace string
+
+	BeforeEach(func() {
+		namespace = randomNamespaceName("postdispatch-test")
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Cleaning up test namespace")
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	Context("Test PostDispatch trait with component status", func() {
+		It("Should render PostDispatch trait after component is healthy and has status", func() {
+			compDefName := "test-worker-" + randomNamespaceName("")
+			traitDefName := "test-status-trait-" + randomNamespaceName("")
+
+			By("Creating ComponentDefinition")
+			compDef := &v1beta1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.ComponentDefinitionSpec{
+					Workload: common.WorkloadTypeDescriptor{
+						Definition: common.WorkloadGVK{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+						},
+					},
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+output: {
+	apiVersion: "apps/v1"
+	kind: "Deployment"
+	metadata: {
+		name: parameter.name
+	}
+	spec: {
+		replicas: parameter.replicas
+		selector: matchLabels: {
+			app: parameter.name
+		}
+		template: {
+			metadata: labels: {
+				app: parameter.name
+			}
+			spec: containers: [{
+				name: parameter.name
+				image: parameter.image
+			}]
+		}
+	}
+}
+
+// Add health policy to wait for status fields
+output: status: {
+	readyReplicas: *0 | int
+	replicas: *0 | int
+}
+
+parameter: {
+	name: string
+	image: string
+	replicas: *1 | int
+}
+`,
+						},
+					},
+					Status: &common.Status{
+						HealthPolicy: `isHealth: context.output.status.readyReplicas > 0`,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, compDef)).Should(Succeed())
+
+			By("Creating PostDispatch TraitDefinition")
+			traitDef := &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      traitDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Stage: v1beta1.PostDispatch,
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+outputs: statusConfigMap: {
+	apiVersion: "v1"
+	kind: "ConfigMap"
+	metadata: {
+		name: context.name + "-status"
+		namespace: context.namespace
+	}
+	data: {
+		// Access the component's output status
+		replicas: "\(context.output.status.replicas)"
+		readyReplicas: "\(context.output.status.readyReplicas)"
+		componentName: context.name
+	}
+}
+`,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, traitDef)).Should(Succeed())
+
+			By("Creating Application with PostDispatch trait")
+			app := &v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-postdispatch-app",
+					Namespace: namespace,
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{
+						{
+							Name: "test-component",
+							Type: compDefName,
+							Properties: &runtime.RawExtension{
+								Raw: []byte(`{"name":"test-worker","image":"nginx:1.14.2","replicas":1}`),
+							},
+							Traits: []common.ApplicationTrait{
+								{
+									Type: traitDefName,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+
+			By("Waiting for Application to be running")
+			Eventually(func(g Gomega) {
+				checkApp := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-postdispatch-app"}, checkApp)).Should(Succeed())
+				g.Expect(checkApp.Status.Phase).Should(Equal(common.ApplicationRunning))
+			}, 60*time.Second, 3*time.Second).Should(Succeed())
+
+			By("Verifying component Deployment is created and healthy")
+			Eventually(func(g Gomega) {
+				deploy := &unstructured.Unstructured{}
+				deploy.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				})
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-worker"}, deploy)).Should(Succeed())
+
+				status, found, _ := unstructured.NestedMap(deploy.Object, "status")
+				g.Expect(found).Should(BeTrue())
+				g.Expect(status).ShouldNot(BeNil())
+
+				replicas, _, _ := unstructured.NestedInt64(status, "replicas")
+				g.Expect(replicas).Should(Equal(int64(1)))
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("Verifying PostDispatch trait ConfigMap was created with status data")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-component-status"}, cm)).Should(Succeed())
+				g.Expect(cm.Data).ShouldNot(BeNil())
+				g.Expect(cm.Data["componentName"]).Should(Equal("test-component"))
+				g.Expect(cm.Data["replicas"]).Should(Equal("1"))
+				g.Expect(cm.Data["readyReplicas"]).Should(Equal("1"))
+			}, 45*time.Second, 3*time.Second).Should(Succeed())
+
+			By("Verifying PostDispatch trait appears in application status")
+			Eventually(func(g Gomega) {
+				checkApp := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-postdispatch-app"}, checkApp)).Should(Succeed())
+				g.Expect(checkApp.Status.Services).Should(HaveLen(1))
+
+				svc := checkApp.Status.Services[0]
+				g.Expect(svc.Healthy).Should(BeTrue())
+
+				// Find the PostDispatch trait in the status
+				var foundTrait bool
+				for _, trait := range svc.Traits {
+					if trait.Type == traitDefName {
+						foundTrait = true
+						g.Expect(trait.Healthy).Should(BeTrue())
+						break
+					}
+				}
+				g.Expect(foundTrait).Should(BeTrue(), "PostDispatch trait should appear in application status")
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("Cleaning up test resources")
+			Expect(k8sClient.Delete(ctx, app)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, traitDef)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, compDef)).Should(Succeed())
+		})
+
+		It("Should show PostDispatch trait as pending before component is healthy", func() {
+			compDefName := "test-slow-worker-" + randomNamespaceName("")
+			traitDefName := "test-pending-trait-" + randomNamespaceName("")
+
+			By("Creating ComponentDefinition with readiness probe")
+			compDef := &v1beta1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.ComponentDefinitionSpec{
+					Workload: common.WorkloadTypeDescriptor{
+						Definition: common.WorkloadGVK{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+						},
+					},
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+output: {
+	apiVersion: "apps/v1"
+	kind: "Deployment"
+	metadata: {
+		name: parameter.name
+	}
+	spec: {
+		replicas: parameter.replicas
+		selector: matchLabels: {
+			app: parameter.name
+		}
+		template: {
+			metadata: labels: {
+				app: parameter.name
+			}
+			spec: containers: [{
+				name: parameter.name
+				image: parameter.image
+				// Add readiness probe that delays health
+				readinessProbe: {
+					httpGet: {
+						path: "/"
+						port: 80
+					}
+					initialDelaySeconds: 10
+					periodSeconds: 2
+				}
+			}]
+		}
+	}
+}
+
+// Add health policy to wait for status fields
+output: status: {
+	readyReplicas: *0 | int
+	replicas: *0 | int
+}
+
+parameter: {
+	name: string
+	image: string
+	replicas: *1 | int
+}
+`,
+						},
+					},
+					Status: &common.Status{
+						HealthPolicy: `isHealth: context.output.status.readyReplicas > 0`,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, compDef)).Should(Succeed())
+
+			By("Creating PostDispatch TraitDefinition")
+			traitDef := &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      traitDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Stage: v1beta1.PostDispatch,
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+outputs: marker: {
+	apiVersion: "v1"
+	kind: "ConfigMap"
+	metadata: {
+		name: context.name + "-marker"
+		namespace: context.namespace
+	}
+	data: {
+		status: "deployed"
+	}
+}
+`,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, traitDef)).Should(Succeed())
+
+			By("Creating Application")
+			app := &v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pending-app",
+					Namespace: namespace,
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{
+						{
+							Name: "slow-component",
+							Type: compDefName,
+							Properties: &runtime.RawExtension{
+								Raw: []byte(`{"name":"slow-worker","image":"nginx:1.14.2","replicas":1}`),
+							},
+							Traits: []common.ApplicationTrait{
+								{
+									Type: traitDefName,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+
+			By("Verifying PostDispatch trait shows as pending while component is not healthy")
+			Eventually(func(g Gomega) {
+				checkApp := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-pending-app"}, checkApp)).Should(Succeed())
+
+				// Application should be running workflow while component is deploying
+				g.Expect(checkApp.Status.Phase).Should(BeElementOf(common.ApplicationRunningWorkflow, common.ApplicationRunning))
+
+				// Look for pending trait in status
+				if len(checkApp.Status.Services) > 0 {
+					svc := checkApp.Status.Services[0]
+					foundPendingTrait := false
+					for _, trait := range svc.Traits {
+						if trait.Type == traitDefName && trait.Pending {
+							// Trait should show as pending and not healthy
+							foundPendingTrait = true
+							g.Expect(trait.Healthy).Should(BeFalse())
+							g.Expect(trait.Message).Should(ContainSubstring("Waiting for component to be healthy"))
+							break
+						}
+					}
+					// If we have services in status, we should see the pending trait
+					if checkApp.Status.Phase == common.ApplicationRunningWorkflow {
+						g.Expect(foundPendingTrait).Should(BeTrue(), "Should have found pending trait while workflow is running")
+					}
+				}
+			}, 20*time.Second, 500*time.Millisecond).Should(Succeed())
+
+			By("Waiting for component to become healthy and PostDispatch trait to be deployed")
+			Eventually(func(g Gomega) {
+				// Check if the PostDispatch ConfigMap has been created
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "slow-component-marker"}, cm)).Should(Succeed())
+				g.Expect(cm.Data).ShouldNot(BeNil())
+				g.Expect(cm.Data["status"]).Should(Equal("deployed"))
+			}, 90*time.Second, 3*time.Second).Should(Succeed())
+
+			By("Verifying PostDispatch trait is no longer pending")
+			Eventually(func(g Gomega) {
+				checkApp := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-pending-app"}, checkApp)).Should(Succeed())
+
+				if len(checkApp.Status.Services) > 0 {
+					svc := checkApp.Status.Services[0]
+					for _, trait := range svc.Traits {
+						if trait.Type == traitDefName {
+							// Trait should be healthy, not pending, and not waiting anymore
+							g.Expect(trait.Pending).Should(BeFalse())
+							g.Expect(trait.Healthy).Should(BeTrue())
+							g.Expect(trait.Message).ShouldNot(ContainSubstring("waiting"))
+						}
+					}
+				}
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, app)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, traitDef)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, compDef)).Should(Succeed())
+		})
+
+		It("Should fail when PostDispatch trait accesses status without health policy", func() {
+			compDefName := "test-no-health-" + randomNamespaceName("")
+			traitDefName := "test-status-access-trait-" + randomNamespaceName("")
+
+			By("Creating ComponentDefinition WITHOUT health policy")
+			compDef := &v1beta1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      compDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.ComponentDefinitionSpec{
+					Workload: common.WorkloadTypeDescriptor{
+						Definition: common.WorkloadGVK{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+						},
+					},
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+output: {
+	apiVersion: "apps/v1"
+	kind: "Deployment"
+	metadata: {
+		name: parameter.name
+	}
+	spec: {
+		replicas: parameter.replicas
+		selector: matchLabels: {
+			app: parameter.name
+		}
+		template: {
+			metadata: labels: {
+				app: parameter.name
+			}
+			spec: containers: [{
+				name: parameter.name
+				image: parameter.image
+			}]
+		}
+	}
+}
+
+parameter: {
+	name: string
+	image: string
+	replicas: *1 | int
+}
+`,
+						},
+					},
+					// Deliberately NO Status or HealthPolicy - component will be immediately healthy
+				},
+			}
+			Expect(k8sClient.Create(ctx, compDef)).Should(Succeed())
+
+			By("Creating PostDispatch trait that accesses output.status")
+			traitDef := &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      traitDefName,
+					Namespace: "vela-system",
+				},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Stage: v1beta1.PostDispatch,
+					Schematic: &common.Schematic{
+						CUE: &common.CUE{
+							Template: `
+outputs: statusConfigMap: {
+	apiVersion: "v1"
+	kind: "ConfigMap"
+	metadata: {
+		name: context.name + "-status"
+		namespace: context.namespace
+	}
+	data: {
+		// This will fail because status fields don't exist
+		replicas: "\(context.output.status.replicas)"
+		readyReplicas: "\(context.output.status.readyReplicas)"
+		componentName: context.name
+	}
+}
+`,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, traitDef)).Should(Succeed())
+
+			By("Creating Application with PostDispatch trait")
+			app := &v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-health-app",
+					Namespace: namespace,
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{
+						{
+							Name: "test-component",
+							Type: compDefName,
+							Properties: &runtime.RawExtension{
+								Raw: []byte(`{"name":"test-worker","image":"nginx:1.14.2","replicas":1}`),
+							},
+							Traits: []common.ApplicationTrait{
+								{
+									Type: traitDefName,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+
+			By("Verifying Application enters failed state due to rendering error")
+			Eventually(func(g Gomega) {
+				checkApp := &v1beta1.Application{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-no-health-app"}, checkApp)).Should(Succeed())
+
+				// Application should fail during workflow execution
+				if checkApp.Status.Workflow != nil {
+					// Workflow should either fail or a step should fail
+					workflowFailed := string(checkApp.Status.Workflow.Phase) == "failed"
+					stepFailed := false
+					for _, step := range checkApp.Status.Workflow.Steps {
+						if string(step.Phase) == "failed" {
+							stepFailed = true
+							// Should have error message about CUE evaluation or status access
+							g.Expect(step.Message).Should(Or(
+								ContainSubstring("failed to evaluate"),
+								ContainSubstring("failed to render"),
+								ContainSubstring("PostDispatch"),
+								ContainSubstring("status"),
+							))
+							break
+						}
+					}
+					g.Expect(workflowFailed || stepFailed).Should(BeTrue(), "Expected workflow or step to fail due to status access error")
+				}
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, app)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, traitDef)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, compDef)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
### Description of your changes

copilot:all

Draft: Delays rendering of PostDispatch traits so that the components (and Pre/DefaultDispatch traits) `context.output.status` can be read and used by PostDispatch traits. 

Fixes #
https://github.com/kubevela/kubevela/issues/6810

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->