### PR TITLE
Fix(chart): use ca.crt CA path for cluster-gateway when cert-manager is enabled

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -282,7 +282,11 @@ spec:
             {{ if .Values.multicluster.clusterGateway.direct }}
             - "--cluster-gateway-url={{ .Release.Name }}-cluster-gateway-service:9443"
             {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
+            {{ if .Values.multicluster.clusterGateway.secureTLS.certManager.enabled }}
+            - "--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca.crt"
+            {{ else }}
             - "--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca"
+            {{ end }}
             {{ end }}
             {{ end }}
             {{ end }}

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -357,6 +357,8 @@ spec:
           {{- end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
+          {{- $needAdmissionTLS := .Values.admissionWebhooks.enabled }}
+          {{- $needClusterGatewayTLS := and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled .Values.multicluster.clusterGateway.direct }}
           {{ if .Values.admissionWebhooks.enabled }}
           ports:
             - containerPort: {{ .Values.webhookService.port }}
@@ -383,23 +385,29 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{ end }}
+          {{ if or $needAdmissionTLS $needClusterGatewayTLS }}
           volumeMounts:
+            {{ if $needAdmissionTLS }}
             - mountPath: {{ .Values.admissionWebhooks.certificate.mountPath }}
               name: tls-cert-vol
               readOnly: true
-          {{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled .Values.multicluster.clusterGateway.direct }}
+            {{ end }}
+            {{ if $needClusterGatewayTLS }}
             - mountPath: /cluster-gateway-tls-cert
               name: tls-cert-vol-cg
               readOnly: true
+            {{ end }}
           {{ end }}
-          {{ end }}
-      {{ if .Values.admissionWebhooks.enabled }}
+      {{ if or $needAdmissionTLS $needClusterGatewayTLS }}
       volumes:
+        {{ if $needAdmissionTLS }}
         - name: tls-cert-vol
           secret:
             defaultMode: 420
             secretName: {{ template "kubevela.fullname" . }}-admission
-      {{ if and .Values.multicluster.enabled .Values.multicluster.clusterGateway.secureTLS.enabled .Values.multicluster.clusterGateway.direct }}
+        {{ end }}
+        {{ if $needClusterGatewayTLS }}
         - name: tls-cert-vol-cg
           secret:
             defaultMode: 420


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes an error that occurs when cert-manager is used to generate the cluster-gateway certificate and the KubeVela controller cannot read the CA file at the default path `--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca`. 

```
│ E0618 09:32:06.045371       1 server.go:183] "Unable to create a controller manager" err="failed to get raw client: open /cluster-gateway-tls-cert/ca: no such file or directory"                                                                                          │
│ Error: failed to get raw client: open /cluster-gateway-tls-cert/ca: no such file or directory
```

When `multicluster.clusterGateway.secureTLS.certManager.enabled=true`, the secret `{{ template "kubevela.fullname" . }}-cluster-gateway-tls-v2` is generated by cert-manager, which does not store the CA under the `ca` key but under `ca.crt`, per the [cert-manager target secret convention](https://cert-manager.io/docs/usage/certificate/#target-secret).

This PR makes the controller's `--cluster-gateway-ca-file` argument conditional on how the secret is produced:
- cert-manager (`secureTLS.certManager.enabled=true`) → `/cluster-gateway-tls-cert/ca.crt`
- certgen job (default) → `/cluster-gateway-tls-cert/ca` (unchanged, backward compatible)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Rendered the chart with `helm template` in both modes:
- `secureTLS.certManager.enabled=true` →
  `--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca.crt`
- `secureTLS.certManager.enabled=false` →
  `--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca`

Or

Deploy a fresh kubevela instance (ensure the kubevela secrets do not exist) using the with cert-manager webhooks enabled:
```bash
 helm upgrade --install kubevela charts/vela-core --set multicluster.clusterGateway.secureTLS.certManager.enabled=true --set admissionWebhooks.certManager.enabled=true
```
Expectation without the fix;

Kubevela core doesnt start and fails with the error:
```
I0629 19:43:42.963951       1 server.go:124] "Configuring Kubernetes client" QPS=400 burst=600                                                                                                                                                  │
│ I0629 19:43:42.964036       1 server.go:276] "Kubernetes Config Loaded" UserAgent="kubevela/git-5a44b5f" QPS=400 Burst=600                                                                                                                      │
│ I0629 19:43:42.964049       1 server.go:139] "Multi-cluster gateway enabled, setting up multi-cluster capability" enableMetrics=false metricsInterval="15s"                                                                                     │
│ I0629 19:43:43.324095       1 server.go:293] "Multi-cluster client initialized successfully"                                                                                                                                                    │
│ I0629 19:43:43.324111       1 server.go:146] "Multi-cluster setup completed successfully"                                                                                                                                                       │
│ I0629 19:43:43.324123       1 server.go:154] "Creating controller manager" metricsAddr=":8080" healthAddr=":9440" webhookPort=9443                                                                                                              │
│ E0629 19:43:43.325460       1 server.go:378] "Unable to create a controller manager" err="failed to get raw client: open /cluster-gateway-tls-cert/ca: no such file or directory"                                                               │
│ E0629 19:43:43.325490       1 server.go:160] "Failed to create controller manager" err="failed to get raw client: open /cluster-gateway-tls-cert/ca: no such file or directory"                                                                 │
│ Error: failed to create controller manager: failed to get raw client: open /cluster-gateway-tls-cert/ca: no such file or directory                                                                                                              │
│ stream closed: EOF for default/kubevela-vela-core-65cb54fd86-qkqbq (kubevela)
```

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

