### PR TITLE
Feat(Resource): add Validate method to ResourceConfig

### DIFF
--- a/cmd/core/app/config/resource.go
+++ b/cmd/core/app/config/resource.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
@@ -40,6 +42,14 @@ func (c *ResourceConfig) AddFlags(fs *pflag.FlagSet) {
 		"max-dispatch-concurrent",
 		c.MaxDispatchConcurrent,
 		"Set the max dispatch concurrent number, default is 10")
+}
+
+// Validate ensures the resource configuration is valid.
+func (c *ResourceConfig) Validate() error {
+	if c.MaxDispatchConcurrent <= 0 {
+		return fmt.Errorf("max-dispatch-concurrent must be greater than 0")
+	}
+	return nil
 }
 
 // SyncToResourceGlobals syncs the parsed configuration values to resource package global variables.

--- a/cmd/core/app/config/resource_test.go
+++ b/cmd/core/app/config/resource_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ResourceConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *ResourceConfig { return NewResourceConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: max dispatch concurrent zero",
+			setupConfig: func() *ResourceConfig {
+				cfg := NewResourceConfig()
+				cfg.MaxDispatchConcurrent = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-dispatch-concurrent must be greater than 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResourceConfig_AddFlags(t *testing.T) {
+	cfg := NewResourceConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--max-dispatch-concurrent=20",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 20, cfg.MaxDispatchConcurrent)
+}


### PR DESCRIPTION
### Description of your changes
Implemented Validate() for ResourceConfig to ensure MaxDispatchConcurrent is always greater than zero, preventing the resource keeper from starting with invalid dispatch concurrency limits.


copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Related to: #6950

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Added table-driven unit tests in cmd/core/app/config/resource_test.go covering:

Valid default configuration
Invalid configuration with max dispatch concurrent zero

### Special notes for your reviewer
This is a follow-up in the series, following the same pattern as previous PRs, scoped only to ResourceConfig. This PR does not touch any shared files. The final integration PR will be the only one wiring everything together into CoreOptions.Validate().
