### PR TITLE
Fix: storage trait gracefully patches env vars that conflict with component definition

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -115,7 +115,8 @@ spec:
         envList: [
         	if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnv != _|_ {
         		{
-        			name: v.mountToEnv.envName
+        			name:  v.mountToEnv.envName
+        			value: ""
         			valueFrom: configMapKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.configMapKey
@@ -124,7 +125,8 @@ spec:
         	},
         	if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
-        			name: k.envName
+        			name:  k.envName
+        			value: ""
         			valueFrom: configMapKeyRef: {
         				name: v.name
         				key:  k.configMapKey
@@ -133,7 +135,8 @@ spec:
         	},
         	if parameter.secret != _|_ for v in parameter.secret if v.mountToEnv != _|_ {
         		{
-        			name: v.mountToEnv.envName
+        			name:  v.mountToEnv.envName
+        			value: ""
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
@@ -142,7 +145,8 @@ spec:
         	},
         	if parameter.secret != _|_ for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
         		{
-        			name: k.envName
+        			name:  k.envName
+        			value: ""
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  k.secretKey
@@ -176,23 +180,13 @@ spec:
         	},
         ]
 
-        _baseContainerEnv: *[] | [...]
-        if context.output.spec.template.spec.containers != _|_ {
-        	if context.output.spec.template.spec.containers[0].env != _|_ {
-        		_baseContainerEnv: context.output.spec.template.spec.containers[0].env
-        	}
-        }
-        _storageEnvNames: {for e in envList {(e.name): true}}
-
         patch: spec: template: spec: {
         	// +patchKey=name
         	volumes: deDupVolumesArray
 
         	containers: [{
-        		if len(envList) > 0 {
-        			// +patchStrategy=replace
-        			env: [for e in _baseContainerEnv if _storageEnvNames[e.name] == _|_ {e}] + envList
-        		}
+        		// +patchKey=name
+        		env: envList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name

--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -176,13 +176,23 @@ spec:
         	},
         ]
 
+        _baseContainerEnv: *[] | [...]
+        if context.output.spec.template.spec.containers != _|_ {
+        	if context.output.spec.template.spec.containers[0].env != _|_ {
+        		_baseContainerEnv: context.output.spec.template.spec.containers[0].env
+        	}
+        }
+        _storageEnvNames: {for e in envList {(e.name): true}}
+
         patch: spec: template: spec: {
         	// +patchKey=name
         	volumes: deDupVolumesArray
 
         	containers: [{
-        		// +patchKey=name
-        		env: envList
+        		if len(envList) > 0 {
+        			// +patchStrategy=replace
+        			env: [for e in _baseContainerEnv if _storageEnvNames[e.name] == _|_ {e}] + envList
+        		}
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller_test.go
@@ -354,6 +354,31 @@ var _ = Describe("Test Application Controller", func() {
 		},
 	}
 
+	appWithEnvConflict := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Application",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-env-conflict",
+		},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{
+					Name:       "conflict-worker",
+					Type:       "worker",
+					Properties: &runtime.RawExtension{Raw: []byte(`{"cmd":["sleep","1000"],"image":"busybox","env":[{"name":"API_KEY","value":"hardcoded"}]}`)},
+				},
+			},
+		},
+	}
+	appWithEnvConflict.Spec.Components[0].Traits = []common.ApplicationTrait{
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte(`{"secret":[{"name":"conflict-secret","mountToEnv":{"envName":"API_KEY","secretKey":"api-key"},"data":{"api-key":"c2VjcmV0"}}]}`)},
+		},
+	}
+
 	appWithAffinity := &v1beta1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
@@ -3565,6 +3590,56 @@ var _ = Describe("Test Application Controller", func() {
 
 		Expect(k8sClient.Delete(ctx, cm)).Should(BeNil())
 		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
+	})
+
+	It("storage trait should replace conflicting env var from component instead of merging", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vela-test-env-conflict",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(BeNil())
+
+		appWithEnvConflict.SetNamespace(ns.Name)
+		app := appWithEnvConflict.DeepCopy()
+		Expect(k8sClient.Create(ctx, app)).Should(BeNil())
+
+		appKey := client.ObjectKey{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+		}
+		testutil.ReconcileOnceAfterFinalizer(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("Check App running successfully")
+		curApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, curApp)).Should(BeNil())
+		Expect(curApp.Status.Phase).Should(Equal(common.ApplicationRunning))
+
+		By("Check Deployment env only has valueFrom for the conflicting var, not both value and valueFrom")
+		deployment := &v1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name,
+		}, deployment)).Should(BeNil())
+
+		containers := deployment.Spec.Template.Spec.Containers
+		Expect(len(containers)).Should(BeNumerically(">", 0))
+
+		var apiKeyEnv *corev1.EnvVar
+		for i := range containers[0].Env {
+			if containers[0].Env[i].Name == "API_KEY" {
+				apiKeyEnv = &containers[0].Env[i]
+				break
+			}
+		}
+		Expect(apiKeyEnv).ShouldNot(BeNil(), "API_KEY env var should be present in Deployment")
+		Expect(apiKeyEnv.Value).Should(BeEmpty(), "API_KEY should not retain plain value when storage trait provides valueFrom")
+		Expect(apiKeyEnv.ValueFrom).ShouldNot(BeNil(), "API_KEY should have valueFrom set by storage trait")
+		Expect(apiKeyEnv.ValueFrom.SecretKeyRef).ShouldNot(BeNil())
+		Expect(apiKeyEnv.ValueFrom.SecretKeyRef.Name).Should(Equal("conflict-secret"))
+		Expect(apiKeyEnv.ValueFrom.SecretKeyRef.Key).Should(Equal("api-key"))
+
 		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
 	})
 

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -109,7 +109,8 @@ template: {
 	envList: [
 		if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnv != _|_ {
 			{
-				name: v.mountToEnv.envName
+				name:  v.mountToEnv.envName
+				value: ""
 				valueFrom: configMapKeyRef: {
 					name: v.name
 					key:  v.mountToEnv.configMapKey
@@ -118,7 +119,8 @@ template: {
 		},
 		if parameter.configMap != _|_ for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
 			{
-				name: k.envName
+				name:  k.envName
+				value: ""
 				valueFrom: configMapKeyRef: {
 					name: v.name
 					key:  k.configMapKey
@@ -127,7 +129,8 @@ template: {
 		},
 		if parameter.secret != _|_ for v in parameter.secret if v.mountToEnv != _|_ {
 			{
-				name: v.mountToEnv.envName
+				name:  v.mountToEnv.envName
+				value: ""
 				valueFrom: secretKeyRef: {
 					name: v.name
 					key:  v.mountToEnv.secretKey
@@ -136,7 +139,8 @@ template: {
 		},
 		if parameter.secret != _|_ for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
 			{
-				name: k.envName
+				name:  k.envName
+				value: ""
 				valueFrom: secretKeyRef: {
 					name: v.name
 					key:  k.secretKey
@@ -170,23 +174,13 @@ template: {
 		},
 	]
 
-	_baseContainerEnv: *[] | [...]
-	if context.output.spec.template.spec.containers != _|_ {
-		if context.output.spec.template.spec.containers[0].env != _|_ {
-			_baseContainerEnv: context.output.spec.template.spec.containers[0].env
-		}
-	}
-	_storageEnvNames: {for e in envList {(e.name): true}}
-
 	patch: spec: template: spec: {
 		// +patchKey=name
 		volumes: deDupVolumesArray
 
 		containers: [{
-			if len(envList) > 0 {
-				// +patchStrategy=replace
-				env: [for e in _baseContainerEnv if _storageEnvNames[e.name] == _|_ {e}] + envList
-			}
+			// +patchKey=name
+			env: envList
 			// +patchKey=name
 			volumeDevices: volumeDevicesList
 			// +patchKey=name

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -170,13 +170,23 @@ template: {
 		},
 	]
 
+	_baseContainerEnv: *[] | [...]
+	if context.output.spec.template.spec.containers != _|_ {
+		if context.output.spec.template.spec.containers[0].env != _|_ {
+			_baseContainerEnv: context.output.spec.template.spec.containers[0].env
+		}
+	}
+	_storageEnvNames: {for e in envList {(e.name): true}}
+
 	patch: spec: template: spec: {
 		// +patchKey=name
 		volumes: deDupVolumesArray
 
 		containers: [{
-			// +patchKey=name
-			env: envList
+			if len(envList) > 0 {
+				// +patchStrategy=replace
+				env: [for e in _baseContainerEnv if _storageEnvNames[e.name] == _|_ {e}] + envList
+			}
 			// +patchKey=name
 			volumeDevices: volumeDevicesList
 			// +patchKey=name


### PR DESCRIPTION
###  Summary

When a component defines an env var with a plain `value` (e.g. `API_KEY: hardcoded`) and the `storage` trait targets the same name via `mountToEnv`/`mountToEnvs`, the previous `+patchKey=name` strategy merged fields rather than replacing the matched entry. The resulting Deployment contained both `value` and `valueFrom` for the same env var, which is invalid and rejected by Kubernetes.

**Root cause:** `// +patchKey=name` on `env: envList` performs a field-level merge on matched items. Since the storage trait entry only has `valueFrom` and the base entry only has `value`, the merge keeps both fields.

**Fix:** Read the base container env from `context.output`, drop entries whose name conflicts with a storage-provided var, and apply `// +patchStrategy=replace` so the full list is replaced atomically. A `len(envList) > 0` guard prevents wiping the component env when no `mountToEnv`/`mountToEnvs` is configured.

Fixes #6841

### How has this code been tested

Added an integration test in `application_controller_test.go`:
- Component declares `env: [{name: "API_KEY", value: "hardcoded"}]`
- Storage trait wires `API_KEY` from a Secret via `mountToEnv`
- Test reconciles the app and fetches the resulting Deployment
- Asserts `API_KEY` has `valueFrom.secretKeyRef` set correctly and no plain `value`
