### PR TITLE
Fix: OutputsGroupIf silently dropped by component and trait CUE generators

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -433,17 +433,37 @@ func (g *CUEGenerator) GenerateTemplate(c *ComponentDefinition) string {
 		g.writeHelper(&sb, helper, 1)
 	}
 
-	// Generate outputs block for auxiliary resources
-	if outputs := tpl.GetOutputs(); len(outputs) > 0 {
-		outputNames := make([]string, 0, len(outputs))
-		for name := range outputs {
-			outputNames = append(outputNames, name)
-		}
-		sort.Strings(outputNames)
+	// Generate outputs block for auxiliary resources.
+	// Includes plain outputs (Outputs/OutputsIf) and grouped outputs (OutputsGroupIf),
+	// which share a single `if cond { ... }` wrapper inside the outputs block.
+	outputs := tpl.GetOutputs()
+	outputGroups := tpl.GetOutputGroups()
+	if len(outputs) > 0 || len(outputGroups) > 0 {
 		sb.WriteString(fmt.Sprintf("%soutputs: {\n", g.indent))
-		for _, name := range outputNames {
-			res := outputs[name]
-			g.writeResourceOutput(&sb, name, res, res.outputCondition, 2)
+		if len(outputs) > 0 {
+			outputNames := make([]string, 0, len(outputs))
+			for name := range outputs {
+				outputNames = append(outputNames, name)
+			}
+			sort.Strings(outputNames)
+			for _, name := range outputNames {
+				res := outputs[name]
+				g.writeResourceOutput(&sb, name, res, res.outputCondition, 2)
+			}
+		}
+		for _, group := range outputGroups {
+			condStr := g.conditionToCUE(group.cond)
+			sb.WriteString(fmt.Sprintf("%s%sif %s {\n", g.indent, g.indent, condStr))
+			gNames := make([]string, 0, len(group.outputs))
+			for gName := range group.outputs {
+				gNames = append(gNames, gName)
+			}
+			sort.Strings(gNames)
+			for _, gName := range gNames {
+				gRes := group.outputs[gName]
+				g.writeResourceOutput(&sb, gName, gRes, nil, 3)
+			}
+			sb.WriteString(fmt.Sprintf("%s%s}\n", g.indent, g.indent))
 		}
 		sb.WriteString(fmt.Sprintf("%s}\n", g.indent))
 	}

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -876,6 +876,156 @@ var _ = Describe("CUEGenerator", func() {
 		})
 	})
 
+	Describe("GenerateFullDefinition with OutputsGroupIf", func() {
+		It("should render a grouped if block with multiple outputs on a component", func() {
+			enabled := defkit.Bool("enabled")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(enabled).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.OutputsGroupIf(defkit.Eq(enabled, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("service", defkit.NewResource("v1", "Service").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+						g.Add("ingress", defkit.NewResource("networking.k8s.io/v1", "Ingress").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring("outputs: {"))
+			Expect(cue).To(ContainSubstring("if parameter.enabled == true {"))
+			Expect(cue).To(ContainSubstring("service: {"))
+			Expect(cue).To(ContainSubstring("ingress: {"))
+
+			ifIdx := strings.Index(cue, "if parameter.enabled == true {")
+			svcIdx := strings.Index(cue, "service: {")
+			ingIdx := strings.Index(cue, "ingress: {")
+			Expect(ifIdx).To(BeNumerically(">=", 0))
+			Expect(ifIdx).To(BeNumerically("<", ingIdx))
+			Expect(ifIdx).To(BeNumerically("<", svcIdx))
+			Expect(ingIdx).To(BeNumerically("<", svcIdx))
+		})
+
+		It("should render plain Outputs before grouped outputs", func() {
+			enabled := defkit.Bool("enabled")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(enabled).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.Outputs("configmap",
+						defkit.NewResource("v1", "ConfigMap").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.OutputsGroupIf(defkit.Eq(enabled, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("service", defkit.NewResource("v1", "Service").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			cmIdx := strings.Index(cue, "configmap: {")
+			ifIdx := strings.Index(cue, "if parameter.enabled == true {")
+			svcIdx := strings.Index(cue, "service: {")
+			Expect(cmIdx).To(BeNumerically(">=", 0))
+			Expect(ifIdx).To(BeNumerically(">=", 0))
+			Expect(svcIdx).To(BeNumerically(">=", 0))
+			Expect(cmIdx).To(BeNumerically("<", ifIdx))
+			Expect(ifIdx).To(BeNumerically("<", svcIdx))
+		})
+
+		It("should render multiple OutputsGroupIf blocks independently", func() {
+			enabled := defkit.Bool("enabled")
+			debug := defkit.Bool("debug")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(enabled, debug).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.OutputsGroupIf(defkit.Eq(enabled, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("service", defkit.NewResource("v1", "Service").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+					tpl.OutputsGroupIf(defkit.Eq(debug, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("debug-cm", defkit.NewResource("v1", "ConfigMap").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring("if parameter.enabled == true {"))
+			Expect(cue).To(ContainSubstring("if parameter.debug == true {"))
+			Expect(cue).To(ContainSubstring("service: {"))
+			Expect(cue).To(ContainSubstring("debug-cm"))
+		})
+
+		It("should render an outputs block even with only grouped outputs (no plain Outputs)", func() {
+			enabled := defkit.Bool("enabled")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(enabled).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.OutputsGroupIf(defkit.Eq(enabled, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("service", defkit.NewResource("v1", "Service").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+						g.Add("ingress", defkit.NewResource("networking.k8s.io/v1", "Ingress").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			Expect(cue).To(ContainSubstring("outputs: {"))
+			Expect(cue).To(ContainSubstring("if parameter.enabled == true {"))
+			Expect(cue).To(ContainSubstring("service: {"))
+			Expect(cue).To(ContainSubstring("ingress: {"))
+		})
+
+		It("should render grouped output names sorted alphabetically", func() {
+			enabled := defkit.Bool("enabled")
+			comp := defkit.NewComponent("test").
+				Workload("apps/v1", "Deployment").
+				Params(enabled).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("apps/v1", "Deployment").
+							Set("metadata.name", defkit.VelaCtx().Name()),
+					)
+					tpl.OutputsGroupIf(defkit.Eq(enabled, defkit.Lit(true)), func(g *defkit.OutputGroup) {
+						g.Add("z-ingress", defkit.NewResource("networking.k8s.io/v1", "Ingress").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+						g.Add("a-svc", defkit.NewResource("v1", "Service").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := gen.GenerateFullDefinition(comp)
+
+			aIdx := strings.Index(cue, "a-svc")
+			zIdx := strings.Index(cue, "z-ingress")
+			Expect(aIdx).To(BeNumerically(">=", 0))
+			Expect(zIdx).To(BeNumerically(">=", 0))
+			Expect(aIdx).To(BeNumerically("<", zIdx))
+		})
+	})
+
 	Describe("Import detection", func() {
 		It("should detect strconv import from FormatInt", func() {
 			port := defkit.Int("port")

--- a/pkg/definition/defkit/trait.go
+++ b/pkg/definition/defkit/trait.go
@@ -700,16 +700,20 @@ func (g *TraitCUEGenerator) writeUnifiedTemplate(sb *strings.Builder, t *TraitDe
 		sb.WriteString("\n")
 	}
 
-	// Generate outputs block if present
-	if outputs := tpl.GetOutputs(); len(outputs) > 0 {
-		outputNames := sortedKeys(outputs)
+	// Generate outputs block if either plain Outputs or grouped OutputsGroupIf
+	// entries exist. Gating solely on len(outputs) > 0 would silently drop a
+	// trait that uses only OutputsGroupIf with no plain Outputs sibling.
+	outputs := tpl.GetOutputs()
+	outputGroups := tpl.GetOutputGroups()
+	if len(outputs) > 0 || len(outputGroups) > 0 {
 		sb.WriteString(fmt.Sprintf("%soutputs: {\n", indent))
-		for _, name := range outputNames {
-			res := outputs[name]
-			g.writeTraitResourceOutput(sb, gen, name, res, depth+1)
+		if len(outputs) > 0 {
+			for _, name := range sortedKeys(outputs) {
+				res := outputs[name]
+				g.writeTraitResourceOutput(sb, gen, name, res, depth+1)
+			}
 		}
-		// Render output groups (multiple outputs under one condition)
-		for _, group := range tpl.GetOutputGroups() {
+		for _, group := range outputGroups {
 			condStr := gen.conditionToCUE(group.cond)
 			sb.WriteString(fmt.Sprintf("%s\tif %s {\n", indent, condStr))
 			for _, gName := range sortedKeys(group.outputs) {

--- a/pkg/definition/defkit/trait_test.go
+++ b/pkg/definition/defkit/trait_test.go
@@ -1849,6 +1849,90 @@ template: {
 		})
 	})
 
+	Context("OutputsGroupIf with no plain Outputs sibling", func() {
+		It("should render an outputs block for a trait with only grouped outputs", func() {
+			trait := defkit.NewTrait("tls-companions").
+				Description("Attach TLS companion resources").
+				Params(defkit.Bool("tlsEnabled").Default(false)).
+				Template(func(tpl *defkit.Template) {
+					tpl.Patch().Set("spec.replicas", defkit.Lit(1))
+					tpl.OutputsGroupIf(defkit.PathExists("parameter.tlsEnabled"), func(g *defkit.OutputGroup) {
+						g.Add("tls-secret", defkit.NewResource("v1", "Secret").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+						g.Add("tls-cm", defkit.NewResource("v1", "ConfigMap").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := trait.ToCue()
+
+			Expect(cue).To(ContainSubstring("outputs: {"))
+			Expect(cue).To(ContainSubstring("if parameter.tlsEnabled != _|_ {"))
+			Expect(cue).To(ContainSubstring("tls-cm"))
+			Expect(cue).To(ContainSubstring("tls-secret"))
+
+			cmIdx := strings.Index(cue, "tls-cm")
+			secIdx := strings.Index(cue, "tls-secret")
+			Expect(cmIdx).To(BeNumerically(">=", 0))
+			Expect(secIdx).To(BeNumerically(">=", 0))
+			Expect(cmIdx).To(BeNumerically("<", secIdx))
+		})
+
+		It("should render multiple independent OutputsGroupIf blocks with no plain outputs", func() {
+			trait := defkit.NewTrait("multi-group").
+				Description("Multiple grouped outputs").
+				Params(
+					defkit.Bool("tlsEnabled").Default(false),
+					defkit.Bool("tracingEnabled").Default(false),
+				).
+				Template(func(tpl *defkit.Template) {
+					tpl.Patch().Set("spec.replicas", defkit.Lit(1))
+					tpl.OutputsGroupIf(defkit.PathExists("parameter.tlsEnabled"), func(g *defkit.OutputGroup) {
+						g.Add("tls-secret", defkit.NewResource("v1", "Secret").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+					tpl.OutputsGroupIf(defkit.PathExists("parameter.tracingEnabled"), func(g *defkit.OutputGroup) {
+						g.Add("tracing-cm", defkit.NewResource("v1", "ConfigMap").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := trait.ToCue()
+
+			Expect(cue).To(ContainSubstring("outputs: {"))
+			Expect(cue).To(ContainSubstring("if parameter.tlsEnabled != _|_ {"))
+			Expect(cue).To(ContainSubstring("if parameter.tracingEnabled != _|_ {"))
+			Expect(cue).To(ContainSubstring("tls-secret"))
+			Expect(cue).To(ContainSubstring("tracing-cm"))
+		})
+
+		It("should render plain Outputs before grouped outputs on a trait", func() {
+			trait := defkit.NewTrait("mixed").
+				Description("Mix plain and grouped outputs").
+				Params(defkit.Bool("extras").Default(false)).
+				Template(func(tpl *defkit.Template) {
+					tpl.Patch().Set("spec.replicas", defkit.Lit(1))
+					tpl.Outputs("always-cm", defkit.NewResource("v1", "ConfigMap").
+						Set("metadata.name", defkit.VelaCtx().Name()))
+					tpl.OutputsGroupIf(defkit.PathExists("parameter.extras"), func(g *defkit.OutputGroup) {
+						g.Add("extra-secret", defkit.NewResource("v1", "Secret").
+							Set("metadata.name", defkit.VelaCtx().Name()))
+					})
+				})
+
+			cue := trait.ToCue()
+
+			alwaysIdx := strings.Index(cue, "always-cm")
+			ifIdx := strings.Index(cue, "if parameter.extras != _|_ {")
+			extraIdx := strings.Index(cue, "extra-secret")
+			Expect(alwaysIdx).To(BeNumerically(">=", 0))
+			Expect(ifIdx).To(BeNumerically(">=", 0))
+			Expect(extraIdx).To(BeNumerically(">=", 0))
+			Expect(alwaysIdx).To(BeNumerically("<", ifIdx))
+			Expect(ifIdx).To(BeNumerically("<", extraIdx))
+		})
+	})
+
 	Context("TemplateBlock with labels", func() {
 		It("should render sorted labels when using TemplateBlock", func() {
 			result := defkit.NewTrait("scaler").


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes two related silent-drop bugs in the defkit CUE generator where `tpl.OutputsGroupIf(...)` was ignored at render time.
                                                                                                                                                                                                                                                                       
  - **Bug 1 — component**: components never rendered `OutputsGroupIf` at all. The method was exposed on the component builder but the generator only read `GetOutputs()` / `GetOutput()`.                                                                              
  - **Bug 2 — trait**: traits rendered grouped outputs only when a plain `Outputs()` sibling was also present; a trait using only `OutputsGroupIf` emitted no `outputs:` block.                                                                                        
                                                                                                                                                                                                                                                                       
  In both cases the fix is the same shape: open the `outputs: { ... }` block whenever either plain outputs OR output groups exist, and render groups as `if <cond> { ... }` with members sorted alphabetically. The two code paths now behave identically.             
                                                                                                                                                                                                                                                                       
  ## Changes                                                                                                                                                                                                                                                           
  - `pkg/definition/defkit/cuegen.go` — component generator: gate + render grouped outputs.                                                                                                                                                                            
  - `pkg/definition/defkit/trait.go` — trait generator: gate fix (the inner render code was already correct).                                           
  - `pkg/definition/defkit/cuegen_test.go` — 5 new tests covering component grouped-only, mixed ordering, multiple groups, and sorting.                                                                                                                                
  - `pkg/definition/defkit/trait_test.go` — 3 new tests covering trait grouped-only (the Bug 2 repro), multiple groups without plain outputs, and mixed ordering.       

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

 - [x] `go test ./pkg/definition/defkit/...` — full suite passes                                                                                                                                                                                                      
  - [x] `go vet ./pkg/definition/defkit/...` — clean                                                                                                                                                                                                                   
  - [x] End-to-end: scratch component + scratch trait each rendered through `NewCUEGenerator`/`ToCue` now produce the expected `if <cond> { ... }` block; previously the block was missing.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
Both bugs collapse to the same broken gate (`len(outputs) > 0`) that treated output groups as nonexistent. The one load-bearing line in each file is the gate change to `len(outputs) > 0 || len(outputGroups) > 0`; everything else is pre-existing render logic or 
  new tests. The component generator now mirrors the trait emission shape exactly — plain outputs sorted first, then one `if <cond> { ... }` block per group with members sorted alphabetically. Scope verified: `PolicyDefinition` / `WorkflowStepDefinition` use     
  their own template types and don't render Kubernetes-resource outputs, so they're unaffected.   