### PR TITLE
Fix: Add bounded LRU byte cache store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/hcl/v2 v2.18.0
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.18.0 h1:wYnG7Lt31t2zYkcquwgKo6MWXzRUDIeIVU5naZwHLl8=

--- a/pkg/utils/cache/lru_byte_store.go
+++ b/pkg/utils/cache/lru_byte_store.go
@@ -72,8 +72,6 @@ func (s *LRUByteStore) Put(key string, data []byte, ttl time.Duration) {
 		return
 	}
 
-	s.pruneExpiredLocked()
-
 	size := int64(len(data))
 	if s.maxBytes <= 0 || size > s.maxBytes {
 		s.deleteLocked(key)
@@ -125,7 +123,6 @@ func (s *LRUByteStore) Delete(key string) {
 func (s *LRUByteStore) Bytes() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.pruneExpiredLocked()
 	return s.bytes
 }
 
@@ -141,15 +138,6 @@ func (s *LRUByteStore) Close() {
 func (s *LRUByteStore) deleteLocked(key string) {
 	if _, ok := s.cache.Peek(key); ok {
 		s.cache.Remove(key)
-	}
-}
-
-func (s *LRUByteStore) pruneExpiredLocked() {
-	for _, key := range s.cache.Keys() {
-		entry, ok := s.cache.Peek(key)
-		if ok && entry.expired() {
-			s.cache.Remove(key)
-		}
 	}
 }
 

--- a/pkg/utils/cache/lru_byte_store.go
+++ b/pkg/utils/cache/lru_byte_store.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// MissReason describes why a cache lookup missed.
+type MissReason string
+
+const (
+	// MissReasonNone means the cache lookup found a value.
+	MissReasonNone MissReason = ""
+	// MissReasonNotFound means the key is not present in the cache.
+	MissReasonNotFound MissReason = "not_found"
+	// MissReasonExpired means the key was present but its TTL had elapsed.
+	MissReasonExpired MissReason = "expired"
+)
+
+type lruByteEntry struct {
+	data      []byte
+	expiresAt time.Time
+}
+
+// LRUByteStore stores byte slices with a maximum byte budget and LRU eviction.
+type LRUByteStore struct {
+	mu       sync.Mutex
+	maxBytes int64
+	bytes    int64
+	cache    *lru.Cache[string, *lruByteEntry]
+	closed   bool
+}
+
+// NewLRUByteStore creates an LRUByteStore bounded by maxBytes.
+func NewLRUByteStore(maxBytes int64) (*LRUByteStore, error) {
+	store := &LRUByteStore{maxBytes: maxBytes}
+	maxEntries := int(^uint(0) >> 1)
+	c, err := lru.NewWithEvict[string, *lruByteEntry](maxEntries, func(_ string, entry *lruByteEntry) {
+		store.bytes -= int64(len(entry.data))
+	})
+	if err != nil {
+		return nil, err
+	}
+	store.cache = c
+	return store, nil
+}
+
+// Put stores data for key until ttl elapses. Non-positive ttl means no expiry.
+func (s *LRUByteStore) Put(key string, data []byte, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+
+	s.pruneExpiredLocked()
+
+	size := int64(len(data))
+	if s.maxBytes <= 0 || size > s.maxBytes {
+		s.deleteLocked(key)
+		return
+	}
+
+	s.deleteLocked(key)
+
+	entry := &lruByteEntry{data: append([]byte(nil), data...)}
+	if ttl > 0 {
+		entry.expiresAt = time.Now().Add(ttl)
+	}
+	s.cache.Add(key, entry)
+	s.bytes += size
+
+	for s.bytes > s.maxBytes {
+		s.cache.RemoveOldest()
+	}
+}
+
+// Get returns cached data for key.
+func (s *LRUByteStore) Get(key string) ([]byte, bool, MissReason) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil, false, MissReasonNotFound
+	}
+
+	entry, ok := s.cache.Get(key)
+	if !ok {
+		return nil, false, MissReasonNotFound
+	}
+	if entry.expired() {
+		s.deleteLocked(key)
+		return nil, false, MissReasonExpired
+	}
+	return append([]byte(nil), entry.data...), true, MissReasonNone
+}
+
+// Delete removes key from the store.
+func (s *LRUByteStore) Delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteLocked(key)
+}
+
+// Bytes reports the current bytes held by the store.
+func (s *LRUByteStore) Bytes() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneExpiredLocked()
+	return s.bytes
+}
+
+// Close releases all entries and ignores future Put calls.
+func (s *LRUByteStore) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache.Purge()
+	s.bytes = 0
+	s.closed = true
+}
+
+func (s *LRUByteStore) deleteLocked(key string) {
+	if _, ok := s.cache.Peek(key); ok {
+		s.cache.Remove(key)
+	}
+}
+
+func (s *LRUByteStore) pruneExpiredLocked() {
+	for _, key := range s.cache.Keys() {
+		entry, ok := s.cache.Peek(key)
+		if ok && entry.expired() {
+			s.cache.Remove(key)
+		}
+	}
+}
+
+func (e *lruByteEntry) expired() bool {
+	return !e.expiresAt.IsZero() && time.Now().After(e.expiresAt)
+}

--- a/pkg/utils/cache/lru_byte_store_test.go
+++ b/pkg/utils/cache/lru_byte_store_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLRUByteStorePutGetAndCopy(t *testing.T) {
+	store, err := NewLRUByteStore(10)
+	require.NoError(t, err)
+	defer store.Close()
+
+	input := []byte("data")
+	store.Put("key", input, 0)
+	input[0] = 'D'
+
+	got, ok, reason := store.Get("key")
+	require.True(t, ok)
+	require.Equal(t, MissReasonNone, reason)
+	require.Equal(t, []byte("data"), got)
+
+	got[0] = 'D'
+	got, ok, reason = store.Get("key")
+	require.True(t, ok)
+	require.Equal(t, MissReasonNone, reason)
+	require.Equal(t, []byte("data"), got)
+	require.EqualValues(t, 4, store.Bytes())
+}
+
+func TestLRUByteStoreEvictsLeastRecentlyUsedToStayWithinBudget(t *testing.T) {
+	store, err := NewLRUByteStore(8)
+	require.NoError(t, err)
+	defer store.Close()
+
+	store.Put("first", []byte("1111"), 0)
+	store.Put("second", []byte("2222"), 0)
+
+	_, ok, reason := store.Get("first")
+	require.True(t, ok)
+	require.Equal(t, MissReasonNone, reason)
+
+	store.Put("third", []byte("3333"), 0)
+
+	_, ok, reason = store.Get("second")
+	require.False(t, ok)
+	require.Equal(t, MissReasonNotFound, reason)
+
+	got, ok, reason := store.Get("first")
+	require.True(t, ok)
+	require.Equal(t, MissReasonNone, reason)
+	require.Equal(t, []byte("1111"), got)
+
+	got, ok, reason = store.Get("third")
+	require.True(t, ok)
+	require.Equal(t, MissReasonNone, reason)
+	require.Equal(t, []byte("3333"), got)
+	require.EqualValues(t, 8, store.Bytes())
+}
+
+func TestLRUByteStoreRejectsOversizedEntries(t *testing.T) {
+	store, err := NewLRUByteStore(4)
+	require.NoError(t, err)
+	defer store.Close()
+
+	store.Put("key", []byte("data"), 0)
+	store.Put("key", []byte("too large"), 0)
+
+	_, ok, reason := store.Get("key")
+	require.False(t, ok)
+	require.Equal(t, MissReasonNotFound, reason)
+	require.Zero(t, store.Bytes())
+}
+
+func TestLRUByteStoreExpiresEntries(t *testing.T) {
+	store, err := NewLRUByteStore(10)
+	require.NoError(t, err)
+	defer store.Close()
+
+	store.Put("key", []byte("data"), time.Nanosecond)
+	require.Eventually(t, func() bool {
+		_, ok, reason := store.Get("key")
+		return !ok && reason == MissReasonExpired
+	}, time.Second, time.Millisecond)
+	require.Zero(t, store.Bytes())
+}
+
+func TestLRUByteStoreDeleteAndClose(t *testing.T) {
+	store, err := NewLRUByteStore(10)
+	require.NoError(t, err)
+
+	store.Put("key", []byte("data"), 0)
+	store.Delete("key")
+	_, ok, reason := store.Get("key")
+	require.False(t, ok)
+	require.Equal(t, MissReasonNotFound, reason)
+	require.Zero(t, store.Bytes())
+
+	store.Put("key", []byte("data"), 0)
+	store.Close()
+	require.Zero(t, store.Bytes())
+
+	store.Put("key", []byte("data"), 0)
+	_, ok, reason = store.Get("key")
+	require.False(t, ok)
+	require.Equal(t, MissReasonNotFound, reason)
+}


### PR DESCRIPTION
### Description of your changes

Adds a bounded `LRUByteStore` under `pkg/utils/cache` for chart/cache byte storage.

This store is backed by `github.com/hashicorp/golang-lru/v2` and provides:
- byte-based accounting through `Bytes()`
- LRU eviction when inserting would exceed the configured byte budget
- oversized entry rejection
- TTL-aware cache misses with `MissReason`
- defensive byte-slice copies on `Put` and `Get`
- cleanup through `Delete()` and `Close()`

## Fixes 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added unit tests for `LRUByteStore` covering:
- put/get behavior
- defensive copy behavior
- LRU eviction under byte budget pressure
- oversized entry rejection
- TTL expiration
- delete and close behavior

Tested with:

```bash
go test ./pkg/utils/cache
```
fixes #7114 

