### PR TITLE
Fix: resolve gosec G304 lint failure on master in Terraform module cache check

### DIFF
--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -268,7 +268,7 @@ func cacheMatchesRemote(cachePath, remoteURL string) bool {
 	if err != nil || len(entities) == 0 {
 		return false
 	}
-	recorded, err := os.ReadFile(cachePath + cacheRemoteMarkerSuffix)
+	recorded, err := os.ReadFile(filepath.Clean(cachePath + cacheRemoteMarkerSuffix))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
### Description of your changes

The `lint` and `check-diff` jobs on master are failing since the merge of the GHSA-fmgp-q6jx-gg3x fix (f6a6439), because the advisory workflow on the private fork did not run the full Go lint job:

```
pkg/controller/utils/capability.go:271:19: G304: Potential file inclusion via variable (gosec)
```

Failed run: https://github.com/kubevela/kubevela/actions/runs/27290105858

This wraps the cache marker read in `filepath.Clean`, which gosec treats as sanitized and which is the pattern already used by other `os.ReadFile` call sites in this repo (`pkg/utils/load.go`, `pkg/addon/reader_local.go`, and others). The path is built from `filepath.Join` plus a constant suffix, with the module name validated by `validateModuleName`, so behavior is unchanged.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. Not applicable, lint-only one line change.
- [x] Run `make reviewable` to ensure this PR is ready for review. Ran golangci-lint v1.60.1 (the exact CI version) on the affected package: it reproduces the G304 finding before this change and reports no issues after it.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- golangci-lint v1.60.1 with Go 1.23.8 on `./pkg/controller/utils/...`: clean after the change, reproduces the CI failure without it.
- `go test ./pkg/controller/utils/ -run TestGetTerraformConfigurationFromRemote`: passes, covering the cache marker read path.

### Special notes for your reviewer

One line change to unblock CI on master. `filepath.Clean` is a no-op here since the path comes from `filepath.Join` plus the constant `.remote-url` suffix.