### PR TITLE
Feat( Controller ): add validation to Controller config

### DIFF
--- a/cmd/core/app/config/controller.go
+++ b/cmd/core/app/config/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	oamcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
@@ -64,4 +66,21 @@ func (c *ControllerConfig) AddFlags(fs *pflag.FlagSet) {
 		"If true, application controller will not process the app without 'app.oam.dev/controller-version-require' annotation")
 	fs.BoolVar(&c.IgnoreDefinitionWithoutControllerRequirement, "ignore-definition-without-controller-version", c.IgnoreDefinitionWithoutControllerRequirement,
 		"If true, trait/component/workflowstep definition controller will not process the definition without 'definition.oam.dev/controller-version-require' annotation")
+}
+
+// Validate checks if the controller configuration is valid.
+func (c *ControllerConfig) Validate() error {
+	if c.ConcurrentReconciles <= 0 {
+		return fmt.Errorf("concurrent-reconciles must be greater than zero")
+	}
+	if c.RevisionLimit < 0 {
+		return fmt.Errorf("revision-limit must be greater than or equal to zero")
+	}
+	if c.AppRevisionLimit < 0 {
+		return fmt.Errorf("application-revision-limit must be greater than or equal to zero")
+	}
+	if c.DefRevisionLimit < 0 {
+		return fmt.Errorf("definition-revision-limit must be greater than or equal to zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/controller_test.go
+++ b/cmd/core/app/config/controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ControllerConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ControllerConfig {
+				return NewControllerConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid concurrent reconciles",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.ConcurrentReconciles = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "concurrent-reconciles must be greater than zero",
+		},
+		{
+			name: "Invalid negative revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.RevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Invalid negative app revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.AppRevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Invalid negative def revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.DefRevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "definition-revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Valid zero limits",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.RevisionLimit = 0
+				cfg.AppRevisionLimit = 0
+				cfg.DefRevisionLimit = 0
+				return cfg
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestControllerConfig_AddFlags(t *testing.T) {
+	cfg := NewControllerConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	cfg.AddFlags(fs)
+
+	args := []string{
+		"--concurrent-reconciles=10",
+		"--revision-limit=100",
+		"--application-revision-limit=50",
+		"--definition-revision-limit=60",
+		"--autogen-workload-definition=false",
+	}
+
+	err := fs.Parse(args)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10, cfg.ConcurrentReconciles)
+	assert.Equal(t, 100, cfg.RevisionLimit)
+	assert.Equal(t, 50, cfg.AppRevisionLimit)
+	assert.Equal(t, 60, cfg.DefRevisionLimit)
+	assert.False(t, cfg.AutoGenWorkloadDefinition)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `ControllerConfig` to enforce valid reconciler and revision limit values — ensuring `ConcurrentReconciles` is always positive and that all revision limits (`RevisionLimit`, `AppRevisionLimit`, `DefRevisionLimit`) are non-negative, preventing the controller from starting with nonsensical configuration.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/controller_test.go` covering:
- Valid default configuration
- Invalid configuration with zero concurrent reconciles
- Invalid configuration with negative concurrent reconciles
- Invalid configuration with negative revision limit
- Invalid configuration with negative application revision limit
- Invalid configuration with negative definition revision limit

### Special notes for your reviewer

This is Part 6 in the series — same pattern as #7111 (`ServerConfig`) and #7120 (`WebhookConfig`)scoped only to `ControllerConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.