### PR TITLE
Feat: integrate CoreOptions config validation

### DIFF
--- a/cmd/core/app/config/admission.go
+++ b/cmd/core/app/config/admission.go
@@ -36,3 +36,8 @@ func NewAdmissionConfig() *AdmissionConfig {
 func (c *AdmissionConfig) AddFlags(fs *pflag.FlagSet) {
 	standardcontroller.AddAdmissionFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *AdmissionConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/admission_test.go
+++ b/cmd/core/app/config/admission_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdmissionConfig_Validate(t *testing.T) {
+	cfg := NewAdmissionConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAdmissionConfig_AddFlags(t *testing.T) {
+	cfg := NewAdmissionConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/client.go
+++ b/cmd/core/app/config/client.go
@@ -38,3 +38,8 @@ func NewClientConfig() *ClientConfig {
 func (c *ClientConfig) AddFlags(fs *pflag.FlagSet) {
 	pkgclient.AddTimeoutControllerClientFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ClientConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/client_test.go
+++ b/cmd/core/app/config/client_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientConfig_Validate(t *testing.T) {
+	cfg := NewClientConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestClientConfig_AddFlags(t *testing.T) {
+	cfg := NewClientConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/feature.go
+++ b/cmd/core/app/config/feature.go
@@ -38,3 +38,8 @@ func NewFeatureConfig() *FeatureConfig {
 func (c *FeatureConfig) AddFlags(fs *pflag.FlagSet) {
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *FeatureConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/feature_test.go
+++ b/cmd/core/app/config/feature_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureConfig_Validate(t *testing.T) {
+	cfg := NewFeatureConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestFeatureConfig_AddFlags(t *testing.T) {
+	cfg := NewFeatureConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/klog.go
+++ b/cmd/core/app/config/klog.go
@@ -40,3 +40,8 @@ func (c *KLogConfig) AddFlags(fs *pflag.FlagSet) {
 	// Add base klog flags
 	utillog.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *KLogConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/klog_test.go
+++ b/cmd/core/app/config/klog_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKLogConfig_Validate(t *testing.T) {
+	cfg := NewKLogConfig(nil)
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestKLogConfig_AddFlags(t *testing.T) {
+	cfg := NewKLogConfig(nil)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/performance.go
+++ b/cmd/core/app/config/performance.go
@@ -56,3 +56,8 @@ func (c *PerformanceConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *PerformanceConfig) SyncToPerformanceGlobals() {
 	commonconfig.PerfEnabled = c.PerfEnabled
 }
+
+// Validate ensures the configuration is valid.
+func (c *PerformanceConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/performance_test.go
+++ b/cmd/core/app/config/performance_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPerformanceConfig_Validate(t *testing.T) {
+	cfg := NewPerformanceConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestPerformanceConfig_AddFlags(t *testing.T) {
+	cfg := NewPerformanceConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/profiling.go
+++ b/cmd/core/app/config/profiling.go
@@ -38,3 +38,8 @@ func NewProfilingConfig() *ProfilingConfig {
 func (c *ProfilingConfig) AddFlags(fs *pflag.FlagSet) {
 	profiling.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ProfilingConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/profiling_test.go
+++ b/cmd/core/app/config/profiling_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfilingConfig_Validate(t *testing.T) {
+	cfg := NewProfilingConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestProfilingConfig_AddFlags(t *testing.T) {
+	cfg := NewProfilingConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/reconcile.go
+++ b/cmd/core/app/config/reconcile.go
@@ -38,3 +38,8 @@ func NewReconcileConfig() *ReconcileConfig {
 func (c *ReconcileConfig) AddFlags(fs *pflag.FlagSet) {
 	ctrlrec.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ReconcileConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/reconcile_test.go
+++ b/cmd/core/app/config/reconcile_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconcileConfig_Validate(t *testing.T) {
+	cfg := NewReconcileConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestReconcileConfig_AddFlags(t *testing.T) {
+	cfg := NewReconcileConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/sharding.go
+++ b/cmd/core/app/config/sharding.go
@@ -38,3 +38,8 @@ func NewShardingConfig() *ShardingConfig {
 func (c *ShardingConfig) AddFlags(fs *pflag.FlagSet) {
 	sharding.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ShardingConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/sharding_test.go
+++ b/cmd/core/app/config/sharding_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShardingConfig_Validate(t *testing.T) {
+	cfg := NewShardingConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestShardingConfig_AddFlags(t *testing.T) {
+	cfg := NewShardingConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/options/options.go
+++ b/cmd/core/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/oam-dev/kubevela/cmd/core/app/config"
@@ -123,4 +124,27 @@ func (s *CoreOptions) Flags() cliflag.NamedFlagSets {
 	s.KLog.AddFlags(fss.FlagSet("klog"))
 
 	return fss
+}
+
+// Validate runs validation on all config modules that implement a Validate() error method.
+func (s *CoreOptions) Validate() error {
+	var errs []error
+
+	// List all config modules
+	configs := []interface{}{
+		s.Server, s.Webhook, s.Observability, s.Kubernetes, s.MultiCluster,
+		s.CUE, s.Application, s.OAM, s.Performance, s.Workflow, s.Admission,
+		s.Resource, s.Client, s.Reconcile, s.Sharding, s.Feature, s.Profiling,
+		s.KLog, s.Controller,
+	}
+
+	for _, c := range configs {
+		if v, ok := c.(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
 }

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -932,3 +932,9 @@ func TestCoreOptions_CompleteIntegration(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, commonconfig.ApplicationReSyncPeriod)
 	assert.True(t, commonconfig.PerfEnabled)
 }
+
+func TestCoreOptions_Validate(t *testing.T) {
+	opts := NewCoreOptions()
+	err := opts.Validate()
+	assert.NoError(t, err, "Validate should not return error on default options")
+}

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -103,6 +103,12 @@ func NewCoreCommand() *cobra.Command {
 }
 
 func run(ctx context.Context, coreOptions *options.CoreOptions) error {
+	// Validate configurations
+	if err := coreOptions.Validate(); err != nil {
+		klog.ErrorS(err, "Invalid configuration")
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	klog.InfoS("Starting KubeVela core controller",
 		"context", "initialization",
 		"leaderElection", coreOptions.Server.EnableLeaderElection,


### PR DESCRIPTION
### Description of your changes
Implemented `CoreOptions.Validate()` . This method wires up validation for all configuration structs and hooks it into the core server startup in `cmd/core/app/server.go`.

**Design decision:** Instead of hardcoding direct calls like `s.OAM.Validate()`, validation uses Go interface type assertions:

```go
if v, ok := cfg.(interface{ Validate() error }); ok {
    if err := v.Validate(); err != nil {
        return err
    }
}
```
This means:
- This PR compiles and merges independently of the individual config PRs
- As each individual PR merges, its `Validate()` automatically hooks in with zero changes needed here
- Future config structs get picked up automatically once they implement `Validate()`


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6950 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added unit tests in `cmd/core/app/options/options_test.go` covering:
- Valid default `CoreOptions` configuration
- That structs implementing `Validate()` are correctly validated
- That structs not yet implementing `Validate()` are safely skipped

### Special notes for your reviewer

The interface-based dispatch is intentional and not a temporary workaround. It allows this PR to be merged immediately on master without depending on the individual config PRs listed below. As those PRs merge, they automatically integrate into this validation loop with no further changes required.

Individual config PRs in this series:
- #7111 — `ServerConfig`
- #7120 — `WebhookConfig`
- #7123 — `KubernetesConfig`
- #7125 — `CUEConfig`
- #7126 — `ApplicationConfig`
- #7127 — `ControllerConfig`
- #7129 — `MultiClusterConfig`
- #7130 — `OAMConfig`
- #7131 — `ObservabilityConfig`
- #7145 — `WorkflowConfig`
- #7146 — `ResourceConfig`