### PR TITLE
Fix: Pin scaffolded go.mod to running vela binary's version in def init-module

### DIFF
--- a/references/cli/def_module.go
+++ b/references/cli/def_module.go
@@ -1701,14 +1701,16 @@ spec:
 `, opts.name, desc)
 }
 
-// generateGoMod generates the go.mod content
+// generateGoMod generates the go.mod content. The kubevela require version
+// tracks the running binary's build-time version so scaffolded modules pin the
+// SDK matching the tool that generated them.
 func generateGoMod(opts initModuleOptions) string {
 	return fmt.Sprintf(`module %s
 
 go 1.23.8
 
-require github.com/oam-dev/kubevela v1.9.0
-`, opts.goModule)
+require github.com/oam-dev/kubevela %s
+`, opts.goModule, velaversion.ModuleRequireVersion())
 }
 
 // generateModuleReadme generates the README.md content

--- a/references/cli/def_module_test.go
+++ b/references/cli/def_module_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
+	velaversion "github.com/oam-dev/kubevela/version"
 )
 
 func TestNewDefinitionApplyModuleCommand(t *testing.T) {
@@ -390,7 +391,7 @@ func TestInitModuleGoModContent(t *testing.T) {
 
 	contentStr := string(content)
 	assert.Contains(t, contentStr, "module github.com/myorg/custom-module")
-	assert.Contains(t, contentStr, "require github.com/oam-dev/kubevela")
+	assert.Contains(t, contentStr, "require github.com/oam-dev/kubevela "+velaversion.ModuleRequireVersion())
 }
 
 func TestInitModuleDefaultValues(t *testing.T) {

--- a/version/version.go
+++ b/version/version.go
@@ -24,6 +24,23 @@ var GitRevision = "UNKNOWN"
 // VelaVersion is the version of cli.
 var VelaVersion = "UNKNOWN"
 
+// defaultModuleRequireVersion is the kubevela SDK version written into
+// scaffolded go.mod files when the running binary was built without a release
+// version (e.g. VelaVersion is the default "UNKNOWN" or the Makefile's
+// "master"). Bump alongside each release.
+const defaultModuleRequireVersion = "v1.11.0"
+
+// ModuleRequireVersion returns a semver suitable for a scaffolded go.mod
+// `require github.com/oam-dev/kubevela <ver>` line. It prefers the running
+// binary's build-time VelaVersion and falls back to defaultModuleRequireVersion
+// when VelaVersion is not a valid semver (dev builds without ldflags).
+func ModuleRequireVersion() string {
+	if IsOfficialKubeVelaVersion(VelaVersion) {
+		return VelaVersion
+	}
+	return defaultModuleRequireVersion
+}
+
 // IsOfficialKubeVelaVersion checks whether the provided version string follows a KubeVela version pattern
 func IsOfficialKubeVelaVersion(versionStr string) bool {
 	_, err := version.NewSemver(versionStr)

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -43,6 +43,27 @@ func TestGetVersion(t *testing.T) {
 	assert.Equal(t, "1.2.0", version)
 }
 
+func TestModuleRequireVersion(t *testing.T) {
+	origVersion := VelaVersion
+	t.Cleanup(func() { VelaVersion = origVersion })
+
+	tests := []struct {
+		name string
+		set  string
+		want string
+	}{
+		{"release build", "v1.10.0", "v1.10.0"},
+		{"dev build default", "UNKNOWN", defaultModuleRequireVersion},
+		{"makefile default", "master", defaultModuleRequireVersion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			VelaVersion = tt.set
+			assert.Equal(t, tt.want, ModuleRequireVersion())
+		})
+	}
+}
+
 func TestShouldUseLegacyHelmRepo(t *testing.T) {
 	tests := []struct {
 		ver  string


### PR DESCRIPTION
### Description of your changes

copilot:all

Replace the hardcoded `require github.com/oam-dev/kubevela v1.9.0` in the `go.mod` generated by `vela def init-module` with the running binary's build-time `VelaVersion`, so scaffolded modules pin the SDK version that matches the tool generating them.

**Background:** `references/cli/def_module.go:generateGoMod` embedded `v1.9.0` as a literal inside a `fmt.Sprintf` template. Whenever the installed `vela` drifted from v1.9.0, scaffolded modules pinned the wrong SDK and users had to hand-edit `go.mod` after scaffolding. The binary already carries its version in `velaversion.VelaVersion` (set at build time via `-ldflags "-X github.com/oam-dev/kubevela/version.VelaVersion=..."`), but `generateGoMod` did not use it.

**This PR:**

- Adds `version.ModuleRequireVersion()`, which returns `VelaVersion` when it is a valid semver (via the existing `IsOfficialKubeVelaVersion`) and falls back to a pinned default otherwise.
- Updates `generateGoMod` to call the helper instead of embedding `v1.9.0`.

**Dev-build handling:**

| `VelaVersion` source                      | Value     | Resulting `require` version     |
|-------------------------------------------|-----------|---------------------------------|
| `-ldflags "-X ...=v1.10.0"` (release)     | `v1.10.0` | `v1.10.0`                       |
| `go build ./...` (no ldflags)             | `UNKNOWN` | `defaultModuleRequireVersion`   |
| `make` without `VELA_VERSION=`            | `master`  | `defaultModuleRequireVersion`   |

Both `UNKNOWN` and `master` are rejected by `IsOfficialKubeVelaVersion`, so `go mod tidy` never sees an invalid semver in the scaffolded module.

`defaultModuleRequireVersion` is set to `v1.9.0` in this PR — matching the value it replaces, so dev builds produce an identical scaffold to what ships today. It is intended to be bumped alongside each release.

**Related PRs:**
- None.

<!--
Fixes #
-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- New `TestModuleRequireVersion` in `version/version_test.go` covers the release case (`v1.10.0`), the raw `go build` case (`UNKNOWN`), and the Makefile-default case (`master`), saving and restoring the package-global `VelaVersion` around each case.
- Extended `TestInitModuleGoModContent` in `references/cli/def_module_test.go` to assert the emitted require line contains `"require github.com/oam-dev/kubevela " + velaversion.ModuleRequireVersion()` — this guards against regression to a hardcoded literal without coupling the test to a specific release version.
- End-to-end: built `vela` with `-ldflags "-X github.com/oam-dev/kubevela/version.VelaVersion=v1.10.0"` and also without ldflags. Ran `vela def init-module` with each binary, inspected the generated `go.mod`, and ran `go mod tidy` inside the scaffolded directory to confirm the require line resolves successfully.

### Special notes for your reviewer

- **Fallback bumped from `v1.9.0` to `v1.11.0`** — the defkit SDK changes that scaffolded modules depend on are only available from v1.11.0, so the fallback must target at least that version. Dev builds therefore emit `require github.com/oam-dev/kubevela v1.11.0` instead of the old `v1.9.0`. Bump alongside future releases.
- **`pkg/addon/init.go:789` has the same issue** — `godefGoModTemplate` hardcodes `v1.10.0` for the addon `godef` scaffold. It is a one-line change using the same helper, but intentionally out of scope for this PR to keep the diff narrow. Happy to follow up in a separate PR if reviewers prefer.
- **No user-facing API change** — only the scaffolded `go.mod` content changes. The `vela/op` CUE surface, CLI flags, and command output are untouched.