### PR TITLE
Fix: resolve goroutine leaks and delayed context cancellation in background polling loops

### DIFF
--- a/pkg/cache/informer.go
+++ b/pkg/cache/informer.go
@@ -198,21 +198,29 @@ func (in *DefinitionCache) Start(ctx context.Context, store cache.Cache, duratio
 	if err != nil {
 		klog.ErrorS(err, "failed to add event handler for definition cache")
 	}
+	pruneFunc := func() {
+		t0 := time.Now()
+		compDefPruned := in.ComponentDefinitionCache.Prune(duration)
+		traitDefPruned := in.TraitDefinitionCache.Prune(duration)
+		wsDefPruned := in.WorkflowStepDefinitionCache.Prune(duration)
+		klog.Infof("DefinitionCache prune finished. ComponentDefinition: %d(-%d), TraitDefinition: %d(-%d), WorkflowStepDefinition: %d(-%d). Time cost: %d ms.",
+			in.ComponentDefinitionCache.Size(), compDefPruned,
+			in.TraitDefinitionCache.Size(), traitDefPruned,
+			in.WorkflowStepDefinitionCache.Size(), wsDefPruned,
+			time.Since(t0).Microseconds())
+	}
+
+	pruneFunc()
+
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			t0 := time.Now()
-			compDefPruned := in.ComponentDefinitionCache.Prune(duration)
-			traitDefPruned := in.TraitDefinitionCache.Prune(duration)
-			wsDefPruned := in.WorkflowStepDefinitionCache.Prune(duration)
-			klog.Infof("DefinitionCache prune finished. ComponentDefinition: %d(-%d), TraitDefinition: %d(-%d), WorkflowStepDefinition: %d(-%d). Time cost: %d ms.",
-				in.ComponentDefinitionCache.Size(), compDefPruned,
-				in.TraitDefinitionCache.Size(), traitDefPruned,
-				in.WorkflowStepDefinitionCache.Size(), wsDefPruned,
-				time.Since(t0).Microseconds())
-			time.Sleep(duration)
+		case <-ticker.C:
+			pruneFunc()
 		}
 	}
 }

--- a/pkg/cache/informer_test.go
+++ b/pkg/cache/informer_test.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockCache struct {
+	ctrlcache.Cache
+}
+
+func (m *mockCache) GetInformer(ctx context.Context, obj client.Object, opts ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	return &mockInformer{}, nil
+}
+
+type mockInformer struct {
+	ctrlcache.Informer
+}
+
+func (m *mockInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func TestDefinitionCache_Start(t *testing.T) {
+	in := NewDefinitionCache()
+	ctx, cancel := context.WithCancel(context.Background())
+	
+	go in.Start(ctx, &mockCache{}, 10*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+}

--- a/pkg/cache/informer_test.go
+++ b/pkg/cache/informer_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cache
 
 import (

--- a/pkg/cache/informer_test.go
+++ b/pkg/cache/informer_test.go
@@ -45,7 +45,7 @@ func (m *mockInformer) AddEventHandler(handler cache.ResourceEventHandler) (cach
 func TestDefinitionCache_Start(t *testing.T) {
 	in := NewDefinitionCache()
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	go in.Start(ctx, &mockCache{}, 10*time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 	cancel()

--- a/pkg/monitor/watcher/application.go
+++ b/pkg/monitor/watcher/application.go
@@ -86,12 +86,13 @@ func (watcher *applicationMetricsWatcher) report() {
 
 func (watcher *applicationMetricsWatcher) run() {
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-watcher.stopCh:
 				return
-			default:
-				time.Sleep(time.Second)
+			case <-ticker.C:
 				watcher.report()
 			}
 		}

--- a/pkg/monitor/watcher/application_test.go
+++ b/pkg/monitor/watcher/application_test.go
@@ -18,6 +18,7 @@ package watcher
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,5 +258,22 @@ func TestApplicationMetricsWatcher(t *testing.T) {
 		assert.Equal(t, "test-app", resultApp.Name)
 		assert.Equal(t, "test-ns", resultApp.Namespace)
 		assert.Equal(t, common.ApplicationRunning, resultApp.Status.Phase)
+	})
+
+	t.Run("run and stop watcher loop", func(t *testing.T) {
+		t.Parallel()
+		watcher := &applicationMetricsWatcher{
+			phaseCounter:     map[string]int{},
+			stepPhaseCounter: map[string]int{},
+			phaseDirty:       map[string]struct{}{},
+			stepPhaseDirty:   map[string]struct{}{},
+			stopCh:           make(chan struct{}),
+		}
+		watcher.run()
+		// Wait for at least one tick (1s) to hit the case <-ticker.C:
+		time.Sleep(1200 * time.Millisecond)
+		close(watcher.stopCh)
+		// Wait a bit for the goroutine to exit via case <-watcher.stopCh:
+		time.Sleep(100 * time.Millisecond)
 	})
 }

--- a/pkg/multicluster/cluster_metrics_management.go
+++ b/pkg/multicluster/cluster_metrics_management.go
@@ -81,17 +81,25 @@ func (cmm *ClusterMetricsMgr) Refresh() ([]VirtualCluster, error) {
 
 // Start will start polling cluster api to collect metrics
 func (cmm *ClusterMetricsMgr) Start(ctx context.Context) {
+	refreshFunc := func() {
+		clusters, _ := cmm.Refresh()
+		for _, cluster := range clusters {
+			exportMetrics(cluster.Metrics, cluster.Name)
+		}
+	}
+
+	refreshFunc()
+
+	ticker := time.NewTicker(cmm.refreshPeriod)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			klog.Warning("Stop cluster metrics polling loop.")
 			return
-		default:
-			clusters, _ := cmm.Refresh()
-			for _, cluster := range clusters {
-				exportMetrics(cluster.Metrics, cluster.Name)
-			}
-			time.Sleep(cmm.refreshPeriod)
+		case <-ticker.C:
+			refreshFunc()
 		}
 	}
 }

--- a/pkg/multicluster/cluster_metrics_management_test.go
+++ b/pkg/multicluster/cluster_metrics_management_test.go
@@ -66,9 +66,10 @@ func TestRefresh(t *testing.T) {
 	fakeClient.AddCluster(DisconnectedClusterName, disconnectedCluster)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	mgr, err := NewClusterMetricsMgr(ctx, fakeClient, 10*time.Millisecond)
 	assert.NoError(t, err)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
 	time.Sleep(20 * time.Millisecond)
 
 	_, err = mgr.Refresh()

--- a/pkg/multicluster/cluster_metrics_management_test.go
+++ b/pkg/multicluster/cluster_metrics_management_test.go
@@ -65,8 +65,11 @@ func TestRefresh(t *testing.T) {
 	fakeClient.AddCluster(NormalClusterName, normalCluster)
 	fakeClient.AddCluster(DisconnectedClusterName, disconnectedCluster)
 
-	mgr, err := NewClusterMetricsMgr(context.Background(), fakeClient, 15*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr, err := NewClusterMetricsMgr(ctx, fakeClient, 10*time.Millisecond)
 	assert.NoError(t, err)
+	time.Sleep(20 * time.Millisecond)
 
 	_, err = mgr.Refresh()
 	assert.NoError(t, err)


### PR DESCRIPTION
### Description of your changes

This pull request addresses a critical concurrency issue where several long-running background goroutines in the Kubevela core controller ignore context cancellations (`<-ctx.Done()`) for extended periods, leading to severe goroutine leaks and delayed garbage collection during controller teardown or component re-syncs.

Specifically, in `DefinitionCache`, `ClusterMetricsMgr`, and the application `watcher`, the code previously utilized a non-blocking `select` loop that defaulted to a synchronous `time.Sleep()` (which in the case of `DefinitionCache` blocked for up to 1 hour). 

This PR replaces the `time.Sleep` anti-pattern with idiomatic `time.Ticker` logic. To ensure no behavioral regressions, the logic payload (e.g., the cache prune or metrics refresh) was extracted into a closure that executes immediately upon startup before the `select` loop begins, ensuring immediate availability of metrics and pruned cache, while still instantly respecting shutdown signals.

Fixes #7117

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I verified the fix by compiling the core controllers and running the local unit test suite using `go test ./pkg/cache/... ./pkg/multicluster/... ./pkg/monitor/watcher/...`. The background routines now gracefully shut down instantly when the context is cancelled, preventing the hanging behaviors seen previously in `pprof` traces during teardown.

### Special notes for your reviewer

Because this replaces `time.Sleep` in the `default` case, it's important to note that a `Ticker` pauses *before* firing the first event. To maintain the original behavior of "run first, then wait", the closures (`pruneFunc()` and `refreshFunc()`) are manually invoked once right before entering the `for` loop. This guarantees exactly the same functional behavior as the previous implementation, but with safe context cancellation.
