### PR TITLE
Feat( Kubernates ): add validation to kubernates config

### DIFF
--- a/cmd/core/app/config/kubernetes.go
+++ b/cmd/core/app/config/kubernetes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -46,4 +47,18 @@ func (c *KubernetesConfig) AddFlags(fs *pflag.FlagSet) {
 		"the burst for reconcile clients. Recommend setting it qps*2.")
 	fs.DurationVar(&c.InformerSyncPeriod, "informer-sync-period", c.InformerSyncPeriod,
 		"The re-sync period for informer in controller-runtime. This is a system-level configuration.")
+}
+
+// Validate ensures the Kubernetes client rate limiting parameters are mathematically sound.
+func (c *KubernetesConfig) Validate() error {
+	if c.QPS < 0 {
+		return fmt.Errorf("kubernetes client QPS cannot be negative")
+	}
+	if c.Burst < 0 {
+		return fmt.Errorf("kubernetes client burst cannot be negative")
+	}
+	if c.QPS > 0 && float64(c.Burst) < c.QPS {
+		return fmt.Errorf("kubernetes client burst (%d) must be greater than or equal to QPS (%v) to prevent token bucket starvation", c.Burst, c.QPS)
+	}
+	return nil
 }

--- a/cmd/core/app/config/kubernetes_test.go
+++ b/cmd/core/app/config/kubernetes_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *KubernetesConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid Configuration - Default",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 50, Burst: 100}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Configuration - Negative QPS",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: -10, Burst: 100}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client QPS cannot be negative",
+		},
+		{
+			name: "Invalid Configuration - Negative Burst",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 50, Burst: -1}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client burst cannot be negative",
+		},
+		{
+			name: "Invalid Configuration - Burst Lower Than QPS",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 100, Burst: 50}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client burst (50) must be greater than or equal to QPS (100) to prevent token bucket starvation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKubernetesConfig_AddFlags(t *testing.T) {
+	cfg := NewKubernetesConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
+		"--informer-sync-period=30m",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(100), cfg.QPS)
+	assert.Equal(t, 200, cfg.Burst)
+	assert.Equal(t, 30*time.Minute, cfg.InformerSyncPeriod)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `KubernetesConfig` to enforce mathematically sound rate-limiting parameters ensuring QPS and Burst are non-negative, and that Burst is always greater than or equal to QPS to prevent token bucket starvation.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/kubernetes_test.go` covering:
- Valid default configuration (QPS: 50, Burst: 100)
- Negative QPS rejection
- Burst lower than QPS rejection (token bucket starvation guard)

### Special notes for your reviewer

This is Part 3 in the series same pattern as #7111 (`ServerConfig`) and #7120 (`WebhookConfig`), scoped only to `KubernetesConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.