### PR TITLE
Fix: propagate errors from GetStatus instead of swallowing CUE health evaluation failures

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/apply.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	monitorContext "github.com/kubevela/pkg/monitor/context"

--- a/pkg/controller/core.oam.dev/v1beta1/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/apply.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -302,7 +303,7 @@ func (h *AppHandler) collectWorkloadHealthStatus(ctx context.Context, comp *appf
 		}
 		statusResult, err := comp.EvalStatus(templateContext)
 		if err != nil {
-			return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, comp.Name)
+			klog.Warningf("app=%s, comp=%s, evaluate workload status message error: %v, will continue with best-effort status", appName, comp.Name, err)
 		}
 		if statusResult != nil {
 			status.Healthy = statusResult.Healthy

--- a/pkg/cue/definition/health/health.go
+++ b/pkg/cue/definition/health/health.go
@@ -18,6 +18,7 @@ package health
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"slices"
 	"strings"
 
@@ -104,7 +105,7 @@ func GetStatus(templateContext map[string]interface{}, request *StatusRequest) (
 		Healthy: healthy,
 		Message: message,
 		Details: statusMap,
-	}, nil
+	}, stderrors.Join(mapErr, healthErr, msgErr)
 }
 
 func getStatusMessage(templateContext map[string]interface{}, customStatusTemplate string, parameter interface{}) (string, error) {

--- a/pkg/cue/definition/health/health_test.go
+++ b/pkg/cue/definition/health/health_test.go
@@ -460,6 +460,7 @@ func TestContextPassing(t *testing.T) {
 		request     StatusRequest
 		expMessage  string
 		expDetails  map[string]string
+		expErr      bool
 		validateCtx func(t *testing.T, ctx map[string]interface{})
 	}{
 		"basic-context-passing": {
@@ -622,6 +623,26 @@ func TestContextPassing(t *testing.T) {
 				assert.Equal(t, "my-app", details["appName"])
 				assert.Equal(t, "production", details["appEnv"])
 				assert.Equal(t, "my-app-production", details["appFullName"])
+			},
+		},
+		"status-message-error-propagation": {
+			initialCtx: map[string]interface{}{},
+			request: StatusRequest{
+				Parameter: map[string]interface{}{},
+				Details: strings.TrimSpace(`
+					stringValue: "example"
+				`),
+				Custom: strings.TrimSpace(`
+					message: {invalid cue
+				`),
+			},
+			expErr:     true,
+			expMessage: "",
+			expDetails: map[string]string{
+				"stringValue": "example",
+			},
+			validateCtx: func(t *testing.T, ctx map[string]interface{}) {
+				assert.NotNil(t, ctx["status"])
 			},
 		},
 		"existing-status-preserved": {
@@ -814,7 +835,11 @@ func TestContextPassing(t *testing.T) {
 			}
 
 			result, err := GetStatus(ctx, &tc.request)
-			assert.NoError(t, err)
+			if tc.expErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tc.expMessage, result.Message)
 			assert.Equal(t, tc.expDetails, result.Details)
 


### PR DESCRIPTION
Propagate errors from `getStatusMap`, `CheckHealth`, and `getStatusMessage`
through `GetStatus` instead of logging and discarding them.

Callers like the application reconciler could not distinguish between:
- Template evaluated; component is genuinely unhealthy (Healthy: false, err: nil)
- Template failed to evaluate at all (Healthy: false, err: nil)

Now errors are returned via `errors.Join` so callers can decide how to surface them.
The function still returns a best-effort status result alongside any errors, preserving
backwards compatibility for existing callers.

Fixes #7141