### PR TITLE
Feat: set stable User-Agent header when downloading Helm repo index.yaml

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -69,6 +69,8 @@ import (
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
 	"github.com/oam-dev/kubevela/pkg/oam"
+
+	"github.com/oam-dev/kubevela/version"
 )
 
 var (
@@ -112,6 +114,8 @@ type HTTPOption struct {
 	// HTTP rather than TLS. Honored only on the OCI fetch path. Insecure
 	// by design; users opt in via the Opaque Secret key insecurePlainHTTP.
 	PlainHTTP bool `json:"plainHTTP,omitempty"`
+	// UserAgent overrides the HTTP User-Agent header. If empty, defaults to "kubevela/<version>".
+	UserAgent string `json:"userAgent,omitempty"`
 }
 
 // InitBaseRestConfig will return reset config for create controller runtime client
@@ -151,6 +155,11 @@ func HTTPGetResponse(ctx context.Context, url string, opts *HTTPOption) (*http.R
 		}
 		req.Header.Set("Authorization", "Bearer "+opts.BearerToken)
 	}
+	ua := "kubevela/" + version.VelaVersion
+	if opts != nil && opts.UserAgent != "" {
+		ua = opts.UserAgent
+	}
+	req.Header.Set("User-Agent", ua)
 	if opts != nil && opts.InsecureSkipTLS {
 		httpClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} // nolint
 	}

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -40,6 +40,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/version"
 )
 
 var ResponseString = "Hello HTTP Get."
@@ -202,6 +204,49 @@ func TestHTTPGetResponse_BearerAndBasicMutuallyExclusive(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "RFC 6750") {
 		t.Fatalf("expected error to cite RFC 6750, got %v", err)
+	}
+}
+
+func TestHTTPGetResponse_UserAgent(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          *HTTPOption
+		expectedAgent string
+	}{
+		{
+			name:          "default user agent when opts is nil",
+			opts:          nil,
+			expectedAgent: "kubevela/" + version.VelaVersion,
+		},
+		{
+			name:          "default user agent when UserAgent field is empty",
+			opts:          &HTTPOption{},
+			expectedAgent: "kubevela/" + version.VelaVersion,
+		},
+		{
+			name:          "custom user agent is used when set",
+			opts:          &HTTPOption{UserAgent: "my-tool/1.0"},
+			expectedAgent: "my-tool/1.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotUA string
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUA = r.Header.Get("User-Agent")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("ok"))
+			}))
+			defer testServer.Close()
+			resp, err := HTTPGetResponse(context.Background(), testServer.URL, tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer resp.Body.Close()
+			if gotUA != tt.expectedAgent {
+				t.Fatalf("expected User-Agent=%q, got %q", tt.expectedAgent, gotUA)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
While looking at how Helm repo index files are fetched, I noticed
HTTPGetResponse in pkg/utils/common/common.go never sets a User-Agent,
so every request goes out as Go-http-client/1.1. Some registries
rate-limit or log by User-Agent so this makes KubeVela traffic
unidentifiable in registry logs.

Added a UserAgent field to HTTPOption so it can be overridden per-call,
and set kubevela/<version> as the default in HTTPGetResponse. Backward
compatible — if UserAgent is empty it falls through to the default.

Added TestHTTPGetResponse_UserAgent covering nil opts, empty UserAgent,
and a custom override. All three pass.

Closes #7134