### PR TITLE
Feat( Oam ): add Validate method to OamConfig

### DIFF
--- a/cmd/core/app/config/oam.go
+++ b/cmd/core/app/config/oam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -51,4 +53,12 @@ func (c *OAMConfig) AddFlags(fs *pflag.FlagSet) {
 // The flow is: CLI flags -> OAMConfig struct fields -> oam globals (via this method)
 func (c *OAMConfig) SyncToOAMGlobals() {
 	oam.SystemDefinitionNamespace = c.SystemDefinitionNamespace
+}
+
+// Validate ensures the OAM configuration is valid.
+func (c *OAMConfig) Validate() error {
+	if c.SystemDefinitionNamespace == "" {
+		return fmt.Errorf("system-definition-namespace must not be empty")
+	}
+	return nil
 }

--- a/cmd/core/app/config/oam_test.go
+++ b/cmd/core/app/config/oam_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAMConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *OAMConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *OAMConfig { return NewOAMConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: empty namespace",
+			setupConfig: func() *OAMConfig {
+				cfg := NewOAMConfig()
+				cfg.SystemDefinitionNamespace = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "system-definition-namespace must not be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAMConfig_AddFlags(t *testing.T) {
+	cfg := NewOAMConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--system-definition-namespace=custom-system",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-system", cfg.SystemDefinitionNamespace)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `OAMConfig` to ensure `SystemDefinitionNamespace` is never empty, preventing the OAM runtime from starting without a valid system namespace.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/oam_test.go` covering:
- Valid default configuration
- Invalid configuration with empty system definition namespace

### Special notes for your reviewer

This is Part 8 in the series — same pattern as previous PRs, scoped only to `OAMConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.