### PR TITLE
Feat(webhook): add validation to webhook config

### DIFF
--- a/cmd/core/app/config/webhook.go
+++ b/cmd/core/app/config/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
@@ -44,4 +46,18 @@ func (c *WebhookConfig) AddFlags(fs *pflag.FlagSet) {
 		"Admission webhook cert/key dir.")
 	fs.IntVar(&c.WebhookPort, "webhook-port", c.WebhookPort,
 		"admission webhook listen address")
+}
+
+// Validate checks if the webhook configuration is valid.
+func (c *WebhookConfig) Validate() error {
+	if c.WebhookPort <= 0 {
+		return fmt.Errorf("webhook-port must be greater than zero")
+	}
+	if c.WebhookPort > 65535 {
+		return fmt.Errorf("webhook-port must be between 1 and 65535 (inclusive)")
+	}
+	if c.UseWebhook && c.CertDir == "" {
+		return fmt.Errorf("webhook-cert-dir must not be empty when use-webhook is true")
+	}
+	return nil
 }

--- a/cmd/core/app/config/webhook_test.go
+++ b/cmd/core/app/config/webhook_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *WebhookConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *WebhookConfig {
+				return NewWebhookConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with webhook enabled and cert dir",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/k8s-webhook-server/certs"
+				cfg.WebhookPort = 9443
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: webhook enabled without cert dir",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-cert-dir must not be empty when use-webhook is true",
+		},
+		{
+			name: "Invalid configuration: webhook enabled with negative port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/certs"
+				cfg.WebhookPort = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook enabled with zero port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/certs"
+				cfg.WebhookPort = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook disabled with negative port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = false
+				cfg.WebhookPort = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook port above 65535",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.WebhookPort = 65536
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be between 1 and 65535 (inclusive)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWebhookConfig_AddFlags(t *testing.T) {
+	cfg := NewWebhookConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--use-webhook=true",
+		"--webhook-cert-dir=/tmp/certs",
+		"--webhook-port=8443",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.UseWebhook)
+	assert.Equal(t, "/tmp/certs", cfg.CertDir)
+	assert.Equal(t, 8443, cfg.WebhookPort)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `WebhookConfig` to enforce valid ports (1-65535) and ensure `CertDir` is provided when webhooks are enabled.

*Note: This is Part 2 of addressing Issue #6950, continuing the module-by-module validation rollout.*

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Appended webhook validation cases to the master table-driven test in `cmd/core/app/options/options_test.go`. Verified the disabled state, valid configurations, and boundary errors for ports and empty directories.

### Special notes for your reviewer

This is Part 2 in the series same pattern as #7111 (`ServerConfig`), scoped only to `WebhookConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.
