### PR TITLE
Feat(Observability): add Validate method to ObservabilityConfig

### DIFF
--- a/cmd/core/app/config/observability.go
+++ b/cmd/core/app/config/observability.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
@@ -52,4 +54,15 @@ func (c *ObservabilityConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enable debug logs for development purpose")
 	fs.BoolVar(&c.DevLogs, "dev-logs", c.DevLogs,
 		"Enable ANSI color formatting for console logs (ignored when log-file-path is set)")
+}
+
+// Validate ensures the observability configuration is valid.
+func (c *ObservabilityConfig) Validate() error {
+	if c.MetricsAddr == "" {
+		return fmt.Errorf("metrics-addr must not be empty")
+	}
+	if c.LogFileMaxSize == 0 {
+		return fmt.Errorf("log-file-max-size must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/observability_test.go
+++ b/cmd/core/app/config/observability_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservabilityConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ObservabilityConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *ObservabilityConfig { return NewObservabilityConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: empty metrics addr",
+			setupConfig: func() *ObservabilityConfig {
+				cfg := NewObservabilityConfig()
+				cfg.MetricsAddr = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "metrics-addr must not be empty",
+		},
+		{
+			name: "Invalid: zero log file max size",
+			setupConfig: func() *ObservabilityConfig {
+				cfg := NewObservabilityConfig()
+				cfg.LogFileMaxSize = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "log-file-max-size must be greater than zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestObservabilityConfig_AddFlags(t *testing.T) {
+	cfg := NewObservabilityConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--metrics-addr=:9090",
+		"--log-file-path=/var/log/vela.log",
+		"--log-file-max-size=2048",
+		"--log-debug=true",
+		"--dev-logs=true",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ":9090", cfg.MetricsAddr)
+	assert.Equal(t, "/var/log/vela.log", cfg.LogFilePath)
+	assert.Equal(t, uint64(2048), cfg.LogFileMaxSize)
+	assert.True(t, cfg.LogDebug)
+	assert.True(t, cfg.DevLogs)
+}


### PR DESCRIPTION
### Description of your changes

Implemented `Validate()` for `ObservabilityConfig` to ensure `MetricsAddr` is never empty and `LogFileMaxSize` is always greater than zero, preventing the controller from starting with invalid metrics or logging configuration.

Related to #6950

I have:
- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven unit tests in `cmd/core/app/config/observability_test.go` covering:
- Valid default configuration
- Invalid configuration with empty metrics address
- Invalid configuration with zero log file max size

### Special notes for your reviewer

This is Part 9 in the series same pattern as previous PRs, scoped only to `ObservabilityConfig`. This PR does **not** touch any shared files. The final integration PR will be the only one wiring everything together into `CoreOptions.Validate()`.