### PR TITLE
Fix(cli): Don't try to load external cuex packages in offline dry-runs

### DIFF
--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kubevela/pkg/cue/cuex"
+
 	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	corev1beta1 "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -135,6 +137,14 @@ vela dry-run -f app.yaml -f policy.yaml -f workflow.yaml
 func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace string, namespaceEnv string) (bytes.Buffer, error) {
 	var err error
 	buff := bytes.Buffer{}
+
+	// Make sure to not contact the server to load external packages in offline mode
+	if cmdOption.OfflineMode && cuex.EnableExternalPackageForDefaultCompiler {
+		cuex.EnableExternalPackageForDefaultCompiler = false
+		defer func() {
+			cuex.EnableExternalPackageForDefaultCompiler = true
+		}()
+	}
 
 	var objs []*unstructured.Unstructured
 	if cmdOption.DefinitionFile != "" {


### PR DESCRIPTION

### Description of your changes

Loading external packages requires listing resources from the server, which isn't desirable in offline mode.

Fixes #6731.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review. (staticcheck isn't working for me, and I haven't gotten to figure out why yet. hopefully CI should take care of this.)
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested manually.

### Special notes for your reviewer

I don't have permission to use labels, but it would be nice if this were backported to 1.10.x.