### PR TITLE
Feat( Application ): add Validate method to ApplicationConfig

### DIFF
--- a/cmd/core/app/config/application.go
+++ b/cmd/core/app/config/application.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -53,4 +54,12 @@ func (c *ApplicationConfig) AddFlags(fs *pflag.FlagSet) {
 // The flow is: CLI flags -> ApplicationConfig struct fields -> commonconfig globals (via this method)
 func (c *ApplicationConfig) SyncToApplicationGlobals() {
 	commonconfig.ApplicationReSyncPeriod = c.ReSyncPeriod
+}
+
+// Validate checks if the application configuration is valid.
+func (c *ApplicationConfig) Validate() error {
+	if c.ReSyncPeriod <= 0 {
+		return fmt.Errorf("application-re-sync-period must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/application_test.go
+++ b/cmd/core/app/config/application_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplicationConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ApplicationConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ApplicationConfig {
+				return NewApplicationConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid custom resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = 5 * time.Minute
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid negative resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = -1 * time.Minute
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-re-sync-period must be greater than zero",
+		},
+		{
+			name: "Invalid zero resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-re-sync-period must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestApplicationConfig_AddFlags(t *testing.T) {
+	cfg := NewApplicationConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--application-re-sync-period=10m",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 10*time.Minute, cfg.ReSyncPeriod)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `ApplicationConfig` to ensure the re-sync period is a positive duration, preventing the application controller from being started with an invalid or zero re-sync interval.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/application_test.go` covering:
- Valid default configuration
- Invalid configuration with zero re-sync period
- Invalid configuration with negative re-sync period

### Special notes for your reviewer

This is Part 5 in the series — same pattern as #7111 (`ServerConfig`), #7120 (`WebhookConfig`) etc scoped only to `ApplicationConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.