### PR TITLE
Feat( Multicluster ): add Validate method to MulticlusterConfig

### DIFF
--- a/cmd/core/app/config/multicluster.go
+++ b/cmd/core/app/config/multicluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	pkgmulticluster "github.com/kubevela/pkg/multicluster"
@@ -50,4 +51,15 @@ func (c *MultiClusterConfig) AddFlags(fs *pflag.FlagSet) {
 
 	// Also register additional multicluster flags from external package
 	pkgmulticluster.AddFlags(fs)
+}
+
+// Validate ensures the multi-cluster configuration is logically consistent.
+func (c *MultiClusterConfig) Validate() error {
+	if c.EnableClusterMetrics && !c.EnableClusterGateway {
+		return fmt.Errorf("enable-cluster-gateway must be true when enable-cluster-metrics is true")
+	}
+	if c.ClusterMetricsInterval <= 0 {
+		return fmt.Errorf("cluster-metrics-interval must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/multicluster_test.go
+++ b/cmd/core/app/config/multicluster_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiClusterConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *MultiClusterConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *MultiClusterConfig { return NewMultiClusterConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Valid with both gateway and metrics enabled",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.EnableClusterGateway = true
+				cfg.EnableClusterMetrics = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: metrics enabled without gateway",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.EnableClusterMetrics = true
+				cfg.EnableClusterGateway = false
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "enable-cluster-gateway must be true when enable-cluster-metrics is true",
+		},
+		{
+			name: "Invalid: zero metrics interval",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.ClusterMetricsInterval = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "cluster-metrics-interval must be greater than zero",
+		},
+		{
+			name: "Invalid: negative metrics interval",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.ClusterMetricsInterval = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "cluster-metrics-interval must be greater than zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMultiClusterConfig_AddFlags(t *testing.T) {
+	cfg := NewMultiClusterConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--enable-cluster-gateway=true",
+		"--enable-cluster-metrics=true",
+		"--cluster-metrics-interval=30s",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.EnableClusterGateway)
+	assert.True(t, cfg.EnableClusterMetrics)
+	assert.Equal(t, 30*time.Second, cfg.ClusterMetricsInterval)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `MultiClusterConfig` to enforce a logical dependency constraint — ensuring `EnableClusterMetrics` cannot be enabled without `EnableClusterGateway`, and that `ClusterMetricsInterval` is always a positive duration.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/multicluster_test.go` covering:
- Valid default configuration
- Valid configuration with both gateway and metrics enabled
- Invalid configuration with metrics enabled but gateway disabled
- Invalid configuration with zero metrics interval
- Invalid configuration with negative metrics interval

### Special notes for your reviewer

This is Part 7 in the series scoped only to `MultiClusterConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.