### PR TITLE
Fix: Fixes #7046 — status.details CUE import statements now compile correctly

### DIFF
--- a/pkg/cue/definition/health/health.go
+++ b/pkg/cue/definition/health/health.go
@@ -148,7 +148,7 @@ func getStatusMap(templateContext map[string]interface{}, statusFields string, p
 		contextLabels = append(contextLabels, util.GetIteratorLabel(*iter))
 	}
 
-	cueBuffer := runtimeContextBuff + "\n" + statusFields
+	cueBuffer := statusFields + "\n" + runtimeContextBuff
 	val := cueCtx.CompileString(cueBuffer)
 	if val.Err() != nil {
 		return templateContext, nil, errors.WithMessage(val.Err(), "compile status fields template")

--- a/pkg/cue/definition/health/health_test.go
+++ b/pkg/cue/definition/health/health_test.go
@@ -329,6 +329,19 @@ func TestGetStatus(t *testing.T) {
 				"sum": "4",
 			},
 		},
+		"test-status-with-import-statement": {
+			tpContext: map[string]interface{}{
+				"output": map[string]interface{}{},
+			},
+			parameter: make(map[string]interface{}),
+			statusCue: strings.TrimSpace(`
+				import "strings"
+				"my.details": strings.Join(["foo", "bar"], ",")
+			`),
+			expStatus: map[string]string{
+				"my.details": "foo,bar",
+			},
+		},
 		"test-key-input-too-large-skipped": {
 			tpContext: map[string]interface{}{
 				"output": map[string]interface{}{


### PR DESCRIPTION
</ul></body></html> Fixes #7046 — `status.details` CUE `import` statements now compile correctly

### Problem

`ComponentDefinition.spec.status.details` failed silently when the CUE snippet contained `import` statements. CUE requires imports to appear at the top of a file, but `getStatusMap` was compiling:

```
runtimeContext + details
```

When `details` begins with `import`, CUE rejects the combined value with:

> `compile status fields template: expected label or ':', found 'STRING' "strings"`

This caused `details` to be missing from the output entirely. `healthPolicy` and `customStatus` were unaffected because they already compile in the correct order.

### Fix

Changed the compile order in `pkg/cue/definition/health/health.go` to:

```
details + runtimeContext
```

This mirrors the pattern already used by `healthPolicy` and `customStatus`.

### Testing

**Automated:**
```bash
go test ./pkg/cue/definition/health -count=1
go test ./pkg/cue/definition/health -run TestGetStatus -count=1 -v
```

New regression test case `test-status-with-import-statement` added in `pkg/cue/definition/health/health_test.go`.


| | Output |
|---|---|
| **Before fix** | `compile status fields template: expected label or ':', found 'STRING' "strings"` — `details` missing |
| **After fix** | `healthy: true`, `message: foo and bar`, `details: map[string]string{"my.details":"foo,bar"}` |
