### PR TITLE
Fix: auto-detect "strings" import for StringParam MinLen/MaxLen in defkit

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -140,6 +140,15 @@ func (g *CUEGenerator) detectRequiredImports(c *ComponentDefinition) {
 		g.collectImportsFromValue(helper.Collection())
 	}
 
+	// Check parameters for import requirements (e.g. StringParam with MinLen/MaxLen needs "strings")
+	for _, param := range c.GetParams() {
+		if ir, ok := param.(ImportRequirer); ok {
+			for _, imp := range ir.RequiredImports() {
+				g.addImportIfMissing(imp)
+			}
+		}
+	}
+
 	// Check resource operations in output
 	if output := tpl.GetOutput(); output != nil {
 		g.collectImportsFromResource(output)

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -910,6 +910,105 @@ var _ = Describe("CUEGenerator", func() {
 
 			Expect(cue).To(ContainSubstring("strings"))
 		})
+
+		It("should detect strings import from StringParam.MinLen", func() {
+			hostname := defkit.String("hostname").MinLen(1)
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(hostname).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", hostname),
+					)
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(ContainSubstring("strings.MinRunes(1)"))
+		})
+
+		It("should detect strings import from StringParam.MaxLen", func() {
+			hostname := defkit.String("hostname").MaxLen(63)
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(hostname).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", hostname),
+					)
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(ContainSubstring("strings.MaxRunes(63)"))
+		})
+
+		It("should detect strings import when both MinLen and MaxLen are set", func() {
+			hostname := defkit.String("hostname").
+				Pattern("^[a-z0-9-]+$").
+				MinLen(1).
+				MaxLen(63)
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(hostname).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", hostname),
+					)
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(ContainSubstring("strings.MinRunes(1)"))
+			Expect(cue).To(ContainSubstring("strings.MaxRunes(63)"))
+			// Only one import statement, not duplicated
+			Expect(strings.Count(cue, `import "strings"`)).To(Equal(1))
+		})
+
+		It("should not emit strings import when no param uses MinLen/MaxLen", func() {
+			name := defkit.String("name")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(name).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", name),
+					)
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).NotTo(ContainSubstring(`import "strings"`))
+			Expect(cue).NotTo(ContainSubstring("strings.MinRunes"))
+			Expect(cue).NotTo(ContainSubstring("strings.MaxRunes"))
+		})
+
+		It("should detect strings import even when MinLen param is not referenced in template", func() {
+			// The param is declared but the template doesn't reference it — the
+			// import must still be emitted because the parameter schema uses it.
+			hostname := defkit.String("hostname").MinLen(1).MaxLen(63)
+			name := defkit.String("name")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(hostname, name).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", name),
+					)
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring(`import "strings"`))
+		})
 	})
 
 	Describe("GenerateFullDefinition with ConditionalOrFieldRef", func() {

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -925,7 +925,7 @@ var _ = Describe("CUEGenerator", func() {
 
 			cue := gen.GenerateFullDefinition(comp)
 
-			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(MatchRegexp(`import\s+\(\s+"strings"\s+\)`))
 			Expect(cue).To(ContainSubstring("strings.MinRunes(1)"))
 		})
 
@@ -943,7 +943,7 @@ var _ = Describe("CUEGenerator", func() {
 
 			cue := gen.GenerateFullDefinition(comp)
 
-			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(MatchRegexp(`import\s+\(\s+"strings"\s+\)`))
 			Expect(cue).To(ContainSubstring("strings.MaxRunes(63)"))
 		})
 
@@ -964,11 +964,11 @@ var _ = Describe("CUEGenerator", func() {
 
 			cue := gen.GenerateFullDefinition(comp)
 
-			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(MatchRegexp(`import\s+\(\s+"strings"\s+\)`))
 			Expect(cue).To(ContainSubstring("strings.MinRunes(1)"))
 			Expect(cue).To(ContainSubstring("strings.MaxRunes(63)"))
-			// Only one import statement, not duplicated
-			Expect(strings.Count(cue, `import "strings"`)).To(Equal(1))
+			// Only one import of "strings", not duplicated
+			Expect(strings.Count(cue, `"strings"`)).To(Equal(1))
 		})
 
 		It("should not emit strings import when no param uses MinLen/MaxLen", func() {
@@ -985,7 +985,7 @@ var _ = Describe("CUEGenerator", func() {
 
 			cue := gen.GenerateFullDefinition(comp)
 
-			Expect(cue).NotTo(ContainSubstring(`import "strings"`))
+			Expect(cue).NotTo(MatchRegexp(`import\s+\(\s+"strings"\s+\)`))
 			Expect(cue).NotTo(ContainSubstring("strings.MinRunes"))
 			Expect(cue).NotTo(ContainSubstring("strings.MaxRunes"))
 		})
@@ -1007,7 +1007,7 @@ var _ = Describe("CUEGenerator", func() {
 
 			cue := gen.GenerateFullDefinition(comp)
 
-			Expect(cue).To(ContainSubstring(`import "strings"`))
+			Expect(cue).To(MatchRegexp(`import\s+\(\s+"strings"\s+\)`))
 		})
 	})
 

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -233,6 +233,15 @@ func (p *StringParam) GetMaxLen() *int {
 	return p.maxLen
 }
 
+// RequiredImports returns the CUE imports needed by this parameter's constraints.
+// MinLen/MaxLen generate strings.MinRunes()/strings.MaxRunes() which require "strings".
+func (p *StringParam) RequiredImports() []string {
+	if p.minLen != nil || p.maxLen != nil {
+		return []string{"strings"}
+	}
+	return nil
+}
+
 // NotEmpty adds a non-empty string constraint.
 // This generates CUE like: string & !=""
 func (p *StringParam) NotEmpty() *StringParam {

--- a/pkg/definition/defkit/param_test.go
+++ b/pkg/definition/defkit/param_test.go
@@ -1085,6 +1085,48 @@ var _ = Describe("Parameters", func() {
 		})
 	})
 
+	Context("StringParam RequiredImports", func() {
+		It("should return nil when neither MinLen nor MaxLen is set", func() {
+			p := defkit.String("name")
+			Expect(p.RequiredImports()).To(BeNil())
+		})
+
+		It("should return [strings] when only MinLen is set", func() {
+			p := defkit.String("name").MinLen(3)
+			Expect(p.RequiredImports()).To(Equal([]string{"strings"}))
+		})
+
+		It("should return [strings] when only MaxLen is set", func() {
+			p := defkit.String("name").MaxLen(63)
+			Expect(p.RequiredImports()).To(Equal([]string{"strings"}))
+		})
+
+		It("should return [strings] when both MinLen and MaxLen are set", func() {
+			p := defkit.String("name").MinLen(1).MaxLen(63)
+			Expect(p.RequiredImports()).To(Equal([]string{"strings"}))
+		})
+
+		It("should return nil when only Pattern is set (no stdlib call)", func() {
+			p := defkit.String("name").Pattern("^[a-z]+$")
+			Expect(p.RequiredImports()).To(BeNil())
+		})
+
+		It("should return nil when only NotEmpty is set (no stdlib call)", func() {
+			p := defkit.String("name").NotEmpty()
+			Expect(p.RequiredImports()).To(BeNil())
+		})
+
+		It("should return nil when only Values is set (no stdlib call)", func() {
+			p := defkit.String("level").Values("info", "debug")
+			Expect(p.RequiredImports()).To(BeNil())
+		})
+
+		It("should still return [strings] when MinLen is combined with other constraints", func() {
+			p := defkit.String("name").NotEmpty().Pattern("^[a-z]+$").MinLen(3)
+			Expect(p.RequiredImports()).To(Equal([]string{"strings"}))
+		})
+	})
+
 	Context("ArrayParam NotEmpty elements", func() {
 		It("should default to false", func() {
 			p := defkit.StringList("tags")


### PR DESCRIPTION
### Description of your changes

copilot:all

`StringParam` with `MinLen(n)` or `MaxLen(n)` generates CUE constraints using `strings.MinRunes()` and `strings.MaxRunes()`, but the CUE generator's `detectRequiredImports` only scanned template elements (helpers, resources, outputs) — never the parameter list itself. This caused generated definitions to fail at admission time with:

```
admission webhook "validating.core.oam-dev.v1beta1.componentdefinitions" denied the request:
parameter.hostname: reference "strings" not found
```

**This PR:**

- Implements `ImportRequirer` on `StringParam`, returning `["strings"]` when `MinLen` or `MaxLen` is set (`param.go`).
- Extends `CUEGenerator.detectRequiredImports` to iterate the component's parameters via `c.GetParams()` and collect imports from any parameter that implements `ImportRequirer` (`cuegen.go`).

The fix is extensible by design — any future parameter type that uses a CUE standard-library helper (e.g. `list.Contains`, `strconv.FormatInt`) can implement `ImportRequirer` and its imports will be auto-detected without further generator changes.

<!--
Fixes #
-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- All existing defkit unit tests pass (`go test ./pkg/definition/defkit/...`).
- Reproduced the original failure end-to-end with a ComponentDefinition whose parameter uses `defkit.String("hostname").Pattern("^[a-z0-9-]+$").MinLen(1).MaxLen(63)`. Before the fix, `vela def apply-module` failed with the admission webhook error above; after the fix, the generated CUE includes `import "strings"` at the top and validation passes.
- Confirmed the inverse — a component with no `MinLen`/`MaxLen` parameters does not emit a spurious `strings` import.

### Special notes for your reviewer

- The `ImportRequirer` interface already existed and was used for template values; this PR just extends its scope to parameters. No new interface surface, no breaking change.
- Only `StringParam` is affected in this PR. Other parameter types don't currently emit stdlib calls at the parameter level, but the generator change is generic — future constraint constructors on `IntParam`/`FloatParam`/etc. can add `RequiredImports()` without touching `cuegen.go`.