### PR TITLE
Feat( Cue ): add validation to Cue config

### DIFF
--- a/cmd/core/app/config/cue.go
+++ b/cmd/core/app/config/cue.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/kubevela/pkg/cue/cuex"
 	"github.com/spf13/pflag"
 )
@@ -58,4 +60,12 @@ func (c *CUEConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *CUEConfig) SyncToCUEGlobals() {
 	cuex.EnableExternalPackageForDefaultCompiler = c.EnableExternalPackage
 	cuex.EnableExternalPackageWatchForDefaultCompiler = c.EnableExternalPackageWatch
+}
+
+// Validate checks if the CUE configuration is valid.
+func (c *CUEConfig) Validate() error {
+	if c.EnableExternalPackageWatch && !c.EnableExternalPackage {
+		return fmt.Errorf("enable-external-package-watch-for-default-compiler cannot be true when enable-external-package-for-default-compiler is false")
+	}
+	return nil
 }

--- a/cmd/core/app/config/cue_test.go
+++ b/cmd/core/app/config/cue_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCUEConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *CUEConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *CUEConfig {
+				return NewCUEConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with external package enabled and watch enabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = true
+				cfg.EnableExternalPackageWatch = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with external package enabled and watch disabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = true
+				cfg.EnableExternalPackageWatch = false
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: external package disabled but watch enabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = false
+				cfg.EnableExternalPackageWatch = true
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "enable-external-package-watch-for-default-compiler cannot be true when enable-external-package-for-default-compiler is false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCUEConfig_AddFlags(t *testing.T) {
+	cfg := NewCUEConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--enable-external-package-for-default-compiler=true",
+		"--enable-external-package-watch-for-default-compiler=true",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.EnableExternalPackage)
+	assert.True(t, cfg.EnableExternalPackageWatch)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `CUEConfig` to enforce a logical dependency constraint — ensuring `EnableExternalPackageWatch` cannot be enabled unless `EnableExternalPackage` is also enabled, since the watch feature has no effect without the external package loader active.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/cue_test.go` covering:
- Valid default configuration
- Valid configuration with both external package flags enabled
- Invalid configuration where watch is enabled but external package is disabled

### Special notes for your reviewer

This is Part 4 in the series — same pattern as #7111 (`ServerConfig`), #7120 (`WebhookConfig`), and #7123 (`KubernetesConfig`), scoped only to `CUEConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.
