### PR TITLE
Docs(KEP): Go SDK for X-Definition Authoring (defkit)

### DIFF
--- a/design/vela-cli/kep-defkit.md
+++ b/design/vela-cli/kep-defkit.md
@@ -113,6 +113,8 @@ def.CustomStatus(defkit.DeploymentStatus().Build())
 
 ### When to Use What
 
+> **Note:** `RawCUE()` is an escape hatch for the rare patterns (~5% of cases) that cannot be expressed in the Go API. It allows embedding raw CUE code directly. See the [RawCUE() Escape Hatch](#rawcue-escape-hatch) section for details.
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                     DECISION FRAMEWORK                          │


### PR DESCRIPTION
  Introduces KEP proposal for defkit, a Go SDK that enables platform
  engineers to author X-Definitions using native Go code instead of CUE.

  Key proposed features:
  - Fluent builder API for Component, Trait, Policy, and WorkflowStep definitions
  - Transparent Go-to-CUE compilation
  - IDE support with autocomplete and type checking
  - Schema-agnostic resource construction
  - Collection operations (map, filter, dedupe)
  - Composable health and status expressions
  - Addon integration with godef/ folder support
  - Module dependencies for definition sharing via go get

