### PR TITLE
Feat: add Validate methods and tests for CoreOptions config modules

### DIFF
--- a/cmd/core/app/config/admission.go
+++ b/cmd/core/app/config/admission.go
@@ -36,3 +36,8 @@ func NewAdmissionConfig() *AdmissionConfig {
 func (c *AdmissionConfig) AddFlags(fs *pflag.FlagSet) {
 	standardcontroller.AddAdmissionFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *AdmissionConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/admission_test.go
+++ b/cmd/core/app/config/admission_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdmissionConfig_Validate(t *testing.T) {
+	cfg := NewAdmissionConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAdmissionConfig_AddFlags(t *testing.T) {
+	cfg := NewAdmissionConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/application.go
+++ b/cmd/core/app/config/application.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -53,4 +54,12 @@ func (c *ApplicationConfig) AddFlags(fs *pflag.FlagSet) {
 // The flow is: CLI flags -> ApplicationConfig struct fields -> commonconfig globals (via this method)
 func (c *ApplicationConfig) SyncToApplicationGlobals() {
 	commonconfig.ApplicationReSyncPeriod = c.ReSyncPeriod
+}
+
+// Validate checks if the application configuration is valid.
+func (c *ApplicationConfig) Validate() error {
+	if c.ReSyncPeriod <= 0 {
+		return fmt.Errorf("application-re-sync-period must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/application_test.go
+++ b/cmd/core/app/config/application_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplicationConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ApplicationConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ApplicationConfig {
+				return NewApplicationConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid custom resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = 5 * time.Minute
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid negative resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = -1 * time.Minute
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-re-sync-period must be greater than zero",
+		},
+		{
+			name: "Invalid zero resync period",
+			setupConfig: func() *ApplicationConfig {
+				cfg := NewApplicationConfig()
+				cfg.ReSyncPeriod = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-re-sync-period must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestApplicationConfig_AddFlags(t *testing.T) {
+	cfg := NewApplicationConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--application-re-sync-period=10m",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 10*time.Minute, cfg.ReSyncPeriod)
+}

--- a/cmd/core/app/config/client.go
+++ b/cmd/core/app/config/client.go
@@ -38,3 +38,8 @@ func NewClientConfig() *ClientConfig {
 func (c *ClientConfig) AddFlags(fs *pflag.FlagSet) {
 	pkgclient.AddTimeoutControllerClientFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ClientConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/client_test.go
+++ b/cmd/core/app/config/client_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientConfig_Validate(t *testing.T) {
+	cfg := NewClientConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestClientConfig_AddFlags(t *testing.T) {
+	cfg := NewClientConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/controller.go
+++ b/cmd/core/app/config/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	oamcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
@@ -64,4 +66,21 @@ func (c *ControllerConfig) AddFlags(fs *pflag.FlagSet) {
 		"If true, application controller will not process the app without 'app.oam.dev/controller-version-require' annotation")
 	fs.BoolVar(&c.IgnoreDefinitionWithoutControllerRequirement, "ignore-definition-without-controller-version", c.IgnoreDefinitionWithoutControllerRequirement,
 		"If true, trait/component/workflowstep definition controller will not process the definition without 'definition.oam.dev/controller-version-require' annotation")
+}
+
+// Validate checks if the controller configuration is valid.
+func (c *ControllerConfig) Validate() error {
+	if c.ConcurrentReconciles <= 0 {
+		return fmt.Errorf("concurrent-reconciles must be greater than zero")
+	}
+	if c.RevisionLimit < 0 {
+		return fmt.Errorf("revision-limit must be greater than or equal to zero")
+	}
+	if c.AppRevisionLimit < 0 {
+		return fmt.Errorf("application-revision-limit must be greater than or equal to zero")
+	}
+	if c.DefRevisionLimit < 0 {
+		return fmt.Errorf("definition-revision-limit must be greater than or equal to zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/controller_test.go
+++ b/cmd/core/app/config/controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ControllerConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ControllerConfig {
+				return NewControllerConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid concurrent reconciles",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.ConcurrentReconciles = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "concurrent-reconciles must be greater than zero",
+		},
+		{
+			name: "Invalid negative revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.RevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Invalid negative app revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.AppRevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "application-revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Invalid negative def revision limit",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.DefRevisionLimit = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "definition-revision-limit must be greater than or equal to zero",
+		},
+		{
+			name: "Valid zero limits",
+			setupConfig: func() *ControllerConfig {
+				cfg := NewControllerConfig()
+				cfg.RevisionLimit = 0
+				cfg.AppRevisionLimit = 0
+				cfg.DefRevisionLimit = 0
+				return cfg
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestControllerConfig_AddFlags(t *testing.T) {
+	cfg := NewControllerConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	cfg.AddFlags(fs)
+
+	args := []string{
+		"--concurrent-reconciles=10",
+		"--revision-limit=100",
+		"--application-revision-limit=50",
+		"--definition-revision-limit=60",
+		"--autogen-workload-definition=false",
+	}
+
+	err := fs.Parse(args)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10, cfg.ConcurrentReconciles)
+	assert.Equal(t, 100, cfg.RevisionLimit)
+	assert.Equal(t, 50, cfg.AppRevisionLimit)
+	assert.Equal(t, 60, cfg.DefRevisionLimit)
+	assert.False(t, cfg.AutoGenWorkloadDefinition)
+}

--- a/cmd/core/app/config/cue.go
+++ b/cmd/core/app/config/cue.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/kubevela/pkg/cue/cuex"
 	"github.com/spf13/pflag"
 )
@@ -58,4 +60,12 @@ func (c *CUEConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *CUEConfig) SyncToCUEGlobals() {
 	cuex.EnableExternalPackageForDefaultCompiler = c.EnableExternalPackage
 	cuex.EnableExternalPackageWatchForDefaultCompiler = c.EnableExternalPackageWatch
+}
+
+// Validate checks if the CUE configuration is valid.
+func (c *CUEConfig) Validate() error {
+	if c.EnableExternalPackageWatch && !c.EnableExternalPackage {
+		return fmt.Errorf("enable-external-package-watch-for-default-compiler cannot be true when enable-external-package-for-default-compiler is false")
+	}
+	return nil
 }

--- a/cmd/core/app/config/cue.go
+++ b/cmd/core/app/config/cue.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kubevela/pkg/cue/cuex"
 	wfupgrade "github.com/kubevela/workflow/pkg/cue/upgrade"
@@ -133,4 +134,12 @@ func (c *CUEConfig) SyncToCUEGlobals(ctx context.Context) {
 	}
 	upgrade.InitCompatibilityCache(ctx, c.CUECompatibilityCacheSize)
 	wfupgrade.InitCompatibilityCache(ctx, c.CUECompatibilityCacheSize)
+}
+
+// Validate checks if the CUE configuration is valid.
+func (c *CUEConfig) Validate() error {
+	if c.EnableExternalPackageWatch && !c.EnableExternalPackage {
+		return fmt.Errorf("enable-external-package-watch-for-default-compiler cannot be true when enable-external-package-for-default-compiler is false")
+	}
+	return nil
 }

--- a/cmd/core/app/config/cue_test.go
+++ b/cmd/core/app/config/cue_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCUEConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *CUEConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *CUEConfig {
+				return NewCUEConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with external package enabled and watch enabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = true
+				cfg.EnableExternalPackageWatch = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with external package enabled and watch disabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = true
+				cfg.EnableExternalPackageWatch = false
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: external package disabled but watch enabled",
+			setupConfig: func() *CUEConfig {
+				cfg := NewCUEConfig()
+				cfg.EnableExternalPackage = false
+				cfg.EnableExternalPackageWatch = true
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "enable-external-package-watch-for-default-compiler cannot be true when enable-external-package-for-default-compiler is false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCUEConfig_AddFlags(t *testing.T) {
+	cfg := NewCUEConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--enable-external-package-for-default-compiler=true",
+		"--enable-external-package-watch-for-default-compiler=true",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.EnableExternalPackage)
+	assert.True(t, cfg.EnableExternalPackageWatch)
+}

--- a/cmd/core/app/config/feature.go
+++ b/cmd/core/app/config/feature.go
@@ -38,3 +38,8 @@ func NewFeatureConfig() *FeatureConfig {
 func (c *FeatureConfig) AddFlags(fs *pflag.FlagSet) {
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *FeatureConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/feature_test.go
+++ b/cmd/core/app/config/feature_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureConfig_Validate(t *testing.T) {
+	cfg := NewFeatureConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestFeatureConfig_AddFlags(t *testing.T) {
+	cfg := NewFeatureConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/klog.go
+++ b/cmd/core/app/config/klog.go
@@ -40,3 +40,8 @@ func (c *KLogConfig) AddFlags(fs *pflag.FlagSet) {
 	// Add base klog flags
 	utillog.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *KLogConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/klog_test.go
+++ b/cmd/core/app/config/klog_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKLogConfig_Validate(t *testing.T) {
+	cfg := NewKLogConfig(nil)
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestKLogConfig_AddFlags(t *testing.T) {
+	cfg := NewKLogConfig(nil)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/kubernetes.go
+++ b/cmd/core/app/config/kubernetes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -46,4 +47,18 @@ func (c *KubernetesConfig) AddFlags(fs *pflag.FlagSet) {
 		"the burst for reconcile clients. Recommend setting it qps*2.")
 	fs.DurationVar(&c.InformerSyncPeriod, "informer-sync-period", c.InformerSyncPeriod,
 		"The re-sync period for informer in controller-runtime. This is a system-level configuration.")
+}
+
+// Validate ensures the Kubernetes client rate limiting parameters are mathematically sound.
+func (c *KubernetesConfig) Validate() error {
+	if c.QPS < 0 {
+		return fmt.Errorf("kubernetes client QPS cannot be negative")
+	}
+	if c.Burst < 0 {
+		return fmt.Errorf("kubernetes client burst cannot be negative")
+	}
+	if c.QPS > 0 && float64(c.Burst) < c.QPS {
+		return fmt.Errorf("kubernetes client burst (%d) must be greater than or equal to QPS (%v) to prevent token bucket starvation", c.Burst, c.QPS)
+	}
+	return nil
 }

--- a/cmd/core/app/config/kubernetes.go
+++ b/cmd/core/app/config/kubernetes.go
@@ -57,8 +57,5 @@ func (c *KubernetesConfig) Validate() error {
 	if c.Burst < 0 {
 		return fmt.Errorf("kubernetes client burst cannot be negative")
 	}
-	if c.QPS > 0 && float64(c.Burst) < c.QPS {
-		return fmt.Errorf("kubernetes client burst (%d) must be greater than or equal to QPS (%v) to prevent token bucket starvation", c.Burst, c.QPS)
-	}
 	return nil
 }

--- a/cmd/core/app/config/kubernetes_test.go
+++ b/cmd/core/app/config/kubernetes_test.go
@@ -59,13 +59,12 @@ func TestKubernetesConfig_Validate(t *testing.T) {
 			errMsg:  "kubernetes client burst cannot be negative",
 		},
 		{
-			name: "Invalid Configuration - Burst Lower Than QPS",
+			name: "Valid Configuration - Burst Lower Than QPS",
 			setupConfig: func() *KubernetesConfig {
 				cfg := &KubernetesConfig{QPS: 100, Burst: 50}
 				return cfg
 			},
-			wantErr: true,
-			errMsg:  "kubernetes client burst (50) must be greater than or equal to QPS (100) to prevent token bucket starvation",
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/core/app/config/kubernetes_test.go
+++ b/cmd/core/app/config/kubernetes_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *KubernetesConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid Configuration - Default",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 50, Burst: 100}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Configuration - Negative QPS",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: -10, Burst: 100}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client QPS cannot be negative",
+		},
+		{
+			name: "Invalid Configuration - Negative Burst",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 50, Burst: -1}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client burst cannot be negative",
+		},
+		{
+			name: "Invalid Configuration - Burst Lower Than QPS",
+			setupConfig: func() *KubernetesConfig {
+				cfg := &KubernetesConfig{QPS: 100, Burst: 50}
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "kubernetes client burst (50) must be greater than or equal to QPS (100) to prevent token bucket starvation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKubernetesConfig_AddFlags(t *testing.T) {
+	cfg := NewKubernetesConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
+		"--informer-sync-period=30m",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(100), cfg.QPS)
+	assert.Equal(t, 200, cfg.Burst)
+	assert.Equal(t, 30*time.Minute, cfg.InformerSyncPeriod)
+}

--- a/cmd/core/app/config/multicluster.go
+++ b/cmd/core/app/config/multicluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	pkgmulticluster "github.com/kubevela/pkg/multicluster"
@@ -50,4 +51,15 @@ func (c *MultiClusterConfig) AddFlags(fs *pflag.FlagSet) {
 
 	// Also register additional multicluster flags from external package
 	pkgmulticluster.AddFlags(fs)
+}
+
+// Validate ensures the multi-cluster configuration is logically consistent.
+func (c *MultiClusterConfig) Validate() error {
+	if c.EnableClusterMetrics && !c.EnableClusterGateway {
+		return fmt.Errorf("enable-cluster-gateway must be true when enable-cluster-metrics is true")
+	}
+	if c.ClusterMetricsInterval <= 0 {
+		return fmt.Errorf("cluster-metrics-interval must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/multicluster_test.go
+++ b/cmd/core/app/config/multicluster_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiClusterConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *MultiClusterConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *MultiClusterConfig { return NewMultiClusterConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Valid with both gateway and metrics enabled",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.EnableClusterGateway = true
+				cfg.EnableClusterMetrics = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: metrics enabled without gateway",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.EnableClusterMetrics = true
+				cfg.EnableClusterGateway = false
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "enable-cluster-gateway must be true when enable-cluster-metrics is true",
+		},
+		{
+			name: "Invalid: zero metrics interval",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.ClusterMetricsInterval = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "cluster-metrics-interval must be greater than zero",
+		},
+		{
+			name: "Invalid: negative metrics interval",
+			setupConfig: func() *MultiClusterConfig {
+				cfg := NewMultiClusterConfig()
+				cfg.ClusterMetricsInterval = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "cluster-metrics-interval must be greater than zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMultiClusterConfig_AddFlags(t *testing.T) {
+	cfg := NewMultiClusterConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--enable-cluster-gateway=true",
+		"--enable-cluster-metrics=true",
+		"--cluster-metrics-interval=30s",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.EnableClusterGateway)
+	assert.True(t, cfg.EnableClusterMetrics)
+	assert.Equal(t, 30*time.Second, cfg.ClusterMetricsInterval)
+}

--- a/cmd/core/app/config/oam.go
+++ b/cmd/core/app/config/oam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/oam-dev/kubevela/pkg/oam"
@@ -51,4 +53,12 @@ func (c *OAMConfig) AddFlags(fs *pflag.FlagSet) {
 // The flow is: CLI flags -> OAMConfig struct fields -> oam globals (via this method)
 func (c *OAMConfig) SyncToOAMGlobals() {
 	oam.SystemDefinitionNamespace = c.SystemDefinitionNamespace
+}
+
+// Validate ensures the OAM configuration is valid.
+func (c *OAMConfig) Validate() error {
+	if c.SystemDefinitionNamespace == "" {
+		return fmt.Errorf("system-definition-namespace must not be empty")
+	}
+	return nil
 }

--- a/cmd/core/app/config/oam.go
+++ b/cmd/core/app/config/oam.go
@@ -18,8 +18,10 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
@@ -59,6 +61,9 @@ func (c *OAMConfig) SyncToOAMGlobals() {
 func (c *OAMConfig) Validate() error {
 	if c.SystemDefinitionNamespace == "" {
 		return fmt.Errorf("system-definition-namespace must not be empty")
+	}
+	if errs := validation.IsDNS1123Label(c.SystemDefinitionNamespace); len(errs) > 0 {
+		return fmt.Errorf("system-definition-namespace is invalid: %s", strings.Join(errs, ", "))
 	}
 	return nil
 }

--- a/cmd/core/app/config/oam_test.go
+++ b/cmd/core/app/config/oam_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAMConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *OAMConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *OAMConfig { return NewOAMConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: empty namespace",
+			setupConfig: func() *OAMConfig {
+				cfg := NewOAMConfig()
+				cfg.SystemDefinitionNamespace = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "system-definition-namespace must not be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAMConfig_AddFlags(t *testing.T) {
+	cfg := NewOAMConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--system-definition-namespace=custom-system",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-system", cfg.SystemDefinitionNamespace)
+}

--- a/cmd/core/app/config/oam_test.go
+++ b/cmd/core/app/config/oam_test.go
@@ -46,6 +46,16 @@ func TestOAMConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "system-definition-namespace must not be empty",
 		},
+		{
+			name: "Invalid: non-DNS-1123 compliant namespace",
+			setupConfig: func() *OAMConfig {
+				cfg := NewOAMConfig()
+				cfg.SystemDefinitionNamespace = "Invalid_NS"
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "system-definition-namespace is invalid: ",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/core/app/config/observability.go
+++ b/cmd/core/app/config/observability.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
@@ -52,4 +54,15 @@ func (c *ObservabilityConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enable debug logs for development purpose")
 	fs.BoolVar(&c.DevLogs, "dev-logs", c.DevLogs,
 		"Enable ANSI color formatting for console logs (ignored when log-file-path is set)")
+}
+
+// Validate ensures the observability configuration is valid.
+func (c *ObservabilityConfig) Validate() error {
+	if c.MetricsAddr == "" {
+		return fmt.Errorf("metrics-addr must not be empty")
+	}
+	if c.LogFileMaxSize == 0 {
+		return fmt.Errorf("log-file-max-size must be greater than zero")
+	}
+	return nil
 }

--- a/cmd/core/app/config/observability_test.go
+++ b/cmd/core/app/config/observability_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservabilityConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ObservabilityConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *ObservabilityConfig { return NewObservabilityConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: empty metrics addr",
+			setupConfig: func() *ObservabilityConfig {
+				cfg := NewObservabilityConfig()
+				cfg.MetricsAddr = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "metrics-addr must not be empty",
+		},
+		{
+			name: "Invalid: zero log file max size",
+			setupConfig: func() *ObservabilityConfig {
+				cfg := NewObservabilityConfig()
+				cfg.LogFileMaxSize = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "log-file-max-size must be greater than zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestObservabilityConfig_AddFlags(t *testing.T) {
+	cfg := NewObservabilityConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--metrics-addr=:9090",
+		"--log-file-path=/var/log/vela.log",
+		"--log-file-max-size=2048",
+		"--log-debug=true",
+		"--dev-logs=true",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ":9090", cfg.MetricsAddr)
+	assert.Equal(t, "/var/log/vela.log", cfg.LogFilePath)
+	assert.Equal(t, uint64(2048), cfg.LogFileMaxSize)
+	assert.True(t, cfg.LogDebug)
+	assert.True(t, cfg.DevLogs)
+}

--- a/cmd/core/app/config/performance.go
+++ b/cmd/core/app/config/performance.go
@@ -56,3 +56,8 @@ func (c *PerformanceConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *PerformanceConfig) SyncToPerformanceGlobals() {
 	commonconfig.PerfEnabled = c.PerfEnabled
 }
+
+// Validate ensures the configuration is valid.
+func (c *PerformanceConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/performance_test.go
+++ b/cmd/core/app/config/performance_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPerformanceConfig_Validate(t *testing.T) {
+	cfg := NewPerformanceConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestPerformanceConfig_AddFlags(t *testing.T) {
+	cfg := NewPerformanceConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/performance_test.go
+++ b/cmd/core/app/config/performance_test.go
@@ -33,5 +33,7 @@ func TestPerformanceConfig_AddFlags(t *testing.T) {
 	cfg := NewPerformanceConfig()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	cfg.AddFlags(fs)
-	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+	err := fs.Parse([]string{"--perf-enabled=true"})
+	assert.NoError(t, err)
+	assert.True(t, cfg.PerfEnabled, "PerfEnabled should be bound to --perf-enabled")
 }

--- a/cmd/core/app/config/profiling.go
+++ b/cmd/core/app/config/profiling.go
@@ -38,3 +38,8 @@ func NewProfilingConfig() *ProfilingConfig {
 func (c *ProfilingConfig) AddFlags(fs *pflag.FlagSet) {
 	profiling.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ProfilingConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/profiling_test.go
+++ b/cmd/core/app/config/profiling_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfilingConfig_Validate(t *testing.T) {
+	cfg := NewProfilingConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestProfilingConfig_AddFlags(t *testing.T) {
+	cfg := NewProfilingConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/reconcile.go
+++ b/cmd/core/app/config/reconcile.go
@@ -38,3 +38,8 @@ func NewReconcileConfig() *ReconcileConfig {
 func (c *ReconcileConfig) AddFlags(fs *pflag.FlagSet) {
 	ctrlrec.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ReconcileConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/reconcile_test.go
+++ b/cmd/core/app/config/reconcile_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconcileConfig_Validate(t *testing.T) {
+	cfg := NewReconcileConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestReconcileConfig_AddFlags(t *testing.T) {
+	cfg := NewReconcileConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/resource.go
+++ b/cmd/core/app/config/resource.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
@@ -40,6 +42,14 @@ func (c *ResourceConfig) AddFlags(fs *pflag.FlagSet) {
 		"max-dispatch-concurrent",
 		c.MaxDispatchConcurrent,
 		"Set the max dispatch concurrent number, default is 10")
+}
+
+// Validate ensures the resource configuration is valid.
+func (c *ResourceConfig) Validate() error {
+	if c.MaxDispatchConcurrent <= 0 {
+		return fmt.Errorf("max-dispatch-concurrent must be greater than 0")
+	}
+	return nil
 }
 
 // SyncToResourceGlobals syncs the parsed configuration values to resource package global variables.

--- a/cmd/core/app/config/resource_test.go
+++ b/cmd/core/app/config/resource_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ResourceConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *ResourceConfig { return NewResourceConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: max dispatch concurrent zero",
+			setupConfig: func() *ResourceConfig {
+				cfg := NewResourceConfig()
+				cfg.MaxDispatchConcurrent = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-dispatch-concurrent must be greater than 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResourceConfig_AddFlags(t *testing.T) {
+	cfg := NewResourceConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--max-dispatch-concurrent=20",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 20, cfg.MaxDispatchConcurrent)
+}

--- a/cmd/core/app/config/server.go
+++ b/cmd/core/app/config/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -62,4 +63,27 @@ func (c *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 		"The duration that the acting controlplane will retry refreshing leadership before giving up")
 	fs.DurationVar(&c.RetryPeriod, "leader-election-retry-period", c.RetryPeriod,
 		"The duration the LeaderElector clients should wait between tries of actions")
+}
+
+// Validate checks if the server configuration is valid.
+func (c *ServerConfig) Validate() error {
+	if !c.EnableLeaderElection {
+		return nil
+	}
+	if c.LeaseDuration <= 0 {
+		return fmt.Errorf("leader-election-lease-duration must be greater than zero")
+	}
+	if c.RenewDeadline <= 0 {
+		return fmt.Errorf("leader-election-renew-deadline must be greater than zero")
+	}
+	if c.RetryPeriod <= 0 {
+		return fmt.Errorf("leader-election-retry-period must be greater than zero")
+	}
+	if c.LeaseDuration <= c.RenewDeadline {
+		return fmt.Errorf("leader-election-lease-duration must be greater than leader-election-renew-deadline")
+	}
+	if c.RetryPeriod >= c.RenewDeadline-c.RenewDeadline/5 {
+		return fmt.Errorf("leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)")
+	}
+	return nil
 }

--- a/cmd/core/app/config/server.go
+++ b/cmd/core/app/config/server.go
@@ -82,7 +82,7 @@ func (c *ServerConfig) Validate() error {
 	if c.LeaseDuration <= c.RenewDeadline {
 		return fmt.Errorf("leader-election-lease-duration must be greater than leader-election-renew-deadline")
 	}
-	if c.RetryPeriod >= c.RenewDeadline-c.RenewDeadline/5 {
+	if c.RetryPeriod*6 >= c.RenewDeadline*5 {
 		return fmt.Errorf("leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)")
 	}
 	return nil

--- a/cmd/core/app/config/server_test.go
+++ b/cmd/core/app/config/server_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *ServerConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *ServerConfig {
+				return NewServerConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with leader election enabled",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: zero lease duration",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative lease duration",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: zero renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RenewDeadline = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RenewDeadline = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: zero retry period",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RetryPeriod = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-retry-period must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: negative retry period",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.RetryPeriod = -1 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-retry-period must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: lease duration equal to renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 10 * time.Second
+				cfg.RenewDeadline = 10 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than leader-election-renew-deadline",
+		},
+		{
+			name: "Invalid configuration: lease duration less than renew deadline",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 5 * time.Second
+				cfg.RenewDeadline = 10 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-lease-duration must be greater than leader-election-renew-deadline",
+		},
+		{
+			name: "Invalid configuration: retry period too close to renew deadline (Jitter)",
+			setupConfig: func() *ServerConfig {
+				cfg := NewServerConfig()
+				cfg.EnableLeaderElection = true
+				cfg.LeaseDuration = 15 * time.Second
+				cfg.RenewDeadline = 5 * time.Second
+				cfg.RetryPeriod = 5 * time.Second
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServerConfig_AddFlags(t *testing.T) {
+	cfg := NewServerConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--health-addr=:9441",
+		"--storage-driver=mysql",
+		"--enable-leader-election=true",
+		"--leader-election-namespace=vela-system",
+		"--leader-election-lease-duration=20s",
+		"--leader-election-renew-deadline=15s",
+		"--leader-election-retry-period=5s",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ":9441", cfg.HealthAddr)
+	assert.Equal(t, "mysql", cfg.StorageDriver)
+	assert.True(t, cfg.EnableLeaderElection)
+	assert.Equal(t, "vela-system", cfg.LeaderElectionNamespace)
+	assert.Equal(t, 20*time.Second, cfg.LeaseDuration)
+	assert.Equal(t, 15*time.Second, cfg.RenewDeadline)
+	assert.Equal(t, 5*time.Second, cfg.RetryPeriod)
+}

--- a/cmd/core/app/config/server_test.go
+++ b/cmd/core/app/config/server_test.go
@@ -139,17 +139,16 @@ func TestServerConfig_Validate(t *testing.T) {
 			errMsg:  "leader-election-lease-duration must be greater than leader-election-renew-deadline",
 		},
 		{
-			name: "Invalid configuration: retry period too close to renew deadline (Jitter)",
+			name: "Valid configuration: retry period safe under corrected jitter threshold",
 			setupConfig: func() *ServerConfig {
 				cfg := NewServerConfig()
 				cfg.EnableLeaderElection = true
 				cfg.LeaseDuration = 15 * time.Second
-				cfg.RenewDeadline = 5 * time.Second
-				cfg.RetryPeriod = 5 * time.Second
+				cfg.RenewDeadline = 10 * time.Second
+				cfg.RetryPeriod = 8200 * time.Millisecond
 				return cfg
 			},
-			wantErr: true,
-			errMsg:  "leader-election-renew-deadline must be greater than leader-election-retry-period * Jitter (1.2)",
+			wantErr: false,
 		},
 	}
 

--- a/cmd/core/app/config/sharding.go
+++ b/cmd/core/app/config/sharding.go
@@ -38,3 +38,8 @@ func NewShardingConfig() *ShardingConfig {
 func (c *ShardingConfig) AddFlags(fs *pflag.FlagSet) {
 	sharding.AddFlags(fs)
 }
+
+// Validate ensures the configuration is valid.
+func (c *ShardingConfig) Validate() error {
+	return nil
+}

--- a/cmd/core/app/config/sharding_test.go
+++ b/cmd/core/app/config/sharding_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShardingConfig_Validate(t *testing.T) {
+	cfg := NewShardingConfig()
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestShardingConfig_AddFlags(t *testing.T) {
+	cfg := NewShardingConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+	assert.True(t, fs.HasFlags(), "AddFlags should register flags")
+}

--- a/cmd/core/app/config/webhook.go
+++ b/cmd/core/app/config/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
@@ -44,4 +46,18 @@ func (c *WebhookConfig) AddFlags(fs *pflag.FlagSet) {
 		"Admission webhook cert/key dir.")
 	fs.IntVar(&c.WebhookPort, "webhook-port", c.WebhookPort,
 		"admission webhook listen address")
+}
+
+// Validate checks if the webhook configuration is valid.
+func (c *WebhookConfig) Validate() error {
+	if c.WebhookPort <= 0 {
+		return fmt.Errorf("webhook-port must be greater than zero")
+	}
+	if c.WebhookPort > 65535 {
+		return fmt.Errorf("webhook-port must be between 1 and 65535 (inclusive)")
+	}
+	if c.UseWebhook && c.CertDir == "" {
+		return fmt.Errorf("webhook-cert-dir must not be empty when use-webhook is true")
+	}
+	return nil
 }

--- a/cmd/core/app/config/webhook_test.go
+++ b/cmd/core/app/config/webhook_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *WebhookConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "Valid default configuration",
+			setupConfig: func() *WebhookConfig {
+				return NewWebhookConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid configuration with webhook enabled and cert dir",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/k8s-webhook-server/certs"
+				cfg.WebhookPort = 9443
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid configuration: webhook enabled without cert dir",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = ""
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-cert-dir must not be empty when use-webhook is true",
+		},
+		{
+			name: "Invalid configuration: webhook enabled with negative port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/certs"
+				cfg.WebhookPort = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook enabled with zero port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = true
+				cfg.CertDir = "/tmp/certs"
+				cfg.WebhookPort = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook disabled with negative port",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.UseWebhook = false
+				cfg.WebhookPort = -1
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be greater than zero",
+		},
+		{
+			name: "Invalid configuration: webhook port above 65535",
+			setupConfig: func() *WebhookConfig {
+				cfg := NewWebhookConfig()
+				cfg.WebhookPort = 65536
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "webhook-port must be between 1 and 65535 (inclusive)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWebhookConfig_AddFlags(t *testing.T) {
+	cfg := NewWebhookConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--use-webhook=true",
+		"--webhook-cert-dir=/tmp/certs",
+		"--webhook-port=8443",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.UseWebhook)
+	assert.Equal(t, "/tmp/certs", cfg.CertDir)
+	assert.Equal(t, 8443, cfg.WebhookPort)
+}

--- a/cmd/core/app/config/workflow.go
+++ b/cmd/core/app/config/workflow.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	wfTypes "github.com/kubevela/workflow/pkg/types"
@@ -52,6 +54,20 @@ func (c *WorkflowConfig) AddFlags(fs *pflag.FlagSet) {
 		"max-workflow-step-error-retry-times",
 		c.MaxStepErrorRetryTimes,
 		"Set the max workflow step error retry times, default is 10")
+}
+
+// Validate ensures the workflow configuration is valid.
+func (c *WorkflowConfig) Validate() error {
+	if c.MaxWaitBackoffTime <= 0 {
+		return fmt.Errorf("max-workflow-wait-backoff-time must be greater than 0")
+	}
+	if c.MaxFailedBackoffTime <= 0 {
+		return fmt.Errorf("max-workflow-failed-backoff-time must be greater than 0")
+	}
+	if c.MaxStepErrorRetryTimes <= 0 {
+		return fmt.Errorf("max-workflow-step-error-retry-times must be greater than 0")
+	}
+	return nil
 }
 
 // SyncToWorkflowGlobals syncs the parsed configuration values to workflow package global variables.

--- a/cmd/core/app/config/workflow_test.go
+++ b/cmd/core/app/config/workflow_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func() *WorkflowConfig
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "Valid default configuration",
+			setupConfig: func() *WorkflowConfig { return NewWorkflowConfig() },
+			wantErr:     false,
+		},
+		{
+			name: "Invalid: max wait backoff time zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxWaitBackoffTime = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-wait-backoff-time must be greater than 0",
+		},
+		{
+			name: "Invalid: max failed backoff time zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxFailedBackoffTime = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-failed-backoff-time must be greater than 0",
+		},
+		{
+			name: "Invalid: max step error retry times zero",
+			setupConfig: func() *WorkflowConfig {
+				cfg := NewWorkflowConfig()
+				cfg.MaxStepErrorRetryTimes = 0
+				return cfg
+			},
+			wantErr: true,
+			errMsg:  "max-workflow-step-error-retry-times must be greater than 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWorkflowConfig_AddFlags(t *testing.T) {
+	cfg := NewWorkflowConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--max-workflow-wait-backoff-time=120",
+		"--max-workflow-failed-backoff-time=600",
+		"--max-workflow-step-error-retry-times=20",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 120, cfg.MaxWaitBackoffTime)
+	assert.Equal(t, 600, cfg.MaxFailedBackoffTime)
+	assert.Equal(t, 20, cfg.MaxStepErrorRetryTimes)
+}

--- a/cmd/core/app/options/options.go
+++ b/cmd/core/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/oam-dev/kubevela/cmd/core/app/config"
@@ -123,4 +124,27 @@ func (s *CoreOptions) Flags() cliflag.NamedFlagSets {
 	s.KLog.AddFlags(fss.FlagSet("klog"))
 
 	return fss
+}
+
+// Validate runs validation on all config modules that implement a Validate() error method.
+func (s *CoreOptions) Validate() error {
+	var errs []error
+
+	// List all config modules
+	configs := []interface{}{
+		s.Server, s.Webhook, s.Observability, s.Kubernetes, s.MultiCluster,
+		s.CUE, s.Application, s.OAM, s.Performance, s.Workflow, s.Admission,
+		s.Resource, s.Client, s.Reconcile, s.Sharding, s.Feature, s.Profiling,
+		s.KLog, s.Controller,
+	}
+
+	for _, c := range configs {
+		if v, ok := c.(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
 }

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -932,3 +932,9 @@ func TestCoreOptions_CompleteIntegration(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, commonconfig.ApplicationReSyncPeriod)
 	assert.True(t, commonconfig.PerfEnabled)
 }
+
+func TestCoreOptions_Validate(t *testing.T) {
+	opts := NewCoreOptions()
+	err := opts.Validate()
+	assert.NoError(t, err, "Validate should not return error on default options")
+}

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -937,4 +937,15 @@ func TestCoreOptions_Validate(t *testing.T) {
 	opts := NewCoreOptions()
 	err := opts.Validate()
 	assert.NoError(t, err, "Validate should not return error on default options")
+
+	// Test validation error propagation
+	opts.OAM.SystemDefinitionNamespace = ""
+	err = opts.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "system-definition-namespace must not be empty")
+
+	opts.OAM.SystemDefinitionNamespace = "Invalid_NS"
+	err = opts.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "system-definition-namespace is invalid")
 }

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -994,3 +994,9 @@ func TestCoreOptions_CompleteIntegration(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, commonconfig.ApplicationReSyncPeriod)
 	assert.True(t, commonconfig.PerfEnabled)
 }
+
+func TestCoreOptions_Validate(t *testing.T) {
+	opts := NewCoreOptions()
+	err := opts.Validate()
+	assert.NoError(t, err, "Validate should not return error on default options")
+}

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -999,4 +999,15 @@ func TestCoreOptions_Validate(t *testing.T) {
 	opts := NewCoreOptions()
 	err := opts.Validate()
 	assert.NoError(t, err, "Validate should not return error on default options")
+
+	// Test validation error propagation
+	opts.OAM.SystemDefinitionNamespace = ""
+	err = opts.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "system-definition-namespace must not be empty")
+
+	opts.OAM.SystemDefinitionNamespace = "Invalid_NS"
+	err = opts.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "system-definition-namespace is invalid")
 }

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -103,6 +103,12 @@ func NewCoreCommand() *cobra.Command {
 }
 
 func run(ctx context.Context, coreOptions *options.CoreOptions) error {
+	// Validate configurations
+	if err := coreOptions.Validate(); err != nil {
+		klog.ErrorS(err, "Invalid configuration")
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	klog.InfoS("Starting KubeVela core controller",
 		"context", "initialization",
 		"leaderElection", coreOptions.Server.EnableLeaderElection,

--- a/cmd/core/app/server_test.go
+++ b/cmd/core/app/server_test.go
@@ -628,6 +628,19 @@ var _ = Describe("Server Tests", func() {
 		// - Application resources in cluster
 	})
 
+	Describe("run", func() {
+		It("should return error when configuration is invalid", func() {
+			ctx := context.Background()
+			coreOpts := options.NewCoreOptions()
+			// Make configuration invalid to test validation flow
+			coreOpts.OAM.SystemDefinitionNamespace = ""
+
+			err := run(ctx, coreOpts)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+		})
+	})
+
 	// Note: The run() function requires full Kubernetes environment with CRDs.
 	// These unit tests focuses on individual functions with mocked dependencies.
 })


### PR DESCRIPTION
### Description of your changes

copilot:all

This pull request systematically implements configuration validation for the Vela Controller's `CoreOptions`, effectively catching invalid configurations early in the startup process to prevent runtime errors.

Specifically, this PR accomplishes the following action items:
1. Implemented a `Validate()` method for each configuration module (server, webhook, observability, etc.) within `cmd/core/app/config`.
2. Integrated the validation logic into the main startup flow after flag parsing via `cmd/core/app/server.go` and `cmd/core/app/options/options.go`.
3. Added comprehensive unit tests targeting the `AddFlags` methods across all configuration modules to guarantee accurate mapping between flags and struct fields.

Fixes #6950

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Developed specific unit tests for all new `Validate()` methods to ensure robust error handling for invalid input constraints.
- Created unit tests for the `AddFlags` methods within every configuration module to confirm that Cobra flags map correctly to the expected structure fields.
- Validated the end-to-end integration within the main application startup flow to verify that the application correctly halts with a clear error message upon encountering invalid flags.
- Executed local tests using `go test ./cmd/core/app/config/... -v` which completed with full success and optimal code coverage.

### Special notes for your reviewer

This pull request consolidates previous separated PRs into a single, clean branch. 

Please note that for configuration modules lacking immediate constraints or specific validation requirements, a stub returning `nil` was added. This satisfies the interface contract and establishes a unified validation framework, making it effortless to append complex logic to these modules in the future.
