### PR TITLE
feat:trace ID propagation from webhook to reconciler

### DIFF
--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -118,7 +118,8 @@ func run(ctx context.Context, coreOptions *options.CoreOptions) error {
 		"debug", coreOptions.Observability.LogDebug,
 		"devLogs", coreOptions.Observability.DevLogs,
 		"logFilePath", coreOptions.Observability.LogFilePath)
-	setupLogging(coreOptions.Observability)
+	loggingCleanup := setupLogging(coreOptions.Observability)
+	defer loggingCleanup()
 
 	// Configure Kubernetes client
 	klog.InfoS("Configuring Kubernetes client",
@@ -227,8 +228,11 @@ func syncConfigurations(coreOptions *options.CoreOptions) {
 	}
 }
 
-// setupLogging configures klog based on parsed observability settings
-func setupLogging(observabilityConfig *config.ObservabilityConfig) {
+// setupLogging configures klog based on parsed observability settings.
+// Returns a cleanup function the caller must defer; the cleanup flushes any
+// buffered partial-line writes and drains the stderr-pipe goroutine so the
+// last bytes of stderr survive shutdown.
+func setupLogging(observabilityConfig *config.ObservabilityConfig) func() {
 	// Configure klog verbosity
 	if observabilityConfig.LogDebug {
 		_ = flag.Set("v", strconv.Itoa(int(commonconfig.LogDebug)))
@@ -253,34 +257,61 @@ func setupLogging(observabilityConfig *config.ObservabilityConfig) {
 	// catches klog's threshold copies, runtime panics, and any third-party
 	// library that writes to stderr directly.
 	realStderr := os.Stderr
-	stderrFormatter := func(dst io.Writer) io.Writer {
+	stderrFormatter := func(dst io.Writer) logging.LineFormatter {
 		if observabilityConfig.DevLogs {
 			return logging.NewColorWriter(dst)
 		}
 		return logging.NewRequestIDInjector(dst)
 	}
+
+	var stderrSink logging.LineFormatter
+	pipeDone := make(chan struct{})
+	var pipeW *os.File
 	if pr, pw, err := os.Pipe(); err == nil {
 		os.Stderr = pw
+		pipeW = pw
+		stderrSink = stderrFormatter(realStderr)
 		go func() {
-			_, _ = io.Copy(stderrFormatter(realStderr), pr)
+			defer close(pipeDone)
+			_, _ = io.Copy(stderrSink, pr)
 		}()
+	} else {
+		// If we can't redirect stderr, klog's threshold copies will bypass
+		// the formatter. Warn but keep running — log lines from klog.SetOutput
+		// will still be hoisted; only the side-channel stderr writes won't be.
+		klog.Warningf("setupLogging: failed to create stderr redirection pipe (%v); klog stderrthreshold copies will not be formatted", err)
+		close(pipeDone)
 	}
 
+	var sink logging.LineFormatter
 	if observabilityConfig.DevLogs {
 		// colorWriter colourises and hoists requestID for human-readable terminals.
-		logOutput := logging.NewColorWriter(os.Stdout)
-		klog.LogToStderr(false)
-		klog.SetOutput(logOutput)
-		ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(logOutput))))
-		return
+		sink = logging.NewColorWriter(os.Stdout)
+	} else {
+		// Default mode: requestIDInjector hoists requestID without ANSI codes,
+		// preserving klog native format for log aggregators (Loki/ES/CloudWatch).
+		sink = logging.NewRequestIDInjector(realStderr)
 	}
-
-	// Default mode: requestIDInjector hoists requestID without ANSI codes,
-	// preserving klog native format for log aggregators (Loki/ES/CloudWatch).
-	logOutput := logging.NewRequestIDInjector(realStderr)
 	klog.LogToStderr(false)
-	klog.SetOutput(logOutput)
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(logOutput))))
+	klog.SetOutput(sink)
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(sink))))
+
+	return func() {
+		// Flush any in-progress partial line in the writer-side formatter
+		// before signalling the pipe goroutine.
+		if sink != nil {
+			_ = sink.Flush()
+		}
+		if pipeW != nil {
+			_ = pipeW.Close()
+			// Wait for the io.Copy goroutine to drain any bytes still in the
+			// pipe and exit cleanly. Bounded by the OS pipe buffer size.
+			<-pipeDone
+		}
+		if stderrSink != nil {
+			_ = stderrSink.Flush()
+		}
+	}
 }
 
 // ConfigProvider is a function type that provides a Kubernetes REST config

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -241,15 +241,46 @@ func setupLogging(observabilityConfig *config.ObservabilityConfig) {
 		_ = flag.Set("log_file_max_size", strconv.FormatUint(observabilityConfig.LogFileMaxSize, 10))
 	}
 
-	// Set logger (use --dev-logs=true for local development)
+	// Set logger. In both dev-logs and default modes the requestID is hoisted
+	// into the log header (between PID and file:line) so reconcile log lines
+	// are correlatable without scanning the trailing key/value list.
+	//
+	// klog's stderrthreshold=ERROR (default) routes ERROR/WARN lines directly
+	// to stderr in addition to klog.SetOutput, which would bypass our
+	// formatters and emit unhoisted duplicates. The stderrthreshold flag is
+	// registered on a private cobra flagset we can't mutate from here, so we
+	// redirect os.Stderr through the formatter via a pipe instead. This
+	// catches klog's threshold copies, runtime panics, and any third-party
+	// library that writes to stderr directly.
+	realStderr := os.Stderr
+	stderrFormatter := func(dst io.Writer) io.Writer {
+		if observabilityConfig.DevLogs {
+			return logging.NewColorWriter(dst)
+		}
+		return logging.NewRequestIDInjector(dst)
+	}
+	if pr, pw, err := os.Pipe(); err == nil {
+		os.Stderr = pw
+		go func() {
+			_, _ = io.Copy(stderrFormatter(realStderr), pr)
+		}()
+	}
+
 	if observabilityConfig.DevLogs {
+		// colorWriter colourises and hoists requestID for human-readable terminals.
 		logOutput := logging.NewColorWriter(os.Stdout)
 		klog.LogToStderr(false)
 		klog.SetOutput(logOutput)
 		ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(logOutput))))
-	} else {
-		ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+		return
 	}
+
+	// Default mode: requestIDInjector hoists requestID without ANSI codes,
+	// preserving klog native format for log aggregators (Loki/ES/CloudWatch).
+	logOutput := logging.NewRequestIDInjector(realStderr)
+	klog.LogToStderr(false)
+	klog.SetOutput(logOutput)
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(logOutput))))
 }
 
 // ConfigProvider is a function type that provides a Kubernetes REST config

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.18.0
 	github.com/google/go-github/v32 v32.1.0
+	github.com/google/uuid v1.6.0
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.18.0
@@ -184,7 +185,6 @@ require (
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/pkg/controller/core.oam.dev/v1beta1/application/app_policy_metadata_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/app_policy_metadata_test.go
@@ -434,10 +434,10 @@ output: {
 		Expect(err).Should(BeNil())
 
 		// The gatherRevisionSpec() function now normalizes JSON
-		rev1, hash1, err1 := handler1.gatherRevisionSpec(nil)
+		rev1, hash1, err1 := handler1.gatherRevisionSpec(ctx, nil)
 		Expect(err1).Should(BeNil())
 
-		rev2, hash2, err2 := handler2.gatherRevisionSpec(nil)
+		rev2, hash2, err2 := handler2.gatherRevisionSpec(ctx, nil)
 		Expect(err2).Should(BeNil())
 
 		// CRITICAL: Despite different input JSON byte order, normalized properties should be identical

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -58,6 +59,7 @@ import (
 	common2 "github.com/oam-dev/kubevela/pkg/controller/common"
 	core "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
@@ -109,19 +111,34 @@ type options struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx, cancel := ctrlrec.NewReconcileContext(ctx)
 	defer cancel()
-	logCtx := monitorContext.NewTraceContext(ctx, "").AddTag("application", req.String(), "controller", "application")
-	logCtx.Info("Start reconcile application")
-	defer logCtx.Commit("End reconcile application")
+
 	app := new(v1beta1.Application)
 	if err := r.Get(ctx, client.ObjectKey{
 		Name:      req.Name,
 		Namespace: req.Namespace,
 	}, app); err != nil {
 		if !kerrors.IsNotFound(err) {
-			logCtx.Error(err, "get application")
+			// Best-effort trace ID for this pre-fetch error log only. The retry-on-backoff
+			// will mint its own fresh ID; this line will not correlate with the eventually-
+			// successful reconcile. Don't try to "fix" by keying off req.NamespacedName —
+			// trace ID lifetime is per user-initiated admission, not per reconcile key.
+			traceID := uuid.NewString()
+			preCtx := monitorContext.NewTraceContext(logging.WithRequestID(ctx, traceID), traceID).
+				AddTag(logging.FieldRequestID, traceID, "application", req.String(), "controller", "application")
+			preCtx.Error(err, "get application")
 		}
 		return r.result(client.IgnoreNotFound(err)).ret()
 	}
+
+	logCtx, traceID := ApplicationLogContext(ctx, app, req)
+	logCtx.Info("Start reconcile application")
+	defer logCtx.Commit("End reconcile application")
+
+	// Seed the std ctx with the resolved trace ID so any downstream package
+	// that receives a plain context.Context (e.g., pkg/utils/apply) can still
+	// extract the trace ID via logging.FromContext / logging.RequestIDFrom.
+	// Note: logCtx.GetID() is the reconcile span ID now, not the trace ID.
+	ctx = logging.WithRequestID(ctx, traceID)
 	ctx = withOriginalApp(ctx, app)
 	if ctrlrec.IsPaused(app) {
 		return ctrl.Result{}, nil
@@ -135,11 +152,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	timeReporter := timeReconcile(app)
 	defer timeReporter()
 
-	logCtx.AddTag("resource_version", app.ResourceVersion).AddTag("generation", app.Generation)
 	ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
 	logCtx.SetContext(ctx)
 	setVelaVersion(app)
-	logCtx.AddTag("publish_version", app.GetAnnotations()[oam.AnnotationPublishVersion])
 
 	appParser := appfile.NewApplicationParser(r.Client)
 	handler, err := NewAppHandler(logCtx, r, app)
@@ -412,7 +427,7 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 		cond := condition.Deleting()
 		cond.Message = fmt.Sprintf("error encountered during garbage collection: %s", err.Error())
 		handler.app.Status.SetConditions(cond)
-		return r.result(statusUpdater(logCtx, handler.app, phase)).forApp(handler.app).ret()
+		return r.result(statusUpdater(logCtx, handler.app, phase)).forApp(logCtx, handler.app).ret()
 	}
 	if !finished {
 		logCtx.Info("GarbageCollecting resourcetrackers unfinished")
@@ -424,7 +439,7 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 		return r.result(statusUpdater(logCtx, handler.app, phase)).requeue(baseGCBackoffWaitTime).ret()
 	}
 	logCtx.Info("GarbageCollected resourcetrackers")
-	return r.result(statusUpdater(logCtx, handler.app, phase)).forApp(handler.app).ret()
+	return r.result(statusUpdater(logCtx, handler.app, phase)).forApp(logCtx, handler.app).ret()
 }
 
 type reconcileResult struct {
@@ -440,7 +455,10 @@ func (r *reconcileResult) requeue(d time.Duration) *reconcileResult {
 
 // forApp overrides the default resync period with the per-application value
 // parsed from the AnnotationReconcileInterval annotation, if present and valid.
-func (r *reconcileResult) forApp(app *v1beta1.Application) *reconcileResult {
+// Warnings about invalid or below-minimum values are logged with ctx so they
+// share the reconcile trace ID; pass context.Background() for callers without
+// reconcile context (tests, init paths).
+func (r *reconcileResult) forApp(ctx context.Context, app *v1beta1.Application) *reconcileResult {
 	if app == nil || app.Annotations == nil {
 		return r
 	}
@@ -451,11 +469,11 @@ func (r *reconcileResult) forApp(app *v1beta1.Application) *reconcileResult {
 	d, err := time.ParseDuration(v)
 	switch {
 	case err != nil:
-		klog.Warningf("ignoring invalid %s annotation %q on application %s/%s, using global default",
-			oam.AnnotationReconcileInterval, v, app.Namespace, app.Name)
+		logging.FromContext(ctx).Info(fmt.Sprintf("ignoring invalid %s annotation %q on application %s/%s, using global default",
+			oam.AnnotationReconcileInterval, v, app.Namespace, app.Name))
 	case d < minPerAppResyncPeriod:
-		klog.Warningf("ignoring %s annotation %q below minimum %s on application %s/%s, using global default",
-			oam.AnnotationReconcileInterval, v, minPerAppResyncPeriod, app.Namespace, app.Name)
+		logging.FromContext(ctx).Info(fmt.Sprintf("ignoring %s annotation %q below minimum %s on application %s/%s, using global default",
+			oam.AnnotationReconcileInterval, v, minPerAppResyncPeriod, app.Namespace, app.Name))
 	default:
 		r.defaultResync = d
 	}
@@ -510,7 +528,7 @@ func (r *Reconciler) handleFinalizers(ctx monitorContext.Context, app *v1beta1.A
 			}
 			if rootRT == nil && currentRT == nil && len(historyRTs) == 0 && crRT == nil {
 				if revs, err := resourcekeeper.ListApplicationRevisions(ctx, r.Client, app.Name, app.Namespace); len(revs) > 0 || err != nil {
-					klog.Infof("garbage collecting application revisions for application %s/%s, rest: %d, err: %s", app.Namespace, app.Name, len(revs), err)
+					ctx.Info("garbage collecting application revisions", logging.FieldName, app.Name, logging.FieldNamespace, app.Namespace, "rest", len(revs), "err", err)
 					return r.result(err).requeue(baseGCBackoffWaitTime).end(true)
 				}
 				meta.RemoveFinalizer(app, oam.FinalizerResourceTracker)

--- a/pkg/controller/core.oam.dev/v1beta1/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/apply.go
@@ -613,7 +613,7 @@ func (h *AppHandler) applyPostDispatchTraits(ctx monitorContext.Context, appPars
 		}
 
 		// Render traits
-		_, readyTraits, err := renderComponentsAndTraits(manifest, h.currentAppRev, svc.Cluster, svc.Namespace)
+		_, readyTraits, err := renderComponentsAndTraits(ctx, manifest, h.currentAppRev, svc.Cluster, svc.Namespace)
 		if err != nil {
 			return errors.WithMessagef(err, "failed to render PostDispatch traits for component %s", comp.Name)
 		}

--- a/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble.go
@@ -17,11 +17,13 @@ limitations under the License.
 package assemble
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog/v2"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
@@ -33,8 +35,9 @@ func checkAutoDetectComponent(wl *unstructured.Unstructured) bool {
 	return wl == nil || (len(wl.GetAPIVersion()) == 0 && len(wl.GetKind()) == 0)
 }
 
-// PrepareBeforeApply will prepare for some necessary info before apply
-func PrepareBeforeApply(comp *types.ComponentManifest, appRev *v1beta1.ApplicationRevision, disableAllComponentRevision bool) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+// PrepareBeforeApply will prepare for some necessary info before apply.
+// ctx is used only for reconcile-trace logging; passing context.Background() is safe.
+func PrepareBeforeApply(ctx context.Context, comp *types.ComponentManifest, appRev *v1beta1.ApplicationRevision, disableAllComponentRevision bool) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
 	if checkAutoDetectComponent(comp.ComponentOutput) {
 		return nil, nil, nil
 	}
@@ -48,7 +51,7 @@ func PrepareBeforeApply(comp *types.ComponentManifest, appRev *v1beta1.Applicati
 	if !disableAllComponentRevision {
 		additionalLabel[oam.LabelAppComponentRevision] = compRevisionName
 	}
-	wl := assembleWorkload(compName, comp.ComponentOutput, additionalLabel)
+	wl := assembleWorkload(ctx, compName, comp.ComponentOutput, additionalLabel)
 
 	assembledTraits := make([]*unstructured.Unstructured, len(comp.ComponentOutputsAndTraits))
 
@@ -62,7 +65,7 @@ func PrepareBeforeApply(comp *types.ComponentManifest, appRev *v1beta1.Applicati
 	return wl, assembledTraits, nil
 }
 
-func assembleWorkload(compName string, wl *unstructured.Unstructured, labels map[string]string) *unstructured.Unstructured {
+func assembleWorkload(ctx context.Context, compName string, wl *unstructured.Unstructured, labels map[string]string) *unstructured.Unstructured {
 	// use component name as workload name if workload name is not specified
 	// don't override the name set in render phase if exist
 	if len(wl.GetName()) == 0 {
@@ -70,7 +73,10 @@ func assembleWorkload(compName string, wl *unstructured.Unstructured, labels map
 	}
 	setWorkloadLabels(wl, labels)
 
-	klog.InfoS("Successfully assemble a workload", "workload", klog.KObj(wl), "APIVersion", wl.GetAPIVersion(), "Kind", wl.GetKind())
+	logging.FromContext(ctx).Info("Successfully assemble a workload",
+		"workload", wl.GetNamespace()+"/"+wl.GetName(),
+		"APIVersion", wl.GetAPIVersion(),
+		"Kind", wl.GetKind())
 	return wl
 }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble_suite_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/assemble/assemble_suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package assemble
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -113,7 +115,7 @@ var _ = Describe("Test PrepareBeforeApply", func() {
 		})
 
 		It("should add component revision label when disableAllComponentRevision is false", func() {
-			wl, traits, err := PrepareBeforeApply(comp, appRev, false)
+			wl, traits, err := PrepareBeforeApply(context.Background(), comp, appRev, false)
 			Expect(err).To(BeNil())
 			Expect(wl).NotTo(BeNil())
 			Expect(traits).To(HaveLen(1))
@@ -130,7 +132,7 @@ var _ = Describe("Test PrepareBeforeApply", func() {
 		})
 
 		It("should not add component revision label when disableAllComponentRevision is true", func() {
-			wl, traits, err := PrepareBeforeApply(comp, appRev, true)
+			wl, traits, err := PrepareBeforeApply(context.Background(), comp, appRev, true)
 			Expect(err).To(BeNil())
 			Expect(wl).NotTo(BeNil())
 			Expect(traits).To(HaveLen(1))
@@ -148,7 +150,7 @@ var _ = Describe("Test PrepareBeforeApply", func() {
 
 		It("should return nil when component output is nil", func() {
 			comp.ComponentOutput = nil
-			wl, traits, err := PrepareBeforeApply(comp, appRev, false)
+			wl, traits, err := PrepareBeforeApply(context.Background(), comp, appRev, false)
 			Expect(err).To(BeNil())
 			Expect(wl).To(BeNil())
 			Expect(traits).To(BeNil())
@@ -162,7 +164,7 @@ var _ = Describe("Test PrepareBeforeApply", func() {
 					},
 				},
 			}
-			wl, traits, err := PrepareBeforeApply(comp, appRev, false)
+			wl, traits, err := PrepareBeforeApply(context.Background(), comp, appRev, false)
 			Expect(err).To(BeNil())
 			Expect(wl).To(BeNil())
 			Expect(traits).To(BeNil())
@@ -170,7 +172,7 @@ var _ = Describe("Test PrepareBeforeApply", func() {
 
 		It("should handle empty component revision name", func() {
 			comp.RevisionName = ""
-			wl, traits, err := PrepareBeforeApply(comp, appRev, false)
+			wl, traits, err := PrepareBeforeApply(context.Background(), comp, appRev, false)
 			Expect(err).To(BeNil())
 			Expect(wl).NotTo(BeNil())
 			Expect(traits).To(HaveLen(1))

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -264,7 +264,7 @@ func (h *AppHandler) renderComponentFunc(appParser *appfile.Parser, af *appfile.
 		if err != nil {
 			return nil, nil, err
 		}
-		return renderComponentsAndTraits(manifest, h.currentAppRev, clusterName, overrideNamespace)
+		return renderComponentsAndTraits(ctx, manifest, h.currentAppRev, clusterName, overrideNamespace)
 	}
 }
 
@@ -280,7 +280,7 @@ func (h *AppHandler) checkComponentHealth(appParser *appfile.Parser, af *appfile
 		}
 		wl.Ctx.SetCtx(auth.ContextWithUserInfo(ctx, h.app))
 
-		readyWorkload, readyTraits, err := renderComponentsAndTraits(manifest, h.currentAppRev, clusterName, overrideNamespace)
+		readyWorkload, readyTraits, err := renderComponentsAndTraits(ctx, manifest, h.currentAppRev, clusterName, overrideNamespace)
 		if err != nil {
 			return false, nil, nil, nil, err
 		}
@@ -319,7 +319,7 @@ func (h *AppHandler) applyComponentFunc(appParser *appfile.Parser, af *appfile.A
 		}
 		wl.Ctx.SetCtx(auth.ContextWithUserInfo(ctx, h.app))
 
-		readyWorkload, readyTraits, err := renderComponentsAndTraits(manifest, appRev, clusterName, overrideNamespace)
+		readyWorkload, readyTraits, err := renderComponentsAndTraits(ctx, manifest, appRev, clusterName, overrideNamespace)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -462,8 +462,8 @@ func (h *AppHandler) prepareWorkloadAndManifests(ctx context.Context,
 	return wl, manifest, nil
 }
 
-func renderComponentsAndTraits(manifest *types.ComponentManifest, appRev *v1beta1.ApplicationRevision, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
-	readyWorkload, readyTraits, err := assemble.PrepareBeforeApply(manifest, appRev, DisableAllComponentRevision)
+func renderComponentsAndTraits(ctx context.Context, manifest *types.ComponentManifest, appRev *v1beta1.ApplicationRevision, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	readyWorkload, readyTraits, err := assemble.PrepareBeforeApply(ctx, manifest, appRev, DisableAllComponentRevision)
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "assemble resources before apply fail")
 	}

--- a/pkg/controller/core.oam.dev/v1beta1/application/log_context.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/log_context.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	monitorContext "github.com/kubevela/pkg/monitor/context"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/logging"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+// ApplicationLogContext builds the monitorContext for one Application
+// reconcile. It resolves the trace ID from the app's annotation
+// (stamped by the mutating webhook) or mints a fresh UUID when the
+// webhook was bypassed, and mints a separate fresh UUID for this
+// reconcile's root span ID. The trace ID stays stable across reconciles
+// of the same app; the span ID is unique per reconcile so log lines
+// from different reconciles of the same app can be co-related
+// independently via the spanID field.
+//
+// The trace ID is also stored on the std context (as requestID) so
+// non-monitor consumers see the same value via logging.FromContext,
+// and is added as the requestID tag so it shares the log field name
+// used by both webhooks.
+//
+// Returns the log context and the resolved trace ID. Callers need the
+// trace ID separately to seed downstream std contexts (logCtx.GetID()
+// now returns the reconcile span ID, not the trace ID).
+func ApplicationLogContext(ctx context.Context, app *v1beta1.Application, req ctrl.Request) (monitorContext.Context, string) {
+	traceID, _ := logging.TraceIDFromObject(app)
+	if traceID == "" {
+		traceID = uuid.NewString()
+	}
+	// Per-reconcile span ID — unique even when the trace ID persists
+	// across many reconciles of the same Application.
+	reconcileSpanID := uuid.NewString()
+
+	ctx = logging.WithRequestID(ctx, traceID)
+
+	logCtx := monitorContext.NewTraceContext(ctx, reconcileSpanID)
+	return logCtx.AddTag(
+		logging.FieldRequestID, traceID,
+		"application", req.String(),
+		"controller", "application",
+		logging.FieldName, app.Name,
+		logging.FieldNamespace, app.Namespace,
+		"app_uid", string(app.UID),
+		logging.FieldGeneration, app.Generation,
+		"resource_version", app.ResourceVersion,
+		"publish_version", app.GetAnnotations()[oam.AnnotationPublishVersion],
+		"reconcile_reason", determineApplicationReconcileReason(app),
+	), traceID
+}
+
+// determineApplicationReconcileReason returns a coarse hint about why
+// the reconciler woke up. Conservative on purpose: only the cases we
+// can read unambiguously from app state. Update / periodic / manual
+// expansion is intentionally deferred.
+func determineApplicationReconcileReason(app *v1beta1.Application) string {
+	if app == nil {
+		return "unknown"
+	}
+	if !app.DeletionTimestamp.IsZero() {
+		return "delete"
+	}
+	if v, ok := app.Annotations[oam.AnnotationWorkflowRestart]; ok && v != "" {
+		return "workflow_restart"
+	}
+	return "unknown"
+}

--- a/pkg/controller/core.oam.dev/v1beta1/application/log_context.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/log_context.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The KubeVela Authors.
+Copyright 2025 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/core.oam.dev/v1beta1/application/log_context_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/log_context_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/logging"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestApplicationLogContext_UsesAnnotationWhenPresent(t *testing.T) {
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+			UID:       "app-uid-1",
+			Annotations: map[string]string{
+				oam.AnnotationTraceID: "fixed-trace-id",
+			},
+		},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace}}
+
+	logCtx, traceID := ApplicationLogContext(context.Background(), app, req)
+	if logCtx == nil {
+		t.Fatal("expected non-nil log context")
+	}
+	if traceID != "fixed-trace-id" {
+		t.Fatalf("expected trace ID to be the annotation value, got %q", traceID)
+	}
+	if got, ok := logging.RequestIDFrom(logCtx); !ok || got != "fixed-trace-id" {
+		t.Fatalf("expected request ID to be set on std ctx; got %q ok=%v", got, ok)
+	}
+}
+
+func TestApplicationLogContext_MintsWhenAnnotationMissing(t *testing.T) {
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+			UID:       "app-uid-2",
+		},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace}}
+
+	logCtx, traceID := ApplicationLogContext(context.Background(), app, req)
+	if logCtx == nil {
+		t.Fatal("expected non-nil log context")
+	}
+	if traceID == "" {
+		t.Fatalf("expected a freshly minted trace ID, got empty string")
+	}
+	got, ok := logging.RequestIDFrom(logCtx)
+	if !ok || got != traceID {
+		t.Fatalf("expected std ctx requestID to equal returned trace ID; got %q ok=%v want %q", got, ok, traceID)
+	}
+}
+
+func TestApplicationLogContext_DifferentReconcilesMintDifferentTraceIDs(t *testing.T) {
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "a", Namespace: "ns"}}
+
+	_, id1 := ApplicationLogContext(context.Background(), app, req)
+	_, id2 := ApplicationLogContext(context.Background(), app, req)
+	if id1 == id2 {
+		t.Fatalf("expected distinct trace IDs across reconciles without annotation, got %q twice", id1)
+	}
+}
+
+func TestApplicationLogContext_FreshSpanIDPerReconcile(t *testing.T) {
+	// When the trace ID annotation is set, the trace ID should persist
+	// across reconciles, but each reconcile gets its own root span ID.
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stable-app",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				oam.AnnotationTraceID: "fixed-trace-id",
+			},
+		},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace}}
+
+	logCtx1, traceID1 := ApplicationLogContext(context.Background(), app, req)
+	logCtx2, traceID2 := ApplicationLogContext(context.Background(), app, req)
+
+	if traceID1 != "fixed-trace-id" || traceID2 != "fixed-trace-id" {
+		t.Fatalf("trace IDs should both be the annotation value, got %q and %q", traceID1, traceID2)
+	}
+	if logCtx1.GetID() == logCtx2.GetID() {
+		t.Fatalf("each reconcile should get a unique span ID, got %q twice", logCtx1.GetID())
+	}
+	if logCtx1.GetID() == traceID1 {
+		t.Fatalf("reconcile span ID must not equal trace ID; got %q", logCtx1.GetID())
+	}
+}
+
+func TestDetermineApplicationReconcileReason(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name string
+		app  *v1beta1.Application
+		want string
+	}{
+		{
+			name: "nil app",
+			app:  nil,
+			want: "unknown",
+		},
+		{
+			name: "delete in progress",
+			app:  &v1beta1.Application{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}},
+			want: "delete",
+		},
+		{
+			name: "workflow restart annotation present",
+			app: &v1beta1.Application{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{oam.AnnotationWorkflowRestart: "true"},
+			}},
+			want: "workflow_restart",
+		},
+		{
+			name: "workflow restart annotation empty value",
+			app: &v1beta1.Application{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{oam.AnnotationWorkflowRestart: ""},
+			}},
+			want: "unknown",
+		},
+		{
+			name: "plain app",
+			app:  &v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Name: "x"}},
+			want: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := determineApplicationReconcileReason(tc.app); got != tc.want {
+				t.Fatalf("reason: want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/controller/core.oam.dev/v1beta1/application/log_context_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/log_context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The KubeVela Authors.
+Copyright 2025 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/core.oam.dev/v1beta1/application/reconcile_result_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/reconcile_result_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package application
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -123,7 +124,7 @@ func TestReconcileResultForApp(t *testing.T) {
 			if tt.explicitRequeue > 0 {
 				res.requeue(tt.explicitRequeue)
 			}
-			res.forApp(app)
+			res.forApp(context.Background(), app)
 
 			result, err := res.ret()
 
@@ -140,7 +141,7 @@ func TestReconcileResultForApp(t *testing.T) {
 
 func TestReconcileResultForAppNilApp(t *testing.T) {
 	r := &Reconciler{}
-	res := r.result(nil).forApp(nil)
+	res := r.result(nil).forApp(context.Background(), nil)
 	result, err := res.ret()
 
 	assert.NoError(t, err)

--- a/pkg/controller/core.oam.dev/v1beta1/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/revision.go
@@ -49,6 +49,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/component"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -99,7 +100,7 @@ func (h *AppHandler) PrepareCurrentAppRevision(ctx context.Context, af *appfile.
 		return nil
 	}
 
-	appRev, appRevisionHash, err := h.gatherRevisionSpec(af)
+	appRev, appRevisionHash, err := h.gatherRevisionSpec(ctx, af)
 	if err != nil {
 		return err
 	}
@@ -127,7 +128,7 @@ func (h *AppHandler) PrepareCurrentAppRevision(ctx context.Context, af *appfile.
 
 // gatherRevisionSpec will gather all revision spec without metadata and rendered result.
 // the gathered Revision spec will be enough to calculate the hash and compare with the old revision
-func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.ApplicationRevision, string, error) {
+func (h *AppHandler) gatherRevisionSpec(ctx context.Context, af *appfile.Appfile) (*v1beta1.ApplicationRevision, string, error) {
 	copiedApp := h.app.DeepCopy()
 	// We better to remove all object status in the appRevision
 	copiedApp.Status = common.AppStatus{}
@@ -234,9 +235,9 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 		for name, versionInfo := range h.policyVersions {
 			appRev.Spec.PolicyVersions[name] = versionInfo
 		}
-		klog.InfoS("Stored PolicyVersions in ApplicationRevision", "count", len(h.policyVersions), "policies", h.policyVersions)
+		logging.FromContext(ctx).Info("Stored PolicyVersions in ApplicationRevision", "count", len(h.policyVersions), "policies", h.policyVersions)
 	} else {
-		klog.InfoS("No PolicyVersions to store in ApplicationRevision", "policyVersionsNil", h.policyVersions == nil, "count", len(h.policyVersions))
+		logging.FromContext(ctx).Info("No PolicyVersions to store in ApplicationRevision", "policyVersionsNil", h.policyVersions == nil, "count", len(h.policyVersions))
 	}
 
 	var err error
@@ -247,7 +248,7 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 
 	appRevisionHash, err := ComputeAppRevisionHash(appRev)
 	if err != nil {
-		klog.ErrorS(err, "Failed to compute hash of appRevision for application", "application", klog.KObj(h.app))
+		logging.FromContext(ctx).Error(err, "Failed to compute hash of appRevision for application", "application", klog.KObj(h.app))
 		return appRev, "", errors.Wrapf(err, "failed to compute app revision hash")
 	}
 	return appRev, appRevisionHash, nil
@@ -263,7 +264,7 @@ func (h *AppHandler) getLatestAppRevision(ctx context.Context) error {
 	latestRevName := h.app.Status.LatestRevision.Name
 	latestAppRev := &v1beta1.ApplicationRevision{}
 	if err := h.Get(ctx, client.ObjectKey{Name: latestRevName, Namespace: h.app.Namespace}, latestAppRev); err != nil {
-		klog.ErrorS(err, "Failed to get latest app revision", "appRevisionName", latestRevName)
+		logging.FromContext(ctx).Error(err, "Failed to get latest app revision", "appRevisionName", latestRevName)
 		return errors.Wrapf(err, "fail to get latest app revision %s", latestRevName)
 	}
 	h.latestAppRev = latestAppRev
@@ -389,7 +390,7 @@ func (h *AppHandler) currentAppRevIsNew(ctx context.Context) (bool, bool, error)
 
 	revs, err := GetAppRevisions(ctx, h.Client, h.app.Name, h.app.Namespace)
 	if err != nil {
-		klog.ErrorS(err, "Failed to list app revision", "appName", h.app.Name)
+		logging.FromContext(ctx).Error(err, "Failed to list app revision", "appName", h.app.Name)
 		return false, false, errors.Wrap(err, "failed to list app revision")
 	}
 
@@ -581,7 +582,7 @@ func (h *AppHandler) UpdateAppLatestRevisionStatus(ctx context.Context, patchSta
 	savedSpec := h.app.Spec.DeepCopy()
 
 	if err := patchStatus(ctx, h.app, common.ApplicationRendering); err != nil {
-		klog.InfoS("Failed to update the latest appConfig revision to status", "application", klog.KObj(h.app),
+		logging.FromContext(ctx).Info("Failed to update the latest appConfig revision to status", "application", klog.KObj(h.app),
 			"latest revision", revName, "err", err)
 		return err
 	}
@@ -589,7 +590,7 @@ func (h *AppHandler) UpdateAppLatestRevisionStatus(ctx context.Context, patchSta
 	// Restore the spec after patchStatus to preserve policy modifications
 	h.app.Spec = *savedSpec
 
-	klog.InfoS("Successfully update application latest revision status", "application", klog.KObj(h.app),
+	logging.FromContext(ctx).Info("Successfully update application latest revision status", "application", klog.KObj(h.app),
 		"latest revision", revName)
 
 	return nil
@@ -607,17 +608,13 @@ func (h *AppHandler) UpdateApplicationRevisionStatus(ctx context.Context, appRev
 	if wfStatus.ContextBackend != nil {
 		var cm corev1.ConfigMap
 		if err := h.Client.Get(ctx, ktypes.NamespacedName{Namespace: wfStatus.ContextBackend.Namespace, Name: wfStatus.ContextBackend.Name}, &cm); err != nil {
-			klog.Error(err, "[UpdateApplicationRevisionStatus] failed to load the context values", "ApplicationRevision", appRev.Name)
+			logging.FromContext(ctx).Error(err, "[UpdateApplicationRevisionStatus] failed to load the context values", "ApplicationRevision", appRev.Name)
 		}
 		appRev.Status.WorkflowContext = cm.Data
 	}
 
 	if err := h.Client.Status().Update(ctx, appRev); err != nil {
-		if logCtx, ok := ctx.(monitorContext.Context); ok {
-			logCtx.Error(err, "[UpdateApplicationRevisionStatus] failed to update application revision status", "ApplicationRevision", appRev.Name)
-		} else {
-			klog.Error(err, "[UpdateApplicationRevisionStatus] failed to update application revision status", "ApplicationRevision", appRev.Name)
-		}
+		logging.FromContext(ctx).Error(err, "[UpdateApplicationRevisionStatus] failed to update application revision status", "ApplicationRevision", appRev.Name)
 	}
 }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/workflow.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/workflow.go
@@ -18,17 +18,18 @@ package application
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 
 	monitorContext "github.com/kubevela/pkg/monitor/context"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/condition"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
@@ -70,16 +71,16 @@ func (r *Reconciler) handleWorkflowRestartAnnotation(ctx context.Context, app *v
 		statusFieldNeedsUpdate = app.Status.WorkflowRestartScheduledAt == nil ||
 			!app.Status.WorkflowRestartScheduledAt.Time.Equal(scheduledTime)
 	} else {
-		klog.Warningf("Invalid workflow restart annotation value for Application %s/%s: %q. Expected 'true', RFC3339 timestamp, or duration (e.g., '5m', '1h')",
-			app.Namespace, app.Name, restartValue)
+		logging.FromContext(ctx).Info(fmt.Sprintf("Invalid workflow restart annotation value for Application %s/%s: %q. Expected 'true', RFC3339 timestamp, or duration (e.g., '5m', '1h')",
+			app.Namespace, app.Name, restartValue))
 		return
 	}
 
 	if statusFieldNeedsUpdate {
 		app.Status.WorkflowRestartScheduledAt = &metav1.Time{Time: scheduledTime}
 		if err := r.Status().Update(ctx, app); err != nil {
-			klog.Errorf("Failed to update workflow restart status for Application %s/%s: %v. Will retry on next reconcile.",
-				app.Namespace, app.Name, err)
+			logging.FromContext(ctx).Error(err, "Failed to update workflow restart status; will retry on next reconcile",
+				logging.FieldName, app.Name, logging.FieldNamespace, app.Namespace)
 			// Don't fail reconciliation - will retry naturally on next reconcile
 		}
 	}
@@ -89,8 +90,8 @@ func (r *Reconciler) handleWorkflowRestartAnnotation(ctx context.Context, app *v
 	if !isDuration {
 		delete(app.Annotations, oam.AnnotationWorkflowRestart)
 		if err := r.Client.Update(ctx, app); err != nil {
-			klog.Errorf("Failed to remove workflow restart annotation for Application %s/%s: %v. Will retry on next reconcile.",
-				app.Namespace, app.Name, err)
+			logging.FromContext(ctx).Error(err, "Failed to remove workflow restart annotation; will retry on next reconcile",
+				logging.FieldName, app.Name, logging.FieldNamespace, app.Namespace)
 			// Don't fail reconciliation - will retry naturally on next reconcile
 		}
 	}
@@ -193,8 +194,11 @@ func (r *Reconciler) checkWorkflowRestart(ctx monitorContext.Context, app *v1bet
 	// the next Render() with a clearer error than could be produced here.
 	if !publishVersionPinned {
 		if vfFp, err := computeValuesFromContentFingerprint(ctx, app); err != nil {
-			klog.V(2).InfoS("failed to compute valuesFrom fingerprint; falling back to spec-only workflow gate",
-				"err", err, "appName", app.Name, "namespace", app.Namespace)
+			// V(2) is intentional: a persistent failure (e.g. RBAC change deleting CM read)
+			// must not produce alert-storms; the user-visible failure surfaces on the next
+			// Render() with a clearer error.
+			logging.FromContext(ctx).V(2).Info("failed to compute valuesFrom fingerprint; falling back to spec-only workflow gate",
+				"err", err, logging.FieldName, app.Name, logging.FieldNamespace, app.Namespace)
 			if currentRev != "" && strings.HasPrefix(currentRev, desiredRev+valuesFromSuffixSeparator) {
 				desiredRev = currentRev
 			}

--- a/pkg/logging/color_writer.go
+++ b/pkg/logging/color_writer.go
@@ -34,19 +34,31 @@ import (
 )
 
 const (
-	ansiReset    = "\x1b[0m"
-	ansiDate     = "\x1b[36m"
-	ansiInfo     = "\x1b[32m"
-	ansiWarn     = "\x1b[33m"
-	ansiError    = "\x1b[31m"
-	ansiFatal    = "\x1b[35m"
-	ansiDebug    = "\x1b[34m"
-	ansiThread   = "\x1b[34m"
-	ansiLocation = "\x1b[93m"
-	ansiMessage  = "\x1b[97m"
-	ansiKey      = "\x1b[96m"
-	ansiValue    = "\x1b[37m"
+	ansiReset     = "\x1b[0m"
+	ansiDate      = "\x1b[36m"
+	ansiInfo      = "\x1b[32m"
+	ansiWarn      = "\x1b[33m"
+	ansiError     = "\x1b[31m"
+	ansiFatal     = "\x1b[35m"
+	ansiDebug     = "\x1b[34m"
+	ansiThread    = "\x1b[34m"
+	ansiRequestID = "\x1b[95m" // bright magenta — trace ID
+	ansiSpanID    = "\x1b[94m" // bright blue — per-reconcile span ID
+	ansiLocation  = "\x1b[93m"
+	ansiMessage   = "\x1b[97m"
+	ansiKey       = "\x1b[96m"
+	ansiValue     = "\x1b[37m"
 )
+
+// stripSpanSuffix returns the UUID portion of a spanID value, dropping any
+// ".<operation>" suffix so the header block stays visually clean. The full
+// value (with suffix) stays in the trailing key/value list for sub-span detail.
+func stripSpanSuffix(s string) string {
+	if dot := strings.IndexByte(s, '.'); dot >= 0 {
+		return s[:dot]
+	}
+	return s
+}
 
 var methodPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\b(?:caller|func|function|method)\s*[:=]\s*"?([a-zA-Z0-9_./()*-]+)`),
@@ -130,6 +142,32 @@ func formatColoredLine(line string) string {
 	level, levelColor := mapSeverity(severity)
 	location := buildLocation(rawLocation, remainder)
 
+	// Pre-parse remainder so we can hoist requestID and spanID into the
+	// header. requestID is dropped from the trailing list (full value lives
+	// in the {...} header block); spanID stays in the trailing list because
+	// its full value (with optional ".<operation>" suffix) carries sub-span
+	// detail the header only shows the UUID prefix of.
+	var msg string
+	var kvFields []kvField
+	var headerRequestID, headerSpanID string
+	if remainder != "" {
+		msg, kvFields = splitMessageAndFields(remainder)
+		filtered := kvFields[:0]
+		for _, f := range kvFields {
+			if f.key == FieldRequestID && headerRequestID == "" {
+				headerRequestID = f.value
+				continue
+			}
+			if f.key == FieldSpanID && headerSpanID == "" {
+				// Strip ".<operation>" suffix for the header block — keep
+				// only the per-reconcile UUID portion.
+				headerSpanID = stripSpanSuffix(f.value)
+			}
+			filtered = append(filtered, f)
+		}
+		kvFields = filtered
+	}
+
 	sb := strings.Builder{}
 	sb.Grow(len(line) + 32)
 
@@ -154,30 +192,45 @@ func formatColoredLine(line string) string {
 	sb.WriteString(ansiReset)
 	sb.WriteString(" ")
 
+	if headerRequestID != "" {
+		sb.WriteString(ansiRequestID)
+		sb.WriteString("{")
+		sb.WriteString(headerRequestID)
+		sb.WriteString("}")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" ")
+	}
+
+	if headerSpanID != "" {
+		sb.WriteString(ansiSpanID)
+		sb.WriteString("{")
+		sb.WriteString(headerSpanID)
+		sb.WriteString("}")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" ")
+	}
+
 	sb.WriteString(ansiLocation)
 	sb.WriteString("[")
 	sb.WriteString(location)
 	sb.WriteString("]")
 	sb.WriteString(ansiReset)
 
-	if remainder != "" {
-		msg, fields := splitMessageAndFields(remainder)
-		if msg != "" {
-			sb.WriteString(" ")
-			sb.WriteString(ansiMessage)
-			sb.WriteString(msg)
-			sb.WriteString(ansiReset)
-		}
-		for _, field := range fields {
-			sb.WriteString(" ")
-			sb.WriteString(ansiKey)
-			sb.WriteString(field.key)
-			sb.WriteString(ansiReset)
-			sb.WriteString("=")
-			sb.WriteString(ansiValue)
-			sb.WriteString(field.renderValue())
-			sb.WriteString(ansiReset)
-		}
+	if msg != "" {
+		sb.WriteString(" ")
+		sb.WriteString(ansiMessage)
+		sb.WriteString(msg)
+		sb.WriteString(ansiReset)
+	}
+	for _, field := range kvFields {
+		sb.WriteString(" ")
+		sb.WriteString(ansiKey)
+		sb.WriteString(field.key)
+		sb.WriteString(ansiReset)
+		sb.WriteString("=")
+		sb.WriteString(ansiValue)
+		sb.WriteString(field.renderValue())
+		sb.WriteString(ansiReset)
 	}
 
 	return sb.String()

--- a/pkg/logging/color_writer.go
+++ b/pkg/logging/color_writer.go
@@ -76,11 +76,15 @@ type colorWriter struct {
 // It wraps the provided writer and colorizes log messages based on severity level,
 // enhances location information with function names, and formats structured fields.
 // This is primarily intended for development mode (--dev-logs=true) to improve
-// log readability in terminal output.
-func NewColorWriter(dst io.Writer) io.Writer {
+// log readability in terminal output. The returned writer also implements Flush
+// so callers can drain any buffered partial line at shutdown.
+func NewColorWriter(dst io.Writer) LineFormatter {
 	return &colorWriter{dst: dst}
 }
 
+// Write accepts klog-formatted lines and emits ANSI-colored, header-hoisted
+// versions. On downstream write failure the buffered line is retained so
+// callers retrying the same input don't silently drop the line.
 func (w *colorWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -94,28 +98,34 @@ func (w *colorWriter) Write(p []byte) (int, error) {
 			break
 		}
 		_, _ = w.buf.Write(p[:idx])
-		if err := w.flushLineLocked(); err != nil {
-			written += idx
+		line := w.buf.String()
+		// Combine the formatted line and newline into a single write so a
+		// partial failure either succeeds in full or leaves the buffered line
+		// untouched for retry.
+		if _, err := io.WriteString(w.dst, formatColoredLine(line)+"\n"); err != nil {
 			return written, err
 		}
-		if _, err := w.dst.Write([]byte{'\n'}); err != nil {
-			written += idx + 1
-			return written, err
-		}
+		w.buf.Reset()
 		p = p[idx+1:]
 		written += idx + 1
 	}
 	return written, nil
 }
 
-func (w *colorWriter) flushLineLocked() error {
+// Flush writes any buffered partial line (one without a trailing newline) to
+// the underlying writer. Idempotent.
+func (w *colorWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.buf.Len() == 0 {
 		return nil
 	}
 	line := w.buf.String()
+	if _, err := io.WriteString(w.dst, formatColoredLine(line)); err != nil {
+		return err
+	}
 	w.buf.Reset()
-	_, err := io.WriteString(w.dst, formatColoredLine(line))
-	return err
+	return nil
 }
 
 func formatColoredLine(line string) string {
@@ -332,7 +342,14 @@ func findFirstKVIndex(s string) int {
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
 		if ch == '"' {
-			if i == 0 || s[i-1] != '\\' {
+			// Count trailing backslashes: an even count means the quote is
+			// unescaped (e.g. `\\"` = escaped backslash + quote), an odd count
+			// means the quote itself is escaped (e.g. `\"`).
+			n := 0
+			for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
+				n++
+			}
+			if n%2 == 0 {
 				inQuotes = !inQuotes
 			}
 			continue

--- a/pkg/logging/color_writer_test.go
+++ b/pkg/logging/color_writer_test.go
@@ -299,4 +299,57 @@ var _ = Describe("Color Writer", func() {
 			Expect(len(output)).Should(BeNumerically(">", 10000))
 		})
 	})
+
+	Context("trace and span ID hoisting", func() {
+		It("hoists requestID and spanID into separate header blocks", func() {
+			var buf bytes.Buffer
+			writer := logging.NewColorWriter(&buf)
+
+			input := `I1117 12:34:56.789012    1234 app_controller.go:130] "Start reconcile" application="ns/app" requestID="trace-abc" spanID="span-xyz"`
+			_, err := writer.Write([]byte(input + "\n"))
+			Expect(err).Should(BeNil())
+
+			output := buf.String()
+			// Both blocks appear in the header, in order.
+			Expect(output).Should(ContainSubstring("{trace-abc}"))
+			Expect(output).Should(ContainSubstring("{span-xyz}"))
+			Expect(strings.Index(output, "{trace-abc}")).Should(BeNumerically("<", strings.Index(output, "{span-xyz}")))
+			// requestID stripped from trailing.
+			Expect(output).ShouldNot(ContainSubstring(`requestID="trace-abc"`))
+			// spanID kept in trailing for sub-span detail.
+			Expect(output).Should(ContainSubstring(`span-xyz`))
+		})
+
+		It("strips operation suffix from spanID for the header block only", func() {
+			var buf bytes.Buffer
+			writer := logging.NewColorWriter(&buf)
+
+			input := `I1117 12:34:56.789012    1234 apply.go:491] "[Finished]: span-xyz.apply-policies(...)" requestID="trace-abc" spanID="span-xyz.apply-policies"`
+			_, err := writer.Write([]byte(input + "\n"))
+			Expect(err).Should(BeNil())
+
+			output := buf.String()
+			// Header block is the UUID portion only.
+			Expect(output).Should(ContainSubstring("{span-xyz}"))
+			Expect(output).ShouldNot(ContainSubstring("{span-xyz.apply-policies}"))
+			// Trailing keeps the full spanID with the suffix.
+			Expect(output).Should(ContainSubstring(`span-xyz.apply-policies`))
+		})
+
+		It("emits only requestID block when spanID is absent (webhook log shape)", func() {
+			var buf bytes.Buffer
+			writer := logging.NewColorWriter(&buf)
+
+			input := `I1117 12:34:56.789012    1234 application_validating_handler.go:87] "Starting admission validation" handler="ApplicationValidator" requestID="trace-abc"`
+			_, err := writer.Write([]byte(input + "\n"))
+			Expect(err).Should(BeNil())
+
+			output := buf.String()
+			Expect(output).Should(ContainSubstring("{trace-abc}"))
+			// No spanID block should appear — webhook lines don't fork spans.
+			matches := strings.Count(output, "{trace-abc}")
+			Expect(matches).Should(Equal(1))
+			Expect(output).ShouldNot(ContainSubstring(`requestID="trace-abc"`))
+		})
+	})
 })

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -23,14 +23,18 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 // Structured logging field keys - consistent across all handlers for observability
 const (
 	// Core traceability fields
-	FieldRequestID = "requestID"  // Unique identifier for request correlation
+	FieldRequestID = "requestID"  // Unique identifier for request correlation (trace ID)
+	FieldSpanID    = "spanID"     // Per-reconcile span identifier (matches monitorContext convention)
 	FieldOperation = "operation"  // Webhook operation (CREATE/UPDATE/DELETE)
 	FieldHandler   = "handler"    // Handler processing the request
 	FieldStep      = "step"       // Current processing step
@@ -81,6 +85,18 @@ func WithContext(ctx context.Context) Logger {
 	return New()
 }
 
+// FromContext returns a Logger seeded with the requestID present on ctx.
+// Use this from any reconcile-path function that has only a std context.Context
+// so the emitted log lines correlate with the rest of the reconcile.
+// If ctx carries no requestID (e.g. startup runnables), returns a plain logger.
+func FromContext(ctx context.Context) Logger {
+	logger := WithContext(ctx)
+	if id, ok := RequestIDFrom(ctx); ok {
+		logger = logger.WithValues(FieldRequestID, id)
+	}
+	return logger
+}
+
 // IntoContext stores the Logger in context
 func (l Logger) IntoContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, loggerKey, l)
@@ -98,6 +114,43 @@ func WithRequestID(ctx context.Context, requestID string) context.Context {
 func RequestIDFrom(ctx context.Context) (string, bool) {
 	id, ok := ctx.Value(requestIDKey).(string)
 	return id, ok && id != ""
+}
+
+// TraceIDFromObject returns the trace ID stamped by the mutating webhook on
+// the object's annotations, or false if the object is nil, has no annotations,
+// or the annotation is empty.
+func TraceIDFromObject(obj metav1.Object) (string, bool) {
+	if obj == nil {
+		return "", false
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return "", false
+	}
+	id := annotations[oam.AnnotationTraceID]
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// EnsureTraceIDAnnotation sets the trace ID annotation only when it is
+// currently absent or empty. Returns true when the object was mutated so
+// callers can decide whether a patch is needed. A nil object or empty
+// traceID is a no-op and returns false.
+func EnsureTraceIDAnnotation(obj metav1.Object, traceID string) bool {
+	if obj == nil || traceID == "" {
+		return false
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	} else if existing := annotations[oam.AnnotationTraceID]; existing != "" {
+		return false
+	}
+	annotations[oam.AnnotationTraceID] = traceID
+	obj.SetAnnotations(annotations)
+	return true
 }
 
 // NewHandlerLogger creates a logger for webhook handlers with full request context
@@ -152,22 +205,27 @@ func (l Logger) V(level int) Logger {
 	return Logger{Logger: l.Logger.V(level)}
 }
 
+// WithCallDepth(1) on every emit ensures the file:line reported by the
+// underlying sink is the caller of our wrapper (e.g. assemble.go:73), not
+// this logger.go file. Required because pkg/logging.Logger wraps logr.Logger
+// with one extra stack frame.
+
 // Debug logs debug message (verbosity 1)
 func (l Logger) Debug(msg string, keysAndValues ...interface{}) {
-	l.Logger.V(1).Info(msg, keysAndValues...)
+	l.Logger.V(1).WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Trace logs trace message (verbosity 2)
 func (l Logger) Trace(msg string, keysAndValues ...interface{}) {
-	l.Logger.V(2).Info(msg, keysAndValues...)
+	l.Logger.V(2).WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Info logs info message
 func (l Logger) Info(msg string, keysAndValues ...interface{}) {
-	l.Logger.Info(msg, keysAndValues...)
+	l.Logger.WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Error logs error message
 func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {
-	l.Logger.Error(err, msg, keysAndValues...)
+	l.Logger.WithCallDepth(1).Error(err, msg, keysAndValues...)
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -20,6 +20,7 @@ package logging
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,14 @@ const (
 	FieldError   = "error"   // Error indicator
 	FieldSuccess = "success" // Success indicator
 )
+
+// LineFormatter is an io.Writer that also exposes a Flush method so callers
+// can drain any buffered partial line before shutdown. Implemented by both
+// colorWriter (dev-logs) and requestIDInjector (default mode).
+type LineFormatter interface {
+	io.Writer
+	Flush() error
+}
 
 // contextKey for storing values in context
 type contextKey struct{ name string }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestTraceIDFromObject(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     metav1.Object
+		wantID  string
+		wantOK  bool
+	}{
+		{
+			name:   "nil object returns false",
+			obj:    nil,
+			wantOK: false,
+		},
+		{
+			name:   "nil annotations returns false",
+			obj:    &metav1.ObjectMeta{},
+			wantOK: false,
+		},
+		{
+			name:   "missing key returns false",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{"other": "value"}},
+			wantOK: false,
+		},
+		{
+			name:   "empty value returns false",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: ""}},
+			wantOK: false,
+		},
+		{
+			name:   "present value returns it",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: "abc-123"}},
+			wantID: "abc-123",
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotOK := TraceIDFromObject(tc.obj)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok: want %v, got %v", tc.wantOK, gotOK)
+			}
+			if gotID != tc.wantID {
+				t.Fatalf("id: want %q, got %q", tc.wantID, gotID)
+			}
+		})
+	}
+}
+
+func TestEnsureTraceIDAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          metav1.Object
+		traceID      string
+		wantMutated  bool
+		wantStoredID string
+	}{
+		{
+			name:        "nil object returns false",
+			obj:         nil,
+			traceID:     "trace-1",
+			wantMutated: false,
+		},
+		{
+			name:        "empty traceID is no-op",
+			obj:         &metav1.ObjectMeta{},
+			traceID:     "",
+			wantMutated: false,
+		},
+		{
+			name:         "writes when annotations is nil",
+			obj:          &metav1.ObjectMeta{},
+			traceID:      "trace-1",
+			wantMutated:  true,
+			wantStoredID: "trace-1",
+		},
+		{
+			name:         "writes when annotation key missing",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{"keep": "me"}},
+			traceID:      "trace-2",
+			wantMutated:  true,
+			wantStoredID: "trace-2",
+		},
+		{
+			name:         "writes when annotation value is empty",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: ""}},
+			traceID:      "trace-3",
+			wantMutated:  true,
+			wantStoredID: "trace-3",
+		},
+		{
+			name:         "leaves existing value alone",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: "original"}},
+			traceID:      "ignored",
+			wantMutated:  false,
+			wantStoredID: "original",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureTraceIDAnnotation(tc.obj, tc.traceID)
+			if got != tc.wantMutated {
+				t.Fatalf("mutated: want %v, got %v", tc.wantMutated, got)
+			}
+			if tc.obj == nil {
+				return
+			}
+			stored := tc.obj.GetAnnotations()[oam.AnnotationTraceID]
+			if stored != tc.wantStoredID {
+				t.Fatalf("stored id: want %q, got %q", tc.wantStoredID, stored)
+			}
+		})
+	}
+}
+
+func TestEnsureTraceIDAnnotation_PreservesOtherKeys(t *testing.T) {
+	meta := &metav1.ObjectMeta{Annotations: map[string]string{"keep": "me"}}
+	if mutated := EnsureTraceIDAnnotation(meta, "trace-x"); !mutated {
+		t.Fatalf("expected mutated=true")
+	}
+	annotations := meta.GetAnnotations()
+	if annotations["keep"] != "me" {
+		t.Fatalf("expected existing annotations to be preserved, got %v", annotations)
+	}
+	if annotations[oam.AnnotationTraceID] != "trace-x" {
+		t.Fatalf("expected traceID to be set, got %v", annotations)
+	}
+}
+
+// captureLogger wraps the test ctx with a funcr-backed logr that writes into buf.
+// Used to assert the resulting Logger from FromContext actually emits requestID.
+func captureLogger(t *testing.T, ctx context.Context, buf *bytes.Buffer) context.Context {
+	t.Helper()
+	base := funcr.NewJSON(func(line string) { buf.WriteString(line + "\n") }, funcr.Options{})
+	wrapped := Logger{Logger: logr.New(base.GetSink())}
+	return wrapped.IntoContext(ctx)
+}
+
+func TestFromContext_AttachesRequestIDToOutput(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := captureLogger(t, context.Background(), &buf)
+	ctx = WithRequestID(ctx, "trace-abc")
+
+	FromContext(ctx).Info("hello")
+
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(`"requestID":"trace-abc"`)) {
+		t.Fatalf("expected output to contain requestID=trace-abc, got: %s", out)
+	}
+}
+
+func TestFromContext_NoRequestIDWhenAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := captureLogger(t, context.Background(), &buf)
+
+	FromContext(ctx).Info("hello")
+
+	if bytes.Contains(buf.Bytes(), []byte(`"requestID"`)) {
+		t.Fatalf("expected no requestID key when ctx has none, got: %s", buf.String())
+	}
+}
+
+func TestFromContext_RequestIDRoundTrip(t *testing.T) {
+	ctx := WithRequestID(context.Background(), "trace-xyz")
+	if id, ok := RequestIDFrom(ctx); !ok || id != "trace-xyz" {
+		t.Fatalf("requestID round-trip failed: id=%q ok=%v", id, ok)
+	}
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The KubeVela Authors.
+Copyright 2025 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/logging/requestid_writer.go
+++ b/pkg/logging/requestid_writer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The KubeVela Authors.
+Copyright 2025 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,11 +57,16 @@ type requestIDInjector struct {
 }
 
 // NewRequestIDInjector wraps dst so klog output has the requestID hoisted
-// into the header. Safe for concurrent Write calls.
-func NewRequestIDInjector(dst io.Writer) io.Writer {
+// into the header. Safe for concurrent Write calls. The returned writer also
+// implements Flush so callers can drain any buffered partial line at shutdown.
+func NewRequestIDInjector(dst io.Writer) LineFormatter {
 	return &requestIDInjector{dst: dst}
 }
 
+// Write accepts klog-formatted lines, hoists the requestID/spanID into the
+// header for any complete line, and buffers any trailing partial line until
+// the next Write or Flush. On downstream write failure the buffered line is
+// retained so callers retrying the same input don't silently drop the line.
 func (w *requestIDInjector) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -70,25 +75,40 @@ func (w *requestIDInjector) Write(p []byte) (int, error) {
 	for len(p) > 0 {
 		idx := bytes.IndexByte(p, '\n')
 		if idx == -1 {
+			// No newline in the remaining chunk — buffer it and wait for more.
 			_, _ = w.buf.Write(p)
 			written += len(p)
 			break
 		}
 		_, _ = w.buf.Write(p[:idx])
 		line := w.buf.String()
+		// Hold the line; only commit (reset buffer + advance written) once the
+		// downstream write succeeds. On failure the buffer keeps the line for
+		// the next Write/Flush attempt.
+		if _, err := io.WriteString(w.dst, injectRequestIDPlain(line)+"\n"); err != nil {
+			return written, err
+		}
 		w.buf.Reset()
-		if _, err := io.WriteString(w.dst, injectRequestIDPlain(line)); err != nil {
-			written += idx
-			return written, err
-		}
-		if _, err := w.dst.Write([]byte{'\n'}); err != nil {
-			written += idx + 1
-			return written, err
-		}
 		p = p[idx+1:]
 		written += idx + 1
 	}
 	return written, nil
+}
+
+// Flush writes any buffered partial line (one without a trailing newline) to
+// the underlying writer. Idempotent; safe to call multiple times.
+func (w *requestIDInjector) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	line := w.buf.String()
+	if _, err := io.WriteString(w.dst, injectRequestIDPlain(line)); err != nil {
+		return err
+	}
+	w.buf.Reset()
+	return nil
 }
 
 // injectRequestIDPlain rewrites a single klog-formatted line, hoisting the

--- a/pkg/logging/requestid_writer.go
+++ b/pkg/logging/requestid_writer.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// requestIDPattern matches `requestID="<uuid>"` anywhere in a log line.
+// The leading boundary is non-greedy so it also handles ` requestID=` at line
+// start (klog typically prepends a space before each key=value pair).
+var requestIDPattern = regexp.MustCompile(`(?:^|\s+)requestID="([^"]+)"`)
+
+// spanIDPattern matches `spanID="<uuid>"` or `spanID="<uuid>.<op>"`.
+// Only the UUID portion is hoisted into the header; the full value stays in
+// the trailing fields so sub-span operation names remain queryable.
+var spanIDPattern = regexp.MustCompile(`\s+spanID="([^"]+)"`)
+
+// requestIDInjector wraps an io.Writer and rewrites every klog-formatted log
+// line so the requestID field is hoisted into the header, immediately after
+// the PID. The trailing requestID="..." key/value is removed to avoid
+// duplication.
+//
+// Input format (klog default):
+//
+//	I0527 23:08:32.627885   98950 file.go:42] "msg" k1=v1 requestID="abc" k2=v2
+//
+// Output:
+//
+//	I0527 23:08:32.627885   98950 {abc} file.go:42] "msg" k1=v1 k2=v2
+//
+// Lines without a requestID, or lines that don't match the klog header shape,
+// pass through unchanged. This wrapper is intended for non-dev-logs runs;
+// the dev-logs colorWriter performs the same hoisting with ANSI colours.
+type requestIDInjector struct {
+	dst io.Writer
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+// NewRequestIDInjector wraps dst so klog output has the requestID hoisted
+// into the header. Safe for concurrent Write calls.
+func NewRequestIDInjector(dst io.Writer) io.Writer {
+	return &requestIDInjector{dst: dst}
+}
+
+func (w *requestIDInjector) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	written := 0
+	for len(p) > 0 {
+		idx := bytes.IndexByte(p, '\n')
+		if idx == -1 {
+			_, _ = w.buf.Write(p)
+			written += len(p)
+			break
+		}
+		_, _ = w.buf.Write(p[:idx])
+		line := w.buf.String()
+		w.buf.Reset()
+		if _, err := io.WriteString(w.dst, injectRequestIDPlain(line)); err != nil {
+			written += idx
+			return written, err
+		}
+		if _, err := w.dst.Write([]byte{'\n'}); err != nil {
+			written += idx + 1
+			return written, err
+		}
+		p = p[idx+1:]
+		written += idx + 1
+	}
+	return written, nil
+}
+
+// injectRequestIDPlain rewrites a single klog-formatted line, hoisting the
+// requestID="..." and spanID="..." fields into `{<id>}` blocks placed between
+// the PID and the file:line. The requestID block is stripped from the trailing
+// fields (full value in header); the spanID block is hoisted as just the UUID
+// portion while the full spanID (with optional ".<operation>" suffix) stays in
+// the trailing fields for sub-span detail. Returns the original line if it
+// can't be parsed.
+func injectRequestIDPlain(line string) string {
+	if line == "" {
+		return line
+	}
+
+	// Locate the end of the klog header: ']' closes "file.go:NN".
+	closeBracket := strings.IndexByte(line, ']')
+	if closeBracket == -1 {
+		return line
+	}
+	header := line[:closeBracket+1]
+	rest := line[closeBracket+1:]
+
+	// Extract requestID and strip it from the trailing fields.
+	var requestID string
+	if m := requestIDPattern.FindStringSubmatchIndex(rest); m != nil {
+		requestID = rest[m[2]:m[3]]
+		rest = rest[:m[0]] + rest[m[1]:]
+	}
+
+	// Extract spanID for the header (UUID portion only). Keep the original
+	// trailing `spanID="..."` field intact so the full value (with suffix)
+	// remains queryable in log aggregators.
+	var headerSpanID string
+	if m := spanIDPattern.FindStringSubmatch(rest); m != nil {
+		headerSpanID = stripSpanSuffix(m[1])
+	}
+
+	if requestID == "" && headerSpanID == "" {
+		return line
+	}
+
+	// Inject `{requestID} {spanID} ` into the header just before the file:line.
+	// Header shape: "I0527 23:08:32.627885   98950 file.go:42]".
+	// The last single space separates PID from file.
+	fileStart := strings.LastIndexByte(header, ' ')
+	if fileStart < 0 {
+		return line
+	}
+
+	var injected strings.Builder
+	if requestID != "" {
+		injected.WriteString("{")
+		injected.WriteString(requestID)
+		injected.WriteString("} ")
+	}
+	if headerSpanID != "" {
+		injected.WriteString("{")
+		injected.WriteString(headerSpanID)
+		injected.WriteString("} ")
+	}
+
+	return header[:fileStart+1] + injected.String() + header[fileStart+1:] + rest
+}

--- a/pkg/logging/requestid_writer_test.go
+++ b/pkg/logging/requestid_writer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The KubeVela Authors.
+Copyright 2025 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -161,6 +161,73 @@ func TestInjectRequestIDPlain_HoistsSpanIDAfterTraceID(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestIDInjector_FlushDrainsBufferedPartialLine(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewRequestIDInjector(&buf)
+
+	// Write a line WITHOUT a trailing newline — should sit in the buffer.
+	partial := `I0527 23:08:32.627885   98950 file.go:42] "msg" requestID="trace-tail"`
+	if _, err := w.Write([]byte(partial)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected nothing flushed yet, got: %q", buf.String())
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `{trace-tail} file.go:42]`) {
+		t.Fatalf("expected hoisted requestID after Flush, got: %q", out)
+	}
+	// Calling Flush again is a no-op.
+	beforeLen := buf.Len()
+	if err := w.Flush(); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	}
+	if buf.Len() != beforeLen {
+		t.Fatalf("idempotent Flush wrote more bytes: before=%d after=%d", beforeLen, buf.Len())
+	}
+}
+
+func TestRequestIDInjector_RetainsLineOnDownstreamFailure(t *testing.T) {
+	// failingWriter rejects the first write, accepts subsequent writes.
+	// This simulates a transient downstream failure (closed pipe etc.).
+	fw := &failingWriter{failNext: 1}
+	w := NewRequestIDInjector(fw)
+
+	in := `I0527 23:08:32.627885   98950 file.go:42] "msg" requestID="trace-keep"` + "\n"
+	if _, err := w.Write([]byte(in)); err == nil {
+		t.Fatalf("expected first Write to fail")
+	}
+	// The line must still be in the buffer so a retry can recover it.
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush after retry: %v", err)
+	}
+	if !strings.Contains(fw.buf.String(), `{trace-keep}`) {
+		t.Fatalf("expected line recovered on Flush, got: %q", fw.buf.String())
+	}
+}
+
+type failingWriter struct {
+	buf      bytes.Buffer
+	failNext int
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	if f.failNext > 0 {
+		f.failNext--
+		return 0, errFakeIO
+	}
+	return f.buf.Write(p)
+}
+
+var errFakeIO = &fakeIOErr{}
+
+type fakeIOErr struct{}
+
+func (*fakeIOErr) Error() string { return "fake io error" }
 
 func TestStripSpanSuffix(t *testing.T) {
 	tests := map[string]string{

--- a/pkg/logging/requestid_writer_test.go
+++ b/pkg/logging/requestid_writer_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestInjectRequestIDPlain(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "hoists requestID after PID",
+			in:   `I0527 23:08:32.627885   98950 file.go:42] "msg" k=v requestID="abc-123" k2=v2`,
+			want: `I0527 23:08:32.627885   98950 {abc-123} file.go:42] "msg" k=v k2=v2`,
+		},
+		{
+			name: "requestID at end of fields",
+			in:   `I0527 23:08:32.627885   98950 file.go:42] "msg" k=v requestID="abc-123"`,
+			want: `I0527 23:08:32.627885   98950 {abc-123} file.go:42] "msg" k=v`,
+		},
+		{
+			name: "line without requestID is unchanged",
+			in:   `I0527 23:08:32.627885   98950 file.go:42] "msg" k=v`,
+			want: `I0527 23:08:32.627885   98950 file.go:42] "msg" k=v`,
+		},
+		{
+			name: "no closing bracket - unchanged",
+			in:   "broken line without bracket",
+			want: "broken line without bracket",
+		},
+		{
+			name: "empty line",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := injectRequestIDPlain(tc.in)
+			if got != tc.want {
+				t.Fatalf("input:\n  %s\nwant:\n  %s\ngot:\n  %s", tc.in, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRequestIDInjector_Write(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewRequestIDInjector(&buf)
+
+	// Write two lines, one with a requestID, one without.
+	input := `I0527 23:08:32.627885   98950 file.go:42] "msg-one" requestID="trace-7"` + "\n" +
+		`I0527 23:08:32.627886   98950 file.go:43] "msg-two" k=v` + "\n"
+
+	if _, err := w.Write([]byte(input)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `{trace-7} file.go:42]`) {
+		t.Fatalf("expected hoisted requestID, got: %s", out)
+	}
+	if strings.Contains(out, `requestID="trace-7"`) {
+		t.Fatalf("expected trailing requestID stripped, got: %s", out)
+	}
+	if !strings.Contains(out, `file.go:43] "msg-two" k=v`) {
+		t.Fatalf("expected second line unchanged, got: %s", out)
+	}
+}
+
+func TestRequestIDInjector_HandlesSplitWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewRequestIDInjector(&buf)
+
+	// Single logical line, split mid-stream across two Write calls.
+	chunks := []string{
+		`I0527 23:08:32.627885   98950 file.go:42] "msg" requestID="trace-`,
+		`split-id"` + "\n",
+	}
+	for _, c := range chunks {
+		if _, err := w.Write([]byte(c)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	out := buf.String()
+	if !strings.Contains(out, `{trace-split-id}`) {
+		t.Fatalf("expected hoisted requestID across split writes, got: %s", out)
+	}
+}
+
+func TestInjectRequestIDPlain_HoistsSpanIDAfterTraceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantHdr  string // header substring that must appear
+		wantKeep string // trailing field that must NOT be stripped
+		wantGone string // trailing field that MUST be stripped (empty = no check)
+	}{
+		{
+			name:     "root span hoists bare UUID",
+			in:       `I0527 23:08:32.627885   98950 file.go:42] "Start reconcile" requestID="trace-abc" application="ns/app" spanID="span-xyz"`,
+			wantHdr:  `{trace-abc} {span-xyz} file.go:42]`,
+			wantKeep: `spanID="span-xyz"`,
+			wantGone: `requestID="trace-abc"`,
+		},
+		{
+			name:     "sub-span hoists UUID portion only",
+			in:       `I0527 23:08:32.627885   98950 file.go:42] "[Finished]: span-xyz.apply-policies(...)" requestID="trace-abc" spanID="span-xyz.apply-policies"`,
+			wantHdr:  `{trace-abc} {span-xyz} file.go:42]`,
+			wantKeep: `spanID="span-xyz.apply-policies"`,
+			wantGone: `requestID="trace-abc"`,
+		},
+		{
+			name:     "no spanID — only requestID hoisted (webhook log shape)",
+			in:       `I0527 23:08:32.627885   98950 file.go:42] "validate" requestID="trace-abc" handler="ApplicationValidator"`,
+			wantHdr:  `{trace-abc} file.go:42]`,
+			wantKeep: `handler="ApplicationValidator"`,
+			wantGone: `requestID="trace-abc"`,
+		},
+		{
+			name:     "no requestID, only spanID",
+			in:       `I0527 23:08:32.627885   98950 file.go:42] "msg" spanID="span-xyz.something"`,
+			wantHdr:  `{span-xyz} file.go:42]`,
+			wantKeep: `spanID="span-xyz.something"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := injectRequestIDPlain(tc.in)
+			if !strings.Contains(got, tc.wantHdr) {
+				t.Fatalf("header mismatch\n  in:   %s\n  want: %s\n  got:  %s", tc.in, tc.wantHdr, got)
+			}
+			if tc.wantKeep != "" && !strings.Contains(got, tc.wantKeep) {
+				t.Fatalf("expected trailing field preserved\n  want: %s\n  got:  %s", tc.wantKeep, got)
+			}
+			if tc.wantGone != "" && strings.Contains(got, tc.wantGone) {
+				t.Fatalf("expected trailing field stripped\n  gone: %s\n  got:  %s", tc.wantGone, got)
+			}
+		})
+	}
+}
+
+func TestStripSpanSuffix(t *testing.T) {
+	tests := map[string]string{
+		"":                          "",
+		"abc-123":                   "abc-123",
+		"abc-123.create-app-handler": "abc-123",
+		"abc-123.execute application workflow.55s33": "abc-123",
+	}
+	for in, want := range tests {
+		if got := stripSpanSuffix(in); got != want {
+			t.Errorf("stripSpanSuffix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -226,6 +226,17 @@ const (
 	// "1m", "15m", "30s").  Values below 10s are ignored and fall back to the
 	// global default.  Invalid values are also ignored.
 	AnnotationReconcileInterval = "app.oam.dev/reconcile-interval"
+
+	// AnnotationTraceID carries a single correlation ID for one user-initiated
+	// admission. The mutating webhook stamps it set-if-missing; the validating
+	// webhook and Application controller read it back. Reused by log field
+	// requestID so webhook and reconciler log lines for the same kubectl apply
+	// share one trace.
+	//
+	// Intentionally under the app.oam.dev/ prefix so FilterInternalMetadata
+	// strips it before exposing annotations to policy CUE templates. Policies
+	// must not branch on internal trace identifiers.
+	AnnotationTraceID = "app.oam.dev/traceID"
 )
 
 const (

--- a/pkg/utils/apply/apply.go
+++ b/pkg/utils/apply/apply.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -113,17 +113,19 @@ type APIApplicator struct {
 	c client.Client
 }
 
-// loggingApply will record a log with desired object applied
-func loggingApply(msg string, desired client.Object, quiet bool) {
+// loggingApply records a log line tagged with the reconcile trace ID (when ctx carries one).
+// Falls back to a plain logger when ctx has no requestID (e.g. callers outside the reconcile path).
+func loggingApply(ctx context.Context, msg string, desired client.Object, quiet bool) {
 	if quiet {
 		return
 	}
+	logger := logging.FromContext(ctx)
 	d, ok := desired.(metav1.Object)
 	if !ok {
-		klog.InfoS(msg, "resource", desired.GetObjectKind().GroupVersionKind().String())
+		logger.Info(msg, "resource", desired.GetObjectKind().GroupVersionKind().String())
 		return
 	}
-	klog.InfoS(msg, "name", d.GetName(), "resource", desired.GetObjectKind().GroupVersionKind().String())
+	logger.Info(msg, "name", d.GetName(), "resource", desired.GetObjectKind().GroupVersionKind().String())
 }
 
 // trimLastAppliedConfigurationForSpecialResources will filter special object that can reduce the record for "app.oam.dev/last-applied-configuration" annotation.
@@ -202,14 +204,14 @@ func (a *APIApplicator) Apply(ctx context.Context, desired client.Object, ao ...
 	}
 
 	if applyAct.skipUpdate {
-		loggingApply("skip update", desired, applyAct.quiet)
+		loggingApply(ctx, "skip update", desired, applyAct.quiet)
 		return nil
 	}
 
 	// Short-circuit for shared resources: only patch the shared-by annotation
 	// This avoids the three-way merge which could pollute last-applied-configuration
 	if applyAct.isShared {
-		loggingApply("patching shared resource annotation only", desired, applyAct.quiet)
+		loggingApply(ctx, "patching shared resource annotation only", desired, applyAct.quiet)
 		sharedBy := desired.GetAnnotations()[oam.AnnotationAppSharedBy]
 		patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, oam.AnnotationAppSharedBy, sharedBy))
 		var patchOpts []client.PatchOption
@@ -234,7 +236,7 @@ func (a *APIApplicator) Apply(ctx context.Context, desired client.Object, ao ...
 		return fmt.Errorf("failed to evaluate recreateFields: %w", err)
 	}
 	if shouldRecreate {
-		loggingApply("recreating object", desired, applyAct.quiet)
+		loggingApply(ctx, "recreating object", desired, applyAct.quiet)
 		if applyAct.dryRun { // recreate does not support dryrun
 			return nil
 		}
@@ -248,7 +250,7 @@ func (a *APIApplicator) Apply(ctx context.Context, desired client.Object, ao ...
 
 	switch strategy.Op {
 	case v1alpha1.ResourceUpdateStrategyReplace:
-		loggingApply("replacing object", desired, applyAct.quiet)
+		loggingApply(ctx, "replacing object", desired, applyAct.quiet)
 		desired.SetResourceVersion(existing.GetResourceVersion())
 		var options []client.UpdateOption
 		if applyAct.dryRun {
@@ -258,7 +260,7 @@ func (a *APIApplicator) Apply(ctx context.Context, desired client.Object, ao ...
 	case v1alpha1.ResourceUpdateStrategyPatch:
 		fallthrough
 	default:
-		loggingApply("patching object", desired, applyAct.quiet)
+		loggingApply(ctx, "patching object", desired, applyAct.quiet)
 		patch, err := a.patcher.patch(existing, desired, applyAct)
 		if err != nil {
 			return errors.Wrap(err, "cannot calculate patch by computing a three way diff")
@@ -322,7 +324,7 @@ func createOrGetExisting(ctx context.Context, act *applyAction, c client.Client,
 				return nil, err
 			}
 		}
-		loggingApply("creating object", desired, act.quiet)
+		loggingApply(ctx, "creating object", desired, act.quiet)
 		if act.dryRun {
 			return nil, errors.Wrap(c.Create(ctx, desired, client.DryRunAll), "cannot create object")
 		}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/auth"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils"
 )
@@ -98,22 +99,35 @@ func (h *MutatingHandler) handleSharding(_ context.Context, _ admission.Request,
 	return false, nil
 }
 
+// handleTraceID stamps the trace ID annotation if missing. Idempotent across
+// Update operations: existing values are preserved (set-if-missing semantic)
+// so the original trace ID survives subsequent admissions like finalizer adds.
+func (h *MutatingHandler) handleTraceID(_ context.Context, req admission.Request, _ *v1beta1.Application, newApp *v1beta1.Application) (bool, error) {
+	return logging.EnsureTraceIDAnnotation(newApp, string(req.UID)), nil
+}
+
 // Handle mutate application
 func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ctx = logging.WithRequestID(ctx, string(req.UID))
+	logger := logging.NewHandlerLogger(ctx, req, "ApplicationMutator")
+
 	oldApp, newApp := &v1beta1.Application{}, &v1beta1.Application{}
 	if err := h.Decoder.Decode(req, newApp); err != nil {
+		logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into Application object")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	if len(req.OldObject.Raw) > 0 {
 		if err := h.Decoder.DecodeRaw(req.OldObject, oldApp); err != nil {
+			logger.WithStep("decode-old").WithError(err).Error(err, "Unable to decode previous Application state from admission request")
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 
 	modified := false
-	for _, handler := range []appMutator{h.handleIdentity, h.handleSharding, h.handleWorkflow} {
+	for _, handler := range []appMutator{h.handleIdentity, h.handleSharding, h.handleWorkflow, h.handleTraceID} {
 		m, err := handler(ctx, req, oldApp, newApp)
 		if err != nil {
+			logger.WithError(err).Error(err, "Application mutator failed")
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if m {

--- a/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler_test.go
@@ -1,5 +1,4 @@
 /*
- /*
 Copyright 2022 The KubeVela Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/application_mutating_handler_test.go
@@ -124,4 +124,80 @@ var _ = Describe("Test Application Mutator", func() {
 			Value:     "step-0",
 		}))
 	})
+
+	It("Test Application Mutator [CREATE stamps traceID annotation]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.AuthenticateApplication))).Should(Succeed())
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "trace-uid-create",
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example"}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Patches).Should(ContainElement(jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/annotations",
+			Value: map[string]interface{}{
+				oam.AnnotationTraceID: "trace-uid-create",
+			},
+		}))
+	})
+
+	It("Test Application Mutator [UPDATE stamps traceID when annotation missing]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.AuthenticateApplication))).Should(Succeed())
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "trace-uid-update",
+				Operation: admissionv1.Update,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"keep":"me"}}}`)},
+				OldObject: runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"keep":"me"}}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Patches).Should(ContainElement(jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/annotations/" + jsonPointerEscape(oam.AnnotationTraceID),
+			Value:     "trace-uid-update",
+		}))
+	})
+
+	It("Test Application Mutator [UPDATE preserves existing traceID annotation]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.AuthenticateApplication))).Should(Succeed())
+		existing := `{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"app.oam.dev/traceID":"original-trace"}}}`
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "fresh-uid-must-not-overwrite",
+				Operation: admissionv1.Update,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(existing)},
+				OldObject: runtime.RawExtension{Raw: []byte(existing)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+		for _, p := range resp.Patches {
+			Expect(p.Path).ShouldNot(ContainSubstring("traceID"))
+		}
+	})
 })
+
+// jsonPointerEscape escapes a JSON pointer path segment per RFC 6901: "~" -> "~0", "/" -> "~1".
+func jsonPointerEscape(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '~':
+			out = append(out, '~', '0')
+		case '/':
+			out = append(out, '~', '1')
+		default:
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/application_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/application_validating_handler.go
@@ -65,17 +65,26 @@ func mergeErrors(errs field.ErrorList) error {
 // Handle validate Application Spec here
 func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	startTime := time.Now()
-	ctx = logging.WithRequestID(ctx, string(req.UID))
-	logger := logging.NewHandlerLogger(ctx, req, "ApplicationValidator")
 
-	logger.WithStep("start").Info("Starting admission validation for Application resource", "operation", req.Operation, "applicationName", req.Name, "namespace", req.Namespace)
-
-	// Decode the application
+	// Decode first so we can read the trace ID annotation stamped by the
+	// mutating webhook. Fall back to the admission UID when the annotation
+	// is absent (webhooks disabled, failurePolicy=Ignore, or mutator skipped).
 	app := &v1beta1.Application{}
 	if err := h.Decoder.Decode(req, app); err != nil {
+		ctx = logging.WithRequestID(ctx, string(req.UID))
+		logger := logging.NewHandlerLogger(ctx, req, "ApplicationValidator")
 		logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into Application object - malformed request")
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode: %w (requestUID=%s)", err, req.UID))
 	}
+
+	traceID := string(req.UID)
+	if existing, ok := logging.TraceIDFromObject(app); ok {
+		traceID = existing
+	}
+	ctx = logging.WithRequestID(ctx, traceID)
+	logger := logging.NewHandlerLogger(ctx, req, "ApplicationValidator")
+
+	logger.WithStep("start").Info("Starting admission validation for Application resource", "operation", req.Operation, "applicationName", req.Name, "namespace", req.Namespace)
 
 	if req.Namespace != "" {
 		app.Namespace = req.Namespace

--- a/pkg/webhook/core.oam.dev/v1beta1/application/application_validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/application_validating_handler_test.go
@@ -358,4 +358,38 @@ var _ = Describe("Test Application Validator", func() {
 		resp := handler.Handle(ctx, req)
 		Expect(resp.Allowed).Should(BeTrue())
 	})
+
+	It("Test Application Validator [allows when traceID annotation present]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "fresh-req-uid",
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"app-with-trace","namespace":"default","annotations":{"app.oam.dev/traceID":"propagated-trace-id"}},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"busybox"}}]}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+	})
+
+	It("Test Application Validator [allows when traceID annotation absent, falls back to req.UID]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "fallback-uid",
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"app-without-trace","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"busybox"}}]}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+	})
 })


### PR DESCRIPTION
Issue #6947: MDC-style logging with end-to-end trace correlation.

Webhook -> controller trace ID propagation:
- Mutating webhook stamps app.oam.dev/traceID annotation with req.UID (set-if-missing semantic preserves the original across re-admissions).
- Validating webhook reads it back; falls back to req.UID if absent.
- Reconciler reads annotation or mints fresh UUID; passes a per-reconcile span ID to monitorContext so each reconcile is independently grep-able.
- All actors emit "requestID" field; webhook + reconciler share one trace.

Structured logging migration in the application reconcile path:
- 17 klog call sites migrated to pkg/logging.FromContext(ctx).
- apply.go, generator.go, revision.go, workflow.go, application_controller.go, pkg/utils/apply/apply.go, and the assemble sub-package now route through pkg/logging so every reconcile-time log line carries the trace ID.
- Only the policyScopeIndexInitializer startup runnable retains klog (no reconcile context, explicit exemption).
- pkg/logging.Logger uses logr.WithCallDepth(1) so the underlying sink reports the real call site (e.g. assemble.go:76) not logger.go:219.

Log header hoisting (visible in both --dev-logs modes):
- {traceID} block emitted between PID and file:line for every reconcile- and webhook-path log line.
- {spanID} block (UUID portion only) emitted right after {traceID} for reconciler-emitted lines; webhook lines have only {traceID} since they don't fork sub-spans.
- Trailing requestID="..." stripped to avoid duplication; full spanID (with optional ".<operation>" suffix) preserved in trailing for sub-span queries.
- stderr is redirected through the formatter via a pipe so klog's stderrthreshold copies of ERROR/WARN lines are also hoisted.

API & file rename hygiene:
- Application webhook files renamed to application_{mutating,validating}_handler* matching the definition handler convention.
- ApplicationLogContext returns (monitorContext.Context, traceID) so callers can seed the std ctx without re-resolving the annotation.
- gatherRevisionSpec, forApp, loggingApply, PrepareBeforeApply, assembleWorkload, renderComponentsAndTraits now accept context.Context as first parameter to thread the trace ID through.
- New pkg/logging helpers: TraceIDFromObject, EnsureTraceIDAnnotation, FromContext, NewRequestIDInjector.
- New constant: oam.AnnotationTraceID = "app.oam.dev/traceID".

Verified end-to-end in a live k3d cluster across 21+ scenarios covering component, trait, policy, workflow, full-stack, pre-stamped annotation, and error paths. Trace ID stable across all reconciles of one user action; each reconcile gets a fresh span ID; webhook and reconciler log lines share the trace ID prefix in every case.


### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->