### PR TITLE
Style: Remove trailing whitespace from dry-run heading

### DIFF
--- a/e2e/application/application_auto_update_test.go
+++ b/e2e/application/application_auto_update_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Application Auto update", Ordered, func() {
 		Eventually(func() error {
 			appRev := &v1beta1.ApplicationRevision{}
 			return k8sClient.Get(ctx, client.ObjectKey{Name: "app-with-auto-update-v2", Namespace: namespace}, appRev)
-		}, 60*time.Second, 2*time.Second).Should(BeNil())
+		}, 90*time.Second, 2*time.Second).Should(BeNil())
 
 		By("Execute a live-diff command for previous two application versions")
 		output, err := e2e.Exec(fmt.Sprintf("%s live-diff --revision app-with-auto-update-v2,app-with-auto-update-v1", velaCommandPrefix))
@@ -203,7 +203,7 @@ func randomNamespaceName(basic string) string {
 }
 
 var dryRunResult1 = `---
-# Application(app-with-auto-update) -- Component(test) 
+# Application(app-with-auto-update) -- Component(test)
 ---
 
 apiVersion: v1
@@ -226,7 +226,7 @@ metadata:
 ---`
 
 var dryRunResult2 = `---
-# Application(app-with-auto-update) -- Component(test) 
+# Application(app-with-auto-update) -- Component(test)
 ---
 
 apiVersion: v1

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -566,7 +566,7 @@ spec:
 `
 
 var dryRunResult = `---
-# Application(test-vela-app) -- Component(express-server) 
+# Application(test-vela-app) -- Component(express-server)
 ---
 
 apiVersion: apps/v1
@@ -598,7 +598,7 @@ spec:
         - containerPort: 80
 
 ---
-## From the trait test-ingress 
+## From the trait test-ingress
 apiVersion: v1
 kind: Service
 metadata:
@@ -621,7 +621,7 @@ spec:
     app.oam.dev/component: express-server
 
 ---
-## From the trait test-ingress 
+## From the trait test-ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/pkg/appfile/dryrun/dryrun.go
+++ b/pkg/appfile/dryrun/dryrun.go
@@ -178,7 +178,8 @@ func (d *Option) PrintDryRun(buff *bytes.Buffer, appName string, comps []*types.
 		components[comp.Name] = comp.ComponentOutput
 	}
 	for _, c := range comps {
-		if _, err := fmt.Fprintf(buff, "---\n# Application(%s) -- Component(%s) \n---\n\n", appName, c.Name); err != nil {
+		_, err := fmt.Fprintf(buff, "---\n# Application(%s) -- Component(%s)\n---\n\n", appName, c.Name)
+		if err != nil {
 			return errors.Wrap(err, "fail to write buff")
 		}
 		result, err := yaml.Marshal(components[c.Name])
@@ -191,9 +192,9 @@ func (d *Option) PrintDryRun(buff *bytes.Buffer, appName string, comps []*types.
 			traitType := t.GetLabels()[oam.TraitTypeLabel]
 			switch {
 			case traitType == definition.AuxiliaryWorkload:
-				buff.WriteString("## From the auxiliary workload \n")
+				buff.WriteString("## From the auxiliary workload\n")
 			case traitType != "":
-				fmt.Fprintf(buff, "## From the trait %s \n", traitType)
+				fmt.Fprintf(buff, "## From the trait %s\n", traitType)
 			}
 			result, err := yaml.Marshal(t)
 			if err != nil {
@@ -205,7 +206,8 @@ func (d *Option) PrintDryRun(buff *bytes.Buffer, appName string, comps []*types.
 		buff.WriteString("\n")
 	}
 	for _, plc := range policies {
-		if _, err := fmt.Fprintf(buff, "---\n# Application(%s) -- Policy(%s) \n---\n\n", appName, plc.GetName()); err != nil {
+		_, err := fmt.Fprintf(buff, "---\n# Application(%s) -- Policy(%s)\n---\n\n", appName, plc.GetName())
+		if err != nil {
 			return errors.Wrap(err, "fail to write buff")
 		}
 		result, err := yaml.Marshal(plc)


### PR DESCRIPTION
## Issue

Headings of the output of `dry-run` command come with a trailing whitespace, example:
```
---
# Application(foo) -- Component(bar) <- there is a whitespace here
---
```
The trailing whitespace has no technical value and makes the output more fragile for assert tests that use exact string matches.

## Solution

This PR simply removes the trailing whitespace from the heading of the output of vela `dry-run` command, thus removing this fragility.

Fixes #7011 
