### PR TITLE
Fix: clear outdated services and applied resources from application status

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
@@ -214,8 +214,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.endWithNegativeCondition(logCtx, app, condition.ErrorCondition(common.WorkflowCondition.String(), err), common.ApplicationRunningWorkflow)
 	}
 
-	handler.addServiceStatus(false, app.Status.Services...)
-	handler.addAppliedResource(true, app.Status.AppliedResources...)
 	app.Status.AppliedResources = handler.appliedResources
 	app.Status.Services = handler.services
 	workflowUpdated := app.Status.Workflow.Message != "" && workflowInstance.Status.Message == ""


### PR DESCRIPTION
### Description of your changes

copilot:all

When deploy is preceeded by some long-running task and new revision has changes like updated clusters in deployment policy or component rename it is observed that services and applied resources from previous revision are still present in the app status. This can cause an application to stay stuck in 'unhealthy' state if outdated service was previously marked as `unhealthy`.

Investigation showed that removing these method calls resolves the issue: when the multicluster/deploy step runs, handler.services is refreshed with the correct, up-to-date service list. If the app already had rendered services before deployment began (e.g., when a workflow is suspended), invoking these methods re-adds old services and applied resources, leaving them stuck in the app status indefinitely.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
TODO: add application examples before and after this change