### PR TITLE
Feat(Workflow): add Validate method to WorkflowConfig

### DIFF
--- a/cmd/core/app/config/workflow.go
+++ b/cmd/core/app/config/workflow.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	wfTypes "github.com/kubevela/workflow/pkg/types"
@@ -52,6 +54,20 @@ func (c *WorkflowConfig) AddFlags(fs *pflag.FlagSet) {
 		"max-workflow-step-error-retry-times",
 		c.MaxStepErrorRetryTimes,
 		"Set the max workflow step error retry times, default is 10")
+}
+
+// Validate ensures the workflow configuration is valid.
+func (c *WorkflowConfig) Validate() error {
+	if c.MaxWaitBackoffTime <= 0 {
+		return fmt.Errorf("max-workflow-wait-backoff-time must be greater than 0")
+	}
+	if c.MaxFailedBackoffTime <= 0 {
+		return fmt.Errorf("max-workflow-failed-backoff-time must be greater than 0")
+	}
+	if c.MaxStepErrorRetryTimes <= 0 {
+		return fmt.Errorf("max-workflow-step-error-retry-times must be greater than 0")
+	}
+	return nil
 }
 
 // SyncToWorkflowGlobals syncs the parsed configuration values to workflow package global variables.

--- a/cmd/core/app/config/workflow_test.go
+++ b/cmd/core/app/config/workflow_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *WorkflowConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *WorkflowConfig { return NewWorkflowConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: max wait backoff time zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxWaitBackoffTime = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-wait-backoff-time must be greater than 0",
+		},
+		{
+			name: "Invalid: max failed backoff time zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxFailedBackoffTime = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-failed-backoff-time must be greater than 0",
+		},
+		{
+			name: "Invalid: max step error retry times zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxStepErrorRetryTimes = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-step-error-retry-times must be greater than 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWorkflowConfig_AddFlags(t *testing.T) {
+	cfg := NewWorkflowConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--max-workflow-wait-backoff-time=120",
+		"--max-workflow-failed-backoff-time=600",
+		"--max-workflow-step-error-retry-times=20",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 120, cfg.MaxWaitBackoffTime)
+	assert.Equal(t, 600, cfg.MaxFailedBackoffTime)
+	assert.Equal(t, 20, cfg.MaxStepErrorRetryTimes)
+}


### PR DESCRIPTION
### Description of your changes

Implemented Validate() for WorkflowConfig to ensure MaxWaitBackoffTime, MaxFailedBackoffTime, and MaxStepErrorRetryTimes are always greater than zero, preventing the workflow engine from starting with invalid backoff or retry configurations.


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example

-->

Related to #6950

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Added table-driven unit tests in cmd/core/app/config/workflow_test.go covering:

Valid default configuration
Invalid configuration with max wait backoff time zero
Invalid configuration with max failed backoff time zero
Invalid configuration with max step error retry times zero

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer
This is Part 10 in the series same pattern as previous PRs, scoped only to WorkflowConfig. This PR does not touch any shared files. The final integration PR will be the only one wiring everything together into CoreOptions.Validate().
