### PR TITLE
Feat(server): add validation to server config

### DIFF
--- a/cmd/core/app/config/server.go
+++ b/cmd/core/app/config/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -62,4 +63,27 @@ func (c *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 		"The duration that the acting controlplane will retry refreshing leadership before giving up")
 	fs.DurationVar(&c.RetryPeriod, "leader-election-retry-period", c.RetryPeriod,
 		"The duration the LeaderElector clients should wait between tries of actions")
+}
+
+// Validate checks if the server configuration is valid.
+func (c *ServerConfig) Validate() error {
+	if !c.EnableLeaderElection {
+		return nil
+	}
+	if c.LeaseDuration <= 0 {
+		return fmt.Errorf("leader-election-lease-duration must be greater than zero")
+	}
+	if c.RenewDeadline <= 0 {
+		return fmt.Errorf("leader-election-renew-deadline must be greater than zero")
+	}
+	if c.RetryPeriod <= 0 {
+		return fmt.Errorf("leader-election-retry-period must be greater than zero")
+	}
+	if c.LeaseDuration <= c.RenewDeadline {
+		return fmt.Errorf("leader-election-lease-duration must be greater than leader-election-renew-deadline")
+	}
+	if c.RetryPeriod >= c.RenewDeadline-c.RenewDeadline/5 {
+		return fmt.Errorf("leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)")
+	}
+	return nil
 }

--- a/cmd/core/app/config/server_test.go
+++ b/cmd/core/app/config/server_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ServerConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ServerConfig {
+				return NewServerConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with leader election enabled",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: zero lease duration",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative lease duration",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: zero renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RenewDeadline = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RenewDeadline = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: zero retry period",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RetryPeriod = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-retry-period must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative retry period",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RetryPeriod = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-retry-period must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: lease duration equal to renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 10 * time.Second
+				cfg.RenewDeadline = 10 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than leader-election-renew-deadline",
+		},
+		{
+			name: "Invalid configuration: lease duration less than renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 5 * time.Second
+				cfg.RenewDeadline = 10 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than leader-election-renew-deadline",
+		},
+		{
+			name: "Invalid configuration: retry period too close to renew deadline (Jitter)",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 15 * time.Second
+				cfg.RenewDeadline = 5 * time.Second
+				cfg.RetryPeriod = 5 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServerConfig_AddFlags(t *testing.T) {
+	cfg := NewServerConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--health-addr=:9441",
+		"--storage-driver=mysql",
+		"--enable-leader-election=true",
+		"--leader-election-namespace=vela-system",
+		"--leader-election-lease-duration=20s",
+		"--leader-election-renew-deadline=15s",
+		"--leader-election-retry-period=5s",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ":9441", cfg.HealthAddr)
+	assert.Equal(t, "mysql", cfg.StorageDriver)
+	assert.True(t, cfg.EnableLeaderElection)
+	assert.Equal(t, "vela-system", cfg.LeaderElectionNamespace)
+	assert.Equal(t, 20*time.Second, cfg.LeaseDuration)
+	assert.Equal(t, 15*time.Second, cfg.RenewDeadline)
+	assert.Equal(t, 5*time.Second, cfg.RetryPeriod)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `ServerConfig` to enforce logical constraints on leader-election timers, with isolated unit tests in `cmd/core/app/config/server_test.go`.

This is **Part 1 of a phased approach** to resolve #6950. To keep reviews small and prevent merge conflicts across all configuration structs, the work is broken down as follows:

- **Phase 1 (Current PRs):** Adding an isolated `Validate()` method and unit tests for each configuration struct in separate, bite-sized PRs one module at a time.
- **Phase 2 (Final Integration):** Once the individual validations are merged, a final PR will wire everything into `CoreOptions.Validate()` and hook it into the core server startup in `cmd/core/app/server.go`.

Related to #6950

I have:
- [x] Read and followed KubeVela's contribution process.
- [x] Related Docs updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/server_test.go` to verify the `Validate()` method correctly rejects invalid lease durations and retry periods, while passing valid configurations.

### Special notes for your reviewer

This is the first PR in the series. Subsequent PRs will follow the same pattern one config module per PR, same structure. The final integration PR will be the only one touching shared files.