### PR TITLE
Fix: add pod readiness guard and FlakeAttempts to Helm adoption E2E test contexts that were missing them

### DIFF
--- a/test/e2e-test/helmchart_test.go
+++ b/test/e2e-test/helmchart_test.go
@@ -632,7 +632,7 @@ var _ = Describe("Helmchart Self-Healing", func() {
 
 var _ = Describe("Helmchart Adoption & Takeover", func() {
 
-	Context("Adopt an Existing Vanilla Helm Release", Ordered, func() {
+	Context("Adopt an Existing Vanilla Helm Release", FlakeAttempts(2), Ordered, func() {
 		h := newHelmTestContext()
 		BeforeAll(func() { h.createNamespace() })
 		AfterAll(func() { h.cleanup() })
@@ -645,13 +645,16 @@ var _ = Describe("Helmchart Adoption & Takeover", func() {
 
 			initialSecretCount := len(h.getHelmSecrets().Items)
 
+			By("Waiting for Deployment to be ready before recording pod UIDs")
+			Eventually(func(g Gomega) {
+				d := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(h.ctx, types.NamespacedName{Namespace: h.namespace, Name: "podinfo"}, d)).Should(Succeed())
+				g.Expect(d.Status.ReadyReplicas).Should(Equal(int32(2)))
+			}, 120*time.Second, 3*time.Second).Should(Succeed())
 			By("Recording running pod UIDs before adoption")
 			var podList corev1.PodList
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.List(h.ctx, &podList, client.InNamespace(h.namespace),
-					client.MatchingLabels{"app.kubernetes.io/name": "podinfo"})).Should(Succeed())
-				g.Expect(len(podList.Items)).Should(BeNumerically(">=", 2))
-			}, 60*time.Second, 3*time.Second).Should(Succeed())
+			Expect(k8sClient.List(h.ctx, &podList, client.InNamespace(h.namespace),
+				client.MatchingLabels{"app.kubernetes.io/name": "podinfo"})).Should(Succeed())
 			originalPodUIDs := make(map[types.UID]bool)
 			for _, pod := range podList.Items {
 				originalPodUIDs[pod.UID] = true
@@ -734,7 +737,7 @@ var _ = Describe("Helmchart Adoption & Takeover", func() {
 		})
 	})
 
-	Context("Re-adopt After Application Deletion", Ordered, func() {
+	Context("Re-adopt After Application Deletion", FlakeAttempts(2), Ordered, func() {
 		h := newHelmTestContext()
 		BeforeAll(func() { h.createNamespace() })
 		AfterAll(func() { h.cleanupNamespaceOnly() })
@@ -744,6 +747,11 @@ var _ = Describe("Helmchart Adoption & Takeover", func() {
 			runCommandSucceed("helm", "install", "podinfo",
 				"--repo", "https://stefanprodan.github.io/podinfo", "podinfo",
 				"--version", "6.11.1", "--set", "replicaCount=2", "-n", h.namespace)
+			Eventually(func(g Gomega) {
+				d := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(h.ctx, types.NamespacedName{Namespace: h.namespace, Name: "podinfo"}, d)).Should(Succeed())
+				g.Expect(d.Status.ReadyReplicas).Should(Equal(int32(2)))
+			}, 120*time.Second, 3*time.Second).Should(Succeed())
 
 			By("Applying KubeVela Application (adopts the release)")
 			h.deployApp()
@@ -763,6 +771,11 @@ var _ = Describe("Helmchart Adoption & Takeover", func() {
 			runCommandSucceed("helm", "install", "podinfo",
 				"--repo", "https://stefanprodan.github.io/podinfo", "podinfo",
 				"--version", "6.11.1", "--set", "replicaCount=2", "-n", h.namespace)
+			Eventually(func(g Gomega) {
+				d := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(h.ctx, types.NamespacedName{Namespace: h.namespace, Name: "podinfo"}, d)).Should(Succeed())
+				g.Expect(d.Status.ReadyReplicas).Should(Equal(int32(2)))
+			}, 120*time.Second, 3*time.Second).Should(Succeed())
 
 			By("Applying the same KubeVela Application again")
 			h.deployApp()
@@ -2011,7 +2024,7 @@ replicaCount: 2
 		})
 	})
 
-	Context("Adoption of an existing vanilla Helm release with valuesFrom", Ordered, func() {
+	Context("Adoption of an existing vanilla Helm release with valuesFrom", FlakeAttempts(2), Ordered, func() {
 		h := newHelmTestContext()
 		BeforeAll(func() { h.createNamespace() })
 		AfterAll(func() { h.cleanup() })


### PR DESCRIPTION
## What

Add Deployment readiness guards and `FlakeAttempts(2)` to Helm adoption E2E test contexts that were missing them.

## Why

While working on PR #7188, the CI run ([#27159484350](https://github.com/kubevela/kubevela/actions/runs/27159484350/job/80170890418)) failed on the "adopt an existing vanilla helm Release" test, the diagnostics showed podss stuck in `ImagePullBackOff` they existed but were never actually ready,

Looking at the test code, the precondition check at line 648-654 only verified `len(podList.Items) >= 2`. That's a count check, not a readiness check. Pods in `ImagePullBackOff` satisfy that condition while never becoming functional, so when the test later checks `countSurvivingPods`, it records UIDs of broken pods and the assertion fails automatcally



I noticed the other adoption contexts in the exact same file already do this correctly:
- "adopt release with different values" (line 699): waits for `d.Status.ReadyReplicas == 1`
- "adoption with valuesFrom" (line 2037): waits for `d.Status.ReadyReplicas == 1`


 

The vanilla adoption and re-adopt contexts were simply written with a weaker precondition his pr aligns them with the samee pattern their siblings already uses it



## Approach

- Replaced the `len(podList.Items) >= 2` check with `Deployment.Status.ReadyReplicas == 2` in the vanilla adoption context
- Added the same readiness wait to the "re-adopt after application deletions" context (both of its `helm install` steps had no readiness check at all before calling `h.deployApp()`)
- Added `flakeAttempts(2)` to all three adoption contexts so that genuine transient infra issues (registry rate limits, KinD network blips) get a single retry rather than failing the entire CI run
- Increased timeout from 60s to 120s to match other adoption waits in the file
- Removed the unused `isPodReady` helper that was initially added but turned out unnecessary since `ReadyReplicas` on the deployment object covers the check more cleanly

## Verification

- `go build ./test/e2e-test/...` ---- passes
- `go vet ./test/e2e-test/...` ---- passes  
- `go fmt` ---- clean
