### PR TITLE
Feat(helm): set User-Agent when downloading Helm repo index.yaml

### DIFF
--- a/pkg/utils/helm/repo_index.go
+++ b/pkg/utils/helm/repo_index.go
@@ -27,6 +27,9 @@ import (
 	"helm.sh/helm/v3/pkg/getter"
 	helmrepo "helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/version"
 )
 
 // IndexYaml is the index.yaml of helm repo
@@ -67,9 +70,10 @@ func loadData(u string, cred *RepoCredential) (*bytes.Buffer, error) {
 	}
 
 	indexURL := parsedURL.String()
-	// TODO add user-agent
+	userAgent := types.KubeVelaName + "/" + version.GitRevision
 	g, _ := getter.NewHTTPGetter()
 	resp, err = g.Get(indexURL,
+		getter.WithUserAgent(userAgent),
 		getter.WithTimeout(5*time.Minute),
 		getter.WithURL(u),
 		getter.WithInsecureSkipVerifyTLS(skipTLS),


### PR DESCRIPTION
## What
Set a stable, identifiable User-Agent header when performing HTTP GET for Helm chart repository index.yaml via the Helm getter package.

## Why
Helm repository operators and HTTP gateways often rely on the User-Agent header to identify clients, apply rate limits, debug traffic, and distinguish automated pulls from browsers. Today, when KubeVela fetches a chart repository's index.yaml, there is an explicit , so requests may use a generic or empty agent string. That makes KubeVela traffic harder to recognize in registry logs and can complicate support when users report connectivity or throttling issues against a specific Helm backend.

## How
- Uses the existing Helm getter option 
- Constructs the user-agent string as , matching the pattern already used in  for the Kubernetes client config
- Removes the  comment

## Testing
- Verified syntax with gofmt
- The change is a straightforward getter option addition; existing integration tests in  cover the load path

Closes #7134