### PR TITLE
Fix: invalid CA PEM validation in HTTP builtin runner

### DIFF
--- a/pkg/builtin/http/http.go
+++ b/pkg/builtin/http/http.go
@@ -98,7 +98,9 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 			return nil, errors.WithMessage(err, "parse ca")
 		} else {
 			pool := x509.NewCertPool()
-			pool.AppendCertsFromPEM([]byte(caCrt))
+			if ok := pool.AppendCertsFromPEM([]byte(caCrt)); !ok {
+				return nil, errors.New("parse ca: invalid PEM data")
+			}
 			tr.TLSClientConfig.RootCAs = pool
 		}
 

--- a/pkg/builtin/http/http_test.go
+++ b/pkg/builtin/http/http_test.go
@@ -118,6 +118,23 @@ url: "https://127.0.0.1:8443/api/v1/token?val=test-token"`)
 	assert.Equal(t, "{\"token\":\"test-token\"}", body)
 }
 
+func TestHTTPSRunInvalidCA(t *testing.T) {
+	s := newMockHttpsServer()
+	defer s.Close()
+	reqInst := cuecontext.New().CompileString(`method: "GET"
+url: "https://127.0.0.1:8443/api/v1/token?val=test-token"`)
+	reqInst = reqInst.FillPath(value.FieldPath("tls_config", "ca"), "not-a-pem-block")
+	reqInst = reqInst.FillPath(value.FieldPath("tls_config", "client_crt"), decodeCert(testdata.MockCerts.ClientCrt))
+	reqInst = reqInst.FillPath(value.FieldPath("tls_config", "client_key"), decodeCert(testdata.MockCerts.ClientKey))
+
+	runner, _ := newHTTPCmd(cue.Value{})
+	_, err := runner.Run(&registry.Meta{Obj: reqInst.Value()})
+	if err == nil {
+		t.Fatal("expected invalid CA to fail")
+	}
+	assert.Contains(t, err.Error(), "parse ca")
+}
+
 // NewMock mock the http server
 func NewMock() *httptest.Server {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Description of your changes


Fix invalid CA PEM handling in the HTTP builtin runner. The runner now validates `tls_config.ca` by checking the result of `AppendCertsFromPEM` and returns a clear parse error when the CA bundle is malformed instead of silently continuing with an unusable trust store.

Fixes #7112


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- `go fmt ./pkg/builtin/http/`
- `go test -v ./pkg/builtin/http/`

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->