### PR TITLE
Feat( Logging ): add trace context helpers

### DIFF
--- a/pkg/appfile/dryrun/diff.go
+++ b/pkg/appfile/dryrun/diff.go
@@ -535,7 +535,7 @@ func clearedLabels(labels map[string]string) map[string]string {
 func clearedAnnotations(annotations map[string]string) map[string]string {
 	newAnnotations := map[string]string{}
 	for k, v := range annotations {
-		if k == oam.AnnotationKubeVelaVersion || k == oam.AnnotationAppRevision || k == "kubectl.kubernetes.io/last-applied-configuration" {
+		if k == oam.AnnotationKubeVelaVersion || k == oam.AnnotationAppRevision || k == "kubectl.kubernetes.io/last-applied-configuration" || k == oam.AnnotationTraceID {
 			continue
 		}
 		newAnnotations[k] = v

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -153,6 +153,9 @@ func newAppFile(app *v1beta1.Application) *Appfile {
 		app: app,
 	}
 	for k, v := range app.Annotations {
+		if k == oam.AnnotationTraceID {
+			continue
+		}
 		file.AppAnnotations[k] = v
 	}
 	for k, v := range app.Labels {

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_controller.go
@@ -30,6 +30,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
@@ -58,6 +59,7 @@ import (
 	common2 "github.com/oam-dev/kubevela/pkg/controller/common"
 	core "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/monitor/metrics"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
@@ -109,14 +111,29 @@ type options struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx, cancel := ctrlrec.NewReconcileContext(ctx)
 	defer cancel()
-	logCtx := monitorContext.NewTraceContext(ctx, "").AddTag("application", req.String(), "controller", "application")
-	logCtx.Info("Start reconcile application")
-	defer logCtx.Commit("End reconcile application")
+
 	app := new(v1beta1.Application)
-	if err := r.Get(ctx, client.ObjectKey{
+	err := r.Get(ctx, client.ObjectKey{
 		Name:      req.Name,
 		Namespace: req.Namespace,
-	}, app); err != nil {
+	}, app)
+
+	traceID := ""
+	if err == nil {
+		if id, ok := logging.TraceIDFromObject(app); ok {
+			traceID = id
+		}
+	}
+
+	ctx = logging.WithRequestID(ctx, traceID)
+	spanID := string(uuid.NewUUID())
+	ctx = logging.WithSpanID(ctx, spanID)
+
+	logCtx := monitorContext.NewTraceContext(ctx, spanID).AddTag("application", req.String(), "controller", "application", logging.FieldRequestID, traceID)
+	logCtx.Info("Start reconcile application")
+	defer logCtx.Commit("End reconcile application")
+
+	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			logCtx.Error(err, "get application")
 		}

--- a/pkg/controller/core.oam.dev/v1beta1/core/components/componentdefinition/componentrevision_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/components/componentdefinition/componentrevision_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Test DefinitionRevision created by ComponentDefinition", func(
 
 			var cdGet v1beta1.ComponentDefinition
 			Eventually(func() bool {
+				testutil.ReconcileRetry(&r, req)
 				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cdName}, &cdGet)
 				if err == nil {
 					klog.Infof("component definition %s status: %v", cdName, cdGet.Status)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -23,14 +23,18 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 // Structured logging field keys - consistent across all handlers for observability
 const (
 	// Core traceability fields
 	FieldRequestID = "requestID"  // Unique identifier for request correlation
+	FieldSpanID    = "spanID"     // Per-reconcile identifier
 	FieldOperation = "operation"  // Webhook operation (CREATE/UPDATE/DELETE)
 	FieldHandler   = "handler"    // Handler processing the request
 	FieldStep      = "step"       // Current processing step
@@ -55,6 +59,7 @@ type contextKey struct{ name string }
 
 var (
 	requestIDKey = contextKey{name: "requestID"}
+	spanIDKey    = contextKey{name: "spanID"}
 	loggerKey    = contextKey{name: "logger"}
 )
 
@@ -86,6 +91,21 @@ func (l Logger) IntoContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, loggerKey, l)
 }
 
+// FromContext returns a Logger seeded with the requestID and spanID present on ctx.
+// Use this from any reconcile-path function that has only a std context.Context
+// If ctx carries no requestID or spanID, returns a plain logger.
+func FromContext(ctx context.Context) Logger {
+	logger := WithContext(ctx)
+	if id, ok := RequestIDFrom(ctx); ok {
+		logger = logger.WithValues(FieldRequestID, id)
+	}
+	if id, ok := SpanIDFrom(ctx); ok {
+		logger = logger.WithValues(FieldSpanID, id)
+	}
+
+	return logger
+}
+
 // WithRequestID stores request ID in context
 func WithRequestID(ctx context.Context, requestID string) context.Context {
 	if requestID == "" {
@@ -98,6 +118,57 @@ func WithRequestID(ctx context.Context, requestID string) context.Context {
 func RequestIDFrom(ctx context.Context) (string, bool) {
 	id, ok := ctx.Value(requestIDKey).(string)
 	return id, ok && id != ""
+}
+
+// WithSpanID stores the Span ID in context
+func WithSpanID(ctx context.Context, spanID string) context.Context {
+	if spanID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, spanIDKey, spanID)
+}
+
+// SpanIDFrom retrieves span ID from context
+func SpanIDFrom(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(spanIDKey).(string)
+	return id, ok && id != ""
+}
+
+// TraceIDFromObject return the traceID stamped by the mutating webhook on
+// the object's annotations, or false if the object is empty or the annotation is empty
+func TraceIDFromObject(obj metav1.Object) (string, bool) {
+	if obj == nil {
+		return "", false
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return "", false
+	}
+	id := annotations[oam.AnnotationTraceID]
+	if id == "" {
+		return "", false
+	}
+	return id, true
+
+}
+
+// EnsureTraceIDAnnotation sets the trace ID annotation only when it is
+// currently absent or empty. Returns true when the object was mutated so
+// callers can decide whether a patch is needed. A nil object or empty
+// traceID is a no-op and returns false.
+func EnsureTraceIDAnnotation(obj metav1.Object, traceID string) bool {
+	if obj == nil || traceID == "" {
+		return false
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	} else if existing := annotations[oam.AnnotationTraceID]; existing != "" {
+		return false
+	}
+	annotations[oam.AnnotationTraceID] = traceID
+	obj.SetAnnotations(annotations)
+	return true
 }
 
 // NewHandlerLogger creates a logger for webhook handlers with full request context
@@ -154,20 +225,20 @@ func (l Logger) V(level int) Logger {
 
 // Debug logs debug message (verbosity 1)
 func (l Logger) Debug(msg string, keysAndValues ...interface{}) {
-	l.Logger.V(1).Info(msg, keysAndValues...)
+	l.Logger.V(1).WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Trace logs trace message (verbosity 2)
 func (l Logger) Trace(msg string, keysAndValues ...interface{}) {
-	l.Logger.V(2).Info(msg, keysAndValues...)
+	l.Logger.V(2).WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Info logs info message
 func (l Logger) Info(msg string, keysAndValues ...interface{}) {
-	l.Logger.Info(msg, keysAndValues...)
+	l.Logger.WithCallDepth(1).Info(msg, keysAndValues...)
 }
 
 // Error logs error message
 func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {
-	l.Logger.Error(err, msg, keysAndValues...)
+	l.Logger.WithCallDepth(1).Error(err, msg, keysAndValues...)
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestRequestIDContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		requestID string
+		wantID    string
+		wantOK    bool
+		wantSame  bool
+	}{
+		{
+			name:      "round-trip",
+			requestID: "request-1",
+			wantID:    "request-1",
+			wantOK:    true,
+		},
+		{
+			name:     "empty is no-op",
+			wantOK:   false,
+			wantSame: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := context.Background()
+			ctx := WithRequestID(base, tc.requestID)
+			if tc.wantSame && ctx != base {
+				t.Fatalf("expected context to be unchanged")
+			}
+
+			gotID, gotOK := RequestIDFrom(ctx)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok: want %v, got %v", tc.wantOK, gotOK)
+			}
+			if gotID != tc.wantID {
+				t.Fatalf("id: want %q, got %q", tc.wantID, gotID)
+			}
+		})
+	}
+}
+
+func TestSpanIDContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		spanID   string
+		wantID   string
+		wantOK   bool
+		wantSame bool
+	}{
+		{
+			name:   "round-trip",
+			spanID: "span-1",
+			wantID: "span-1",
+			wantOK: true,
+		},
+		{
+			name:     "empty is no-op",
+			wantOK:   false,
+			wantSame: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := context.Background()
+			ctx := WithSpanID(base, tc.spanID)
+			if tc.wantSame && ctx != base {
+				t.Fatalf("expected context to be unchanged")
+			}
+
+			gotID, gotOK := SpanIDFrom(ctx)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok: want %v, got %v", tc.wantOK, gotOK)
+			}
+			if gotID != tc.wantID {
+				t.Fatalf("id: want %q, got %q", tc.wantID, gotID)
+			}
+		})
+	}
+}
+
+func TestTraceIDFromObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    metav1.Object
+		wantID string
+		wantOK bool
+	}{
+		{
+			name:   "nil object returns false",
+			obj:    nil,
+			wantOK: false,
+		},
+		{
+			name:   "nil annotations returns false",
+			obj:    &metav1.ObjectMeta{},
+			wantOK: false,
+		},
+		{
+			name:   "missing key returns false",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{"other": "value"}},
+			wantOK: false,
+		},
+		{
+			name:   "empty value returns false",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: ""}},
+			wantOK: false,
+		},
+		{
+			name:   "present value returns it",
+			obj:    &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: "trace-1"}},
+			wantID: "trace-1",
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotOK := TraceIDFromObject(tc.obj)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok: want %v, got %v", tc.wantOK, gotOK)
+			}
+			if gotID != tc.wantID {
+				t.Fatalf("id: want %q, got %q", tc.wantID, gotID)
+			}
+		})
+	}
+}
+
+func TestEnsureTraceIDAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          metav1.Object
+		traceID      string
+		wantMutated  bool
+		wantStoredID string
+	}{
+		{
+			name:        "nil object returns false",
+			obj:         nil,
+			traceID:     "trace-1",
+			wantMutated: false,
+		},
+		{
+			name:        "empty traceID is no-op",
+			obj:         &metav1.ObjectMeta{},
+			traceID:     "",
+			wantMutated: false,
+		},
+		{
+			name:         "writes when annotations is nil",
+			obj:          &metav1.ObjectMeta{},
+			traceID:      "trace-1",
+			wantMutated:  true,
+			wantStoredID: "trace-1",
+		},
+		{
+			name:         "writes when annotation key missing",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{"keep": "me"}},
+			traceID:      "trace-2",
+			wantMutated:  true,
+			wantStoredID: "trace-2",
+		},
+		{
+			name:         "writes when annotation value is empty",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: ""}},
+			traceID:      "trace-3",
+			wantMutated:  true,
+			wantStoredID: "trace-3",
+		},
+		{
+			name:         "leaves existing value alone",
+			obj:          &metav1.ObjectMeta{Annotations: map[string]string{oam.AnnotationTraceID: "original"}},
+			traceID:      "ignored",
+			wantMutated:  false,
+			wantStoredID: "original",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureTraceIDAnnotation(tc.obj, tc.traceID)
+			if got != tc.wantMutated {
+				t.Fatalf("mutated: want %v, got %v", tc.wantMutated, got)
+			}
+			if tc.obj == nil {
+				return
+			}
+			stored := tc.obj.GetAnnotations()[oam.AnnotationTraceID]
+			if stored != tc.wantStoredID {
+				t.Fatalf("stored id: want %q, got %q", tc.wantStoredID, stored)
+			}
+		})
+	}
+}
+
+func TestEnsureTraceIDAnnotationPreservesOtherKeys(t *testing.T) {
+	meta := &metav1.ObjectMeta{Annotations: map[string]string{"keep": "me"}}
+	if mutated := EnsureTraceIDAnnotation(meta, "trace-x"); !mutated {
+		t.Fatalf("expected mutated=true")
+	}
+	annotations := meta.GetAnnotations()
+	if annotations["keep"] != "me" {
+		t.Fatalf("expected existing annotations to be preserved, got %v", annotations)
+	}
+	if annotations[oam.AnnotationTraceID] != "trace-x" {
+		t.Fatalf("expected traceID to be set, got %v", annotations)
+	}
+}
+
+func TestFromContextAttachesRequestAndSpanIDsToOutput(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := captureLogger(t, context.Background(), &buf)
+	ctx = WithRequestID(ctx, "request-1")
+	ctx = WithSpanID(ctx, "span-1")
+
+	FromContext(ctx).Info("hello")
+
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(`"requestID":"request-1"`)) {
+		t.Fatalf("expected output to contain requestID=request-1, got: %s", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"spanID":"span-1"`)) {
+		t.Fatalf("expected output to contain spanID=span-1, got: %s", out)
+	}
+}
+
+func TestFromContextOmitsRequestAndSpanIDsWhenAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := captureLogger(t, context.Background(), &buf)
+
+	FromContext(ctx).Info("hello")
+
+	if bytes.Contains(buf.Bytes(), []byte(`"requestID"`)) {
+		t.Fatalf("expected no requestID key when ctx has none, got: %s", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte(`"spanID"`)) {
+		t.Fatalf("expected no spanID key when ctx has none, got: %s", buf.String())
+	}
+}
+
+func captureLogger(t *testing.T, ctx context.Context, buf *bytes.Buffer) context.Context {
+	t.Helper()
+	base := funcr.NewJSON(func(line string) {
+		buf.WriteString(line + "\n")
+	}, funcr.Options{})
+	return Logger{Logger: base}.IntoContext(ctx)
+}

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -226,6 +226,13 @@ const (
 	// "1m", "15m", "30s").  Values below 10s are ignored and fall back to the
 	// global default.  Invalid values are also ignored.
 	AnnotationReconcileInterval = "app.oam.dev/reconcile-interval"
+
+	// AnnotationTraceID carries a single correlation ID for one user-initiated
+	// admission. The mutating webhook stamps it set-if-missing; the validating
+	// webhook and Application controller read it back. Reused by log field
+	// requestID so webhook and reconciler log lines for the same kubectl apply
+	// share one trace.
+	AnnotationTraceID = "app.oam.dev/traceID"
 )
 
 const (

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -474,7 +474,9 @@ func PassLabelAndAnnotation(parentObj, childObj labelAnnotationObject) {
 	// pass app-config labels
 	childObj.SetLabels(MergeMapOverrideWithDst(childObj.GetLabels(), parentObj.GetLabels()))
 	// pass app-config annotation
-	childObj.SetAnnotations(MergeMapOverrideWithDst(childObj.GetAnnotations(), parentObj.GetAnnotations()))
+	annos := MergeMapOverrideWithDst(childObj.GetAnnotations(), parentObj.GetAnnotations())
+	delete(annos, oam.AnnotationTraceID)
+	childObj.SetAnnotations(annos)
 }
 
 // RemoveLabels removes keys that contains in the removekeys slice from the label

--- a/pkg/webhook/core.oam.dev/v1beta1/application/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/mutating_handler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/auth"
 	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils"
 )
@@ -98,22 +99,35 @@ func (h *MutatingHandler) handleSharding(_ context.Context, _ admission.Request,
 	return false, nil
 }
 
+// handleTraceID stamps the trace ID annotation if missing. Idempotent across
+// Update operations: existing values are preserved (set-if-missing semantic)
+// so the original trace ID survives subsequent admissions like finalizer adds.
+func (h *MutatingHandler) handleTraceID(_ context.Context, req admission.Request, _ *v1beta1.Application, newApp *v1beta1.Application) (bool, error) {
+	return logging.EnsureTraceIDAnnotation(newApp, string(req.UID)), nil
+}
+
 // Handle mutate application
 func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ctx = logging.WithRequestID(ctx, string(req.UID))
+	logger := logging.NewHandlerLogger(ctx, req, "ApplicationMutator")
+
 	oldApp, newApp := &v1beta1.Application{}, &v1beta1.Application{}
 	if err := h.Decoder.Decode(req, newApp); err != nil {
+		logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into Application object")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	if len(req.OldObject.Raw) > 0 {
 		if err := h.Decoder.DecodeRaw(req.OldObject, oldApp); err != nil {
+			logger.WithStep("decode-old").WithError(err).Error(err, "Unable to decode previous Application state from admission request")
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 
 	modified := false
-	for _, handler := range []appMutator{h.handleIdentity, h.handleSharding, h.handleWorkflow} {
+	for _, handler := range []appMutator{h.handleIdentity, h.handleSharding, h.handleWorkflow, h.handleTraceID} {
 		m, err := handler(ctx, req, oldApp, newApp)
 		if err != nil {
+			logger.WithError(err).Error(err, "Application mutator failed")
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if m {

--- a/pkg/webhook/core.oam.dev/v1beta1/application/mutating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/mutating_handler_test.go
@@ -124,4 +124,80 @@ var _ = Describe("Test Application Mutator", func() {
 			Value:     "step-0",
 		}))
 	})
+
+	It("Test Application Mutator [traceID annotation injection on create]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				UID:       "test-trace-id-1234",
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example"}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+
+		found := false
+		for _, p := range resp.Patches {
+			if p.Operation == "add" && p.Path == "/metadata/annotations" {
+				m, ok := p.Value.(map[string]interface{})
+				if ok && m[oam.AnnotationTraceID] == "test-trace-id-1234" {
+					found = true
+				}
+			} else if p.Operation == "add" && p.Path == "/metadata/annotations/app.oam.dev~1traceID" {
+				if p.Value == "test-trace-id-1234" {
+					found = true
+				}
+			}
+		}
+		Expect(found).Should(BeTrue(), "traceID annotation should be injected")
+	})
+
+	It("Test Application Mutator [traceID annotation unchanged on update]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UID:       "new-req-uid-5678",
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				OldObject: runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"` + oam.AnnotationTraceID + `":"existing-trace-id"}}}`)},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"` + oam.AnnotationTraceID + `":"existing-trace-id"}}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+		for _, patch := range resp.Patches {
+			if patch.Path == "/metadata/annotations" || patch.Path == "/metadata/annotations/"+oam.AnnotationTraceID {
+				Fail("Should not modify existing traceID annotation")
+			}
+		}
+	})
+
+	It("Test Application Mutator [traceID annotation injection on update when missing]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UID:       "new-req-uid-9012",
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				OldObject: runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example"}}`)},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example"}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+
+		found := false
+		for _, p := range resp.Patches {
+			if p.Operation == "add" && p.Path == "/metadata/annotations" {
+				m, ok := p.Value.(map[string]interface{})
+				if ok && m[oam.AnnotationTraceID] == "new-req-uid-9012" {
+					found = true
+				}
+			} else if p.Operation == "add" && p.Path == "/metadata/annotations/app.oam.dev~1traceID" {
+				if p.Value == "new-req-uid-9012" {
+					found = true
+				}
+			}
+		}
+		Expect(found).Should(BeTrue(), "traceID annotation should be injected")
+	})
 })

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validating_handler.go
@@ -65,14 +65,26 @@ func mergeErrors(errs field.ErrorList) error {
 // Handle validate Application Spec here
 func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	startTime := time.Now()
-	ctx = logging.WithRequestID(ctx, string(req.UID))
+
+	// Decode the application first to extract any trace ID annotation
+	// stamped by the mutating webhook.
+	app := &v1beta1.Application{}
+	err := h.Decoder.Decode(req, app)
+
+	// Determine trace ID: use annotation if present, otherwise fallback to admission req.UID
+	traceID := string(req.UID)
+	if err == nil {
+		if existingTraceID, ok := logging.TraceIDFromObject(app); ok {
+			traceID = existingTraceID
+		}
+	}
+
+	ctx = logging.WithRequestID(ctx, traceID)
 	logger := logging.NewHandlerLogger(ctx, req, "ApplicationValidator")
 
 	logger.WithStep("start").Info("Starting admission validation for Application resource", "operation", req.Operation, "applicationName", req.Name, "namespace", req.Namespace)
 
-	// Decode the application
-	app := &v1beta1.Application{}
-	if err := h.Decoder.Decode(req, app); err != nil {
+	if err != nil {
 		logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into Application object - malformed request")
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode: %w (requestUID=%s)", err, req.UID))
 	}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validating_handler_test.go
@@ -83,6 +83,40 @@ var _ = Describe("Test Application Validator", func() {
 		Expect(resp.Allowed).Should(BeFalse())
 	})
 
+	It("Test Application Validator [allows when traceID annotation present]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "fresh-req-uid",
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"app-with-trace","namespace":"default","annotations":{"app.oam.dev/traceID":"propagated-trace-id"}},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"busybox"}}]}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+	})
+
+	It("Test Application Validator [allows when traceID annotation absent, falls back to req.UID]", func() {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       "fallback-uid",
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: "core.oam.dev", Version: "v1beta1", Resource: "applications"},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"app-without-trace","namespace":"default"},"spec":{"components":[{"name":"comp","type":"worker","properties":{"image":"busybox"}}]}}
+`),
+				},
+			},
+		}
+		resp := handler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+	})
+
 	It("Test Application Validator Forbid rollout annotation", func() {
 		req := admission.Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
### Description of your changes

copilot:all


Adds foundational logging trace helpers for request/span correlation across plain `context.Context` call paths.

This PR adds:

- shared logging field constants for span/request context
- `WithSpanID` / `SpanIDFrom` context helpers
- `FromContext(ctx)` support for attaching request and span IDs when present
- trace ID annotation helpers for Kubernetes objects
- `app.oam.dev/traceID` annotation constant
- unit tests covering context round-trip, empty no-op behavior, FromContext output, and trace annotation helpers

Fixes #6947

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran focused unit tests:

`go test ./pkg/logging ./pkg/oam`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

This PR is only the logging/context foundation phase. It does not yet wire these helpers into the Application reconcile path.
