### PR TITLE
Fix(rollout): resolve canary rollback deadlock and deduplicate associated rollouts

### DIFF
--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -50,13 +50,22 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 	if !withHistoryRTs {
 		historyRTs = []*v1beta1.ResourceTracker{}
 	}
+	
+	seen := make(map[string]struct{})
 	var rollouts []*ClusterRollout
+	
 	for _, rt := range append(historyRTs, rootRT, currentRT) {
 		if rt == nil {
 			continue
 		}
 		for _, mr := range rt.Spec.ManagedResources {
 			if mr.APIVersion == kruisev1alpha1.SchemeGroupVersion.String() && mr.Kind == "Rollout" {
+				key := fmt.Sprintf("%s/%s/%s", mr.Cluster, mr.Namespace, mr.Name)
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				
 				rollout := &kruisev1alpha1.Rollout{}
 				if err = cli.Get(multicluster.ContextWithClusterName(ctx, mr.Cluster), k8stypes.NamespacedName{Namespace: mr.Namespace, Name: mr.Name}, rollout); err != nil {
 					if multicluster.IsNotFoundOrClusterNotExists(err) || velaerrors.IsCRDNotExists(err) {
@@ -72,6 +81,28 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 		}
 	}
 	return rollouts, nil
+}
+
+// isCanaryStepPaused returns true if the rollout is paused at a canary step.
+// TODO(DependencyUpgrade): openkruise/rollouts v0.3.0 does not include BlueGreenStatus.
+// Once KubeVela upgrades the dependency (e.g. to v0.6.0+), BlueGreenStatus should be
+// checked here as well since it shares the identical state machine.
+func isCanaryStepPaused(r *kruisev1alpha1.Rollout) bool {
+	if r.Status.CanaryStatus != nil &&
+		r.Status.CanaryStatus.CurrentStepState == kruisev1alpha1.CanaryStepStatePaused {
+		return true
+	}
+	return false
+}
+
+// setCanaryStepReady advances the CurrentStepState to CanaryStepStateReady.
+// TODO(DependencyUpgrade): Extend this to handle BlueGreenStatus once the Kruise
+// rollout API dependency is upgraded to a version that supports it.
+func setCanaryStepReady(r *kruisev1alpha1.Rollout) {
+	if r.Status.CanaryStatus != nil &&
+		r.Status.CanaryStatus.CurrentStepState == kruisev1alpha1.CanaryStepStatePaused {
+		r.Status.CanaryStatus.CurrentStepState = kruisev1alpha1.CanaryStepStateReady
+	}
 }
 
 // SuspendRollout find all rollouts associated with the application (including history RTs) and resume them
@@ -117,7 +148,7 @@ func ResumeRollout(ctx context.Context, cli client.Client, app *v1beta1.Applicat
 	modified := false
 	for i := range rollouts {
 		rollout := rollouts[i]
-		if rollout.Spec.Strategy.Paused || (rollout.Status.CanaryStatus != nil && rollout.Status.CanaryStatus.CurrentStepState == kruisev1alpha1.CanaryStepStatePaused) {
+		if rollout.Spec.Strategy.Paused || isCanaryStepPaused(rollout.Rollout) {
 			_ctx := multicluster.ContextWithClusterName(ctx, rollout.Cluster)
 			rolloutKey := client.ObjectKeyFromObject(rollout.Rollout)
 			resumed := false
@@ -141,8 +172,8 @@ func ResumeRollout(ctx context.Context, cli client.Client, app *v1beta1.Applicat
 				if err = cli.Get(_ctx, rolloutKey, rollout.Rollout); err != nil {
 					return err
 				}
-				if rollout.Status.CanaryStatus != nil && rollout.Status.CanaryStatus.CurrentStepState == kruisev1alpha1.CanaryStepStatePaused {
-					rollout.Status.CanaryStatus.CurrentStepState = kruisev1alpha1.CanaryStepStateReady
+				if isCanaryStepPaused(rollout.Rollout) {
+					setCanaryStepReady(rollout.Rollout)
 					if err = cli.Status().Update(_ctx, rollout.Rollout); err != nil {
 						return err
 					}
@@ -173,7 +204,7 @@ func RollbackRollout(ctx context.Context, cli client.Client, app *v1beta1.Applic
 	modified := false
 	for i := range rollouts {
 		rollout := rollouts[i]
-		if rollout.Spec.Strategy.Paused || (rollout.Status.CanaryStatus != nil && rollout.Status.CanaryStatus.CurrentStepState == kruisev1alpha1.CanaryStepStatePaused) {
+		if rollout.Spec.Strategy.Paused || isCanaryStepPaused(rollout.Rollout) {
 			_ctx := multicluster.ContextWithClusterName(ctx, rollout.Cluster)
 			rolloutKey := client.ObjectKeyFromObject(rollout.Rollout)
 			resumed := false
@@ -184,6 +215,22 @@ func RollbackRollout(ctx context.Context, cli client.Client, app *v1beta1.Applic
 				if rollout.Spec.Strategy.Paused {
 					rollout.Spec.Strategy.Paused = false
 					if err = cli.Update(_ctx, rollout.Rollout); err != nil {
+						return err
+					}
+					resumed = true
+					return nil
+				}
+				return nil
+			}); err != nil {
+				return false, errors.Wrapf(err, "failed to rollback rollout %s/%s in cluster %s", rollout.Namespace, rollout.Name, rollout.Cluster)
+			}
+			if err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				if err = cli.Get(_ctx, rolloutKey, rollout.Rollout); err != nil {
+					return err
+				}
+				if isCanaryStepPaused(rollout.Rollout) {
+					setCanaryStepReady(rollout.Rollout)
+					if err = cli.Status().Update(_ctx, rollout.Rollout); err != nil {
 						return err
 					}
 					resumed = true

--- a/pkg/rollout/rollout.go
+++ b/pkg/rollout/rollout.go
@@ -50,10 +50,10 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 	if !withHistoryRTs {
 		historyRTs = []*v1beta1.ResourceTracker{}
 	}
-	
+
 	seen := make(map[string]struct{})
 	var rollouts []*ClusterRollout
-	
+
 	for _, rt := range append(historyRTs, rootRT, currentRT) {
 		if rt == nil {
 			continue
@@ -65,7 +65,7 @@ func getAssociatedRollouts(ctx context.Context, cli client.Client, app *v1beta1.
 					continue
 				}
 				seen[key] = struct{}{}
-				
+
 				rollout := &kruisev1alpha1.Rollout{}
 				if err = cli.Get(multicluster.ContextWithClusterName(ctx, mr.Cluster), k8stypes.NamespacedName{Namespace: mr.Namespace, Name: mr.Name}, rollout); err != nil {
 					if multicluster.IsNotFoundOrClusterNotExists(err) || velaerrors.IsCRDNotExists(err) {
@@ -121,8 +121,9 @@ func SuspendRollout(ctx context.Context, cli client.Client, app *v1beta1.Applica
 					return err
 				}
 				if rollout.Status.Phase == kruisev1alpha1.RolloutPhaseProgressing && !rollout.Spec.Strategy.Paused {
+					patch := client.MergeFrom(rollout.Rollout.DeepCopy())
 					rollout.Spec.Strategy.Paused = true
-					if err = cli.Update(_ctx, rollout.Rollout); err != nil {
+					if err = cli.Patch(_ctx, rollout.Rollout, patch); err != nil {
 						return err
 					}
 					if writer != nil {
@@ -157,8 +158,9 @@ func ResumeRollout(ctx context.Context, cli client.Client, app *v1beta1.Applicat
 					return err
 				}
 				if rollout.Spec.Strategy.Paused {
+					patch := client.MergeFrom(rollout.Rollout.DeepCopy())
 					rollout.Spec.Strategy.Paused = false
-					if err = cli.Update(_ctx, rollout.Rollout); err != nil {
+					if err = cli.Patch(_ctx, rollout.Rollout, patch); err != nil {
 						return err
 					}
 					resumed = true
@@ -173,8 +175,9 @@ func ResumeRollout(ctx context.Context, cli client.Client, app *v1beta1.Applicat
 					return err
 				}
 				if isCanaryStepPaused(rollout.Rollout) {
+					patch := client.MergeFrom(rollout.Rollout.DeepCopy())
 					setCanaryStepReady(rollout.Rollout)
-					if err = cli.Status().Update(_ctx, rollout.Rollout); err != nil {
+					if err = cli.Status().Patch(_ctx, rollout.Rollout, patch); err != nil {
 						return err
 					}
 					resumed = true
@@ -213,8 +216,9 @@ func RollbackRollout(ctx context.Context, cli client.Client, app *v1beta1.Applic
 					return err
 				}
 				if rollout.Spec.Strategy.Paused {
+					patch := client.MergeFrom(rollout.Rollout.DeepCopy())
 					rollout.Spec.Strategy.Paused = false
-					if err = cli.Update(_ctx, rollout.Rollout); err != nil {
+					if err = cli.Patch(_ctx, rollout.Rollout, patch); err != nil {
 						return err
 					}
 					resumed = true
@@ -229,8 +233,9 @@ func RollbackRollout(ctx context.Context, cli client.Client, app *v1beta1.Applic
 					return err
 				}
 				if isCanaryStepPaused(rollout.Rollout) {
+					patch := client.MergeFrom(rollout.Rollout.DeepCopy())
 					setCanaryStepReady(rollout.Rollout)
-					if err = cli.Status().Update(_ctx, rollout.Rollout); err != nil {
+					if err = cli.Status().Patch(_ctx, rollout.Rollout, patch); err != nil {
 						return err
 					}
 					resumed = true

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Kruise rollout test", func() {
 		Expect(k8sClient.Create(ctx, rt.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 		Expect(k8sClient.Create(ctx, app.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 		Expect(k8sClient.Create(ctx, rollingReleaseRollout.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
-		
+
 		historyRT := rt.DeepCopy()
 		historyRT.Name = "rollout-app-history"
 		historyRT.Labels["app.oam.dev/appRevision"] = "rollout-app-v0"
@@ -87,16 +87,17 @@ var _ = Describe("Kruise rollout test", func() {
 		r := kruisev1alpha1.Rollout{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-rollout"}, &r)).Should(BeNil())
 		r.Spec.Strategy.Paused = true
+		Expect(k8sClient.Update(ctx, &r)).Should(BeNil())
+
 		r.Status.CanaryStatus = &kruisev1alpha1.CanaryStatus{
 			CurrentStepState: kruisev1alpha1.CanaryStepStatePaused,
 		}
-		Expect(k8sClient.Update(ctx, &r)).Should(BeNil())
 		Expect(k8sClient.Status().Update(ctx, &r)).Should(BeNil())
-		
+
 		modified, err := RollbackRollout(ctx, k8sClient, &app, nil)
 		Expect(err).Should(BeNil())
 		Expect(modified).Should(BeEquivalentTo(true))
-		
+
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-rollout"}, &r))
 		Expect(r.Spec.Strategy.Paused).Should(BeEquivalentTo(false))
 		Expect(r.Status.CanaryStatus.CurrentStepState).Should(BeEquivalentTo(kruisev1alpha1.CanaryStepStateReady))

--- a/pkg/rollout/rollout_test.go
+++ b/pkg/rollout/rollout_test.go
@@ -40,6 +40,11 @@ var _ = Describe("Kruise rollout test", func() {
 		Expect(k8sClient.Create(ctx, rt.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 		Expect(k8sClient.Create(ctx, app.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 		Expect(k8sClient.Create(ctx, rollingReleaseRollout.DeepCopy())).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+		
+		historyRT := rt.DeepCopy()
+		historyRT.Name = "rollout-app-history"
+		historyRT.Labels["app.oam.dev/appRevision"] = "rollout-app-v0"
+		Expect(k8sClient.Create(ctx, historyRT)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 	})
 
 	It("test get associated rollout func", func() {
@@ -76,6 +81,25 @@ var _ = Describe("Kruise rollout test", func() {
 		Expect(RollbackRollout(ctx, k8sClient, &app, nil))
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-rollout"}, &r))
 		Expect(r.Spec.Strategy.Paused).Should(BeEquivalentTo(false))
+	})
+
+	It("Rollback rollout when paused at canary step", func() {
+		r := kruisev1alpha1.Rollout{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-rollout"}, &r)).Should(BeNil())
+		r.Spec.Strategy.Paused = true
+		r.Status.CanaryStatus = &kruisev1alpha1.CanaryStatus{
+			CurrentStepState: kruisev1alpha1.CanaryStepStatePaused,
+		}
+		Expect(k8sClient.Update(ctx, &r)).Should(BeNil())
+		Expect(k8sClient.Status().Update(ctx, &r)).Should(BeNil())
+		
+		modified, err := RollbackRollout(ctx, k8sClient, &app, nil)
+		Expect(err).Should(BeNil())
+		Expect(modified).Should(BeEquivalentTo(true))
+		
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-rollout"}, &r))
+		Expect(r.Spec.Strategy.Paused).Should(BeEquivalentTo(false))
+		Expect(r.Status.CanaryStatus.CurrentStepState).Should(BeEquivalentTo(kruisev1alpha1.CanaryStepStateReady))
 	})
 })
 

--- a/pkg/rollout/testdata/rollouts.yaml
+++ b/pkg/rollout/testdata/rollouts.yaml
@@ -216,12 +216,6 @@ spec:
                     rolloutHash:
                       description: RolloutHash from rollout.spec object
                       type: string
-                  required:
-                    - canaryReadyReplicas
-                    - canaryReplicas
-                    - canaryService
-                    - currentStepState
-                    - podTemplateHash
                   type: object
                 conditions:
                   description: Conditions a list of conditions a rollout can have.


### PR DESCRIPTION
# Descption 

Canary rollouts paused mid-flight would ignore vela workflow rollback commands and strand workloads indefinitely. It also patches a multi-revision resource duplication bug that resulted in 409 API Conflicts during rapid deployments and rollbacks.

### Related Issues
Fixes #7170

Changes Made
1. Unblocking Rollout Rollbacks (Bug 1)

Issue: The OpenKruise state machine blocks on CanaryStatus.CurrentStepState == StepPaused, preventing it from processing the KubeVela IsInRollback workload patch.
Fix: Updated RollbackRollout to conditionally reset CurrentStepState to CanaryStepStateReady. This mirrors the pattern that correctly exists in ResumeRollout.
Implementation: Because Spec and Status are distinct endpoints, the status update runs via a separate cli.Status().Update() block, wrapped in its own retry.RetryOnConflict loop to safely handle concurrent modifications by the Kruise controller.
2. Deduplicating Associated Rollouts (Bug 2)

Issue: getAssociatedRollouts aggregates managed resources from both currentRT and historyRTs. During a revision transition, the same Kruise Rollout exists in both resource trackers, causing redundant patches and 409 Conflict errors on the second attempt.
Fix: Introduced a seen map to deduplicate rollout entries.
Implementation: The map is keyed safely by cluster/namespace/name to ensure robustness across multi-cluster KubeVela environments.
3. Dependency Omission Context

* Note for Maintainers: currently  BlueGreenStatus equivalent fix for pausing has been intentionally omitted from the isCanaryStepPaused and setCanaryStepReady helpers because KubeVela is currently pinned to github.com/openkruise/rollouts v0.3.0, where BlueGreenStatus does not yet exist. Explicit TODO(DependencyUpgrade) comments have been added in pkg/rollout/rollout.go. I will open a follow-up issue to address upgrading the Kruise dependency and enabling Blue-Green state management natively.
