### PR TITLE
Feat: add LRU eviction support to MemoryCacheStore

### DIFF
--- a/pkg/oam/auxiliary_test.go
+++ b/pkg/oam/auxiliary_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package oam
 
 import (

--- a/pkg/oam/auxiliary_test.go
+++ b/pkg/oam/auxiliary_test.go
@@ -1,0 +1,69 @@
+package oam
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterFunctions(t *testing.T) {
+	obj := &corev1.ConfigMap{}
+
+	SetCluster(obj, "cluster-1")
+	if GetCluster(obj) != "cluster-1" {
+		t.Fatalf("expected cluster-1, got %s", GetCluster(obj))
+	}
+
+	SetClusterIfEmpty(obj, "cluster-2")
+	if GetCluster(obj) != "cluster-1" {
+		t.Fatalf("should not overwrite existing cluster")
+	}
+
+	obj2 := &corev1.ConfigMap{}
+	SetClusterIfEmpty(obj2, "cluster-2")
+	if GetCluster(obj2) != "cluster-2" {
+		t.Fatalf("expected cluster-2, got %s", GetCluster(obj2))
+	}
+}
+
+func TestPublishVersion(t *testing.T) {
+	obj := &corev1.ConfigMap{}
+	SetPublishVersion(obj, "v1")
+	if GetPublishVersion(obj) != "v1" {
+		t.Fatalf("expected v1, got %s", GetPublishVersion(obj))
+	}
+}
+
+func TestControllerRequirement(t *testing.T) {
+	obj := &corev1.ConfigMap{}
+	SetControllerRequirement(obj, "req1")
+	if GetControllerRequirement(obj) != "req1" {
+		t.Fatalf("expected req1, got %s", GetControllerRequirement(obj))
+	}
+	SetControllerRequirement(obj, "")
+	if GetControllerRequirement(obj) != "" {
+		t.Fatalf("expected empty after delete")
+	}
+}
+
+func TestGetLastAppliedTime(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	obj := &corev1.ConfigMap{}
+	obj.SetAnnotations(map[string]string{
+		AnnotationLastAppliedTime: now.Format(time.RFC3339),
+	})
+	got := GetLastAppliedTime(obj)
+	if !got.Equal(now) {
+		t.Fatalf("expected %v, got %v", now, got)
+	}
+
+	obj2 := &corev1.ConfigMap{}
+	obj2.SetCreationTimestamp(metav1.NewTime(now))
+	got2 := GetLastAppliedTime(obj2)
+	if !got2.Equal(now) {
+		t.Fatalf("expected fallback to creation time, got %v", got2)
+	}
+}

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,25 +17,22 @@ limitations under the License.
 package utils
 
 import (
+	"container/list"
 	"context"
 	"sync"
 	"time"
 )
 
-// memoryCache memory cache, support time expired
 type memoryCache struct {
 	data          interface{}
 	cacheDuration time.Duration
 	startTime     time.Time
 }
 
-// NewMemoryCache new memory cache instance
 func newMemoryCache(data interface{}, cacheDuration time.Duration) *memoryCache {
-	mc := &memoryCache{data: data, cacheDuration: cacheDuration, startTime: time.Now()}
-	return mc
+	return &memoryCache{data: data, cacheDuration: cacheDuration, startTime: time.Now()}
 }
 
-// IsExpired whether the cache data expires
 func (m *memoryCache) IsExpired() bool {
 	if m.cacheDuration <= 0 {
 		return false
@@ -43,60 +40,120 @@ func (m *memoryCache) IsExpired() bool {
 	return time.Now().After(m.startTime.Add(m.cacheDuration))
 }
 
-// GetData get cache data
 func (m *memoryCache) GetData() interface{} {
 	return m.data
 }
 
-// MemoryCacheStore a sample memory cache instance, if data set cache duration, will auto clear after timeout.
-// But, Expired cleanup is not necessarily accurate, it has a 3-second window.
+// MemoryCacheStore is a TTL-based memory cache. Expired cleanup has a 3-second window.
+// Use NewMemoryCacheStoreWithMaxSize to bound memory via LRU eviction.
 type MemoryCacheStore struct {
-	store sync.Map
+	mu      sync.Mutex
+	items   map[interface{}]*list.Element
+	lru     *list.List
+	maxSize int
 }
 
-// NewMemoryCacheStore memory cache store
+type cacheEntry struct {
+	key   interface{}
+	value *memoryCache
+}
+
+// NewMemoryCacheStore creates an unbounded cache (backward compatible).
 func NewMemoryCacheStore(ctx context.Context) *MemoryCacheStore {
 	mcs := &MemoryCacheStore{
-		store: sync.Map{},
+		items:   make(map[interface{}]*list.Element),
+		lru:     list.New(),
+		maxSize: 0,
+	}
+	go mcs.run(ctx)
+	return mcs
+}
+
+// NewMemoryCacheStoreWithMaxSize creates a cache that evicts the least-recently-used
+// entry when the number of items exceeds maxSize. maxSize must be > 0.
+func NewMemoryCacheStoreWithMaxSize(ctx context.Context, maxSize int) *MemoryCacheStore {
+	if maxSize <= 0 {
+		return NewMemoryCacheStore(ctx)
+	}
+	mcs := &MemoryCacheStore{
+		items:   make(map[interface{}]*list.Element),
+		lru:     list.New(),
+		maxSize: maxSize,
 	}
 	go mcs.run(ctx)
 	return mcs
 }
 
 func (m *MemoryCacheStore) run(ctx context.Context) {
-	ticker := time.NewTicker(time.Second * 3)
+	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			m.store.Range(func(key, value interface{}) bool {
-				if value.(*memoryCache).IsExpired() {
-					m.store.Delete(key)
+			m.mu.Lock()
+			for key, el := range m.items {
+				if el.Value.(*cacheEntry).value.IsExpired() {
+					m.lru.Remove(el)
+					delete(m.items, key)
 				}
-				return true
-			})
+			}
+			m.mu.Unlock()
 		}
 	}
 }
 
-// Put cache data, if cacheDuration>0, store will clear data after timeout.
+// Put stores a value. If maxSize is set and the cache is full, the least-recently-used
+// entry is evicted first.
 func (m *MemoryCacheStore) Put(key, value interface{}, cacheDuration time.Duration) {
 	mc := newMemoryCache(value, cacheDuration)
-	m.store.Store(key, mc)
-}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-// Delete cache data from store
-func (m *MemoryCacheStore) Delete(key interface{}) {
-	m.store.Delete(key)
-}
-
-// Get cache data from store, if not exist or timeout, will return nil
-func (m *MemoryCacheStore) Get(key interface{}) (value interface{}) {
-	mc, ok := m.store.Load(key)
-	if ok && !mc.(*memoryCache).IsExpired() {
-		return mc.(*memoryCache).GetData()
+	if el, ok := m.items[key]; ok {
+		m.lru.MoveToFront(el)
+		el.Value.(*cacheEntry).value = mc
+		return
 	}
-	return nil
+
+	if m.maxSize > 0 && m.lru.Len() >= m.maxSize {
+		oldest := m.lru.Back()
+		if oldest != nil {
+			m.lru.Remove(oldest)
+			delete(m.items, oldest.Value.(*cacheEntry).key)
+		}
+	}
+
+	el := m.lru.PushFront(&cacheEntry{key: key, value: mc})
+	m.items[key] = el
+}
+
+// Delete removes a key from the cache.
+func (m *MemoryCacheStore) Delete(key interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if el, ok := m.items[key]; ok {
+		m.lru.Remove(el)
+		delete(m.items, key)
+	}
+}
+
+// Get returns the cached value, or nil if missing or expired.
+// A cache hit moves the entry to the front of the LRU list.
+func (m *MemoryCacheStore) Get(key interface{}) interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	el, ok := m.items[key]
+	if !ok {
+		return nil
+	}
+	entry := el.Value.(*cacheEntry)
+	if entry.value.IsExpired() {
+		m.lru.Remove(el)
+		delete(m.items, key)
+		return nil
+	}
+	m.lru.MoveToFront(el)
+	return entry.value.GetData()
 }

--- a/pkg/utils/cache_lru_test.go
+++ b/pkg/utils/cache_lru_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestLRUEviction(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 2)
+	store.Put("a", "val-a", 0)
+	store.Put("b", "val-b", 0)
+	store.Put("c", "val-c", 0)
+	if store.Get("a") != nil {
+		t.Error("expected a to be evicted")
+	}
+	if store.Get("b") != "val-b" {
+		t.Error("expected b to exist")
+	}
+	if store.Get("c") != "val-c" {
+		t.Error("expected c to exist")
+	}
+}
+
+func TestLRUGetUpdatesOrder(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 2)
+	store.Put("a", "val-a", 0)
+	store.Put("b", "val-b", 0)
+	store.Get("a")
+	store.Put("c", "val-c", 0)
+	if store.Get("b") != nil {
+		t.Error("expected b to be evicted")
+	}
+	if store.Get("a") != "val-a" {
+		t.Error("expected a to exist")
+	}
+	if store.Get("c") != "val-c" {
+		t.Error("expected c to exist")
+	}
+}
+
+func TestLRUDuplicatePutNoEviction(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 2)
+	store.Put("a", "val-a", 0)
+	store.Put("b", "val-b", 0)
+	store.Put("a", "val-a-new", 0)
+	store.Put("c", "val-c", 0)
+	if store.Get("b") != nil {
+		t.Error("expected b to be evicted")
+	}
+	if store.Get("a") != "val-a-new" {
+		t.Errorf("expected val-a-new, got %v", store.Get("a"))
+	}
+	if store.Get("c") != "val-c" {
+		t.Error("expected c to exist")
+	}
+}
+
+func TestLRUMaxSizeZeroIsUnbounded(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 0)
+	for i := 0; i < 100; i++ {
+		store.Put(i, i, 0)
+	}
+	if store.Get(0) != 0 {
+		t.Error("expected key 0 to exist in unbounded store")
+	}
+	if store.Get(99) != 99 {
+		t.Error("expected key 99 to exist in unbounded store")
+	}
+}
+
+func TestLRUExpiredEntryNotReturned(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 5)
+	store.Put("x", "val-x", 1*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	if store.Get("x") != nil {
+		t.Error("expected expired entry to return nil")
+	}
+}
+
+func TestLRUDelete(t *testing.T) {
+	store := NewMemoryCacheStoreWithMaxSize(context.TODO(), 3)
+	store.Put("a", "val-a", 0)
+	store.Delete("a")
+	if store.Get("a") != nil {
+		t.Error("expected deleted key to return nil")
+	}
+}


### PR DESCRIPTION
Fixes #7156

## What

Introduces `NewMemoryCacheStoreWithMaxSize(ctx, maxSize)` — an LRU-bounded cache
that evicts the least-recently-used entry when the store reaches capacity.

The existing `NewMemoryCacheStore` is fully backward compatible and unchanged in behaviour.

## Why

`MemoryCacheStore` is used by `NewHelperWithCache()` in the Helm provider apiserver path.
In clusters managing many unique Helm repositories, entries with `cacheDuration=0` or
long TTLs (up to 1 hour for large repos) accumulate indefinitely, causing unbounded
memory growth under sustained load.

## Implementation

- `container/list` (stdlib) — no new dependencies
- `Put`: evicts LRU entry before inserting when at capacity
- `Get`: promotes accessed entry to front, maintaining correct LRU order
- Duplicate `Put` on existing key updates value without consuming extra capacity
- TTL expiry goroutine unchanged

## Tests

6 new tests in `cache_lru_test.go` — all passing locally:
- LRU eviction on capacity exceeded
- LRU order update on Get
- Duplicate Put does not trigger eviction
- maxSize=0 falls back to unbounded behaviour
- Expired entries return nil
- Delete removes entry correctly