### PR TITLE
Feat: 7024 Enable custom errors in components similar to traits

### DIFF
--- a/pkg/cue/definition/template_test.go
+++ b/pkg/cue/definition/template_test.go
@@ -240,6 +240,39 @@ output:{
 				"kind":       "Ingress",
 			}},
 		},
+		"using errs field in workload": {
+			workloadTemplate: `
+output: {
+	apiVersion: "apps/v1"
+	kind: "Deployment"
+	metadata: name: context.name
+}
+errs: parameter.errs
+parameter: { errs: [...string] }`,
+			params: map[string]interface{}{
+				"errs": []string{"custom workload error"},
+			},
+			hasCompileErr: true,
+		},
+		"user errors and validation errors together": {
+			workloadTemplate: `
+output: {
+	apiVersion: "apps/v1"
+	kind: "Deployment"
+	metadata: name: context.name
+	spec: replicas: parameter.replicas
+}
+errs: (if parameter.replicas < 1 {["replicas must be at least 1"]} else {[]})
+parameter: {
+	replicas: int
+	required: string  // This will cause a validation error
+}`,
+			params: map[string]interface{}{
+				"replicas": 0,
+				// missing "required" field
+			},
+			hasCompileErr: true,
+		},
 	}
 
 	for _, v := range testCases {


### PR DESCRIPTION
### Description of your changes

copilot:all

Add support for custom `errs` field in component definitions and improve error formatting to group user-defined, parameter, and template errors separately.

Fixes #7024

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Manual testing of custom definitions
- Unit tests
