### PR TITLE
Ruben

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -46,6 +46,8 @@ const (
 	TypeWorkflowStep CapType = "workflowstep"
 	// TypePolicy represent OAM Policy
 	TypePolicy CapType = "policy"
+	// TypePackage represents Package CRD
+	TypePackage CapType = "package"
 )
 
 // CapabilityConfigMapNamePrefix is the prefix for capability ConfigMap name

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -118,6 +118,7 @@ func NewCommandWithIOStreams(ioStream util.IOStreams) *cobra.Command {
 		TemplateCommandGroup(f, "5", ioStream),
 
 		// Extension
+		NewPackageCommand(commandArgs, "5", ioStream),
 		// Addon
 		NewAddonCommand(commandArgs, "1", ioStream),
 		NewUISchemaCommand(commandArgs, "2", ioStream),

--- a/references/cli/package.go
+++ b/references/cli/package.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context" // Provides context for kubernetes API calls
+
+	"github.com/pkg/errors" // Wraps errors with more context for better debugging messages
+	"github.com/spf13/cobra" // CLI framework used to define commands like vela package list
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured" // // Allows working with kubernetes resources without go structs
+	"k8s.io/apimachinery/pkg/runtime/schema" // Defines GroupVersionKind to identify kubernetes resource types
+
+	"github.com/oam-dev/kubevela/apis/types" // Contains CLI metadata constants
+	common2 "github.com/oam-dev/kubevela/pkg/utils/common" // Provides shared CLI utilities
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util" // provides IOStreams for consistent CLI input and output handling
+)
+
+// Makes the 'package' command and attaches its subcommands
+func NewPackageCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "package",
+		Aliases: []string{"packages"},
+		Short:   "List installed packages.",
+		Long:    "List Package objects installed in the cluster.",
+		Example: `vela package list`,
+		Annotations: map[string]string{
+			types.TagCommandType:  types.TypeExtension,
+			types.TagCommandOrder: order,
+		},
+	}
+
+	cmd.SetOut(ioStreams.Out)
+	cmd.AddCommand(
+		NewPackageListCommand(c, ioStreams),
+	)
+	return cmd
+}
+
+// Makes the 'list' subcommand
+func NewPackageListCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List packages.",
+		Long:  "List Package objects installed in the cluster.",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return PrintInstalledPackages(c, ioStreams)
+		},
+	}
+	return cmd
+}
+
+// Connects to the cluster, lists Package CRDs, and prints them in a table
+func PrintInstalledPackages(c common2.Args, io cmdutil.IOStreams) error {
+	clt, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+
+	var list unstructured.UnstructuredList
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cue.oam.dev",
+		Version: "v1alpha1",
+		Kind:    "PackageList",
+	})
+
+	err = clt.List(context.Background(), &list)
+	if err != nil {
+		return errors.Wrap(err, "get package list error")
+	}
+
+	table := newUITable()
+	table.AddRow("NAME", "NAMESPACE")
+
+	for _, pkg := range list.Items {
+		table.AddRow(pkg.GetName(), pkg.GetNamespace())
+	}
+
+	io.Info(table.String())
+	return nil
+}

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -82,13 +82,13 @@ func getShowCommandOrder(order string) string {
 	return order
 }
 
-// NewCapabilityShowCommand shows the reference doc for a component type or trait
+// NewCapabilityShowCommand shows the reference doc for supported capability types
 func NewCapabilityShowCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *cobra.Command {
 	var revision, path, location, i18nPath string
 	cmd := &cobra.Command{
 		Use:   "show",
-		Short: "Show the reference doc for a component, trait, policy or workflow.",
-		Long:  "Show the reference doc for component, trait, policy or workflow types. 'vela show' equals with 'vela def show'. ",
+		Short: "Show the reference doc for a component, trait, policy, workflow, or package.",
+		Long:  "Show the reference doc for component, trait, policy, workflow, or package types. 'vela show' equals with 'vela def show'. ",
 		Example: `0. Run 'vela show' directly to start a web server for all reference docs.  
 1. Generate documentation for ComponentDefinition webservice:
 > vela show webservice -n vela-system
@@ -214,7 +214,7 @@ func startReferenceDocsSite(ctx context.Context, ns string, c common.Args, ioStr
 		}
 	}
 	if !capabilityIsValid {
-		return fmt.Errorf("%s is not a valid component, trait, policy or workflow", capabilityName)
+		return fmt.Errorf("%s is not a valid component, trait, policy, workflow, or package", capabilityName)
 	}
 
 	cli, err := c.GetClient()
@@ -289,7 +289,7 @@ func launch(server *http.Server, errChan chan<- error) {
 
 func generateSideBar(capabilities []types.Capability, docsPath string) error {
 	sideBar := filepath.Join(docsPath, SideBar)
-	components, traits, workflowSteps, policies := getDefinitions(capabilities)
+	components, traits, workflowSteps, policies, packages := getDefinitions(capabilities)
 	f, err := os.Create(sideBar) // nolint
 	if err != nil {
 		return err
@@ -325,6 +325,14 @@ func generateSideBar(capabilities []types.Capability, docsPath string) error {
 	}
 	for _, t := range policies {
 		if _, err := fmt.Fprintf(f, "  - [%s](%s/%s.md)\n", t, types.TypePolicy, t); err != nil {
+			return err
+		}
+	}
+	if _, err := f.WriteString("- Packages\n"); err != nil {
+    	return err
+	}
+	for _, p := range packages {
+		if _, err := fmt.Fprintf(f, "  - [%s](%s/%s.md)\n", p, types.TypePackage, p); err != nil {
 			return err
 		}
 	}
@@ -399,7 +407,7 @@ func generateREADME(capabilities []types.Capability, docsPath string) error {
 		return err
 	}
 
-	workloads, traits, workflowSteps, policies := getDefinitions(capabilities)
+	workloads, traits, workflowSteps, policies, packages := getDefinitions(capabilities)
 
 	if _, err := f.WriteString("## Component Types\n"); err != nil {
 		return err
@@ -438,11 +446,20 @@ func generateREADME(capabilities []types.Capability, docsPath string) error {
 		}
 	}
 
+	if _, err := f.WriteString("## Packages\n"); err != nil {
+		return err
+	}
+	for _, p := range packages {
+		if _, err := fmt.Fprintf(f, "  - [%s](%s/%s.md)\n", p, types.TypePackage, p); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-func getDefinitions(capabilities []types.Capability) ([]string, []string, []string, []string) {
-	var components, traits, workflowSteps, policies []string
+func getDefinitions(capabilities []types.Capability) ([]string, []string, []string, []string, []string ) {
+	var components, traits, workflowSteps, policies, packages []string
 	for _, c := range capabilities {
 		switch c.Type {
 		case types.TypeComponentDefinition:
@@ -453,11 +470,14 @@ func getDefinitions(capabilities []types.Capability) ([]string, []string, []stri
 			workflowSteps = append(workflowSteps, c.Name)
 		case types.TypePolicy:
 			policies = append(policies, c.Name)
+		case types.TypePackage:
+			packages = append(packages, c.Name)
 		case types.TypeWorkload:
 		default:
 		}
+		
 	}
-	return components, traits, workflowSteps, policies
+	return components, traits, workflowSteps, policies, packages
 }
 
 // ShowReferenceConsole will show capability reference in console

--- a/references/cli/show_test.go
+++ b/references/cli/show_test.go
@@ -147,6 +147,7 @@ func TestGetWorkloadAndTraits(t *testing.T) {
 		workloads []string
 		traits    []string
 		policies  []string
+		packages  []string
 	}
 
 	var (
@@ -191,8 +192,8 @@ func TestGetWorkloadAndTraits(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			gotWorkloads, gotTraits, _, gotPolicies := getDefinitions(tc.capabilities)
-			assert.Equal(t, tc.want, want{workloads: gotWorkloads, traits: gotTraits, policies: gotPolicies})
+			gotWorkloads, gotTraits, _, gotPolicies, gotPackages := getDefinitions(tc.capabilities)
+			assert.Equal(t, tc.want, want{workloads: gotWorkloads, traits: gotTraits, policies: gotPolicies, packages:  gotPackages,})
 		})
 	}
 }

--- a/references/docgen/cluster.go
+++ b/references/docgen/cluster.go
@@ -39,6 +39,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/references/docgen/fix"
+	"github.com/kubevela/pkg/apis/cue/v1alpha1"
 )
 
 // DescriptionUndefined indicates the description is not defined
@@ -81,6 +82,15 @@ func GetCapabilitiesFromCluster(ctx context.Context, namespace string, c common.
 	}
 	caps = append(caps, wfs...)
 
+	pkgs, erl, err := GetPackages(ctx, namespace, c)
+	if err != nil {
+		return nil, err
+	}
+	for _, er := range erl {
+		klog.Infof("get package capability %v", er)
+	}
+	caps = append(caps, pkgs...)
+
 	return caps, nil
 }
 
@@ -105,6 +115,10 @@ func GetNamespacedCapabilitiesFromCluster(ctx context.Context, namespace string,
 		capabilities = append(capabilities, policies...)
 	}
 
+	if packages, _, err := GetPackages(ctx, namespace, c); err == nil {
+		capabilities = append(capabilities, packages...)
+	}
+
 	if namespace != types.DefaultKubeVelaNS {
 		// get components from default namespace
 		if workloads, _, err := GetComponentsFromClusterWithValidateOption(ctx, types.DefaultKubeVelaNS, c, selector, false); err == nil {
@@ -123,12 +137,16 @@ func GetNamespacedCapabilitiesFromCluster(ctx context.Context, namespace string,
 		if policies, _, err := GetPolicies(ctx, types.DefaultKubeVelaNS, c); err == nil {
 			capabilities = append(capabilities, policies...)
 		}
+
+		if packages, _, err := GetPackages(ctx, types.DefaultKubeVelaNS, c); err == nil {
+			capabilities = append(capabilities, packages...)
+		}
 	}
 
 	if len(capabilities) > 0 {
 		return capabilities, nil
 	}
-	return nil, fmt.Errorf("could not find any components, traits or workflowSteps from namespace %s and %s", namespace, types.DefaultKubeVelaNS)
+	return nil, fmt.Errorf("could not find any components, traits, workflow steps, policies, or packages from namespace %s and %s", namespace, types.DefaultKubeVelaNS)
 }
 
 // GetComponentsFromCluster will get capability from K8s cluster
@@ -263,6 +281,32 @@ func GetPolicies(ctx context.Context, namespace string, c common.Args) ([]types.
 	var templateErrors []error
 	for _, def := range defs.Items {
 		tmp, err := GetCapabilityByPolicyDefinitionObject(def)
+		if err != nil {
+			templateErrors = append(templateErrors, err)
+			continue
+		}
+		templates = append(templates, *tmp)
+	}
+	return templates, templateErrors, nil
+}
+
+// GetPackages will get Package list from K8s cluster
+func GetPackages(ctx context.Context, namespace string, c common.Args) ([]types.Capability, []error, error) {
+	newClient, err := c.GetClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var templates []types.Capability
+	var defs v1alpha1.PackageList
+	err = newClient.List(ctx, &defs, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list Package err: %w", err)
+	}
+
+	var templateErrors []error
+	for _, def := range defs.Items {
+		tmp, err := GetCapabilityByPackageObject(def)
 		if err != nil {
 			templateErrors = append(templateErrors, err)
 			continue
@@ -462,6 +506,25 @@ func GetCapabilityByName(ctx context.Context, c common.Args, capabilityName stri
 		}
 		return capability, nil
 	}
+	
+	foundCapability = false
+	var pkg v1alpha1.Package
+	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &pkg)
+	if err == nil {
+		foundCapability = true
+	} else if kerrors.IsNotFound(err) {
+		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &pkg)
+		if err == nil {
+			foundCapability = true
+		}
+	}
+	if foundCapability {
+		capability, err = GetCapabilityByPackageObject(pkg)
+		if err != nil {
+			return nil, err
+		}
+		return capability, nil
+	}
 
 	if ns == types.DefaultKubeVelaNS {
 		return nil, fmt.Errorf("could not find %s in namespace %s", capabilityName, ns)
@@ -566,5 +629,17 @@ func GetCapabilityByPolicyDefinitionObject(def v1beta1.PolicyDefinition) (*types
 		return nil, errors.Wrap(err, "failed to handle PolicyDefinition")
 	}
 	capability.Namespace = def.Namespace
+	return &capability, nil
+}
+
+// GetCapabilityByPackageObject converts a Package object into a Capability
+func GetCapabilityByPackageObject(pkg v1alpha1.Package) (*types.Capability, error) {
+	capability := types.Capability{
+		Name:      pkg.Name,
+		Type:      types.TypePackage,
+		Namespace: pkg.Namespace,
+		Labels:    pkg.Labels,
+		Path:      pkg.Spec.Path,
+	}
 	return &capability, nil
 }

--- a/references/docgen/markdown.go
+++ b/references/docgen/markdown.go
@@ -135,7 +135,7 @@ func (ref *MarkdownReference) GenerateMarkdownForCap(_ context.Context, c types.
 		err           error
 	)
 	switch c.Type {
-	case types.TypeWorkload, types.TypeComponentDefinition, types.TypeTrait, types.TypeWorkflowStep, types.TypePolicy:
+	case types.TypeWorkload, types.TypeComponentDefinition, types.TypeTrait, types.TypeWorkflowStep, types.TypePolicy, types.TypePackage:
 	default:
 		return "", fmt.Errorf("type(%s) of the capability(%s) is not supported for now", c.Type, c.Name)
 	}


### PR DESCRIPTION
###Description of your changes

This PR adds support for the Package CRD in the vela CLI.

Adds a new vela package list command to list Package resources
Extends vela show to support Package capabilities
Integrates Package into the docgen/capability pipeline
Updates CLI help text and documentation generation to include packages

Fixes #6742

I have:

 - [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md)
 - [ ] [Related Docs](https://github.com/kubevela/kubevela.io)
 updated properly. In a new feature or configuration option, an update to the documentation is necessary.
 - [ ] Run make reviewable to ensure this PR is ready for review.
 - [ ]Added backport release-x.y labels to auto-backport this PR if necessary.

###How has this code been tested
- Verified vela package list works against a local kind cluster with the Package CRD installed
- Verified vela show --help and vela show run successfully after adding Package support
- Built and tested affected packages:
- go build ./references/cli
- go build ./references/docgen

###Special notes for your reviewer
- Package support uses the typed API from github.com/kubevela/pkg/apis/cue/v1alpha1
- Capability mapping for Package includes name, namespace, path, and labels
- Package is handled separately from HandleDefinition(...) since it does not follow the same schema as other capability types
- Existing lint warnings in unrelated files were not modified