### PR TITLE
Feat: auto remediate cue issues

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-application-in-parallel.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-application-in-parallel.yaml
@@ -15,7 +15,8 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         output: op.#ApplyApplicationInParallel & {}
 

--- a/charts/vela-core/templates/defwithtemplate/apply-application.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-application.yaml
@@ -16,8 +16,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         // apply application
         output: op.#ApplyApplication & {}
 

--- a/charts/vela-core/templates/defwithtemplate/apply-deployment.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-deployment.yaml
@@ -13,9 +13,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/builtin"
-
+        import (
+        	"vela/kube"
+        	"vela/builtin"
+        )
         output: kube.#Apply & {
         	$params: {
         		cluster: parameter.cluster

--- a/charts/vela-core/templates/defwithtemplate/apply-object.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-object.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-
+        import (
+        	"vela/kube"
+        )
         apply: kube.#Apply & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/apply-remaining.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-remaining.yaml
@@ -16,8 +16,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         // apply remaining components and traits
         apply: op.#ApplyRemaining & {
         	parameter

--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-config.yaml
@@ -13,9 +13,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/builtin"
-
+        import (
+        	"vela/kube"
+        	"vela/builtin"
+        )
         apply: kube.#Apply & {
         	$params: value: {
         		apiVersion: "terraform.core.oam.dev/v1beta2"

--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
@@ -13,10 +13,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/config"
-        import "vela/kube"
-        import "vela/builtin"
-
+        import (
+        	"vela/config"
+        	"vela/kube"
+        	"vela/builtin"
+        )
         cfg: config.#CreateConfig & {
         	$params: {
         		name:      "\(context.name)-\(context.stepName)"

--- a/charts/vela-core/templates/defwithtemplate/build-push-image.yaml
+++ b/charts/vela-core/templates/defwithtemplate/build-push-image.yaml
@@ -13,11 +13,12 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/builtin"
-        import "vela/kube"
-        import "vela/util"
-        import "strings"
-
+        import (
+        	"vela/builtin"
+        	"vela/kube"
+        	"vela/util"
+        	"strings"
+        )
         url: {
         	if parameter.context.git != _|_ {
         		address: strings.TrimPrefix(parameter.context.git, "git://")

--- a/charts/vela-core/templates/defwithtemplate/check-metrics.yaml
+++ b/charts/vela-core/templates/defwithtemplate/check-metrics.yaml
@@ -14,9 +14,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/metrics"
-        import "vela/builtin"
-
+        import (
+        	"vela/metrics"
+        	"vela/builtin"
+        )
         check: metrics.#PromCheck & {
         	$params: {
         		query:          parameter.query

--- a/charts/vela-core/templates/defwithtemplate/clean-jobs.yaml
+++ b/charts/vela-core/templates/defwithtemplate/clean-jobs.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-
+        import (
+        	"vela/kube"
+        )
         parameter: {
         	labelselector?: {...}
         	namespace: *context.namespace | string

--- a/charts/vela-core/templates/defwithtemplate/collect-service-endpoints.yaml
+++ b/charts/vela-core/templates/defwithtemplate/collect-service-endpoints.yaml
@@ -12,10 +12,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/builtin"
-        import "vela/query"
-        import "strconv"
-
+        import (
+        	"vela/builtin"
+        	"vela/query"
+        	"strconv"
+        )
         collect: query.#CollectServiceEndpoints & {
         	$params: app: {
         		name:      parameter.name

--- a/charts/vela-core/templates/defwithtemplate/command.yaml
+++ b/charts/vela-core/templates/defwithtemplate/command.yaml
@@ -17,7 +17,6 @@ spec:
     cue:
       template: |
         import "list"
-
         #PatchParams: {
         	// +usage=Specify the name of the target container, if not set, use the component name
         	containerName: *"" | string

--- a/charts/vela-core/templates/defwithtemplate/container-ports.yaml
+++ b/charts/vela-core/templates/defwithtemplate/container-ports.yaml
@@ -17,10 +17,12 @@ spec:
   schematic:
     cue:
       template: |
-        import "strconv"
-        import "strings"
         import "list"
 
+        import (
+        	"strconv"
+        	"strings"
+        )
         #PatchParams: {
         	// +usage=Specify the name of the target container, if not set, use the component name
         	containerName: *"" | string

--- a/charts/vela-core/templates/defwithtemplate/create-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/create-config.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/config"
-
+        import (
+        	"vela/config"
+        )
         deploy: config.#CreateConfig & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -12,7 +12,6 @@ spec:
     cue:
       template: |
         import "list"
-
         mountsArray: {
         	pvc: *[
         		for v in parameter.volumeMounts.pvc {
@@ -232,7 +231,7 @@ spec:
         									}}]
         							}
         							if parameter["volumeMounts"] != _|_ {
-        								volumeMounts: mountsArray.pvc + mountsArray.configMap + mountsArray.secret + mountsArray.emptyDir + mountsArray.hostPath
+        								volumeMounts: list.Concat([mountsArray.pvc, mountsArray.configMap, mountsArray.secret, mountsArray.emptyDir, mountsArray.hostPath])
         							}
         						}]
         						if parameter["volumes"] != _|_ if parameter["volumeMounts"] == _|_ {

--- a/charts/vela-core/templates/defwithtemplate/daemon.yaml
+++ b/charts/vela-core/templates/defwithtemplate/daemon.yaml
@@ -11,8 +11,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "strconv"
-
+        import (
+        	"strconv"
+        )
         mountsArray: [
         	if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         		{

--- a/charts/vela-core/templates/defwithtemplate/delete-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/delete-config.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/config"
-
+        import (
+        	"vela/config"
+        )
         deploy: config.#DeleteConfig & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/depends-on-app.yaml
+++ b/charts/vela-core/templates/defwithtemplate/depends-on-app.yaml
@@ -12,10 +12,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/builtin"
-        import "encoding/yaml"
-
+        import (
+        	"vela/kube"
+        	"vela/builtin"
+        	"encoding/yaml"
+        )
         dependsOn: kube.#Read & {
         	$params: value: {
         		apiVersion: "core.oam.dev/v1beta1"

--- a/charts/vela-core/templates/defwithtemplate/deploy-cloud-resource.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy-cloud-resource.yaml
@@ -14,8 +14,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         app: op.#DeployCloudResource & {
         	env:    parameter.env
         	policy: parameter.policy

--- a/charts/vela-core/templates/defwithtemplate/deploy.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy.yaml
@@ -14,10 +14,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/multicluster"
-        import "vela/builtin"
-
-
+        import (
+        	"vela/multicluster"
+        	"vela/builtin"
+        )
         if parameter.auto == false {
         	suspend: builtin.#Suspend & {$params: message: "Waiting approval to the deploy step \"\(context.stepName)\""}
         }

--- a/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
@@ -15,8 +15,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         app: op.#ApplyEnvBindApp & {
         	env:      parameter.env
         	policy:   parameter.policy

--- a/charts/vela-core/templates/defwithtemplate/deploy2runtime.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy2runtime.yaml
@@ -15,8 +15,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         app: op.#Steps & {
         	load: op.#Load
         	clusters: [...string]

--- a/charts/vela-core/templates/defwithtemplate/env.yaml
+++ b/charts/vela-core/templates/defwithtemplate/env.yaml
@@ -17,7 +17,6 @@ spec:
     cue:
       template: |
         import "list"
-
         #PatchParams: {
         	// +usage=Specify the name of the target container, if not set, use the component name
         	containerName: *"" | string

--- a/charts/vela-core/templates/defwithtemplate/export-data.yaml
+++ b/charts/vela-core/templates/defwithtemplate/export-data.yaml
@@ -14,9 +14,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-        import "vela/kube"
-
+        import (
+        	"vela/op"
+        	"vela/kube"
+        )
         object: {
         	apiVersion: "v1"
         	kind:       parameter.kind

--- a/charts/vela-core/templates/defwithtemplate/export-service.yaml
+++ b/charts/vela-core/templates/defwithtemplate/export-service.yaml
@@ -14,9 +14,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-        import "vela/kube"
-
+        import (
+        	"vela/op"
+        	"vela/kube"
+        )
         meta: {
         	name:      *context.name | string
         	namespace: *context.namespace | string

--- a/charts/vela-core/templates/defwithtemplate/export2config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/export2config.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-
+        import (
+        	"vela/kube"
+        )
         apply: kube.#Apply & {
         	$params: {
         		value: {

--- a/charts/vela-core/templates/defwithtemplate/export2secret.yaml
+++ b/charts/vela-core/templates/defwithtemplate/export2secret.yaml
@@ -12,10 +12,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "encoding/base64"
-        import "encoding/json"
-
+        import (
+        	"vela/kube"
+        	"encoding/base64"
+        	"encoding/json"
+        )
         secret: {
         	data: *parameter.data | {}
         	if parameter.kind == "docker-registry" && parameter.dockerRegistry != _|_ {

--- a/charts/vela-core/templates/defwithtemplate/expose.yaml
+++ b/charts/vela-core/templates/defwithtemplate/expose.yaml
@@ -15,9 +15,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "strconv"
-        import "strings"
-
+        import (
+        	"strconv"
+        	"strings"
+        )
         outputs: service: {
         	apiVersion: "v1"
         	kind:       "Service"

--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -16,8 +16,6 @@ spec:
     cue:
       template: |
         import "strconv"
-
-
         let nameSuffix = {
         	if parameter.name != _|_ {"-" + parameter.name}
         	if parameter.name == _|_ {""}

--- a/charts/vela-core/templates/defwithtemplate/generate-jdbc-connection.yaml
+++ b/charts/vela-core/templates/defwithtemplate/generate-jdbc-connection.yaml
@@ -12,10 +12,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/util"
-        import "encoding/base64"
-
+        import (
+        	"vela/kube"
+        	"vela/util"
+        	"encoding/base64"
+        )
         output: kube.#Read & {
         	$params: value: {
         		apiVersion: "v1"

--- a/charts/vela-core/templates/defwithtemplate/init-container.yaml
+++ b/charts/vela-core/templates/defwithtemplate/init-container.yaml
@@ -18,7 +18,6 @@ spec:
     cue:
       template: |
         import "list"
-
         patch: spec: template: spec: {
         	// +patchKey=name
         	containers: [{

--- a/charts/vela-core/templates/defwithtemplate/list-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/list-config.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/config"
-
+        import (
+        	"vela/config"
+        )
         output: config.#ListConfig & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/nocalhost.yaml
+++ b/charts/vela-core/templates/defwithtemplate/nocalhost.yaml
@@ -19,8 +19,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "encoding/json"
-
+        import (
+        	"encoding/json"
+        )
         outputs: nocalhostService: {
         	apiVersion: "v1"
         	kind:       "Service"

--- a/charts/vela-core/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/notification.yaml
@@ -12,13 +12,14 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/http"
-        import "vela/email"
-        import "vela/kube"
-        import "vela/util"
-        import "encoding/base64"
-        import "encoding/json"
-
+        import (
+        	"vela/http"
+        	"vela/email"
+        	"vela/kube"
+        	"vela/util"
+        	"encoding/base64"
+        	"encoding/json"
+        )
         parameter: {
         	// +usage=Please fulfill its url and message if you want to send Lark messages
         	lark?: {

--- a/charts/vela-core/templates/defwithtemplate/print-message-in-status.yaml
+++ b/charts/vela-core/templates/defwithtemplate/print-message-in-status.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/builtin"
-
+        import (
+        	"vela/builtin"
+        )
         parameter: message: string
 
         msg: builtin.#Message & {

--- a/charts/vela-core/templates/defwithtemplate/read-config.yaml
+++ b/charts/vela-core/templates/defwithtemplate/read-config.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/config"
-
+        import (
+        	"vela/config"
+        )
         output: config.#ReadConfig & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/read-object.yaml
+++ b/charts/vela-core/templates/defwithtemplate/read-object.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-
+        import (
+        	"vela/kube"
+        )
         output: kube.#Read & {
         	$params: {
         		cluster: parameter.cluster

--- a/charts/vela-core/templates/defwithtemplate/request.yaml
+++ b/charts/vela-core/templates/defwithtemplate/request.yaml
@@ -13,10 +13,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-        import "vela/http"
-        import "encoding/json"
-
+        import (
+        	"vela/op"
+        	"vela/http"
+        	"encoding/json"
+        )
         req: http.#HTTPDo & {
         	$params: {
         		method: parameter.method

--- a/charts/vela-core/templates/defwithtemplate/restart-workflow.yaml
+++ b/charts/vela-core/templates/defwithtemplate/restart-workflow.yaml
@@ -14,9 +14,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/builtin"
-
+        import (
+        	"vela/kube"
+        	"vela/builtin"
+        )
         // Count how many parameters are provided
         _paramCount: len([
         	if parameter.at != _|_ {1},

--- a/charts/vela-core/templates/defwithtemplate/share-cloud-resource.yaml
+++ b/charts/vela-core/templates/defwithtemplate/share-cloud-resource.yaml
@@ -14,8 +14,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/op"
-
+        import (
+        	"vela/op"
+        )
         app: op.#ShareCloudResource & {
         	env:        parameter.env
         	policy:     parameter.policy

--- a/charts/vela-core/templates/defwithtemplate/statefulset.yaml
+++ b/charts/vela-core/templates/defwithtemplate/statefulset.yaml
@@ -11,9 +11,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "strconv"
-        import "strings"
-
+        import (
+        	"strconv"
+        	"strings"
+        )
         mountsArray: [
         	if parameter.volumeMounts != _|_ if parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         		{

--- a/charts/vela-core/templates/defwithtemplate/suspend.yaml
+++ b/charts/vela-core/templates/defwithtemplate/suspend.yaml
@@ -12,8 +12,9 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/builtin"
-
+        import (
+        	"vela/builtin"
+        )
         suspend: builtin.#Suspend & {
         	$params: parameter
         }

--- a/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
+++ b/charts/vela-core/templates/defwithtemplate/vela-cli.yaml
@@ -12,10 +12,11 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/kube"
-        import "vela/builtin"
-        import "vela/util"
-
+        import (
+        	"vela/kube"
+        	"vela/builtin"
+        	"vela/util"
+        )
         mountsArray: [
         	if parameter.storage != _|_ && parameter.storage.secret != _|_ for v in parameter.storage.secret {
         		{

--- a/charts/vela-core/templates/defwithtemplate/webhook.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webhook.yaml
@@ -12,12 +12,13 @@ spec:
   schematic:
     cue:
       template: |
-        import "vela/http"
-        import "vela/kube"
-        import "vela/util"
-        import "encoding/json"
-        import "encoding/base64"
-
+        import (
+        	"vela/http"
+        	"vela/kube"
+        	"vela/util"
+        	"encoding/json"
+        	"encoding/base64"
+        )
         data: {
         	if parameter.data == _|_ {
         		read: kube.#Read & {

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -11,9 +11,10 @@ spec:
   schematic:
     cue:
       template: |
-        import "strconv"
-        import "strings"
-
+        import (
+        	"strconv"
+        	"strings"
+        )
         mountsArray: [
         	if parameter.volumeMounts != _|_ && parameter.volumeMounts.pvc != _|_ for v in parameter.volumeMounts.pvc {
         		{

--- a/cmd/core/app/config/cue.go
+++ b/cmd/core/app/config/cue.go
@@ -17,21 +17,29 @@ limitations under the License.
 package config
 
 import (
+	"context"
+
 	"github.com/kubevela/pkg/cue/cuex"
 	"github.com/spf13/pflag"
+
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 )
 
 // CUEConfig contains CUE language configuration.
 type CUEConfig struct {
-	EnableExternalPackage      bool
-	EnableExternalPackageWatch bool
+	EnableExternalPackage         bool
+	EnableExternalPackageWatch    bool
+	EnableCUEVersionCompatibility bool
+	CUECompatibilityCacheSize     int
 }
 
 // NewCUEConfig creates a new CUEConfig with defaults.
 func NewCUEConfig() *CUEConfig {
 	return &CUEConfig{
-		EnableExternalPackage:      cuex.EnableExternalPackageForDefaultCompiler,
-		EnableExternalPackageWatch: cuex.EnableExternalPackageWatchForDefaultCompiler,
+		EnableExternalPackage:         cuex.EnableExternalPackageForDefaultCompiler,
+		EnableExternalPackageWatch:    cuex.EnableExternalPackageWatchForDefaultCompiler,
+		EnableCUEVersionCompatibility: upgrade.EnableCUEVersionCompatibility,
+		CUECompatibilityCacheSize:     upgrade.CompatibilityCacheSize,
 	}
 }
 
@@ -45,6 +53,14 @@ func (c *CUEConfig) AddFlags(fs *pflag.FlagSet) {
 		"enable-external-package-watch-for-default-compiler",
 		c.EnableExternalPackageWatch,
 		"Enable watching for changes in external CUE packages and automatically reload them when modified. Requires enable-external-package-for-default-compiler to be enabled.")
+	fs.BoolVar(&c.EnableCUEVersionCompatibility,
+		"enable-cue-version-compatibility",
+		c.EnableCUEVersionCompatibility,
+		"Automatically rewrite legacy CUE syntax in stored definitions at render time.")
+	fs.IntVar(&c.CUECompatibilityCacheSize,
+		"cue-compatibility-cache-size",
+		c.CUECompatibilityCacheSize,
+		"Maximum number of CUE templates to cache after version compatibility rewriting.")
 }
 
 // SyncToCUEGlobals syncs the parsed configuration values to CUE package global variables.
@@ -54,8 +70,11 @@ func (c *CUEConfig) AddFlags(fs *pflag.FlagSet) {
 // variables in the cuex package. Ideally, the CUE compiler configuration should be injected
 // rather than relying on globals.
 //
-// The flow is: CLI flags -> CUEConfig struct fields -> cuex globals (via this method)
-func (c *CUEConfig) SyncToCUEGlobals() {
+// The flow is: CLI flags -> CUEConfig struct fields -> cuex/upgrade globals (via this method)
+// ctx should be the controller's root context so cache eviction goroutines are tied to its lifetime.
+func (c *CUEConfig) SyncToCUEGlobals(ctx context.Context) {
 	cuex.EnableExternalPackageForDefaultCompiler = c.EnableExternalPackage
 	cuex.EnableExternalPackageWatchForDefaultCompiler = c.EnableExternalPackageWatch
+	upgrade.EnableCUEVersionCompatibility = c.EnableCUEVersionCompatibility
+	upgrade.InitCompatibilityCache(ctx, c.CUECompatibilityCacheSize)
 }

--- a/cmd/core/app/options/options_test.go
+++ b/cmd/core/app/options/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -248,7 +249,7 @@ func TestCuexOptions_SyncToGlobals(t *testing.T) {
 	assert.False(t, cuex.EnableExternalPackageWatchForDefaultCompiler)
 
 	// After sync, globals should be updated
-	opts.CUE.SyncToCUEGlobals()
+	opts.CUE.SyncToCUEGlobals(context.Background())
 	assert.True(t, cuex.EnableExternalPackageForDefaultCompiler)
 	assert.True(t, cuex.EnableExternalPackageWatchForDefaultCompiler)
 }
@@ -597,8 +598,8 @@ func TestCoreOptions_MultipleSyncCalls(t *testing.T) {
 	opts.Performance.PerfEnabled = true
 
 	// Call sync multiple times
-	opts.CUE.SyncToCUEGlobals()
-	opts.CUE.SyncToCUEGlobals()
+	opts.CUE.SyncToCUEGlobals(context.Background())
+	opts.CUE.SyncToCUEGlobals(context.Background())
 
 	opts.Workflow.SyncToWorkflowGlobals()
 	opts.Workflow.SyncToWorkflowGlobals()
@@ -849,7 +850,7 @@ func TestCoreOptions_CLIOverridesWork(t *testing.T) {
 	opt.OAM.SyncToOAMGlobals()
 	opt.Application.SyncToApplicationGlobals()
 	opt.Performance.SyncToPerformanceGlobals()
-	opt.CUE.SyncToCUEGlobals()
+	opt.CUE.SyncToCUEGlobals(context.Background())
 
 	// Verify globals got the CLI values
 	assert.Equal(t, 999, wfTypes.MaxWorkflowWaitBackoffTime, "Global should have CLI value")
@@ -917,7 +918,7 @@ func TestCoreOptions_CompleteIntegration(t *testing.T) {
 	assert.Equal(t, 30*time.Second, opt.MultiCluster.ClusterMetricsInterval)
 
 	// Sync all configurations that need it
-	opt.CUE.SyncToCUEGlobals()
+	opt.CUE.SyncToCUEGlobals(context.Background())
 	opt.Workflow.SyncToWorkflowGlobals()
 	opt.Resource.SyncToResourceGlobals()
 	opt.OAM.SyncToOAMGlobals()

--- a/cmd/core/app/server.go
+++ b/cmd/core/app/server.go
@@ -110,7 +110,7 @@ func run(ctx context.Context, coreOptions *options.CoreOptions) error {
 
 	// Sync configurations
 	klog.V(2).InfoS("Syncing configurations to global variables")
-	syncConfigurations(coreOptions)
+	syncConfigurations(ctx, coreOptions)
 	klog.InfoS("Configuration sync completed successfully")
 
 	// Setup logging
@@ -200,14 +200,14 @@ func run(ctx context.Context, coreOptions *options.CoreOptions) error {
 }
 
 // syncConfigurations syncs parsed config values to external package global variables
-func syncConfigurations(coreOptions *options.CoreOptions) {
+func syncConfigurations(ctx context.Context, coreOptions *options.CoreOptions) {
 	if coreOptions.Workflow != nil {
 		klog.V(3).InfoS("Syncing workflow configuration")
 		coreOptions.Workflow.SyncToWorkflowGlobals()
 	}
 	if coreOptions.CUE != nil {
 		klog.V(3).InfoS("Syncing CUE configuration")
-		coreOptions.CUE.SyncToCUEGlobals()
+		coreOptions.CUE.SyncToCUEGlobals(ctx)
 	}
 	if coreOptions.Application != nil {
 		klog.V(3).InfoS("Syncing application configuration")

--- a/cmd/core/app/server_test.go
+++ b/cmd/core/app/server_test.go
@@ -150,11 +150,11 @@ var _ = Describe("Server Tests", func() {
 				coreOpts.Kubernetes.InformerSyncPeriod = 10 * time.Hour
 
 				// Call sync function
-				syncConfigurations(coreOpts)
+				syncConfigurations(context.Background(), coreOpts)
 
 				// Verify globals were updated (this is a smoke test - actual values depend on implementation)
 				// The key point is the function runs without panicking
-				Expect(func() { syncConfigurations(coreOpts) }).NotTo(Panic())
+				Expect(func() { syncConfigurations(context.Background(), coreOpts) }).NotTo(Panic())
 			})
 		})
 
@@ -171,7 +171,7 @@ var _ = Describe("Server Tests", func() {
 
 				// Should not panic even with nil fields
 				Expect(func() {
-					syncConfigurations(opts)
+					syncConfigurations(context.Background(), opts)
 				}).NotTo(Panic())
 			})
 		})
@@ -181,7 +181,7 @@ var _ = Describe("Server Tests", func() {
 				nilOpts := &options.CoreOptions{}
 				// Should not panic even with nil fields
 				Expect(func() {
-					syncConfigurations(nilOpts)
+					syncConfigurations(context.Background(), nilOpts)
 				}).NotTo(Panic())
 			})
 		})

--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/pkg/cue/definition/health"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -405,11 +406,30 @@ func ConvertTemplateJSON2Object(capabilityName string, in *runtime.RawExtension,
 	return t, nil
 }
 
+// definitionKind returns the upgrade.DefinitionKind for this template, derived from
+// whichever definition pointer is populated. Defaults to ComponentKind.
+func (t *Template) definitionKind() upgrade.DefinitionKind {
+	switch {
+	case t.TraitDefinition != nil:
+		return upgrade.TraitKind
+	case t.PolicyDefinition != nil:
+		return upgrade.PolicyKind
+	case t.WorkflowStepDefinition != nil:
+		return upgrade.WorkflowStepKind
+	default:
+		return upgrade.ComponentKind
+	}
+}
+
 func (t *Template) AsStatusRequest(parameter map[string]interface{}) *health.StatusRequest {
+	kind := t.definitionKind()
+	healthCUE := upgrade.EnsureCueVersionCompatibility(t.Health, "health", kind, upgrade.TemplateAreaHealth)
+	customCUE := upgrade.EnsureCueVersionCompatibility(t.CustomStatus, "customStatus", kind, upgrade.TemplateAreaCustomStatus)
+	detailsCUE := upgrade.EnsureCueVersionCompatibility(t.Details, "statusDetails", kind, upgrade.TemplateAreaStatusDetail)
 	return &health.StatusRequest{
-		Health:    t.Health,
-		Custom:    t.CustomStatus,
-		Details:   t.Details,
+		Health:    healthCUE,
+		Custom:    customCUE,
+		Details:   detailsCUE,
 		Parameter: parameter,
 	}
 }

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -32,6 +32,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
 	cueutils "github.com/oam-dev/kubevela/pkg/cue"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/features"
 
 	"github.com/pkg/errors"
@@ -126,8 +127,11 @@ func (p *Parser) ValidateComponentParams(ctxData velaprocess.ContextData, wl *Co
 		return errors.WithMessagef(err, "component %q: invalid params", wl.Name)
 	}
 
+	// Apply the cue compatibility upgrades so that the render path applies
+	templateStr := upgrade.EnsureCueVersionCompatibility(wl.FullTemplate.TemplateStr, wl.Name, upgrade.ComponentKind, upgrade.TemplateAreaMain)
+
 	cueSrc := strings.Join([]string{
-		renderTemplate(wl.FullTemplate.TemplateStr),
+		renderTemplate(templateStr),
 		paramSnippet,
 		baseCtx,
 	}, "\n")
@@ -158,7 +162,7 @@ func (p *Parser) ValidateComponentParams(ctxData velaprocess.ContextData, wl *Co
 	if utilfeature.DefaultMutableFeatureGate.Enabled(features.ValidateUndeclaredParameters) {
 		// Compile the template WITHOUT user params to get the pure schema.
 		schemaSrc := strings.Join([]string{
-			renderTemplate(wl.FullTemplate.TemplateStr),
+			renderTemplate(templateStr),
 			baseCtx,
 		}, "\n")
 		schemaRoot, schemaErr := cuex.DefaultCompiler.Get().CompileString(ctx.GetCtx(), schemaSrc)
@@ -183,7 +187,7 @@ func (p *Parser) ValidateComponentParams(ctxData velaprocess.ContextData, wl *Co
 					condSnippet, fErr := cueParamBlock(filteredParams)
 					if fErr == nil {
 						condSrc := strings.Join([]string{
-							renderTemplate(wl.FullTemplate.TemplateStr),
+							renderTemplate(templateStr),
 							condSnippet,
 							baseCtx,
 						}, "\n")
@@ -620,8 +624,9 @@ func (p *Parser) augmentComponentParamsForValidation(wl *Component, workflowPara
 		return false, wl.Params
 	}
 
+	templateStr := upgrade.EnsureCueVersionCompatibility(wl.FullTemplate.TemplateStr, wl.Name, upgrade.ComponentKind, upgrade.TemplateAreaMain)
 	cueSrc := strings.Join([]string{
-		renderTemplate(wl.FullTemplate.TemplateStr),
+		renderTemplate(templateStr),
 		paramSnippet,
 		baseCtx,
 	}, "\n")

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/features"
 )
 
@@ -181,6 +182,7 @@ func TestParser_ValidateComponentParams(t *testing.T) {
 		template string
 		params   map[string]interface{}
 		wantErr  string
+		setup    func(t *testing.T)
 	}{
 		{
 			name:     "valid params and template",
@@ -266,10 +268,35 @@ func TestParser_ValidateComponentParams(t *testing.T) {
 			},
 			wantErr: "parameter constraint violation",
 		},
+		{
+			name:     "legacy list-arithmetic syntax is accepted when flag enabled",
+			compName: "legacy-list",
+			template: `
+			envWithDefaults: parameter.env + [{name: "MANAGED_BY", value: "kubevela"}]
+			output: {
+				apiVersion: "apps/v1"
+				kind: "Deployment"
+				spec: containers: [{env: envWithDefaults}]
+			}
+			parameter: {
+				env: *[] | [...{name: string, value?: string}]
+			}
+			`,
+			params:  map[string]interface{}{},
+			wantErr: "",
+			setup: func(t *testing.T) {
+				prev := upgrade.EnableCUEVersionCompatibility
+				upgrade.EnableCUEVersionCompatibility = true
+				t.Cleanup(func() { upgrade.EnableCUEVersionCompatibility = prev })
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
 			wl := &Component{
 				Name:         tc.compName,
 				Type:         "worker",
@@ -1277,5 +1304,57 @@ func TestValidateCUESchematicAppfile_WorkflowSuppliedParams(t *testing.T) {
 		p := &Parser{}
 		err := p.ValidateCUESchematicAppfile(appfile)
 		assert.NoError(t, err, "Should use existing param value, not augment from workflow")
+	})
+}
+
+func TestValidateCUESchematicAppfile_LegacySyntax(t *testing.T) {
+	assert.NoError(t, utilfeature.DefaultMutableFeatureGate.Set(string(features.EnableCueValidation)+"=true"))
+	t.Cleanup(func() {
+		assert.NoError(t, utilfeature.DefaultMutableFeatureGate.Set(string(features.EnableCueValidation)+"=false"))
+	})
+
+	legacyTemplate := `
+		envWithDefaults: parameter.env + [{name: "MANAGED_BY", value: "kubevela"}]
+		output: {
+			apiVersion: "apps/v1"
+			kind: "Deployment"
+			spec: containers: [{env: envWithDefaults}]
+		}
+		parameter: {
+			env: *[] | [...{name: string, value?: string}]
+		}
+	`
+
+	newAppfile := func(template string) *Appfile {
+		return &Appfile{
+			Name:      "test-app",
+			Namespace: "test-ns",
+			ParsedComponents: []*Component{{
+				Name:               "my-comp",
+				Type:               "worker",
+				CapabilityCategory: types.CUECategory,
+				Params:             map[string]any{},
+				FullTemplate:       &Template{TemplateStr: template},
+				engine:             definition.NewWorkloadAbstractEngine("my-comp"),
+			}},
+		}
+	}
+
+	t.Run("legacy list-arithmetic is accepted when flag enabled", func(t *testing.T) {
+		original := upgrade.EnableCUEVersionCompatibility
+		upgrade.EnableCUEVersionCompatibility = true
+		t.Cleanup(func() { upgrade.EnableCUEVersionCompatibility = original })
+
+		err := (&Parser{}).ValidateCUESchematicAppfile(newAppfile(legacyTemplate))
+		assert.NoError(t, err)
+	})
+
+	t.Run("legacy list-arithmetic is rejected when flag disabled", func(t *testing.T) {
+		original := upgrade.EnableCUEVersionCompatibility
+		upgrade.EnableCUEVersionCompatibility = false
+		t.Cleanup(func() { upgrade.EnableCUEVersionCompatibility = original })
+
+		err := (&Parser{}).ValidateCUESchematicAppfile(newAppfile(legacyTemplate))
+		assert.Error(t, err)
 	})
 }

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
@@ -47,6 +47,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/config"
 	velaprocess "github.com/oam-dev/kubevela/pkg/cue/process"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
@@ -561,8 +562,9 @@ func (h *AppHandler) renderPolicyCUETemplate(ctx monitorContext.Context, app *v1
 		return cue.Value{}, errors.Wrap(err, "failed to generate base context")
 	}
 
+	template := upgrade.EnsureCueVersionCompatibility(policyDef.Spec.Schematic.CUE.Template, policyDef.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
 	cueSource := strings.Join([]string{
-		policyDef.Spec.Schematic.CUE.Template,
+		template,
 		paramFile,
 		baseContext,
 	}, "\n")

--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
@@ -28,6 +28,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/features"
 	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
 )
@@ -84,10 +85,13 @@ func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition) *PolicyValidatio
 		}
 	}
 
-	// CUE syntax validation (output field structure is validated at render time)
-	if err := webhookutils.ValidateCueTemplate(policy.Spec.Schematic.CUE.Template); err != nil {
+	// CUE syntax validation (output field structure is validated at render time).
+	// Upgrade legacy syntax before validating so definitions using deprecated constructs
+	// are accepted and auto-upgraded at render time.
+	cueTemplate := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
+	if err := webhookutils.ValidateCueTemplate(cueTemplate); err != nil {
 		result.Errors = append(result.Errors, err.Error())
-	} else if err := validateEnabledFieldType(policy.Spec.Schematic.CUE.Template); err != nil {
+	} else if err := validateEnabledFieldType(cueTemplate); err != nil {
 		result.Errors = append(result.Errors, err.Error())
 	}
 
@@ -151,7 +155,7 @@ func isASTBoolExpr(expr ast.Expr) bool {
 // validateNoRequiredParameters checks that all parameters have default values
 // For global policies, ALL parameters must have defaults since users can't provide values
 func validateNoRequiredParameters(policy *v1beta1.PolicyDefinition) error {
-	cueTemplate := policy.Spec.Schematic.CUE.Template
+	cueTemplate := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
 
 	ctx := cuecontext.New()
 	value := ctx.CompileString(cueTemplate)

--- a/pkg/cue/definition/metrics.go
+++ b/pkg/cue/definition/metrics.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// CUERenderDuration measures the end-to-end duration of a definition Complete call,
+// covering CUE version compatibility rewriting, compilation, and validation.
+// Labels:
+//   - definition_kind: definition type, e.g. "Component", "Trait"
+//   - status: "ok" on success, "error" on failure
+//
+// Use this metric to track overall render latency per definition type.
+var CUERenderDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	Name: "kubevela_cue_render_duration_seconds",
+	Help: "End-to-end duration of CUE definition rendering (compat rewrite + compile + validate), by definition kind and status.",
+	Objectives: map[float64]float64{
+		0.5:  0.05,
+		0.9:  0.01,
+		0.99: 0.001,
+	},
+}, []string{"definition_kind", "status"})
+
+func init() {
+	metrics.Registry.MustRegister(CUERenderDuration)
+}

--- a/pkg/cue/definition/template.go
+++ b/pkg/cue/definition/template.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
@@ -46,6 +47,7 @@ import (
 
 	velaprocess "github.com/oam-dev/kubevela/pkg/cue/process"
 	"github.com/oam-dev/kubevela/pkg/cue/task"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
@@ -106,7 +108,16 @@ func NewWorkloadAbstractEngine(name string) AbstractEngine {
 }
 
 // Complete do workload definition's rendering
-func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, params interface{}) error {
+func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, params interface{}) (retErr error) {
+	start := time.Now()
+	defer func() {
+		status := "ok"
+		if retErr != nil {
+			status = "error"
+		}
+		CUERenderDuration.WithLabelValues(string(upgrade.ComponentKind), status).Observe(time.Since(start).Seconds())
+	}()
+
 	var paramFile = velaprocess.ParameterFieldName + ": {}"
 	if params != nil {
 		bt, err := json.Marshal(params)
@@ -123,10 +134,11 @@ func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, pa
 		return err
 	}
 
+	abstractTemplate = upgrade.EnsureCueVersionCompatibility(abstractTemplate, wd.name, upgrade.ComponentKind, upgrade.TemplateAreaMain)
+
 	val, err := cuex.DefaultCompiler.Get().CompileString(ctx.GetCtx(), strings.Join([]string{
 		renderTemplate(abstractTemplate), paramFile, c,
 	}, "\n"))
-
 	if err != nil {
 		return errors.WithMessagef(err, "failed to compile workload %s after merge parameter and context", wd.name)
 	}
@@ -278,7 +290,17 @@ func NewTraitAbstractEngine(name string) AbstractEngine {
 
 // Complete do trait definition's rendering
 // nolint:gocyclo
-func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, params interface{}) error {
+func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, params interface{}) (retErr error) {
+	start := time.Now()
+	defer func() {
+		status := "ok"
+		if retErr != nil {
+			status = "error"
+		}
+		CUERenderDuration.WithLabelValues(string(upgrade.TraitKind), status).Observe(time.Since(start).Seconds())
+	}()
+
+	abstractTemplate = upgrade.EnsureCueVersionCompatibility(abstractTemplate, td.name, upgrade.TraitKind, upgrade.TemplateAreaMain)
 	buff := abstractTemplate + "\n"
 	if params != nil {
 		bt, err := json.Marshal(params)
@@ -310,7 +332,6 @@ func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, param
 	buff += c
 
 	val, err := cuex.DefaultCompiler.Get().CompileString(ctx.GetCtx(), buff)
-
 	if err != nil {
 		return errors.WithMessagef(err, "failed to compile trait %s after merge parameter and context", td.name)
 	}

--- a/pkg/cue/upgrade/cache.go
+++ b/pkg/cue/upgrade/cache.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// CompatibilityCacheSize is the maximum number of cache entries. Default 2000
+// Overridden at startup via --cue-compatibility-cache-size.
+var CompatibilityCacheSize = 2000
+
+// compatCache stores the result of each template compatibility check, keyed by SHA-256 of the raw template.
+var compatCache = newLRUCache(CompatibilityCacheSize)
+
+// compatCacheCancel cancels the eviction goroutine of the current compatCache instance.
+var compatCacheCancel context.CancelFunc
+
+// CacheEntryTTL is how long an unaccessed entry lives before being swept.
+var CacheEntryTTL = 1 * time.Hour
+
+// InitCompatibilityCache reinitialises the cache with the given size and starts background TTL eviction.
+// Safe to call multiple times (e.g. in tests): the previous eviction goroutine is stopped before the
+// new cache is installed.
+func InitCompatibilityCache(ctx context.Context, size int) {
+	if compatCacheCancel != nil {
+		compatCacheCancel()
+	}
+	CompatibilityCacheSize = size
+	compatCache = newLRUCache(CompatibilityCacheSize)
+	cacheCtx, cancel := context.WithCancel(ctx)
+	compatCacheCancel = cancel
+	compatCache.startEvictionLoop(cacheCtx)
+}
+
+// templateHash returns the SHA-256 hex digest of s, used as the cache key.
+func templateHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", sum)
+}
+
+// compatEntry is the cached result for a single template.
+// If requiresUpgrade is false, upgraded is empty and the original template is returned as-is.
+type compatEntry struct {
+	requiresUpgrade bool
+	upgraded        string
+}
+
+// lruCache is a goroutine-safe LRU cache with TTL eviction.
+type lruCache struct {
+	mu       sync.Mutex
+	capacity int
+	ll       *list.List
+	items    map[string]*list.Element
+}
+
+type lruEntry struct {
+	key        string
+	value      compatEntry
+	lastAccess time.Time
+}
+
+func newLRUCache(capacity int) *lruCache {
+	return &lruCache{
+		capacity: capacity,
+		ll:       list.New(),
+		items:    make(map[string]*list.Element, capacity),
+	}
+}
+
+func (c *lruCache) startEvictionLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(CacheEntryTTL / 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.evictStale()
+			}
+		}
+	}()
+}
+
+func (c *lruCache) evictStale() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for key, el := range c.items {
+		if now.Sub(el.Value.(*lruEntry).lastAccess) > CacheEntryTTL {
+			c.ll.Remove(el)
+			delete(c.items, key)
+			CUECompatCacheEvictionsTotal.WithLabelValues("ttl").Inc()
+		}
+	}
+}
+
+func (c *lruCache) get(key string) (compatEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
+	if !ok {
+		return compatEntry{}, false
+	}
+	entry := el.Value.(*lruEntry)
+	entry.lastAccess = time.Now()
+	c.ll.MoveToFront(el)
+	return entry.value, true
+}
+
+func (c *lruCache) put(key string, value compatEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		entry := el.Value.(*lruEntry)
+		entry.value = value
+		entry.lastAccess = time.Now()
+		c.ll.MoveToFront(el)
+		return
+	}
+	if c.ll.Len() >= c.capacity {
+		oldest := c.ll.Back()
+		if oldest != nil {
+			c.ll.Remove(oldest)
+			delete(c.items, oldest.Value.(*lruEntry).key)
+			CUECompatCacheEvictionsTotal.WithLabelValues("capacity").Inc()
+		}
+	}
+	el := c.ll.PushFront(&lruEntry{key: key, value: value, lastAccess: time.Now()})
+	c.items[key] = el
+}
+
+func (c *lruCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ll.Len()
+}

--- a/pkg/cue/upgrade/cache_test.go
+++ b/pkg/cue/upgrade/cache_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"testing"
+)
+
+func entry(requiresUpgrade bool, upgraded string) compatEntry {
+	return compatEntry{requiresUpgrade: requiresUpgrade, upgraded: upgraded}
+}
+
+func TestLRUCacheBasic(t *testing.T) {
+	c := newLRUCache(3)
+
+	c.put("a", entry(false, "1"))
+	c.put("b", entry(false, "2"))
+	c.put("c", entry(false, "3"))
+
+	if v, ok := c.get("a"); !ok || v.upgraded != "1" {
+		t.Errorf("expected a.upgraded=1, got %q %v", v.upgraded, ok)
+	}
+
+	// Adding a 4th entry should evict the LRU — "b" (least recently used after "a" was promoted)
+	c.put("d", entry(false, "4"))
+	if _, ok := c.get("b"); ok {
+		t.Error("expected b to be evicted")
+	}
+	if v, ok := c.get("d"); !ok || v.upgraded != "4" {
+		t.Errorf("expected d.upgraded=4, got %q %v", v.upgraded, ok)
+	}
+}
+
+func TestLRUCacheUpdate(t *testing.T) {
+	c := newLRUCache(2)
+	c.put("a", entry(false, "1"))
+	c.put("a", entry(true, "2"))
+	if v, ok := c.get("a"); !ok || v.upgraded != "2" || !v.requiresUpgrade {
+		t.Errorf("expected updated value a.upgraded=2 requiresUpgrade=true, got %q %v %v", v.upgraded, v.requiresUpgrade, ok)
+	}
+	if c.len() != 1 {
+		t.Errorf("expected len 1, got %d", c.len())
+	}
+}
+
+func TestLRUCacheCapacity(t *testing.T) {
+	capacity := 10
+	c := newLRUCache(capacity)
+	for i := range capacity * 2 {
+		c.put(string(rune('a'+i)), entry(false, ""))
+	}
+	if c.len() != capacity {
+		t.Errorf("expected len %d, got %d", capacity, c.len())
+	}
+}
+
+func TestEnsureCueVersionCompatibilityCacheHit(t *testing.T) {
+	compatCache = newLRUCache(512)
+
+	input := `
+list1: [1, 2, 3]
+list2: [4, 5, 6]
+combined: list1 + list2
+`
+	// First call — cache miss, runs upgrade
+	result1 := EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+
+	const sentinel = "CACHE_HIT_SENTINEL"
+	key := templateHash(input)
+	compatCache.put(key, compatEntry{requiresUpgrade: true, upgraded: sentinel})
+
+	// Second call — must return the sentinel from cache, not a freshly computed value
+	result2 := EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+
+	if result2 != sentinel {
+		t.Errorf("second call did not use cache: expected sentinel %q, got %q (first result was %q)", sentinel, result2, result1)
+	}
+	if compatCache.len() != 1 {
+		t.Errorf("expected 1 cache entry, got %d", compatCache.len())
+	}
+}
+
+func TestEnsureCueVersionCompatibilityAlreadyCompatible(t *testing.T) {
+	compatCache = newLRUCache(512)
+
+	// Use canonical CUE formatting (no leading newline, blank line after import).
+	input := `import "list"
+
+list1: [1, 2, 3]
+list2: [4, 5, 6]
+combined: list.Concat([list1, list2])`
+	result1 := EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+	if result1 != input {
+		t.Errorf("already-compatible template should be returned unchanged on first call, got %q", result1)
+	}
+	const sentinel = "CACHE_HIT_SENTINEL"
+	key := templateHash(input)
+	compatCache.put(key, compatEntry{requiresUpgrade: true, upgraded: sentinel})
+
+	result2 := EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+	if result2 != sentinel {
+		t.Errorf("second call did not use cache: expected sentinel %q, got %q", sentinel, result2)
+	}
+	if compatCache.len() != 1 {
+		t.Errorf("expected 1 cache entry, got %d", compatCache.len())
+	}
+}

--- a/pkg/cue/upgrade/metrics.go
+++ b/pkg/cue/upgrade/metrics.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// CUECompatRewriteTotal counts the number of CUE compatibility rewrites applied at render time.
+// Labels:
+//   - upgrade_id: stable fix identifier, e.g. "list-arithmetic"
+//   - upgrade_version: KubeVela version that introduced the incompatibility, e.g. "1.11"
+//   - definition_kind: definition type, e.g. "Component"
+//   - template_area: which part of the definition was rewritten, e.g. "template", "health"
+//
+// Use this metric to track which legacy syntax fixes are still active cluster-wide.
+// The metric is the smoke detector; run `vela def compat definitions` to identify which
+// specific definitions need remediation.
+var CUECompatRewriteTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "kubevela_cue_compat_rewrite_total",
+	Help: "Total number of CUE compatibility rewrites applied at render time, by upgrade ID, version introduced, definition kind, and template area.",
+}, []string{"upgrade_id", "upgrade_version", "definition_kind", "template_area"})
+
+// CUECompatUpgradeDuration measures how long EnsureCueVersionCompatibility takes per call.
+// Only recorded on cache misses (i.e. when the actual upgrade logic runs).
+// Labels:
+//   - definition_kind: definition type, e.g. "Component"
+//
+// Use _count for frequency and quantiles for latency of the upgrade work itself.
+// Cache hits are not recorded — they are too cheap to be meaningful.
+var CUECompatUpgradeDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	Name: "kubevela_cue_compat_upgrade_duration_seconds",
+	Help: "Duration of CUE version compatibility checks at render time (cache misses only), by definition kind.",
+	Objectives: map[float64]float64{
+		0.5:  0.05,
+		0.9:  0.01,
+		0.99: 0.001,
+	},
+}, []string{"definition_kind"})
+
+// CUECompatCacheEvictionsTotal counts cache entries evicted, by reason.
+// Labels:
+//   - reason: "capacity" (LRU eviction when cache is full) or "ttl" (idle entry swept by background loop)
+//
+// A sustained capacity eviction rate means the working set exceeds cache size;
+// increase --cue-compatibility-cache-size or migrate definitions to compliant CUE
+// syntax (run `vela def compat` to identify which definitions need remediation).
+var CUECompatCacheEvictionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "kubevela_cue_compat_cache_evictions_total",
+	Help: "Total number of CUE compatibility cache evictions, by reason (capacity or ttl).",
+}, []string{"reason"})
+
+func init() {
+	metrics.Registry.MustRegister(
+		CUECompatRewriteTotal,
+		CUECompatUpgradeDuration,
+		CUECompatCacheEvictionsTotal,
+	)
+}

--- a/pkg/cue/upgrade/upgrade.go
+++ b/pkg/cue/upgrade/upgrade.go
@@ -18,119 +18,454 @@ package upgrade
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
-	"github.com/oam-dev/kubevela/version"
+	"cuelang.org/go/cue"
+	cueast "cuelang.org/go/cue/ast"
+	cueformat "cuelang.org/go/cue/format"
+	cueparser "cuelang.org/go/cue/parser"
+	"k8s.io/klog/v2"
+
+	velaversion "github.com/oam-dev/kubevela/version"
 )
 
-// UpgradeFunc represents a function that upgrades CUE code for version compatibility
-type UpgradeFunc func(string) (string, error)
+// EnableCUEVersionCompatibility controls whether EnsureCueVersionCompatibility is applied at
+// render time. Defaults to true. Can be disabled via --enable-cue-version-compatibility=false
+var EnableCUEVersionCompatibility = true
 
-// upgradeRegistry holds upgrade functions for different CUE versions
-var upgradeRegistry = make(map[string][]UpgradeFunc)
+// DefinitionKind identifies the type of definition for metrics, logs, and compatibility reports.
+// It is an open string type — each consuming repo declares its own constants.
+// Values should match the definition's Kind string for consistency, e.g. "Component", "Trait".
+type DefinitionKind string
 
-// RegisterUpgrade registers an upgrade function for a specific KubeVela version
-// version should be in format "1.11", "1.12", etc.
-func RegisterUpgrade(version string, upgradeFunc UpgradeFunc) {
-	upgradeRegistry[version] = append(upgradeRegistry[version], upgradeFunc)
+const (
+	// ComponentKind represents a ComponentDefinition.
+	ComponentKind DefinitionKind = "Component"
+	// TraitKind represents a TraitDefinition.
+	TraitKind DefinitionKind = "Trait"
+	// PolicyKind represents a PolicyDefinition.
+	PolicyKind DefinitionKind = "Policy"
+	// WorkflowStepKind represents a WorkflowStepDefinition.
+	WorkflowStepKind DefinitionKind = "WorkflowStep"
+)
+
+// TemplateArea identifies which part of a definition's CUE template a rewrite was applied to.
+// It is an open string type — each consuming repo declares its own constants.
+type TemplateArea string
+
+const (
+	// TemplateAreaMain is the primary output/parameter template block.
+	TemplateAreaMain TemplateArea = "template"
+	// TemplateAreaHealth is the health check CUE block.
+	TemplateAreaHealth TemplateArea = "health"
+	// TemplateAreaCustomStatus is the custom status CUE block.
+	TemplateAreaCustomStatus TemplateArea = "custom_status"
+	// TemplateAreaStatusDetail is the status detail CUE block.
+	TemplateAreaStatusDetail TemplateArea = "status_detail"
+)
+
+// Version identifies a release version for upgrade ordering.
+type Version struct {
+	Major int
+	Minor int
 }
 
-// getCurrentKubeVelaMinorVersion extracts the minor version (e.g., "1.11") from the full KubeVela version
-func getCurrentKubeVelaMinorVersion() (string, error) {
-	versionStr := version.VelaVersion
+// String returns the canonical "Major.Minor" representation, e.g. "1.11".
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// less reports whether v is strictly earlier than other.
+func (v Version) less(other Version) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	return v.Minor < other.Minor
+}
+
+// ParseVersion parses a "Major.Minor" string (with optional leading "v") into a Version.
+func ParseVersion(s string) (Version, error) {
+	s = strings.TrimPrefix(s, "v")
+	re := regexp.MustCompile(`^(\d+)\.(\d+)(?:\.\d+)?(?:[+-].*)?$`)
+	m := re.FindStringSubmatch(s)
+	if len(m) < 3 {
+		return Version{}, fmt.Errorf("cannot parse version %q: expected Major.Minor format", s)
+	}
+	var v Version
+	fmt.Sscanf(m[1], "%d", &v.Major)
+	fmt.Sscanf(m[2], "%d", &v.Minor)
+	return v, nil
+}
+
+// upgradeEntry is the internal interface satisfied by all registered upgrade types.
+// It is unexported; callers interact via the concrete public types.
+type upgradeEntry interface {
+	// id returns the stable machine-readable identifier, e.g. "list-arithmetic".
+	id() string
+	// reason returns the human-readable description for compatibility reports.
+	reason() string
+	// source identifies the origin of the incompatibility, e.g. "cue" or "kubevela".
+	// Used in logs and compatibility reports to distinguish CUE language changes from
+	// KubeVela template changes.
+	source() string
+	// versionLabel returns the version string used in metrics and reason output, e.g. "1.11" or "v0.11.0".
+	versionLabel() string
+	// appliesToTarget reports whether this fix should be applied given the explicit target KubeVela version.
+	// For CUEUpgradeFunc this is determined by the runtime CUE language version, not the target.
+	appliesToTarget(target Version) bool
+	// precheck is an optional cheap heuristic; if set and returns false the fix is skipped.
+	precheck() func(string) bool
+	// upgrade applies the rewrite. Receives both raw string and pre-parsed AST.
+	upgrade() func(string, *cueast.File) (string, error)
+	// velaVersion returns the KubeVela Version associated with this entry, used for registry bucketing.
+	// CUEUpgradeFunc entries are bucketed under their associated KubeVela version (for ordering).
+	velaVersion() Version
+}
+
+// KubeVelaUpgradeFunc is a CUE compatibility fix triggered by a KubeVela version.
+// It applies when the running (or target) KubeVela version is >= VelaVersion.
+// Register with RegisterUpgrade.
+//
+// This type is intentionally self-contained: it can be constructed inline and
+// passed directly to RegisterUpgrade without any additional wiring:
+//
+//	RegisterUpgrade(KubeVelaUpgradeFunc{
+//	    ID:         "my-fix-1.12",
+//	    VelaVersion: Version{1, 12},
+//	    Reason:     "...",
+//	    Upgrade:    myFixFunc,
+//	})
+type KubeVelaUpgradeFunc struct {
+	ID          string // stable identifier, e.g. "list-arithmetic"
+	VelaVersion Version
+	Reason      string
+	Precheck    func(cueStr string) bool
+	Upgrade     func(cueStr string, file *cueast.File) (string, error)
+}
+
+func (u KubeVelaUpgradeFunc) id() string           { return u.ID }
+func (u KubeVelaUpgradeFunc) reason() string       { return u.Reason }
+func (u KubeVelaUpgradeFunc) source() string       { return "kubevela" }
+func (u KubeVelaUpgradeFunc) versionLabel() string { return u.VelaVersion.String() }
+func (u KubeVelaUpgradeFunc) velaVersion() Version { return u.VelaVersion }
+func (u KubeVelaUpgradeFunc) precheck() func(string) bool {
+	return u.Precheck
+}
+func (u KubeVelaUpgradeFunc) upgrade() func(string, *cueast.File) (string, error) {
+	return u.Upgrade
+}
+func (u KubeVelaUpgradeFunc) appliesToTarget(target Version) bool {
+	v := u.VelaVersion
+	return v.less(target) || v == target
+}
+
+// CUEUpgradeFunc is a CUE compatibility fix triggered by the CUE language version.
+// It applies when the running CUE language version (cue.LanguageVersion()) is >= CUEVersion,
+// regardless of the KubeVela version. The AssociatedVelaVersion field is used only for
+// registry ordering (fixes introduced at the same KubeVela release).
+//
+// Register with RegisterUpgrade:
+//
+//	RegisterUpgrade(CUEUpgradeFunc{
+//	    ID:                    "error-field-label",
+//	    CUEVersion:            Version{0, 14},
+//	    AssociatedVelaVersion: Version{1, 11},
+//	    Reason:                "...",
+//	    Upgrade:               myFixFunc,
+//	})
+type CUEUpgradeFunc struct {
+	ID                    string  // stable identifier
+	CUEVersion            Version // minimum CUE language version that introduced the change, e.g. Version{0, 14}
+	AssociatedVelaVersion Version // KubeVela version at which this fix was added (for ordering)
+	Reason                string
+	Precheck              func(cueStr string) bool
+	Upgrade               func(cueStr string, file *cueast.File) (string, error)
+}
+
+func (u CUEUpgradeFunc) id() string           { return u.ID }
+func (u CUEUpgradeFunc) reason() string       { return u.Reason }
+func (u CUEUpgradeFunc) source() string       { return "cue" }
+func (u CUEUpgradeFunc) versionLabel() string { return u.CUEVersion.String() }
+func (u CUEUpgradeFunc) velaVersion() Version { return u.AssociatedVelaVersion }
+func (u CUEUpgradeFunc) precheck() func(string) bool {
+	return u.Precheck
+}
+func (u CUEUpgradeFunc) upgrade() func(string, *cueast.File) (string, error) {
+	return u.Upgrade
+}
+func (u CUEUpgradeFunc) appliesToTarget(_ Version) bool {
+	// CUE-language fixes apply whenever the running CUE library is >= CUEVersion.
+	// The target KubeVela version is irrelevant.
+	current, err := ParseVersion(cue.LanguageVersion())
+	if err != nil {
+		return true // fail-open: apply the fix
+	}
+	return u.CUEVersion.less(current) || u.CUEVersion == current
+}
+
+// UpgradeFunc is a type alias for KubeVelaUpgradeFunc, preserved for backward compatibility.
+// New code should use KubeVelaUpgradeFunc or CUEUpgradeFunc directly.
+type UpgradeFunc = KubeVelaUpgradeFunc
+
+// upgradeRegistry holds all registered upgrade entries, keyed by their associated KubeVela Version.
+var upgradeRegistry = make(map[Version][]upgradeEntry)
+
+// RegisterUpgrade registers an upgrade entry. Both KubeVelaUpgradeFunc and CUEUpgradeFunc
+// satisfy the internal upgradeEntry interface and can be passed directly.
+func RegisterUpgrade(u upgradeEntry) {
+	if u.id() == "" {
+		panic(fmt.Sprintf("upgrade.RegisterUpgrade: upgrade entry for version %s has empty ID", u.velaVersion()))
+	}
+	v := u.velaVersion()
+	upgradeRegistry[v] = append(upgradeRegistry[v], u)
+}
+
+// sortedVersions returns all registered KubeVela versions in ascending order.
+func sortedVersions() []Version {
+	versions := make([]Version, 0, len(upgradeRegistry))
+	for v := range upgradeRegistry {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].less(versions[j])
+	})
+	return versions
+}
+
+// latestSupportedVersion returns the highest registered KubeVela version.
+func latestSupportedVersion() Version {
+	vs := sortedVersions()
+	return vs[len(vs)-1]
+}
+
+// getCurrentKubeVelaVersion parses the running KubeVela version into a Version.
+// If the version is unknown it returns the latest registered version.
+func getCurrentKubeVelaVersion() (Version, error) {
+	versionStr := velaversion.VelaVersion
 	if versionStr == "" || versionStr == "UNKNOWN" {
-		return "", fmt.Errorf("unable to determine KubeVela version (got %q). Please specify the target version explicitly using --target-version=1.11", versionStr)
+		latest := latestSupportedVersion()
+		klog.InfoS("cue/upgrade: KubeVela version is unknown (dev build), applying all upgrades", "assumedVersion", latest)
+		return latest, nil
 	}
-
-	// Remove 'v' prefix if present
-	versionStr = strings.TrimPrefix(versionStr, "v")
-
-	// Use regex to extract major.minor version (e.g., "1.11.2" -> "1.11")
-	re := regexp.MustCompile(`^(\d+\.\d+)`)
-	matches := re.FindStringSubmatch(versionStr)
-	if len(matches) >= 2 {
-		return matches[1], nil
+	v, err := ParseVersion(versionStr)
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to parse KubeVela version: %w. Please specify the target version explicitly using --target-version=1.11", err)
 	}
-
-	return "", fmt.Errorf("unable to parse KubeVela version %q. Please specify the target version explicitly using --target-version=1.11", versionStr)
+	return v, nil
 }
 
-// Upgrade applies all registered upgrades for KubeVela versions up to and including the target version
-// targetVersion should be in format "1.11", "1.12", etc.
-// If targetVersion is empty, applies upgrades for the current KubeVela CLI version
-func Upgrade(cueStr string, targetVersion ...string) (string, error) {
-	var version string
+// Upgrade applies all registered upgrades that apply to the given target version.
+// If no targetVersion is provided, uses the current KubeVela CLI version.
+func Upgrade(cueStr string, targetVersion ...Version) (string, error) {
+	var target Version
 	var err error
 
-	if len(targetVersion) > 0 && targetVersion[0] != "" {
-		version = targetVersion[0]
+	if len(targetVersion) > 0 {
+		target = targetVersion[0]
 	} else {
-		version, err = getCurrentKubeVelaMinorVersion() // Default to current CLI version
+		target, err = getCurrentKubeVelaVersion()
 		if err != nil {
 			return "", err
 		}
 	}
 
+	// Normalise whitespace before comparing so that formatting differences
+	// don't cause a template to appear as needing upgrade when it doesn't.
+	normalized, err := normalizeCUEWhitespace(cueStr)
+	if err == nil {
+		cueStr = normalized
+	}
+
 	result := cueStr
 
-	// Apply upgrades for all versions up to and including the target version
-	// Currently we only support 1.11, but this can be extended
-	supportedVersions := []string{"1.11"}
-
-	for _, v := range supportedVersions {
-		if shouldApplyUpgrade(v, version) {
-			if upgrades, exists := upgradeRegistry[v]; exists {
-				for _, upgrade := range upgrades {
-					result, err = upgrade(result)
-					if err != nil {
-						return cueStr, fmt.Errorf("failed to apply upgrade for version %s: %w", v, err)
-					}
-				}
+	for _, v := range sortedVersions() {
+		for _, u := range upgradeRegistry[v] {
+			if !u.appliesToTarget(target) {
+				continue
+			}
+			pc := u.precheck()
+			if pc != nil && !pc(result) {
+				continue
+			}
+			// Parse once per fix, after Precheck passes.
+			file, parseErr := cueparser.ParseFile("", result, cueparser.ParseComments)
+			if parseErr != nil {
+				return cueStr, fmt.Errorf("failed to parse CUE for upgrade %s: %w", v, parseErr)
+			}
+			result, err = u.upgrade()(result, file)
+			if err != nil {
+				return cueStr, fmt.Errorf("failed to apply upgrade for version %s: %w", v, err)
 			}
 		}
+	}
+
+	// Normalise the result so both input and output are in canonical form.
+	if normalizedResult, err := normalizeCUEWhitespace(result); err == nil {
+		result = normalizedResult
 	}
 
 	return result, nil
 }
 
-// shouldApplyUpgrade determines if upgrades for a given version should be applied
-// based on the target version
-func shouldApplyUpgrade(upgradeVersion, targetVersion string) bool {
-	// For now, simple string comparison works since we only have 1.11
-	// In the future, this could be enhanced with proper semantic version comparison
-	return upgradeVersion <= targetVersion
+// GetSupportedVersions returns all registered KubeVela versions in ascending order.
+func GetSupportedVersions() []Version {
+	return sortedVersions()
 }
 
-// GetSupportedVersions returns a list of supported upgrade versions
-func GetSupportedVersions() []string {
-	versions := make([]string, 0, len(upgradeRegistry))
-	for version := range upgradeRegistry {
-		versions = append(versions, version)
+// normalizeCUEWhitespace parses and reformats a CUE string to produce a canonical
+// representation, so that whitespace-only differences don't appear as upgrades.
+func normalizeCUEWhitespace(cueStr string) (string, error) {
+	f, err := cueparser.ParseFile("", cueStr, cueparser.ParseComments)
+	if err != nil {
+		return cueStr, err
 	}
-	return versions
+	b, err := cueformat.Node(f)
+	if err != nil {
+		return cueStr, err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
 }
 
-// RequiresUpgrade checks if the CUE string requires upgrading to the target version
-// Returns: (needsUpgrade bool, reasons []string, error)
-// If targetVersion is empty, uses the current KubeVela CLI version
-func RequiresUpgrade(cueStr string, targetVersion ...string) (bool, []string, error) {
-	var version string
+// appliedFix records a single upgrade fix that changed the template.
+type appliedFix struct {
+	id      string
+	version string
+}
+
+// upgradeWithIDs applies all registered upgrades and returns the rewritten CUE string along with
+// metadata for every fix that changed the template. Used internally to drive metrics.
+func upgradeWithIDs(cueStr string) (result string, applied []appliedFix, err error) {
+	target, err := getCurrentKubeVelaVersion()
+	if err != nil {
+		return cueStr, nil, err
+	}
+
+	normalized, normErr := normalizeCUEWhitespace(cueStr)
+	if normErr == nil {
+		cueStr = normalized
+	}
+
+	result = cueStr
+	for _, v := range sortedVersions() {
+		for _, u := range upgradeRegistry[v] {
+			if !u.appliesToTarget(target) {
+				continue
+			}
+			pc := u.precheck()
+			if pc != nil && !pc(result) {
+				continue
+			}
+			file, parseErr := cueparser.ParseFile("", result, cueparser.ParseComments)
+			if parseErr != nil {
+				return cueStr, nil, fmt.Errorf("failed to parse CUE for upgrade %s: %w", v, parseErr)
+			}
+			rewritten, upgradeErr := u.upgrade()(result, file)
+			if upgradeErr != nil {
+				return cueStr, nil, fmt.Errorf("failed to apply upgrade for version %s: %w", v, upgradeErr)
+			}
+			if rewritten != result {
+				applied = append(applied, appliedFix{id: u.id(), version: v.String()})
+			}
+			result = rewritten
+		}
+	}
+
+	if normalizedResult, normErr := normalizeCUEWhitespace(result); normErr == nil {
+		result = normalizedResult
+	}
+	return result, applied, nil
+}
+
+// EnsureCueVersionCompatibility applies all upgrades for the current KubeVela version to the
+// provided CUE string, ensuring backward compatibility with legacy CUE syntax
+// Returns the original string unchanged if EnableCUEVersionCompatibility is false.
+func EnsureCueVersionCompatibility(cueStr, defName string, defKind DefinitionKind, area TemplateArea) string {
+	if !EnableCUEVersionCompatibility {
+		return cueStr
+	}
+
+	key := templateHash(cueStr)
+	start := time.Now()
+
+	if entry, ok := compatCache.get(key); ok {
+		if !entry.requiresUpgrade {
+			klog.V(4).InfoS("cue/upgrade: skip (already compatible)", "definition", defName)
+			return cueStr
+		}
+		klog.V(4).InfoS("cue/upgrade: cache hit (upgraded template)", "definition", defName)
+		return entry.upgraded
+	}
+
+	upgraded, applied, err := upgradeWithIDs(cueStr)
+	elapsed := time.Since(start)
+	CUECompatUpgradeDuration.WithLabelValues(string(defKind)).Observe(elapsed.Seconds())
+
+	if err != nil {
+		klog.InfoS("cue/upgrade: skipping compatibility upgrade (fail-open)", "definition", defName, "err", err, "elapsed", elapsed)
+		return cueStr
+	}
+
+	if upgraded != cueStr {
+		compatCache.put(key, compatEntry{requiresUpgrade: true, upgraded: upgraded})
+		for _, fix := range applied {
+			CUECompatRewriteTotal.WithLabelValues(fix.id, fix.version, string(defKind), string(area)).Inc()
+		}
+		klog.InfoS("cue/upgrade: applied CUE version compatibility fixes", "definition", defName, "elapsed", elapsed)
+	} else {
+		compatCache.put(key, compatEntry{requiresUpgrade: false})
+		klog.V(4).InfoS("cue/upgrade: no compatibility fixes needed", "definition", defName, "elapsed", elapsed)
+	}
+
+	return upgraded
+}
+
+// RequiresUpgrade checks if the CUE string requires upgrading to the target version.
+// If no targetVersion is provided, uses the current KubeVela CLI version.
+func RequiresUpgrade(cueStr string, targetVersion ...Version) (bool, []string, error) {
+	var target Version
 	var err error
 
-	if len(targetVersion) > 0 && targetVersion[0] != "" {
-		version = targetVersion[0]
+	if len(targetVersion) > 0 {
+		target = targetVersion[0]
 	} else {
-		version, err = getCurrentKubeVelaMinorVersion()
+		target, err = getCurrentKubeVelaVersion()
 		if err != nil {
 			return false, nil, err
 		}
 	}
 
-	// For now, we only check for v1.11 upgrades
-	// In the future, this can check against multiple version requirements
-	if version >= "1.11" {
-		return requires111Upgrade(cueStr)
+	// Normalise whitespace so formatting-only differences don't appear as upgrades.
+	normalized, err := normalizeCUEWhitespace(cueStr)
+	if err == nil {
+		cueStr = normalized
 	}
 
-	return false, nil, nil
+	var allReasons []string
+
+	for _, v := range sortedVersions() {
+		for _, u := range upgradeRegistry[v] {
+			if !u.appliesToTarget(target) {
+				continue
+			}
+			pc := u.precheck()
+			if pc != nil && !pc(cueStr) {
+				continue
+			}
+			file, parseErr := cueparser.ParseFile("", cueStr, cueparser.ParseComments)
+			if parseErr != nil {
+				return false, nil, fmt.Errorf("failed to parse CUE for version %s: %w", v, parseErr)
+			}
+			result, err := u.upgrade()(cueStr, file)
+			if err != nil {
+				return false, nil, fmt.Errorf("failed to check upgrade for version %s: %w", v, err)
+			}
+			if result != cueStr {
+				allReasons = append(allReasons, fmt.Sprintf("[%s@%s] [%s] %s", u.source(), u.versionLabel(), u.id(), u.reason()))
+			}
+		}
+	}
+
+	return len(allReasons) > 0, allReasons, nil
 }

--- a/pkg/cue/upgrade/upgrade_1_11.go
+++ b/pkg/cue/upgrade/upgrade_1_11.go
@@ -17,68 +17,48 @@ package upgrade
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/ast/astutil"
 	"cuelang.org/go/cue/format"
-	"cuelang.org/go/cue/parser"
 	"cuelang.org/go/cue/token"
 )
 
+var v1_11 = Version{Major: 1, Minor: 11}
+
+// errorFieldLabelRe matches an unquoted `error` used as a field label, i.e. `error` followed by
+// optional whitespace and a colon. This avoids false positives on identifiers like `errorMessage`.
+var errorFieldLabelRe = regexp.MustCompile(`\berror\s*:`)
+
 func init() {
-	RegisterUpgrade("1.11", upgradeListConcatenation)
-}
+	// list arithmetic (+ and *) was deprecated in CUE v0.11 and became a hard error in v0.14.
+	// Associated with KubeVela 1.11 which first shipped CUE >= v0.14.
+	RegisterUpgrade(CUEUpgradeFunc{
+		ID:                    "list-arithmetic",
+		CUEVersion:            Version{0, 14},
+		AssociatedVelaVersion: v1_11,
+		Reason:                "contains deprecated list operators (+ or *) that need upgrading to list.Concat() or list.Repeat()",
+		Precheck:              func(s string) bool { return strings.Contains(s, "+") || strings.Contains(s, "*") },
+		Upgrade:               upgradeListConcatenation,
+	})
 
-func requires111Upgrade(cueStr string) (bool, []string, error) {
-	file, err := parser.ParseFile("", cueStr, parser.ParseComments)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to parse CUE: %w", err)
-	}
-
-	var reasons []string
-	if hasOldListConcatenation(file) {
-		reasons = append(reasons, "contains deprecated list operators (+ or *) that need upgrading to list.Concat() or list.Repeat()")
-	}
-
-	return len(reasons) > 0, reasons, nil
-}
-
-func hasOldListConcatenation(file *ast.File) bool {
-	listRegistry := collectListDeclarations(file)
-
-	found := false
-	astutil.Apply(file, func(cursor astutil.Cursor) bool {
-		if binExpr, ok := cursor.Node().(*ast.BinaryExpr); ok {
-			if binExpr.Op.String() == "+" {
-				if isListExpression(binExpr.X, listRegistry) && isListExpression(binExpr.Y, listRegistry) {
-					found = true
-					return false
-				}
-			}
-			if binExpr.Op.String() == "*" {
-				if (isListExpression(binExpr.X, listRegistry) && isNumericExpression(binExpr.Y, listRegistry)) ||
-					(isNumericExpression(binExpr.X, listRegistry) && isListExpression(binExpr.Y, listRegistry)) {
-					found = true
-					return false
-				}
-			}
-		}
-		return true
-	}, nil)
-
-	return found
+	// The `error` built-in was introduced in CUE v0.14; unquoted `error` field labels now conflict.
+	RegisterUpgrade(CUEUpgradeFunc{
+		ID:                    "error-field-label",
+		CUEVersion:            Version{0, 14},
+		AssociatedVelaVersion: v1_11,
+		Reason:                `contains field named 'error' which conflicts with the CUE 0.14 built-in; must be quoted as "error"`,
+		Precheck:              func(s string) bool { return errorFieldLabelRe.MatchString(s) },
+		Upgrade:               upgradeErrorFieldLabel,
+	})
 }
 
 // upgradeListConcatenation handles:
 // - list1 + list2 -> list.Concat([list1, list2])
 // - list * n -> list.Repeat(list, n)
-// - n * list -> list.Repeat(list, n)
-func upgradeListConcatenation(cueStr string) (string, error) {
-	file, err := parser.ParseFile("", cueStr, parser.ParseComments)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse CUE: %w", err)
-	}
-
+func upgradeListConcatenation(cueStr string, file *ast.File) (string, error) {
 	transformed := upgradeListConcatenationAST(file)
 
 	result, err := format.Node(transformed)
@@ -86,7 +66,7 @@ func upgradeListConcatenation(cueStr string) (string, error) {
 		return "", fmt.Errorf("failed to format CUE: %w", err)
 	}
 
-	return string(result), nil
+	return strings.TrimRight(string(result), "\n"), nil
 }
 
 func upgradeListConcatenationAST(file *ast.File) *ast.File {
@@ -97,19 +77,20 @@ func upgradeListConcatenationAST(file *ast.File) *ast.File {
 	result := astutil.Apply(file, func(cursor astutil.Cursor) bool {
 		if binExpr, ok := cursor.Node().(*ast.BinaryExpr); ok {
 			if binExpr.Op.String() == "+" {
-				if isListExpression(binExpr.X, listRegistry) && isListExpression(binExpr.Y, listRegistry) {
+				// Collect all operands from a left-associative + chain so that
+				// a + b + c + d becomes list.Concat([a, b, c, d]) in one pass
+				// rather than nested list.Concat(list.Concat(...)) calls.
+				operands := collectAddChain(binExpr, listRegistry)
+				if len(operands) >= 2 {
 					callExpr := &ast.CallExpr{
 						Fun: &ast.SelectorExpr{
 							X:   &ast.Ident{Name: "list"},
 							Sel: &ast.Ident{Name: "Concat"},
 						},
 						Args: []ast.Expr{
-							&ast.ListLit{
-								Elts: []ast.Expr{binExpr.X, binExpr.Y},
-							},
+							&ast.ListLit{Elts: operands},
 						},
 					}
-
 					cursor.Replace(callExpr)
 					needsListImport = true
 				}
@@ -152,6 +133,55 @@ func upgradeListConcatenationAST(file *ast.File) *ast.File {
 	}
 
 	return file
+}
+
+// collectAddChain flattens a left-associative + chain into a flat slice of operands,
+// returning nil if any operand is not a list expression (so non-list + is left alone).
+// If any operand is itself a list.Concat([...]) call (from a prior upgrade pass),
+// its inner elements are inlined so the result is always a single flat list.Concat call.
+func collectAddChain(expr ast.Expr, listRegistry map[string]bool) []ast.Expr {
+	bin, ok := expr.(*ast.BinaryExpr)
+	if !ok || bin.Op.String() != "+" {
+		if isListExpression(expr, listRegistry) {
+			return extractListConcatArgs(expr)
+		}
+		return nil
+	}
+	left := collectAddChain(bin.X, listRegistry)
+	if left == nil {
+		return nil
+	}
+	if !isListExpression(bin.Y, listRegistry) {
+		return nil
+	}
+	return append(left, extractListConcatArgs(bin.Y)...)
+}
+
+// extractListConcatArgs returns the inner elements of a list.Concat([...]) call,
+// or wraps expr in a single-element slice if it is not such a call.
+// This allows repeated upgrade passes to produce a flat rather than nested result.
+func extractListConcatArgs(expr ast.Expr) []ast.Expr {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return []ast.Expr{expr}
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return []ast.Expr{expr}
+	}
+	base, ok := sel.X.(*ast.Ident)
+	if !ok || base.Name != "list" {
+		return []ast.Expr{expr}
+	}
+	selName, ok := sel.Sel.(*ast.Ident)
+	if !ok || selName.Name != "Concat" {
+		return []ast.Expr{expr}
+	}
+	listLit, ok := call.Args[0].(*ast.ListLit)
+	if !ok {
+		return []ast.Expr{expr}
+	}
+	return listLit.Elts
 }
 
 func ensureListImport(file *ast.File) {
@@ -283,6 +313,15 @@ func isListLiteral(expr ast.Expr) bool {
 			}
 		}
 		return false
+	case *ast.BinaryExpr:
+		// Handle disjunctions like `*[] | [...string]` — if either side is a list, treat as list
+		if e.Op.String() == "|" {
+			return isListLiteral(e.X) || isListLiteral(e.Y)
+		}
+		return false
+	case *ast.UnaryExpr:
+		// Handle default markers like `*[]`
+		return isListLiteral(e.X)
 	}
 	return false
 }
@@ -350,4 +389,28 @@ func isListOperationResult(expr ast.Expr, listRegistry map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// upgradeErrorFieldLabel rewrites any field label named `error` (an unquoted identifier)
+// to `"error"` (a quoted string label) to avoid conflict with the CUE 0.14 built-in.
+func upgradeErrorFieldLabel(cueStr string, file *ast.File) (string, error) {
+	astutil.Apply(file, func(cursor astutil.Cursor) bool {
+		field, ok := cursor.Node().(*ast.Field)
+		if !ok {
+			return true
+		}
+		ident, ok := field.Label.(*ast.Ident)
+		if !ok || ident.Name != "error" {
+			return true
+		}
+		field.Label = ast.NewString("error")
+		return true
+	}, nil)
+
+	result, err := format.Node(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to format CUE: %w", err)
+	}
+
+	return strings.TrimRight(string(result), "\n"), nil
 }

--- a/pkg/cue/upgrade/upgrade_test.go
+++ b/pkg/cue/upgrade/upgrade_test.go
@@ -16,8 +16,12 @@ limitations under the License.
 package upgrade
 
 import (
+	"slices"
 	"strings"
 	"testing"
+
+	cueast "cuelang.org/go/cue/ast"
+	dto "github.com/prometheus/client_model/go"
 
 	"github.com/oam-dev/kubevela/version"
 )
@@ -119,7 +123,7 @@ repeated: concatenated * 2
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Upgrade(tt.input, "1.11") // Explicitly provide version for tests
+			got, err := Upgrade(tt.input, Version{Major: 1, Minor: 11}) // Explicitly provide version for tests
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Upgrade() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -144,6 +148,184 @@ repeated: concatenated * 2
 			}
 		})
 	}
+}
+
+func TestUpgradeErrorFieldLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		absent   string
+	}{
+		{
+			name: "top-level error field",
+			input: `
+error: "something went wrong"
+output: {name: "test"}
+`,
+			contains: `"error": "something went wrong"`,
+			absent:   "error: \"something went wrong\"",
+		},
+		{
+			name: "nested error field",
+			input: `
+template: {
+	error: "bad"
+	output: {}
+}
+`,
+			contains: `"error": "bad"`,
+		},
+		{
+			name: "error field not confused with error() call",
+			input: `
+result: error("something")
+`,
+			// error() call should be left alone — it's not a field label
+			contains: `error("something")`,
+		},
+		{
+			name: "already quoted error field unchanged",
+			input: `
+"error": "already quoted"
+`,
+			contains: `"error": "already quoted"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Upgrade(tt.input, Version{Major: 1, Minor: 11})
+			if err != nil {
+				t.Fatalf("Upgrade() error = %v", err)
+			}
+			if tt.contains != "" && !strings.Contains(got, tt.contains) {
+				t.Errorf("expected output to contain %q, got:\n%s", tt.contains, got)
+			}
+			if tt.absent != "" && strings.Contains(got, tt.absent) {
+				t.Errorf("expected output NOT to contain %q, got:\n%s", tt.absent, got)
+			}
+			t.Logf("output:\n%s", got)
+		})
+	}
+}
+
+func TestRequiresUpgradeErrorField(t *testing.T) {
+	input := `
+template: {
+	error: "something"
+	output: {}
+}
+`
+	needsUpgrade, reasons, err := RequiresUpgrade(input, Version{Major: 1, Minor: 11})
+	if err != nil {
+		t.Fatalf("RequiresUpgrade() error = %v", err)
+	}
+	if !needsUpgrade {
+		t.Error("expected upgrade required for error field label")
+	}
+	if len(reasons) != 1 {
+		t.Errorf("expected 1 reason, got %d: %v", len(reasons), reasons)
+	}
+}
+
+func TestUpgradeChainedListConcat(t *testing.T) {
+	// Chained a + b + c + d must become list.Concat([a, b, c, d]) in a single pass,
+	// not nested list.Concat(list.Concat(...)) calls.
+	// This is the real-world pattern from vela-templates/definitions/internal/component/cron-task.cue
+	common := `mountsArray: {
+	pvc:       [{mountPath: "/pvc"}]
+	configMap: [{mountPath: "/cm"}]
+	secret:    [{mountPath: "/secret"}]
+	emptyDir:  [{mountPath: "/empty"}]
+	hostPath:  [{mountPath: "/host"}]
+}`
+	want := "list.Concat([mountsArray.pvc, mountsArray.configMap, mountsArray.secret, mountsArray.emptyDir, mountsArray.hostPath])"
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "fresh chain",
+			input: "volumeMounts: mountsArray.pvc + mountsArray.configMap + mountsArray.secret + mountsArray.emptyDir + mountsArray.hostPath\n" + common,
+		},
+		{
+			// Simulates a partially-upgraded file (previous upgrade pass converted only the first pair).
+			name:  "partially upgraded chain",
+			input: "volumeMounts: list.Concat([mountsArray.pvc, mountsArray.configMap]) + mountsArray.secret + mountsArray.emptyDir + mountsArray.hostPath\n" + common,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EnsureCueVersionCompatibility(tt.input, "test", ComponentKind, TemplateAreaMain)
+			if strings.Contains(result, "list.Concat([list.Concat(") {
+				t.Errorf("got nested list.Concat instead of flat: %s", result)
+			}
+			if !strings.Contains(result, want) {
+				t.Errorf("expected flat list.Concat with all 5 operands, got:\n%s", result)
+			}
+		})
+	}
+}
+
+func TestRequiresUpgradeErrorFieldNegative(t *testing.T) {
+	// Templates that contain "error" but NOT as an unquoted field label should not trigger.
+	cases := []string{
+		`output: { message: "error occurred" }`,
+		`output: { errorMessage: "bad" }`,
+		`// handle error cases\noutput: {}`,
+		`output: { "error": "already quoted" }`, // already quoted — upgrade would be a no-op, precheck still fires (fine)
+	}
+	for _, input := range cases {
+		if errorFieldLabelRe.MatchString(input) {
+			// Only "error:" (field label) should match; none of the above have an unquoted error: label.
+			t.Errorf("errorFieldLabelRe false positive on: %q", input)
+		}
+	}
+	// Positive: unquoted error field label must match.
+	positive := `output: { error: "something" }`
+	if !errorFieldLabelRe.MatchString(positive) {
+		t.Errorf("errorFieldLabelRe failed to match: %q", positive)
+	}
+}
+
+func TestUpgradeWithOpenListParameter(t *testing.T) {
+	// Real-world pattern: parameter declared as open list type `*[] | [...{...}]`
+	// The old registry only matched literal list values; this tests the disjunction case.
+	input := `
+template: {
+	envWithDefaults: parameter.env + [{name: "MANAGED_BY", value: "kubevela"}]
+
+	output: {
+		spec: containers: [{
+			env: envWithDefaults
+		}]
+	}
+
+	parameter: {
+		env: *[] | [...{
+			name:   string
+			value?: string
+		}]
+	}
+}
+`
+	got, err := Upgrade(input, Version{Major: 1, Minor: 11})
+	if err != nil {
+		t.Fatalf("Upgrade() error = %v", err)
+	}
+
+	if !strings.Contains(got, "list.Concat") {
+		t.Errorf("Upgrade() did not transform open list parameter concatenation, got:\n%s", got)
+	}
+
+	if !strings.Contains(got, `import "list"`) {
+		t.Errorf("Upgrade() did not add list import, got:\n%s", got)
+	}
+
+	t.Logf("Transformed:\n%s", got)
 }
 
 func TestUpgradeWithComplexTemplate(t *testing.T) {
@@ -175,7 +357,7 @@ parameter: {
 output: template
 `
 
-	got, err := Upgrade(input, "1.11") // Explicitly provide version for tests
+	got, err := Upgrade(input, Version{Major: 1, Minor: 11}) // Explicitly provide version for tests
 	if err != nil {
 		t.Fatalf("Upgrade() error = %v", err)
 	}
@@ -227,7 +409,7 @@ template: {
 }
 `
 
-	got, err := Upgrade(input, "1.11") // Explicitly provide version for tests
+	got, err := Upgrade(input, Version{Major: 1, Minor: 11}) // Explicitly provide version for tests
 	if err != nil {
 		t.Fatalf("Upgrade() error = %v", err)
 	}
@@ -261,7 +443,7 @@ list1: [1, 2, 3]
 list2: [4, 5, 6]
 result: list1 + list2
 `
-	result, err := Upgrade(input, "1.11") // Provide explicit version for test
+	result, err := Upgrade(input, Version{Major: 1, Minor: 11}) // Provide explicit version for test
 	if err != nil {
 		t.Fatalf("Upgrade() error = %v", err)
 	}
@@ -270,7 +452,7 @@ result: list1 + list2
 	}
 
 	// Test explicit version 1.11
-	result, err = Upgrade(input, "1.11")
+	result, err = Upgrade(input, Version{Major: 1, Minor: 11})
 	if err != nil {
 		t.Fatalf("Upgrade() error = %v", err)
 	}
@@ -279,7 +461,7 @@ result: list1 + list2
 	}
 
 	// Test future version (should still apply 1.11 upgrades)
-	result, err = Upgrade(input, "1.12")
+	result, err = Upgrade(input, Version{Major: 1, Minor: 12})
 	if err != nil {
 		t.Fatalf("Upgrade() error = %v", err)
 	}
@@ -295,19 +477,12 @@ func TestGetSupportedVersions(t *testing.T) {
 	}
 
 	// Should include 1.11 since that's registered in init()
-	found := false
-	for _, v := range versions {
-		if v == "1.11" {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(versions, Version{Major: 1, Minor: 11}) {
 		t.Errorf("Expected 1.11 to be in supported versions, got %v", versions)
 	}
 }
 
-func TestGetCurrentKubeVelaMinorVersion(t *testing.T) {
+func TestGetCurrentKubeVelaVersion(t *testing.T) {
 	tests := []struct {
 		name            string
 		mockVersion     string
@@ -333,14 +508,16 @@ func TestGetCurrentKubeVelaMinorVersion(t *testing.T) {
 			expectError:     false,
 		},
 		{
-			name:        "unknown version error",
-			mockVersion: "UNKNOWN",
-			expectError: true,
+			name:            "unknown version uses latest",
+			mockVersion:     "UNKNOWN",
+			expectedVersion: "1.11",
+			expectError:     false,
 		},
 		{
-			name:        "empty version error",
-			mockVersion: "",
-			expectError: true,
+			name:            "empty version uses latest",
+			mockVersion:     "",
+			expectedVersion: "1.11",
+			expectError:     false,
 		},
 		{
 			name:        "invalid version error",
@@ -357,24 +534,23 @@ func TestGetCurrentKubeVelaMinorVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock the version
 			version.VelaVersion = tt.mockVersion
 
-			got, err := getCurrentKubeVelaMinorVersion()
+			got, err := getCurrentKubeVelaVersion()
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("getCurrentKubeVelaMinorVersion() expected error but got none")
+					t.Errorf("getCurrentKubeVelaVersion() expected error but got none")
 				}
 				return
 			}
 
 			if err != nil {
-				t.Errorf("getCurrentKubeVelaMinorVersion() unexpected error: %v", err)
+				t.Errorf("getCurrentKubeVelaVersion() unexpected error: %v", err)
 				return
 			}
 
-			if got != tt.expectedVersion {
-				t.Errorf("getCurrentKubeVelaMinorVersion() = %v, want %v", got, tt.expectedVersion)
+			if got.String() != tt.expectedVersion {
+				t.Errorf("getCurrentKubeVelaVersion() = %v, want %v", got, tt.expectedVersion)
 			}
 		})
 	}
@@ -453,7 +629,7 @@ repeated: list.Repeat(items, 5)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			needsUpgrade, reasons, err := RequiresUpgrade(tt.input, "1.11")
+			needsUpgrade, reasons, err := RequiresUpgrade(tt.input, Version{Major: 1, Minor: 11})
 			if err != nil {
 				t.Fatalf("RequiresUpgrade() error = %v", err)
 			}
@@ -470,14 +646,109 @@ repeated: list.Repeat(items, 5)
 	}
 }
 
-func TestUpgradeWithUnknownVersionError(t *testing.T) {
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantMajor int
+		wantMinor int
+		wantErr   bool
+	}{
+		{"1.11", 1, 11, false},
+		{"v1.11", 1, 11, false},
+		{"1.11.2", 1, 11, false},
+		{"v1.11.2", 1, 11, false},
+		{"1.9", 1, 9, false},
+		{"2.0", 2, 0, false},
+		{"v1.13.0-alpha.1+dev", 1, 13, false},
+		{"1.11foo", 0, 0, true},
+		{"1.11.2foo", 0, 0, true},
+		{"invalid", 0, 0, true},
+		{"", 0, 0, true},
+		{"v", 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.Major != tt.wantMajor || got.Minor != tt.wantMinor {
+				t.Errorf("ParseVersion(%q) = {%d,%d}, want {%d,%d}", tt.input, got.Major, got.Minor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	tests := []struct {
+		v    Version
+		want string
+	}{
+		{Version{1, 11}, "1.11"},
+		{Version{2, 0}, "2.0"},
+		{Version{0, 9}, "0.9"},
+	}
+	for _, tt := range tests {
+		if got := tt.v.String(); got != tt.want {
+			t.Errorf("Version%v.String() = %q, want %q", tt.v, got, tt.want)
+		}
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		a, b Version
+		want bool
+	}{
+		{Version{1, 9}, Version{1, 11}, true},   // minor ordering (not lexicographic)
+		{Version{1, 11}, Version{1, 9}, false},  // reverse
+		{Version{1, 11}, Version{1, 11}, false}, // equal
+		{Version{1, 11}, Version{2, 0}, true},   // major ordering
+		{Version{2, 0}, Version{1, 11}, false},
+	}
+	for _, tt := range tests {
+		if got := tt.a.less(tt.b); got != tt.want {
+			t.Errorf("Version%v.less(Version%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestSortedVersionsOrdering(t *testing.T) {
+	vs := sortedVersions()
+	for i := 1; i < len(vs); i++ {
+		if !vs[i-1].less(vs[i]) {
+			t.Errorf("sortedVersions() not in ascending order: %v >= %v at index %d", vs[i-1], vs[i], i)
+		}
+	}
+}
+
+func TestEnsureCueVersionCompatibilityDisabled(t *testing.T) {
+	original := EnableCUEVersionCompatibility
+	defer func() { EnableCUEVersionCompatibility = original }()
+	EnableCUEVersionCompatibility = false
+
+	input := `
+list1: [1, 2, 3]
+list2: [4, 5, 6]
+combined: list1 + list2
+`
+	got := EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+	if got != input {
+		t.Errorf("expected input returned unchanged when compatibility disabled, got %q", got)
+	}
+}
+
+func TestUpgradeWithUnknownVersion(t *testing.T) {
 	// Save original version
 	originalVersion := version.VelaVersion
 	defer func() {
 		version.VelaVersion = originalVersion
 	}()
 
-	// Mock unknown version
+	// Mock unknown version (dev build)
 	version.VelaVersion = "UNKNOWN"
 
 	input := `
@@ -486,24 +757,87 @@ list2: [4, 5, 6]
 combined: list1 + list2
 `
 
-	// Should return error when no version is specified and VelaVersion is UNKNOWN
-	_, err := Upgrade(input)
-	if err == nil {
-		t.Errorf("Upgrade() expected error when version is UNKNOWN but got none")
-	}
-
-	// Should contain helpful message
-	expectedMsg := "Please specify the target version explicitly using --target-version=1.11"
-	if !strings.Contains(err.Error(), expectedMsg) {
-		t.Errorf("Error message should contain guidance about using --target-version flag, got: %v", err.Error())
-	}
-
-	// Should work when explicit version is provided
-	result, err := Upgrade(input, "1.11")
+	// Should apply all upgrades (treating UNKNOWN as latest) rather than erroring
+	result, err := Upgrade(input)
 	if err != nil {
-		t.Errorf("Upgrade() with explicit version should work even when VelaVersion is UNKNOWN, got error: %v", err)
+		t.Errorf("Upgrade() should not error on UNKNOWN version, got: %v", err)
 	}
 	if !strings.Contains(result, "list.Concat") {
-		t.Errorf("Upgrade() with explicit version should still apply transformations")
+		t.Errorf("Upgrade() with UNKNOWN version should still apply all upgrades, got: %v", result)
+	}
+}
+
+func TestUpgradeFuncIDRequired(t *testing.T) {
+	// RegisterUpgrade must panic if ID is empty.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("RegisterUpgrade with empty ID should panic")
+		}
+	}()
+	RegisterUpgrade(KubeVelaUpgradeFunc{
+		ID:          "", // intentionally empty
+		VelaVersion: Version{Major: 99, Minor: 0},
+		Reason:      "test",
+		Upgrade:     func(s string, f *cueast.File) (string, error) { return s, nil },
+	})
+}
+
+func TestUpgradeFuncIDsPresent(t *testing.T) {
+	// All registered upgrade functions must have non-empty IDs.
+	for v, funcs := range upgradeRegistry {
+		for i, u := range funcs {
+			if u.id() == "" {
+				t.Errorf("upgradeRegistry[%s][%d] has empty ID", v, i)
+			}
+		}
+	}
+}
+
+func TestRequiresUpgradeReasonsContainID(t *testing.T) {
+	// Reasons returned by RequiresUpgrade must include the upgrade ID.
+	input := `
+list1: [1, 2, 3]
+list2: [4, 5, 6]
+combined: list1 + list2
+`
+	_, reasons, err := RequiresUpgrade(input, Version{Major: 1, Minor: 11})
+	if err != nil {
+		t.Fatalf("RequiresUpgrade() error = %v", err)
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected at least one reason")
+	}
+	for _, r := range reasons {
+		if !strings.Contains(r, "[cue@0.14] [list-arithmetic]") {
+			t.Errorf("reason %q does not contain expected prefix '[cue@0.14] [list-arithmetic]'", r)
+		}
+	}
+}
+
+func TestEnsureCueVersionCompatibilityIncrementsMetric(t *testing.T) {
+	// Reset cache so the upgrade path actually runs.
+	compatCache = newLRUCache(512)
+
+	// Reset the counter before the test.
+	CUECompatRewriteTotal.Reset()
+
+	input := `
+list1: [1, 2, 3]
+list2: [4, 5, 6]
+combined: list1 + list2
+`
+	EnsureCueVersionCompatibility(input, "test-def", ComponentKind, TemplateAreaMain)
+
+	// Gather the metric value for the expected label triple.
+	mf, err := CUECompatRewriteTotal.GetMetricWithLabelValues("list-arithmetic", "1.11", string(ComponentKind), string(TemplateAreaMain))
+	if err != nil {
+		t.Fatalf("failed to get metric: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := mf.Write(m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.Counter == nil || m.Counter.GetValue() < 1 {
+		t.Errorf("expected counter >= 1 for list-arithmetic/1.11/Component, got %v", m)
 	}
 }

--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -227,10 +227,14 @@ func (def *Definition) ToCUEString() (string, error) {
 		return "", errors.Wrapf(err, "failed to parse template cue string")
 	}
 
-	// Extract imports before fix.File() clears them
+	// Extract imports from original file; fix.File may drop unreferenced ones.
 	importPaths := extractImportsFromFile(f)
 
 	f = fix.File(f)
+
+	// Merge any new imports added by fix.File (e.g. "list" when rewriting list arithmetic).
+	importPaths = mergeImports(importPaths, extractImportsFromFile(f))
+
 	var templateDecls []ast.Decl
 	for _, decl := range f.Decls {
 		if _, ok := decl.(*ast.ImportDecl); !ok {
@@ -423,9 +427,8 @@ func (def *Definition) FromCUEString(cueString string, _ *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	n := fix.File(f)
 	var importDecls, metadataDecls, templateDecls []ast.Decl
-	for _, decl := range n.Decls {
+	for _, decl := range f.Decls {
 		if importDecl, ok := decl.(*ast.ImportDecl); ok {
 			importDecls = append(importDecls, importDecl)
 		} else if field, ok := decl.(*ast.Field); ok {
@@ -476,12 +479,16 @@ func (def *Definition) FromCUEString(cueString string, _ *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	templateString, err = formatCUEString(importString + templateString)
+	// Validate by compiling the upgraded template; store the original user-supplied syntax.
+	upgradedTemplate, err := formatCUEString(importString + templateString)
 	if err != nil {
 		return err
 	}
-	if _, err := providers.DefaultCompiler.Get().CompileStringWithOptions(context.Background(), templateString+"\n"+velacue.BaseTemplate, cuex.DisableResolveProviderFunctions{}); err != nil {
+	if _, err := providers.DefaultCompiler.Get().CompileStringWithOptions(context.Background(), upgradedTemplate+"\n"+velacue.BaseTemplate, cuex.DisableResolveProviderFunctions{}); err != nil {
 		return err
+	}
+	if imp := strings.TrimSpace(importString); imp != "" {
+		return def.FromCUE(&inst, imp+"\n"+templateString)
 	}
 	return def.FromCUE(&inst, templateString)
 }
@@ -683,20 +690,39 @@ func extractImportsFromFile(f *ast.File) []string {
 	return importPaths
 }
 
+// mergeImports appends any paths from additional that are not already in base.
+func mergeImports(base, additional []string) []string {
+	for _, p := range additional {
+		found := false
+		for _, existing := range base {
+			if existing == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			base = append(base, p)
+		}
+	}
+	return base
+}
+
 func formatCUEString(cueString string) (string, error) {
 	f, err := parser.ParseFile("-", cueString, parser.ParseComments)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse file during format cue string")
 	}
 
-	// Extract imports before fix.File() clears them
+	// Extract imports from original file; fix.File may drop unreferenced ones.
 	importPaths := extractImportsFromFile(f)
 
-	n := fix.File(f)
+	fixed := fix.File(f)
 
-	// Format only non-import declarations
+	// Merge any new imports added by fix.File (e.g. "list" when rewriting list arithmetic).
+	importPaths = mergeImports(importPaths, extractImportsFromFile(fixed))
+
 	var nonImportDecls []ast.Decl
-	for _, decl := range n.Decls {
+	for _, decl := range fixed.Decls {
 		if _, ok := decl.(*ast.ImportDecl); !ok {
 			nonImportDecls = append(nonImportDecls, decl)
 		}

--- a/pkg/definition/definition_test.go
+++ b/pkg/definition/definition_test.go
@@ -360,3 +360,35 @@ func TestStringStatusFromCueString(t *testing.T) {
 	require.True(t, ok, "status field not found in CUE definition")
 	require.IsType(t, &ast2.StructLit{}, statusField.Value, "expected status field to be of type StructLit ")
 }
+
+// TestFromCUEString_PreservesLegacySyntax verifies that FromCUEString stores the
+// original user-supplied CUE verbatim. Validation runs against the upgraded form,
+// but the stored template retains the legacy syntax for the compat layer to handle at render time.
+func TestFromCUEString_PreservesLegacySyntax(t *testing.T) {
+	legacyCUE := strings.TrimSpace(`
+"legacy-worker": {
+  type: "component"
+  annotations: {}
+}
+template: {
+  envWithDefaults: parameter.env + [{name: "MANAGED_BY", value: "kubevela"}]
+  output: {
+    apiVersion: "apps/v1"
+    kind:       "Deployment"
+    spec: containers: [{env: envWithDefaults}]
+  }
+  parameter: {
+    env: *[] | [...{name: string, value?: string}]
+  }
+}
+`)
+	def := &Definition{}
+	require.NoError(t, def.FromCUEString(legacyCUE, nil))
+
+	storedTemplate, found, err := unstructured.NestedString(def.Object, DefinitionTemplateKeys...)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	assert.Contains(t, storedTemplate, "parameter.env +")
+	assert.NotContains(t, storedTemplate, "list.Concat")
+}

--- a/pkg/definition/gen_sdk/testdata/apply-terraform-provider.cue
+++ b/pkg/definition/gen_sdk/testdata/apply-terraform-provider.cue
@@ -2,7 +2,6 @@ import (
 	"vela/config"
 	"vela/kube"
 	"vela/builtin"
-	"strings"
 )
 
 "apply-terraform-provider": {

--- a/pkg/definition/gen_sdk/testdata/one_of.cue
+++ b/pkg/definition/gen_sdk/testdata/one_of.cue
@@ -1,8 +1,3 @@
-import (
-	"vela/op"
-	"encoding/base64"
-)
-
 "one_of": {
 	type:        "workflow-step"
 	description: "Send notifications to Email, DingTalk, Slack, Lark or webhook in your workflow. For test one_of"

--- a/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/component_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/component_definition_validating_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -68,6 +70,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
+		var warnings []string
 		if err := h.Decoder.Decode(req, obj); err != nil {
 			logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into ComponentDefinition object - malformed request")
 			return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s (requestUID=%s)", err.Error(), req.UID))
@@ -94,12 +97,23 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
 			logger.WithStep("validate-cue").Info("Validating CUE template syntax and semantics for ComponentDefinition schematic")
 
-			if err := webhookutils.ValidateCuexTemplate(ctx, obj.Spec.Schematic.CUE.Template); err != nil {
+			// Validate against the effective template; with auto-upgrade is enabled
+			cueTemplate := obj.Spec.Schematic.CUE.Template
+			if upgrade.EnableCUEVersionCompatibility {
+				if needsUpgrade, reasons, err := upgrade.RequiresUpgrade(cueTemplate); err == nil && needsUpgrade {
+					warnings = append(warnings, fmt.Sprintf(
+						"CUE template uses legacy syntax that will be auto-upgraded at render time. Run `vela def compat definitions` to scan all definitions for legacy syntax. Reasons: %s",
+						strings.Join(reasons, "; ")))
+					cueTemplate = upgrade.EnsureCueVersionCompatibility(cueTemplate, obj.Name, upgrade.ComponentKind, upgrade.TemplateAreaMain)
+				}
+			}
+
+			if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
 				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
 
-			if err := webhookutils.ValidateOutputResourcesExist(obj.Spec.Schematic.CUE.Template, h.Client.RESTMapper(), obj); err != nil {
+			if err := webhookutils.ValidateOutputResourcesExist(cueTemplate, h.Client.RESTMapper(), obj); err != nil {
 				logger.WithStep("validate-output-resources").WithError(err).Error(err, "CUE template references output resources that don't exist in cluster - unknown resource types detected")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
@@ -134,6 +148,9 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 		// Log successful completion
 		logger.WithStep("complete").WithSuccess(true, startTime).Info("ComponentDefinition admission validation completed successfully - resource is valid and will be admitted", "definitionName", obj.Name, "operation", req.Operation)
+		if len(warnings) > 0 {
+			return admission.ValidationResponse(true, "").WithWarnings(warnings...)
+		}
 	} else {
 		logger.WithStep("skip-validation").Info("Skipping ComponentDefinition validation - operation does not require validation", "operation", req.Operation, "reason", "only CREATE and UPDATE operations are validated")
 	}

--- a/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	applicationcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1beta1/application"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
@@ -65,6 +67,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
+		var cueWarnings []string
 		if err := h.Decoder.Decode(req, obj); err != nil {
 			logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into PolicyDefinition object - malformed request")
 			return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s (requestUID=%s)", err.Error(), req.UID))
@@ -80,11 +83,23 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
 			logger.WithStep("validate-cue").Info("Validating CUE template syntax and semantics for PolicyDefinition schematic")
-			if err := webhookutils.ValidateCueTemplate(obj.Spec.Schematic.CUE.Template); err != nil {
+
+			// Validate against the effective template; with auto-upgrade is enabled
+			cueTemplate := obj.Spec.Schematic.CUE.Template
+			if upgrade.EnableCUEVersionCompatibility {
+				if needsUpgrade, reasons, err := upgrade.RequiresUpgrade(cueTemplate); err == nil && needsUpgrade {
+					cueWarnings = append(cueWarnings, fmt.Sprintf(
+						"CUE template uses legacy syntax that will be auto-upgraded at render time. Run `vela def compat definitions` to scan all definitions for legacy syntax. Reasons: %s",
+						strings.Join(reasons, "; ")))
+					cueTemplate = upgrade.EnsureCueVersionCompatibility(cueTemplate, obj.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
+				}
+			}
+
+			if err := webhookutils.ValidateCueTemplate(cueTemplate); err != nil {
 				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
-			if err := webhookutils.ValidateOutputResourcesExist(obj.Spec.Schematic.CUE.Template, h.Client.RESTMapper(), obj); err != nil {
+			if err := webhookutils.ValidateOutputResourcesExist(cueTemplate, h.Client.RESTMapper(), obj); err != nil {
 				logger.WithStep("validate-output-resources").WithError(err).Error(err, "CUE template references output resources that don't exist in cluster - unknown resource types detected")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
@@ -116,6 +131,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 		// Validate Application-scoped policy constraints (global=true rules, scope consistency)
 		validationResult := applicationcontroller.ValidatePolicyDefinition(obj)
+		validationResult.Warnings = append(validationResult.Warnings, cueWarnings...)
 		if !validationResult.IsValid() {
 			logger.WithStep("validate-policy-definition").Error(nil, "PolicyDefinition failed Application-scoped policy validation", "errors", validationResult.Errors)
 			return admission.Denied(fmt.Sprintf("invalid PolicyDefinition: %v (requestUID=%s)", validationResult.Errors, req.UID))

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,6 +33,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/logging"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
@@ -89,6 +91,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
+		var warnings []string
 		if err := h.Decoder.Decode(req, obj); err != nil {
 			logger.WithStep("decode").WithError(err).Error(err, "Unable to decode admission request payload into TraitDefinition object - malformed request")
 			return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s (requestUID=%s)", err.Error(), req.UID))
@@ -112,11 +115,23 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		// validate cueTemplate
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
 			logger.WithStep("validate-cue").Info("Validating CUE template syntax and semantics for TraitDefinition schematic")
-			if err := webhookutils.ValidateCuexTemplate(ctx, obj.Spec.Schematic.CUE.Template); err != nil {
+
+			// Validate against the effective template; with auto-upgrade is enabled
+			cueTemplate := obj.Spec.Schematic.CUE.Template
+			if upgrade.EnableCUEVersionCompatibility {
+				if needsUpgrade, reasons, err := upgrade.RequiresUpgrade(cueTemplate); err == nil && needsUpgrade {
+					warnings = append(warnings, fmt.Sprintf(
+						"CUE template uses legacy syntax that will be auto-upgraded at render time. Run `vela def compat definitions` to scan all definitions for legacy syntax. Reasons: %s",
+						strings.Join(reasons, "; ")))
+					cueTemplate = upgrade.EnsureCueVersionCompatibility(cueTemplate, obj.Name, upgrade.TraitKind, upgrade.TemplateAreaMain)
+				}
+			}
+
+			if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
 				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
-			if err := webhookutils.ValidateOutputResourcesExist(obj.Spec.Schematic.CUE.Template, h.Client.RESTMapper(), obj); err != nil {
+			if err := webhookutils.ValidateOutputResourcesExist(cueTemplate, h.Client.RESTMapper(), obj); err != nil {
 				logger.WithStep("validate-output-resources").WithError(err).Error(err, "CUE template references output resources that don't exist in cluster - unknown resource types detected")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
@@ -145,6 +160,9 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 			return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 		}
 		logger.WithStep("complete").WithSuccess(true, startTime).Info("TraitDefinition admission validation completed successfully - resource is valid and will be admitted", "definitionName", obj.Name, "operation", req.Operation)
+		if len(warnings) > 0 {
+			return admission.ValidationResponse(true, "").WithWarnings(warnings...)
+		}
 	} else {
 		logger.WithStep("skip-validation").Info("Skipping TraitDefinition validation - operation does not require validation", "operation", req.Operation, "reason", "only CREATE and UPDATE operations are validated")
 	}

--- a/pkg/webhook/core.oam.dev/v1beta1/workflowstepdefinition/workflowstep_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/workflowstepdefinition/workflowstep_validating_handler.go
@@ -106,6 +106,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	// Validate output resources
 	if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
 		logger.WithStep("validate-output-resources").Info("Validating output resources referenced in WorkflowStepDefinition CUE template")
+
 		if err := webhookutils.ValidateOutputResourcesExist(obj.Spec.Schematic.CUE.Template, h.Client.RESTMapper(), obj); err != nil {
 			logger.WithStep("validate-output-resources").WithError(err).Error(err, "CUE template references output resources that don't exist in cluster - unknown resource types detected")
 			return admission.Denied(fmt.Sprintf("output resource validation failed: %s (requestUID=%s)", err.Error(), req.UID))

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -65,12 +65,10 @@ func ValidateDefinitionRevision(ctx context.Context, cli client.Client, def runt
 
 // ValidateCueTemplate validate cueTemplate
 func ValidateCueTemplate(cueTemplate string) error {
-
 	val := cuecontext.New().CompileString(cueTemplate)
 	if e := checkError(val.Err()); e != nil {
 		return e
 	}
-
 	err := val.Validate()
 	return checkError(err)
 }

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -34,6 +34,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/encoding/gocode/gocodec"
+	"github.com/fatih/color"
 	"github.com/kubevela/pkg/util/slices"
 	"github.com/kubevela/workflow/pkg/cue/model/sets"
 	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
@@ -96,6 +97,7 @@ func DefinitionCommandGroup(c common.Args, order string, ioStreams util.IOStream
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
 		NewDefinitionUpgradeCommand(c, ioStreams),
+		NewDefinitionCompatibilityCommand(c, ioStreams),
 		NewDefinitionDocGenCommand(c, ioStreams),
 		NewCapabilityShowCommand(c, "", ioStreams),
 		NewDefinitionGenAPICommand(c),
@@ -1177,7 +1179,7 @@ func NewDefinitionRenderCommand(c common.Args) *cobra.Command {
 				return errors.Wrapf(err, "failed to get `%s`", FlagFormat)
 			}
 			// Validate output format
-			if outputFormat != "yaml" && outputFormat != "cue" {
+			if outputFormat != outputFormatYAML && outputFormat != "cue" {
 				return errors.Errorf("invalid format %q, must be 'yaml' or 'cue'", outputFormat)
 			}
 
@@ -1554,43 +1556,53 @@ func defApplyOne(ctx context.Context, c common.Args, namespace, defpath string, 
 		}
 		return []string{fmt.Sprintf("%s %s in namespace %s %s.\n", def.GetKind(), def.GetName(), def.GetNamespace(), op)}, nil
 	default:
+		var results []string
+		if upgrade.EnableCUEVersionCompatibility {
+			if needsUpgrade, reasons, err := upgrade.RequiresUpgrade(string(defBytes)); err == nil && needsUpgrade {
+				relpath := defpath
+				if rel, err := filepath.Rel(".", defpath); err == nil {
+					relpath = rel
+				}
+				header := color.New(color.Bold).Sprint("Compatibility Warning:")
+				results = append(results, fmt.Sprintf("%s %s uses legacy CUE syntax that will be auto-upgraded at render time.\n  - %s\nRun `vela def upgrade <file> -o <file>` to rewrite the file.\n\n",
+					header, relpath, strings.Join(reasons, "\n  - ")))
+			}
+		}
 		if err := def.FromCUEString(string(defBytes), config); err != nil {
 			return nil, errors.Wrapf(err, "failed to parse CUE for definition")
 		}
 		def.SetNamespace(namespace)
-	}
-
-	if dryRun {
-		s, err := prettyYAMLMarshal(def.Object)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to marshal CRD into YAML")
-		}
-		return []string{s}, nil
-	}
-
-	oldDef := pkgdef.Definition{Unstructured: unstructured.Unstructured{}}
-	oldDef.SetGroupVersionKind(def.GroupVersionKind())
-	err = k8sClient.Get(ctx, types2.NamespacedName{
-		Namespace: def.GetNamespace(),
-		Name:      def.GetName(),
-	}, &oldDef)
-	if err != nil {
-		if errors2.IsNotFound(err) {
-			kind := def.GetKind()
-			if err = k8sClient.Create(ctx, &def); err != nil {
-				return nil, errors.Wrapf(err, "failed to create new definition in kubernetes")
+		if dryRun {
+			s, err := prettyYAMLMarshal(def.Object)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to marshal CRD into YAML")
 			}
-			return []string{fmt.Sprintf("%s %s created in namespace %s.\n", kind, def.GetName(), def.GetNamespace())}, nil
+			return append(results, s), nil
 		}
-		return nil, errors.Wrapf(err, "failed to check existence of target definition in kubernetes")
+		oldDef := pkgdef.Definition{Unstructured: unstructured.Unstructured{}}
+		oldDef.SetGroupVersionKind(def.GroupVersionKind())
+		err = k8sClient.Get(ctx, types2.NamespacedName{
+			Namespace: def.GetNamespace(),
+			Name:      def.GetName(),
+		}, &oldDef)
+		if err != nil {
+			if errors2.IsNotFound(err) {
+				kind := def.GetKind()
+				if err = k8sClient.Create(ctx, &def); err != nil {
+					return nil, errors.Wrapf(err, "failed to create new definition in kubernetes")
+				}
+				return append(results, fmt.Sprintf("%s %s created in namespace %s.\n", kind, def.GetName(), def.GetNamespace())), nil
+			}
+			return nil, errors.Wrapf(err, "failed to check existence of target definition in kubernetes")
+		}
+		if err := oldDef.FromCUEString(string(defBytes), config); err != nil {
+			return nil, errors.Wrapf(err, "failed to merge with existing definition")
+		}
+		if err = k8sClient.Update(ctx, &oldDef); err != nil {
+			return nil, errors.Wrapf(err, "failed to update existing definition in kubernetes")
+		}
+		return append(results, fmt.Sprintf("%s %s in namespace %s updated.\n", oldDef.GetKind(), oldDef.GetName(), oldDef.GetNamespace())), nil
 	}
-	if err := oldDef.FromCUEString(string(defBytes), config); err != nil {
-		return nil, errors.Wrapf(err, "failed to merge with existing definition")
-	}
-	if err = k8sClient.Update(ctx, &oldDef); err != nil {
-		return nil, errors.Wrapf(err, "failed to update existing definition in kubernetes")
-	}
-	return []string{fmt.Sprintf("%s %s in namespace %s updated.\n", oldDef.GetKind(), oldDef.GetName(), oldDef.GetNamespace())}, nil
 }
 
 // defApplyGoFile handles applying Go definition files
@@ -2042,16 +2054,17 @@ func NewDefinitionUpgradeCommand(c common.Args, ioStreams util.IOStreams) *cobra
 				return fmt.Errorf("failed to read source file %s: %w", sourceFile, err)
 			}
 
-			// Prepare target version (strip 'v' prefix if present for consistency)
-			version := strings.TrimPrefix(targetVersion, "v")
-
 			// Check-only mode
 			if checkOnly {
 				var needsUpgrade bool
 				var reasons []string
 
-				if version != "" {
-					needsUpgrade, reasons, err = upgrade.RequiresUpgrade(string(content), version)
+				if targetVersion != "" {
+					v, parseErr := upgrade.ParseVersion(targetVersion)
+					if parseErr != nil {
+						return fmt.Errorf("invalid --target-version: %w", parseErr)
+					}
+					needsUpgrade, reasons, err = upgrade.RequiresUpgrade(string(content), v)
 				} else {
 					needsUpgrade, reasons, err = upgrade.RequiresUpgrade(string(content))
 				}
@@ -2076,10 +2089,13 @@ func NewDefinitionUpgradeCommand(c common.Args, ioStreams util.IOStreams) *cobra
 
 			// Apply upgrades
 			var upgradedContent string
-			if version != "" {
-				upgradedContent, err = upgrade.Upgrade(string(content), version)
+			if targetVersion != "" {
+				v, parseErr := upgrade.ParseVersion(targetVersion)
+				if parseErr != nil {
+					return fmt.Errorf("invalid --target-version: %w", parseErr)
+				}
+				upgradedContent, err = upgrade.Upgrade(string(content), v)
 			} else {
-				// Use default version (current KubeVela)
 				upgradedContent, err = upgrade.Upgrade(string(content))
 			}
 

--- a/references/cli/def_compat.go
+++ b/references/cli/def_compat.go
@@ -1,0 +1,821 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	oamcommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
+	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/utils/filters"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+// --- Shared types ---
+
+// CompatibilityHint records a specific reason, the upgrade ID, and the KubeVela version that introduced it.
+type CompatibilityHint struct {
+	Introduced string `json:"introduced" yaml:"introduced"`
+	ID         string `json:"id"         yaml:"id"`
+	Reason     string `json:"reason"     yaml:"reason"`
+}
+
+// revisionNum returns the numeric value of a "vN" revision string for ordering.
+// Non-numeric or non-"v"-prefixed strings return -1 so they sort before real revisions.
+func revisionNum(rev string) int {
+	n, err := strconv.Atoi(strings.TrimPrefix(rev, "v"))
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// parseHints parses reason strings of the form "[cue@0.14] [list-arithmetic] description"
+// into structured CompatibilityHints.
+func parseHints(reasons []string) []CompatibilityHint {
+	var hints []CompatibilityHint
+	for _, r := range reasons {
+		// First bracket: source@version, e.g. "[cue@0.14]"
+		ver, rest, _ := strings.Cut(r, "] ")
+		introduced := strings.TrimPrefix(ver, "[")
+		// Second bracket: upgrade ID, e.g. "[list-arithmetic]"
+		var id, issue string
+		if strings.HasPrefix(rest, "[") {
+			idPart, desc, _ := strings.Cut(rest, "] ")
+			id = strings.TrimPrefix(idPart, "[")
+			issue = desc
+		} else {
+			issue = rest
+		}
+		hints = append(hints, CompatibilityHint{
+			Introduced: introduced,
+			ID:         id,
+			Reason:     issue,
+		})
+	}
+	return hints
+}
+
+// parseSelectorMap parses a comma-separated "key=value" selector string into a map.
+// Returns an error if any pair is malformed.
+func parseSelectorMap(sel string) (map[string]string, error) {
+	if sel == "" {
+		return nil, nil
+	}
+	m := map[string]string{}
+	for _, pair := range strings.Split(sel, ",") {
+		pair = strings.TrimSpace(pair)
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid selector %q: expected key=value", pair)
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+// matchesSelector returns true if all key=value pairs in sel are present in meta.
+func matchesSelector(meta map[string]string, sel map[string]string) bool {
+	for k, v := range sel {
+		if meta[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Definitions report types ---
+
+// DefCompatReport is the serialisable report for `vela def compatibility-check definitions`.
+type DefCompatReport struct {
+	Total       int              `json:"total"       yaml:"total"`
+	Definitions []DefCompatEntry `json:"definitions" yaml:"definitions"`
+}
+
+// DefCompatEntry groups all incompatible revisions of one definition.
+type DefCompatEntry struct {
+	Name      string          `json:"name"      yaml:"name"`
+	Kind      string          `json:"kind"      yaml:"kind"`
+	Namespace string          `json:"namespace" yaml:"namespace"`
+	Issues    []DefIssueEntry `json:"issues"    yaml:"issues"`
+}
+
+// DefIssueEntry is one unique compatibility issue with the list of revisions it affects.
+type DefIssueEntry struct {
+	Introduced string   `json:"introduced" yaml:"introduced"`
+	ID         string   `json:"id"         yaml:"id"`
+	Reason     string   `json:"reason"     yaml:"reason"`
+	Revisions  []string `json:"revisions"  yaml:"revisions"`
+}
+
+// defRevCompatEntry is an internal type used only during scanning, before deduplication.
+type defRevCompatEntry struct {
+	revision string
+	reasons  []CompatibilityHint
+}
+
+// --- Applications report types ---
+
+// AppCompatReport is the serialisable report for `vela def compatibility-check applications`.
+type AppCompatReport struct {
+	Total        int              `json:"total"        yaml:"total"`
+	Applications []AppCompatEntry `json:"applications" yaml:"applications"`
+}
+
+// AppCompatEntry groups all incompatible definition snapshots found in one Application's active revision.
+type AppCompatEntry struct {
+	Application string          `json:"application" yaml:"application"`
+	Namespace   string          `json:"namespace"   yaml:"namespace"`
+	Revision    string          `json:"revision"    yaml:"revision"`
+	Issues      []AppIssueEntry `json:"issues"      yaml:"issues"`
+}
+
+// AppIssueEntry is one unique compatibility issue with affected snapshots grouped by kind.
+type AppIssueEntry struct {
+	Introduced    string   `json:"introduced"               yaml:"introduced"`
+	ID            string   `json:"id"                       yaml:"id"`
+	Reason        string   `json:"reason"                   yaml:"reason"`
+	Components    []string `json:"components,omitempty"     yaml:"components,omitempty"`
+	Traits        []string `json:"traits,omitempty"         yaml:"traits,omitempty"`
+	Policies      []string `json:"policies,omitempty"       yaml:"policies,omitempty"`
+	WorkflowSteps []string `json:"workflowSteps,omitempty"  yaml:"workflowSteps,omitempty"`
+}
+
+// --- Command group ---
+
+// NewDefinitionCompatibilityCommand creates the `vela def compatibility-check` subcommand group.
+func NewDefinitionCompatibilityCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "compatibility-check",
+		Aliases: []string{"compat"},
+		Short:   "Scan for CUE version incompatibilities in definitions and applications",
+		Long: "Subcommands for scanning CUE version incompatibilities across\n" +
+			"definitions, their revision history, and active ApplicationRevisions.",
+		Annotations: map[string]string{
+			types.TagCommandType:  types.TypeDefManagement,
+			types.TagCommandOrder: "6",
+		},
+	}
+	cmd.AddCommand(
+		NewDefinitionCompatibilityDefinitionsCommand(c, ioStreams),
+		NewDefinitionCompatibilityApplicationsCommand(c, ioStreams),
+	)
+	return cmd
+}
+
+// --- `vela def compatibility-check definitions` ---
+
+// NewDefinitionCompatibilityDefinitionsCommand creates `vela def compatibility-check definitions`.
+func NewDefinitionCompatibilityDefinitionsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
+	var (
+		latestOnly         bool
+		outputFormat       string
+		namespace          string
+		labelSelector      string
+		annotationSelector string
+	)
+
+	allTypes := []string{"component", "trait", "workflow-step", "policy"}
+
+	cmd := &cobra.Command{
+		Use:   "definitions",
+		Short: "Scan all definitions and their revision history for CUE incompatibilities",
+		Long: "Scans every definition across all namespaces for CUE syntax incompatible\n" +
+			"with the current KubeVela version, grouped by definition with the affected\n" +
+			"DefinitionRevisions listed under each.\n\n" +
+			"Use --latest-revision-only to skip revision history and check only the\n" +
+			"current live definition.",
+		Example: "# Scan all definitions and all their historical revisions\n" +
+			"vela def compatibility-check definitions\n\n" +
+			"# Scan only the current live definition (skip revision history)\n" +
+			"vela def compatibility-check definitions --latest-revision-only\n\n" +
+			"# Output as YAML\n" +
+			"vela def compatibility-check definitions -o yaml",
+		Annotations: map[string]string{
+			types.TagCommandType:  types.TypeDefManagement,
+			types.TagCommandOrder: "1",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8sClient, err := c.GetClient()
+			if err != nil {
+				return errors.Wrap(err, "failed to get k8s client")
+			}
+			report, err := scanDefinitions(context.Background(), k8sClient, scanDefsOptions{
+				allTypes:           allTypes,
+				namespace:          namespace,
+				labelSelector:      labelSelector,
+				annotationSelector: annotationSelector,
+				latestOnly:         latestOnly,
+			})
+			if err != nil {
+				return err
+			}
+			return printDefCompatReport(ioStreams, report, outputFormat)
+		},
+	}
+
+	cmd.Flags().BoolVar(&latestOnly, "latest-revision-only", false,
+		"Only check the current live definition; skip DefinitionRevision history.")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format. One of: table, yaml, json.")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Only scan definitions in this namespace (default: all namespaces).")
+	cmd.Flags().StringVarP(&labelSelector, "label-selector", "l", "", "Filter by labels, e.g. -l app=foo,env=prod.")
+	cmd.Flags().StringVar(&annotationSelector, "annotation-selector", "", "Filter by annotations, e.g. --annotation-selector owner=team-a.")
+	return cmd
+}
+
+// scanDefsOptions holds parameters for scanDefinitions.
+type scanDefsOptions struct {
+	allTypes           []string
+	namespace          string
+	labelSelector      string
+	annotationSelector string
+	latestOnly         bool
+}
+
+// defRawEntry accumulates per-revision compat findings for a single definition.
+type defRawEntry struct {
+	name, kind, ns string
+	revisions      []defRevCompatEntry
+}
+
+type defKey struct{ ns, name, kind string }
+
+func normaliseDefKind(kind string) string {
+	switch kind {
+	case "Component":
+		return v1beta1.ComponentDefinitionKind
+	case "Trait":
+		return v1beta1.TraitDefinitionKind
+	case "WorkflowStep":
+		return v1beta1.WorkflowStepDefinitionKind
+	case "Policy":
+		return v1beta1.PolicyDefinitionKind
+	}
+	return kind
+}
+
+func scanDefinitions(ctx context.Context, k8sClient client.Client, opts scanDefsOptions) (DefCompatReport, error) {
+	labelSel, err := parseSelectorMap(opts.labelSelector)
+	if err != nil {
+		return DefCompatReport{}, errors.Wrap(err, "--label-selector")
+	}
+	annotationSel, err := parseSelectorMap(opts.annotationSelector)
+	if err != nil {
+		return DefCompatReport{}, errors.Wrap(err, "--annotation-selector")
+	}
+
+	rawEntries := map[defKey]*defRawEntry{}
+	ensureRaw := func(ns, name, kind string) *defRawEntry {
+		kind = normaliseDefKind(kind)
+		k := defKey{ns, name, kind}
+		if rawEntries[k] == nil {
+			rawEntries[k] = &defRawEntry{name: name, kind: kind, ns: ns}
+		}
+		return rawEntries[k]
+	}
+
+	var defFilters []filters.Filter
+	if len(labelSel) > 0 {
+		defFilters = append(defFilters, func(obj unstructured.Unstructured) bool {
+			return matchesSelector(obj.GetLabels(), labelSel)
+		})
+	}
+	if len(annotationSel) > 0 {
+		defFilters = append(defFilters, func(obj unstructured.Unstructured) bool {
+			return matchesSelector(obj.GetAnnotations(), annotationSel)
+		})
+	}
+
+	for _, defType := range opts.allTypes {
+		defs, err := pkgdef.SearchDefinition(k8sClient, defType, opts.namespace, defFilters...)
+		if err != nil {
+			return DefCompatReport{}, errors.Wrapf(err, "failed to list %s", defType)
+		}
+		for _, def := range defs {
+			template, ok := extractCUETemplate(def.Object)
+			if !ok || template == "" {
+				continue
+			}
+			needs, reasons, err := upgrade.RequiresUpgrade(template)
+			if err != nil || !needs {
+				continue
+			}
+			e := ensureRaw(def.GetNamespace(), def.GetName(), def.GetKind())
+			e.revisions = append(e.revisions, defRevCompatEntry{revision: "current", reasons: parseHints(reasons)})
+		}
+	}
+
+	if !opts.latestOnly {
+		if err := scanDefRevisions(ctx, k8sClient, opts, labelSel, annotationSel, ensureRaw); err != nil {
+			return DefCompatReport{}, err
+		}
+	}
+
+	return buildDefCompatReport(rawEntries), nil
+}
+
+func scanDefRevisions(
+	ctx context.Context,
+	k8sClient client.Client,
+	opts scanDefsOptions,
+	labelSel, annotationSel map[string]string,
+	ensureRaw func(ns, name, kind string) *defRawEntry,
+) error {
+	typeMap := map[string]oamcommon.DefinitionType{
+		"component":     oamcommon.ComponentType,
+		"trait":         oamcommon.TraitType,
+		"workflow-step": oamcommon.WorkflowStepType,
+		"policy":        oamcommon.PolicyType,
+	}
+	for _, t := range opts.allTypes {
+		defRevs, err := pkgdef.SearchDefinitionRevisions(ctx, k8sClient, opts.namespace, "", typeMap[t], 0)
+		if err != nil {
+			return errors.Wrapf(err, "failed to list DefinitionRevisions for %s", t)
+		}
+		for _, dr := range defRevs {
+			if len(labelSel) > 0 && !matchesSelector(dr.GetLabels(), labelSel) {
+				continue
+			}
+			if len(annotationSel) > 0 && !matchesSelector(dr.GetAnnotations(), annotationSel) {
+				continue
+			}
+			template := extractDefRevTemplate(dr)
+			if template == "" {
+				continue
+			}
+			needs, reasons, err := upgrade.RequiresUpgrade(template)
+			if err != nil || !needs {
+				continue
+			}
+			defName := defNameFromRevision(dr)
+			e := ensureRaw(dr.GetNamespace(), defName, string(dr.Spec.DefinitionType))
+			e.revisions = append(e.revisions, defRevCompatEntry{
+				revision: fmt.Sprintf("v%d", dr.Spec.Revision),
+				reasons:  parseHints(reasons),
+			})
+		}
+	}
+	return nil
+}
+
+func buildDefCompatReport(rawEntries map[defKey]*defRawEntry) DefCompatReport {
+	var defList []DefCompatEntry
+	for _, e := range rawEntries {
+		// Promote "current" to the highest vN revision if DefinitionRevisions exist.
+		highestVN := ""
+		for _, r := range e.revisions {
+			if r.revision != "current" && revisionNum(r.revision) > revisionNum(highestVN) {
+				highestVN = r.revision
+			}
+		}
+		if highestVN != "" {
+			for i := range e.revisions {
+				if e.revisions[i].revision == "current" {
+					e.revisions[i].revision = highestVN
+				}
+			}
+		}
+		sort.Slice(e.revisions, func(i, j int) bool {
+			return revisionNum(e.revisions[i].revision) < revisionNum(e.revisions[j].revision)
+		})
+		defList = append(defList, DefCompatEntry{
+			Name:      e.name,
+			Kind:      e.kind,
+			Namespace: e.ns,
+			Issues:    deduplicateDefHints(e.revisions),
+		})
+	}
+	sort.Slice(defList, func(i, j int) bool {
+		if defList[i].Namespace != defList[j].Namespace {
+			return defList[i].Namespace < defList[j].Namespace
+		}
+		return defList[i].Name < defList[j].Name
+	})
+	report := DefCompatReport{Total: len(defList), Definitions: defList}
+	if report.Definitions == nil {
+		report.Definitions = []DefCompatEntry{}
+	}
+	return report
+}
+
+func deduplicateDefHints(revisions []defRevCompatEntry) []DefIssueEntry {
+	type hintKey struct{ introduced, id, reason string }
+	issueRevisions := map[hintKey][]string{}
+	var issueOrder []hintKey
+	seenIssue := map[hintKey]bool{}
+	seenRev := map[string]bool{}
+	for _, r := range revisions {
+		if seenRev[r.revision] {
+			continue
+		}
+		seenRev[r.revision] = true
+		for _, h := range r.reasons {
+			k := hintKey{h.Introduced, h.ID, h.Reason}
+			issueRevisions[k] = append(issueRevisions[k], r.revision)
+			if !seenIssue[k] {
+				issueOrder = append(issueOrder, k)
+				seenIssue[k] = true
+			}
+		}
+	}
+	var issues []DefIssueEntry
+	for _, k := range issueOrder {
+		issues = append(issues, DefIssueEntry{
+			Introduced: k.introduced,
+			ID:         k.id,
+			Reason:     k.reason,
+			Revisions:  issueRevisions[k],
+		})
+	}
+	return issues
+}
+
+func printDefCompatReport(ioStreams util.IOStreams, report DefCompatReport, format string) error {
+	switch format {
+	case "json":
+		b, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(ioStreams.Out, string(b))
+		return nil
+	case outputFormatYAML:
+		b, err := yaml.Marshal(report)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(ioStreams.Out, string(b))
+		return nil
+	default:
+		if len(report.Definitions) == 0 {
+			fmt.Fprintln(ioStreams.Out, "All definitions are compatible.")
+			return nil
+		}
+		fmt.Fprintf(ioStreams.Out, "Found %d incompatible definition(s):\n", report.Total)
+		for _, d := range report.Definitions {
+			fmt.Fprintln(ioStreams.Out)
+			fmt.Fprintf(ioStreams.Out, "  %s (%s, %s)\n", d.Name, d.Kind, d.Namespace)
+
+			for i, issue := range d.Issues {
+				fmt.Fprintf(ioStreams.Out, "    - introduced: %s\n", issue.Introduced)
+				fmt.Fprintf(ioStreams.Out, "      id: %s\n", issue.ID)
+				fmt.Fprintf(ioStreams.Out, "      reason: %s\n", issue.Reason)
+				fmt.Fprintf(ioStreams.Out, "      revisions: %s\n", strings.Join(issue.Revisions, ", "))
+				if i < len(d.Issues)-1 {
+					fmt.Fprintln(ioStreams.Out)
+				}
+			}
+		}
+		fmt.Fprintln(ioStreams.Out)
+		fmt.Fprintln(ioStreams.Out, "Run `vela def upgrade <file>` to fix individual definition files.")
+		return nil
+	}
+}
+
+// scanAppsOptions holds parameters for scanApplications.
+type scanAppsOptions struct {
+	allTypes           []string
+	namespace          string
+	labelSelector      string
+	annotationSelector string
+}
+
+func scanApplications(ctx context.Context, k8sClient client.Client, opts scanAppsOptions) (AppCompatReport, error) {
+	typeSet := map[string]bool{}
+	for _, t := range opts.allTypes {
+		typeSet[t] = true
+	}
+	labelSel, err := parseSelectorMap(opts.labelSelector)
+	if err != nil {
+		return AppCompatReport{}, errors.Wrap(err, "--label-selector")
+	}
+	annotationSel, err := parseSelectorMap(opts.annotationSelector)
+	if err != nil {
+		return AppCompatReport{}, errors.Wrap(err, "--annotation-selector")
+	}
+
+	var listOpts []client.ListOption
+	if opts.namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(opts.namespace))
+	}
+	if len(labelSel) > 0 {
+		listOpts = append(listOpts, client.MatchingLabels(labelSel))
+	}
+
+	appList := &v1beta1.ApplicationList{}
+	if err := k8sClient.List(ctx, appList, listOpts...); err != nil {
+		return AppCompatReport{}, errors.Wrap(err, "failed to list Applications")
+	}
+
+	var appEntries []AppCompatEntry
+	for _, app := range appList.Items {
+		if len(annotationSel) > 0 && !matchesSelector(app.GetAnnotations(), annotationSel) {
+			continue
+		}
+		if app.Status.LatestRevision == nil || app.Status.LatestRevision.Name == "" {
+			continue
+		}
+		rev := &v1beta1.ApplicationRevision{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: app.Namespace,
+			Name:      app.Status.LatestRevision.Name,
+		}, rev); err != nil {
+			continue
+		}
+		appIssues := scanAppRevision(rev, typeSet)
+		if len(appIssues) == 0 {
+			continue
+		}
+		appEntries = append(appEntries, AppCompatEntry{
+			Application: app.Name,
+			Namespace:   app.Namespace,
+			Revision:    app.Status.LatestRevision.Name,
+			Issues:      appIssues,
+		})
+	}
+	sort.Slice(appEntries, func(i, j int) bool {
+		if appEntries[i].Namespace != appEntries[j].Namespace {
+			return appEntries[i].Namespace < appEntries[j].Namespace
+		}
+		return appEntries[i].Application < appEntries[j].Application
+	})
+	report := AppCompatReport{Total: len(appEntries), Applications: appEntries}
+	if report.Applications == nil {
+		report.Applications = []AppCompatEntry{}
+	}
+	return report, nil
+}
+
+func scanAppRevision(rev *v1beta1.ApplicationRevision, typeSet map[string]bool) []AppIssueEntry {
+	type rawDefEntry struct {
+		name    string
+		kind    string
+		reasons []CompatibilityHint
+	}
+	var rawDefs []rawDefEntry
+	collect := func(name, kind, template string) {
+		if needs, reasons, err := upgrade.RequiresUpgrade(template); err == nil && needs {
+			rawDefs = append(rawDefs, rawDefEntry{name: name, kind: kind, reasons: parseHints(reasons)})
+		}
+	}
+	for defName, def := range rev.Spec.ComponentDefinitions {
+		if typeSet["component"] && def != nil && def.Spec.Schematic != nil && def.Spec.Schematic.CUE != nil {
+			collect(defName, "component", def.Spec.Schematic.CUE.Template)
+		}
+	}
+	for defName, def := range rev.Spec.TraitDefinitions {
+		if typeSet["trait"] && def != nil && def.Spec.Schematic != nil && def.Spec.Schematic.CUE != nil {
+			collect(defName, "trait", def.Spec.Schematic.CUE.Template)
+		}
+	}
+	for defName, def := range rev.Spec.WorkflowStepDefinitions {
+		if typeSet["workflow-step"] && def != nil && def.Spec.Schematic != nil && def.Spec.Schematic.CUE != nil {
+			collect(defName, "workflow-step", def.Spec.Schematic.CUE.Template)
+		}
+	}
+	for defName, def := range rev.Spec.PolicyDefinitions {
+		if typeSet["policy"] && def.Spec.Schematic != nil && def.Spec.Schematic.CUE != nil {
+			collect(defName, "policy", def.Spec.Schematic.CUE.Template)
+		}
+	}
+	if len(rawDefs) == 0 {
+		return nil
+	}
+	sort.Slice(rawDefs, func(i, j int) bool {
+		if rawDefs[i].kind != rawDefs[j].kind {
+			return rawDefs[i].kind < rawDefs[j].kind
+		}
+		return rawDefs[i].name < rawDefs[j].name
+	})
+
+	type hintKey struct{ introduced, id, reason string }
+	type kindBuckets struct{ components, traits, policies, workflowSteps []string }
+	issueMap := map[hintKey]*kindBuckets{}
+	var issueOrder []hintKey
+	seenIssue := map[hintKey]bool{}
+	for _, rd := range rawDefs {
+		for _, h := range rd.reasons {
+			k := hintKey{h.Introduced, h.ID, h.Reason}
+			if !seenIssue[k] {
+				issueMap[k] = &kindBuckets{}
+				issueOrder = append(issueOrder, k)
+				seenIssue[k] = true
+			}
+			switch rd.kind {
+			case "component":
+				issueMap[k].components = append(issueMap[k].components, rd.name)
+			case "trait":
+				issueMap[k].traits = append(issueMap[k].traits, rd.name)
+			case "policy":
+				issueMap[k].policies = append(issueMap[k].policies, rd.name)
+			case "workflow-step":
+				issueMap[k].workflowSteps = append(issueMap[k].workflowSteps, rd.name)
+			}
+		}
+	}
+	var appIssues []AppIssueEntry
+	for _, k := range issueOrder {
+		b := issueMap[k]
+		appIssues = append(appIssues, AppIssueEntry{
+			Introduced:    k.introduced,
+			ID:            k.id,
+			Reason:        k.reason,
+			Components:    b.components,
+			Traits:        b.traits,
+			Policies:      b.policies,
+			WorkflowSteps: b.workflowSteps,
+		})
+	}
+	return appIssues
+}
+
+// --- `vela def compatibility-check applications` ---
+
+// NewDefinitionCompatibilityApplicationsCommand creates `vela def compatibility-check applications`.
+func NewDefinitionCompatibilityApplicationsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
+	var (
+		outputFormat       string
+		namespace          string
+		labelSelector      string
+		annotationSelector string
+	)
+
+	allTypes := []string{"component", "trait", "workflow-step", "policy"}
+
+	cmd := &cobra.Command{
+		Use:   "applications",
+		Short: "Scan active ApplicationRevisions for CUE incompatibilities",
+		Long: "Scans the active ApplicationRevision for every Application across all\n" +
+			"namespaces, reporting incompatible definition snapshots grouped by Application.",
+		Example: "# Scan all active ApplicationRevisions\n" +
+			"vela def compatibility-check applications\n\n" +
+			"# Output as YAML\n" +
+			"vela def compatibility-check applications -o yaml",
+		Annotations: map[string]string{
+			types.TagCommandType:  types.TypeDefManagement,
+			types.TagCommandOrder: "2",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8sClient, err := c.GetClient()
+			if err != nil {
+				return errors.Wrap(err, "failed to get k8s client")
+			}
+			report, err := scanApplications(context.Background(), k8sClient, scanAppsOptions{
+				allTypes:           allTypes,
+				namespace:          namespace,
+				labelSelector:      labelSelector,
+				annotationSelector: annotationSelector,
+			})
+			if err != nil {
+				return err
+			}
+			return printAppCompatReport(ioStreams, report, outputFormat)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format. One of: table, yaml, json.")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Only scan Applications in this namespace (default: all namespaces).")
+	cmd.Flags().StringVarP(&labelSelector, "label-selector", "l", "", "Filter Applications by labels, e.g. -l env=prod.")
+	cmd.Flags().StringVar(&annotationSelector, "annotation-selector", "", "Filter Applications by annotations, e.g. --annotation-selector owner=team-a.")
+	return cmd
+}
+
+func printAppCompatReport(ioStreams util.IOStreams, report AppCompatReport, format string) error {
+	switch format {
+	case "json":
+		b, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(ioStreams.Out, string(b))
+		return nil
+	case outputFormatYAML:
+		b, err := yaml.Marshal(report)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(ioStreams.Out, string(b))
+		return nil
+	default:
+		if len(report.Applications) == 0 {
+			fmt.Fprintln(ioStreams.Out, "All active ApplicationRevisions are compatible.")
+			return nil
+		}
+		fmt.Fprintf(ioStreams.Out, "Found %d application(s) with incompatible definition snapshots:\n", report.Total)
+		for _, app := range report.Applications {
+			fmt.Fprintln(ioStreams.Out)
+			fmt.Fprintf(ioStreams.Out, "  %s (%s)  revision: %s\n", app.Application, app.Namespace, app.Revision)
+			for i, issue := range app.Issues {
+				fmt.Fprintf(ioStreams.Out, "    - introduced: %s\n", issue.Introduced)
+				fmt.Fprintf(ioStreams.Out, "      id: %s\n", issue.ID)
+				fmt.Fprintf(ioStreams.Out, "      reason: %s\n", issue.Reason)
+				if len(issue.Components) > 0 {
+					fmt.Fprintf(ioStreams.Out, "      components: %s\n", strings.Join(issue.Components, ", "))
+				}
+				if len(issue.Traits) > 0 {
+					fmt.Fprintf(ioStreams.Out, "      traits: %s\n", strings.Join(issue.Traits, ", "))
+				}
+				if len(issue.Policies) > 0 {
+					fmt.Fprintf(ioStreams.Out, "      policies: %s\n", strings.Join(issue.Policies, ", "))
+				}
+				if len(issue.WorkflowSteps) > 0 {
+					fmt.Fprintf(ioStreams.Out, "      workflowSteps: %s\n", strings.Join(issue.WorkflowSteps, ", "))
+				}
+				if i < len(app.Issues)-1 {
+					fmt.Fprintln(ioStreams.Out)
+				}
+			}
+		}
+		fmt.Fprintln(ioStreams.Out)
+		fmt.Fprintln(ioStreams.Out, "Run `vela def upgrade <file>` to fix individual definition files.")
+		return nil
+	}
+}
+
+// --- Helpers ---
+
+// extractCUETemplate walks spec.schematic.cue.template in an unstructured object.
+func extractCUETemplate(obj map[string]any) (string, bool) {
+	spec, ok := obj["spec"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	schematic, ok := spec["schematic"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	cue, ok := schematic["cue"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	tmpl, ok := cue["template"].(string)
+	return tmpl, ok
+}
+
+// extractDefRevTemplate returns the CUE template from a DefinitionRevision regardless of type.
+func extractDefRevTemplate(dr v1beta1.DefinitionRevision) string {
+	switch dr.Spec.DefinitionType {
+	case oamcommon.ComponentType:
+		if dr.Spec.ComponentDefinition.Spec.Schematic != nil && dr.Spec.ComponentDefinition.Spec.Schematic.CUE != nil {
+			return dr.Spec.ComponentDefinition.Spec.Schematic.CUE.Template
+		}
+	case oamcommon.TraitType:
+		if dr.Spec.TraitDefinition.Spec.Schematic != nil && dr.Spec.TraitDefinition.Spec.Schematic.CUE != nil {
+			return dr.Spec.TraitDefinition.Spec.Schematic.CUE.Template
+		}
+	case oamcommon.WorkflowStepType:
+		if dr.Spec.WorkflowStepDefinition.Spec.Schematic != nil && dr.Spec.WorkflowStepDefinition.Spec.Schematic.CUE != nil {
+			return dr.Spec.WorkflowStepDefinition.Spec.Schematic.CUE.Template
+		}
+	case oamcommon.PolicyType:
+		if dr.Spec.PolicyDefinition.Spec.Schematic != nil && dr.Spec.PolicyDefinition.Spec.Schematic.CUE != nil {
+			return dr.Spec.PolicyDefinition.Spec.Schematic.CUE.Template
+		}
+	}
+	return ""
+}
+
+// defNameFromRevision extracts the underlying definition name from a DefinitionRevision
+// using the well-known label for its type (e.g. componentdefinitions.core.oam.dev/name).
+func defNameFromRevision(dr v1beta1.DefinitionRevision) string {
+	if labelKey, ok := pkgdef.DefinitionKindToNameLabel[dr.Spec.DefinitionType]; ok {
+		if name := dr.GetLabels()[labelKey]; name != "" {
+			return name
+		}
+	}
+	// Fallback: strip the trailing "-vN" from the revision object name.
+	name := dr.GetName()
+	if idx := strings.LastIndex(name, "-v"); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}

--- a/references/cli/def_compat_test.go
+++ b/references/cli/def_compat_test.go
@@ -1,0 +1,519 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	oamcommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+// ── parseHints ────────────────────────────────────────────────────────────────
+
+func TestParseHints(t *testing.T) {
+	tests := []struct {
+		name      string
+		reasons   []string
+		wantHints []CompatibilityHint
+	}{
+		{
+			name:      "empty",
+			reasons:   nil,
+			wantHints: nil,
+		},
+		{
+			name:    "single hint",
+			reasons: []string{"[v1.11] contains deprecated list operators"},
+			wantHints: []CompatibilityHint{
+				{Introduced: "v1.11", Reason: "contains deprecated list operators"},
+			},
+		},
+		{
+			name: "multiple hints",
+			reasons: []string{
+				"[v1.11] contains deprecated list operators",
+				"[v1.11] contains field named 'error'",
+			},
+			wantHints: []CompatibilityHint{
+				{Introduced: "v1.11", Reason: "contains deprecated list operators"},
+				{Introduced: "v1.11", Reason: "contains field named 'error'"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseHints(tt.reasons)
+			if len(got) != len(tt.wantHints) {
+				t.Fatalf("parseHints() len = %d, want %d", len(got), len(tt.wantHints))
+			}
+			for i, h := range got {
+				if h != tt.wantHints[i] {
+					t.Errorf("hint[%d] = %+v, want %+v", i, h, tt.wantHints[i])
+				}
+			}
+		})
+	}
+}
+
+// ── parseSelectorMap ──────────────────────────────────────────────────────────
+
+func TestParseSelectorMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      map[string]string
+		wantError bool
+	}{
+		{name: "empty", input: "", want: nil},
+		{
+			name:  "single pair",
+			input: "app=foo",
+			want:  map[string]string{"app": "foo"},
+		},
+		{
+			name:  "multiple pairs",
+			input: "app=foo,env=prod",
+			want:  map[string]string{"app": "foo", "env": "prod"},
+		},
+		{
+			name:  "value with equals sign",
+			input: "key=a=b",
+			want:  map[string]string{"key": "a=b"},
+		},
+		{
+			name:      "missing value separator",
+			input:     "badkey",
+			wantError: true,
+		},
+		{
+			name:      "empty key",
+			input:     "=value",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSelectorMap(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("parseSelectorMap(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSelectorMap(%q) unexpected error: %v", tt.input, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseSelectorMap(%q) len = %d, want %d", tt.input, len(got), len(tt.want))
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("parseSelectorMap(%q)[%q] = %q, want %q", tt.input, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// ── matchesSelector ───────────────────────────────────────────────────────────
+
+func TestMatchesSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]string
+		sel  map[string]string
+		want bool
+	}{
+		{name: "nil selector matches anything", meta: map[string]string{"a": "b"}, sel: nil, want: true},
+		{name: "empty selector matches anything", meta: map[string]string{"a": "b"}, sel: map[string]string{}, want: true},
+		{name: "exact match", meta: map[string]string{"app": "foo"}, sel: map[string]string{"app": "foo"}, want: true},
+		{name: "subset match", meta: map[string]string{"app": "foo", "env": "prod"}, sel: map[string]string{"app": "foo"}, want: true},
+		{name: "value mismatch", meta: map[string]string{"app": "foo"}, sel: map[string]string{"app": "bar"}, want: false},
+		{name: "missing key", meta: map[string]string{"app": "foo"}, sel: map[string]string{"env": "prod"}, want: false},
+		{name: "nil meta", meta: nil, sel: map[string]string{"app": "foo"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesSelector(tt.meta, tt.sel); got != tt.want {
+				t.Errorf("matchesSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ── extractCUETemplate ────────────────────────────────────────────────────────
+
+func TestExtractCUETemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      map[string]any
+		wantTmpl string
+		wantOk   bool
+	}{
+		{
+			name:   "missing spec",
+			obj:    map[string]any{},
+			wantOk: false,
+		},
+		{
+			name:   "missing schematic",
+			obj:    map[string]any{"spec": map[string]any{}},
+			wantOk: false,
+		},
+		{
+			name: "missing cue",
+			obj: map[string]any{"spec": map[string]any{
+				"schematic": map[string]any{},
+			}},
+			wantOk: false,
+		},
+		{
+			name: "template present",
+			obj: map[string]any{"spec": map[string]any{
+				"schematic": map[string]any{
+					"cue": map[string]any{
+						"template": "output: {}",
+					},
+				},
+			}},
+			wantTmpl: "output: {}",
+			wantOk:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractCUETemplate(tt.obj)
+			if ok != tt.wantOk {
+				t.Errorf("extractCUETemplate() ok = %v, want %v", ok, tt.wantOk)
+			}
+			if got != tt.wantTmpl {
+				t.Errorf("extractCUETemplate() = %q, want %q", got, tt.wantTmpl)
+			}
+		})
+	}
+}
+
+// ── defNameFromRevision ───────────────────────────────────────────────────────
+
+func TestDefNameFromRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		drName   string
+		drType   oamcommon.DefinitionType
+		labels   map[string]string
+		wantName string
+	}{
+		{
+			name:     "name from label",
+			drName:   "worker-v3",
+			drType:   oamcommon.ComponentType,
+			labels:   map[string]string{"componentdefinition.oam.dev/name": "worker"},
+			wantName: "worker",
+		},
+		{
+			name:     "fallback strip -vN",
+			drName:   "my-trait-v12",
+			drType:   oamcommon.TraitType,
+			labels:   map[string]string{},
+			wantName: "my-trait",
+		},
+		{
+			name:     "fallback no -vN suffix",
+			drName:   "standalone",
+			drType:   oamcommon.ComponentType,
+			labels:   map[string]string{},
+			wantName: "standalone",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dr := v1beta1.DefinitionRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   tt.drName,
+					Labels: tt.labels,
+				},
+			}
+			dr.Spec.DefinitionType = tt.drType
+			got := defNameFromRevision(dr)
+			if got != tt.wantName {
+				t.Errorf("defNameFromRevision() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+// ── extractDefRevTemplate ─────────────────────────────────────────────────────
+
+func TestExtractDefRevTemplate(t *testing.T) {
+	tmpl := "output: {}"
+
+	tests := []struct {
+		name string
+		dr   v1beta1.DefinitionRevision
+		want string
+	}{
+		{
+			name: "component",
+			dr: v1beta1.DefinitionRevision{Spec: v1beta1.DefinitionRevisionSpec{
+				DefinitionType: oamcommon.ComponentType,
+				ComponentDefinition: v1beta1.ComponentDefinition{Spec: v1beta1.ComponentDefinitionSpec{
+					Schematic: &oamcommon.Schematic{CUE: &oamcommon.CUE{Template: tmpl}},
+				}},
+			}},
+			want: tmpl,
+		},
+		{
+			name: "trait",
+			dr: v1beta1.DefinitionRevision{Spec: v1beta1.DefinitionRevisionSpec{
+				DefinitionType: oamcommon.TraitType,
+				TraitDefinition: v1beta1.TraitDefinition{Spec: v1beta1.TraitDefinitionSpec{
+					Schematic: &oamcommon.Schematic{CUE: &oamcommon.CUE{Template: tmpl}},
+				}},
+			}},
+			want: tmpl,
+		},
+		{
+			name: "no schematic",
+			dr: v1beta1.DefinitionRevision{Spec: v1beta1.DefinitionRevisionSpec{
+				DefinitionType: oamcommon.ComponentType,
+			}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDefRevTemplate(tt.dr)
+			if got != tt.want {
+				t.Errorf("extractDefRevTemplate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ── printDefCompatReport ──────────────────────────────────────────────────────
+
+func TestPrintDefCompatReport(t *testing.T) {
+	report := DefCompatReport{
+		Total: 1,
+		Definitions: []DefCompatEntry{
+			{
+				Name:      "worker",
+				Kind:      "ComponentDefinition",
+				Namespace: "vela-system",
+				Issues: []DefIssueEntry{
+					{
+						Introduced: "v1.11",
+						Reason:     "contains deprecated list operators",
+						Revisions:  []string{"v1", "v2"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("table output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printDefCompatReport(streams, report, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "worker") {
+			t.Error("expected definition name 'worker' in output")
+		}
+		if !strings.Contains(out, "v1.11") {
+			t.Error("expected introduced version 'v1.11' in output")
+		}
+		if !strings.Contains(out, "v1, v2") {
+			t.Error("expected revisions 'v1, v2' in output")
+		}
+	})
+
+	t.Run("empty table output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		empty := DefCompatReport{Total: 0, Definitions: []DefCompatEntry{}}
+		if err := printDefCompatReport(streams, empty, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "compatible") {
+			t.Error("expected 'compatible' message for empty report")
+		}
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printDefCompatReport(streams, report, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var decoded DefCompatReport
+		if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+			t.Fatalf("json output not valid: %v", err)
+		}
+		if decoded.Total != 1 {
+			t.Errorf("json total = %d, want 1", decoded.Total)
+		}
+		if decoded.Definitions[0].Issues[0].Introduced != "v1.11" {
+			t.Errorf("json introduced = %q, want v1.11", decoded.Definitions[0].Issues[0].Introduced)
+		}
+	})
+
+	t.Run("yaml output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printDefCompatReport(streams, report, "yaml"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "introduced: v1.11") {
+			t.Errorf("yaml output missing introduced field, got:\n%s", out)
+		}
+		if !strings.Contains(out, "- v1") {
+			t.Errorf("yaml output missing revision v1, got:\n%s", out)
+		}
+	})
+}
+
+// ── printAppCompatReport ──────────────────────────────────────────────────────
+
+func TestPrintAppCompatReport(t *testing.T) {
+	report := AppCompatReport{
+		Total: 1,
+		Applications: []AppCompatEntry{
+			{
+				Application: "my-app",
+				Namespace:   "default",
+				Revision:    "my-app-v1",
+				Issues: []AppIssueEntry{
+					{
+						Introduced: "v1.11",
+						Reason:     "contains deprecated list operators",
+						Components: []string{"worker"},
+						Traits:     []string{"scaler"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("table output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printAppCompatReport(streams, report, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "my-app") {
+			t.Error("expected app name in output")
+		}
+		if !strings.Contains(out, "my-app-v1") {
+			t.Error("expected revision in output")
+		}
+		if !strings.Contains(out, "components: worker") {
+			t.Error("expected components in output")
+		}
+		if !strings.Contains(out, "traits: scaler") {
+			t.Error("expected traits in output")
+		}
+	})
+
+	t.Run("empty table output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		empty := AppCompatReport{Total: 0, Applications: []AppCompatEntry{}}
+		if err := printAppCompatReport(streams, empty, "table"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "compatible") {
+			t.Error("expected 'compatible' message for empty report")
+		}
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printAppCompatReport(streams, report, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var decoded AppCompatReport
+		if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+			t.Fatalf("json output not valid: %v", err)
+		}
+		if decoded.Total != 1 {
+			t.Errorf("json total = %d, want 1", decoded.Total)
+		}
+		issue := decoded.Applications[0].Issues[0]
+		if issue.Introduced != "v1.11" {
+			t.Errorf("json introduced = %q, want v1.11", issue.Introduced)
+		}
+		if len(issue.Components) != 1 || issue.Components[0] != "worker" {
+			t.Errorf("json components = %v, want [worker]", issue.Components)
+		}
+	})
+
+	t.Run("yaml output", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		if err := printAppCompatReport(streams, report, "yaml"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "application: my-app") {
+			t.Errorf("yaml output missing application field, got:\n%s", out)
+		}
+		if !strings.Contains(out, "components:") {
+			t.Errorf("yaml output missing components field, got:\n%s", out)
+		}
+	})
+
+	t.Run("omitempty hides empty kind fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		streams := util.IOStreams{Out: &buf}
+		noTraits := AppCompatReport{
+			Total: 1,
+			Applications: []AppCompatEntry{{
+				Application: "app",
+				Namespace:   "default",
+				Revision:    "app-v1",
+				Issues: []AppIssueEntry{{
+					Introduced: "v1.11",
+					Reason:     "some issue",
+					Components: []string{"worker"},
+				}},
+			}},
+		}
+		if err := printAppCompatReport(streams, noTraits, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(buf.String(), "traits") {
+			t.Error("expected traits to be omitted when empty")
+		}
+	})
+}

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/rest"
 
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/references/a/preimport"
@@ -30,6 +31,7 @@ func main() {
 	preimport.ResumeLogging()
 	_ = utilfeature.DefaultMutableFeatureGate.Set("AllAlpha=true")
 	system.BindEnvironmentVariables()
+	rest.SetDefaultWarningHandler(rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{Deduplicate: true}))
 
 	command := cli.NewCommand()
 

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -276,8 +276,11 @@ var _ = Describe("Application Normal tests", func() {
 		}, 5*time.Second).Should(BeNil())
 
 		By("check trait status")
-		Expect(testApp.Status.Services[0].Traits[0].Message).Should(Equal("configMap:app-file-html"))
-		Expect(testApp.Status.Services[0].Traits[1].Message).Should(Equal("secret:app-env-config"))
+		traitMessages := []string{
+			testApp.Status.Services[0].Traits[0].Message,
+			testApp.Status.Services[0].Traits[1].Message,
+		}
+		Expect(traitMessages).Should(ContainElements("configMap:app-file-html", "secret:app-env-config"))
 	})
 
 	It("Test app have components with same name", func() {
@@ -550,6 +553,65 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(app.Status.Services[0].Traits[0].Healthy).Should(BeTrue())
 		Expect(app.Status.Services[0].Traits[0].Message).Should(Equal(fmt.Sprintf("Healthy - %v / %v replicas are ready", traitReplicas, traitReplicas)))
 		Expect(app.Status.Services[0].Traits[0].Details["allReplicasReady"]).Should(Equal("true"))
+	})
+
+	It("test app with legacy CUE syntax renders and becomes healthy", func() {
+		By("Applying the legacy-cue-component ComponentDefinition (uses deprecated + list arithmetic)")
+		var compDef v1beta1.ComponentDefinition
+		Expect(common.ReadYamlToObject("testdata/definition/legacy-cue-component.yaml", &compDef)).Should(BeNil())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, compDef.DeepCopy())
+		}, 10*time.Second, 500*time.Millisecond).Should(SatisfyAny(util.AlreadyExistMatcher{}, BeNil()))
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &compDef)
+		})
+
+		By("Applying the legacy-cue-trait TraitDefinition (uses deprecated + list arithmetic)")
+		var traitDef v1beta1.TraitDefinition
+		Expect(common.ReadYamlToObject("testdata/definition/legacy-cue-trait.yaml", &traitDef)).Should(BeNil())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, traitDef.DeepCopy())
+		}, 10*time.Second, 500*time.Millisecond).Should(SatisfyAny(util.AlreadyExistMatcher{}, BeNil()))
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &traitDef)
+		})
+
+		By("Applying the legacy-cue-policy PolicyDefinition (uses deprecated + list arithmetic)")
+		var policyDef v1beta1.PolicyDefinition
+		Expect(common.ReadYamlToObject("testdata/definition/legacy-cue-policy.yaml", &policyDef)).Should(BeNil())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, policyDef.DeepCopy())
+		}, 10*time.Second, 500*time.Millisecond).Should(SatisfyAny(util.AlreadyExistMatcher{}, BeNil()))
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &policyDef)
+		})
+
+		By("Creating an application that uses legacy CUE definitions")
+		var app v1beta1.Application
+		applyApp(ctx, namespaceName, "app_with_legacy_cue.yaml", &app)
+
+		By("Waiting for the deployment to be running")
+		verifyWorkloadRunningExpected(ctx, namespaceName, "legacy-cue-component", 1, "nginx")
+
+		By("Waiting for the app component to become healthy")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: app.Name}, &app)
+			if err != nil || len(app.Status.Services) == 0 {
+				return false
+			}
+			return app.Status.Services[0].Healthy
+		}, 60*time.Second, 2*time.Second).Should(BeTrue(), "Expected application with legacy CUE syntax to become healthy")
+
+		By("Verifying component health and status messages from upgraded CUE templates")
+		Expect(app.Status.Services[0].Healthy).Should(BeTrue())
+		Expect(app.Status.Services[0].Message).Should(ContainSubstring("Healthy"))
+
+		By("Verifying the legacy CUE policy rendered correctly (ConfigMap produced by upgraded list arithmetic)")
+		cm := &corev1.ConfigMap{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: "legacy-cue-policy"}, cm)
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+		Expect(cm.Data["team"]).Should(Equal("platform"))
 	})
 })
 

--- a/test/e2e-test/policy_transforms_test.go
+++ b/test/e2e-test/policy_transforms_test.go
@@ -467,4 +467,5 @@ output: {
 			g.Expect(app.Labels).Should(HaveKeyWithValue("versioned.io/label", "from-v2"))
 		}, policyTransformWaitTimeout, 3*time.Second).Should(Succeed())
 	})
+
 })

--- a/test/e2e-test/testdata/app/app_with_legacy_cue.yaml
+++ b/test/e2e-test/testdata/app/app_with_legacy_cue.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-with-legacy-cue
+spec:
+  components:
+    - name: legacy-cue-component
+      type: legacy-cue-component
+      traits:
+        - type: legacy-cue-trait
+  policies:
+    - name: legacy-cue-policy
+      type: legacy-cue-policy
+      properties:
+        team: platform

--- a/test/e2e-test/testdata/definition/legacy-cue-component.yaml
+++ b/test/e2e-test/testdata/definition/legacy-cue-component.yaml
@@ -1,0 +1,64 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: legacy-cue-component
+  namespace: vela-system
+  annotations:
+    definition.oam.dev/description: "Component with legacy CUE list-arithmetic syntax for compat layer testing"
+spec:
+  workload:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+  schematic:
+    cue:
+      template: |
+        // Legacy list-arithmetic: baseEnv + extraEnv uses deprecated + operator
+        baseEnv: [{name: "APP", value: context.name}]
+        extraEnv: [{name: "MANAGED_BY", value: "kubevela"}]
+        envList: baseEnv + extraEnv
+
+        output: {
+          apiVersion: "apps/v1"
+          kind:       "Deployment"
+          metadata: name: "legacy-cue-component"
+          spec: {
+            replicas: 1
+            selector: matchLabels: app: "legacy-cue-component"
+            template: {
+              metadata: labels: app: "legacy-cue-component"
+              spec: containers: [{
+                name:  "legacy-cue-component"
+                image: "nginx"
+                env:   envList
+              }]
+            }
+          }
+        }
+        parameter: {}
+  status:
+    details: |
+      // Legacy list-arithmetic in details: deprecated + operator concatenating diagnostic tags
+      baseTags: ["kubevela"]
+      extraTags: ["legacy-compat"]
+      allTags: baseTags + extraTags
+      readyReplicas: *context.output.status.readyReplicas | 0
+      $expectedReplicas: context.output.spec.replicas
+      deploymentReady: *(context.output.status.replicas == context.output.status.readyReplicas) | false
+    healthPolicy: |
+      // Legacy list-arithmetic in healthPolicy: deprecated + operator
+      baseChecks: [context.status.details.deploymentReady]
+      extraChecks: [true]
+      allChecks: baseChecks + extraChecks
+      isHealth: context.status.details.readyReplicas == context.status.details.$expectedReplicas
+    customStatus: |
+      // Legacy list-arithmetic in customStatus: deprecated + operator
+      baseMsg: ["replicas:"]
+      extraMsg: ["\(context.status.details.readyReplicas)/\(context.status.details.$expectedReplicas)"]
+      msgParts: baseMsg + extraMsg
+      if context.status.healthy {
+        message: "Healthy - \(context.status.details.readyReplicas) / \(context.status.details.$expectedReplicas) replicas are ready"
+      }
+      if !context.status.healthy {
+        message: "Unhealthy - \(context.status.details.readyReplicas) / \(context.status.details.$expectedReplicas) replicas are ready"
+      }

--- a/test/e2e-test/testdata/definition/legacy-cue-policy.yaml
+++ b/test/e2e-test/testdata/definition/legacy-cue-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: core.oam.dev/v1beta1
+kind: PolicyDefinition
+metadata:
+  name: legacy-cue-policy
+  namespace: vela-system
+  annotations:
+    definition.oam.dev/description: "Policy with legacy CUE list-arithmetic syntax for compat layer testing"
+spec:
+  schematic:
+    cue:
+      template: |
+        // Legacy list-arithmetic: deprecated + operator
+        baseTags: ["kubevela"]
+        extraTags: [parameter.team]
+        allTags: baseTags + extraTags
+        output: {
+          apiVersion: "v1"
+          kind:       "ConfigMap"
+          metadata: name: context.name
+          data: team: allTags[1]
+        }
+        parameter: {
+          team: *"platform" | string
+        }

--- a/test/e2e-test/testdata/definition/legacy-cue-trait.yaml
+++ b/test/e2e-test/testdata/definition/legacy-cue-trait.yaml
@@ -1,0 +1,29 @@
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  name: legacy-cue-trait
+  namespace: vela-system
+  annotations:
+    definition.oam.dev/description: "Trait with legacy CUE list-arithmetic syntax for compat layer testing"
+spec:
+  appliesToWorkloads:
+    - legacy-cue-component
+  podDisruptive: false
+  schematic:
+    cue:
+      template: |
+        // Legacy list-arithmetic: baseLabels + extraLabels uses deprecated + operator
+        baseLabels: [{key: "managed-by", value: "kubevela"}]
+        extraLabels: [{key: "legacy-compat", value: "tested"}]
+        allLabels: baseLabels + extraLabels
+
+        outputs: configmap: {
+          apiVersion: "v1"
+          kind:       "ConfigMap"
+          metadata: {
+            name: context.name + "-legacy-labels"
+            labels: "managed-by": "kubevela"
+          }
+          data: "label-count": "\(len(allLabels))"
+        }
+        parameter: {}

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -227,7 +227,7 @@ template: {
 										}}]
 								}
 								if parameter["volumeMounts"] != _|_ {
-									volumeMounts: mountsArray.pvc + mountsArray.configMap + mountsArray.secret + mountsArray.emptyDir + mountsArray.hostPath
+									volumeMounts: list.Concat([mountsArray.pvc, mountsArray.configMap, mountsArray.secret, mountsArray.emptyDir, mountsArray.hostPath])
 								}
 							}]
 							if parameter["volumes"] != _|_ if parameter["volumeMounts"] == _|_ {

--- a/vela-templates/definitions/internal/trait/command.cue
+++ b/vela-templates/definitions/internal/trait/command.cue
@@ -1,3 +1,5 @@
+import "list"
+
 command: {
 	type: "trait"
 	annotations: {}
@@ -64,7 +66,7 @@ template: {
 			}
 
 			// +patchStrategy=replace
-			args: [for a in _args if _delArgs[a] == _|_ {a}] + [for a in _addArgs if _delArgs[a] == _|_ && _argsMap[a] == _|_ {a}]
+			args: list.Concat([[for a in _args if _delArgs[a] == _|_ {a}], [for a in _addArgs if _delArgs[a] == _|_ && _argsMap[a] == _|_ {a}]])
 		}
 	}
 	// +patchStrategy=open

--- a/vela-templates/definitions/internal/trait/container-ports.cue
+++ b/vela-templates/definitions/internal/trait/container-ports.cue
@@ -1,3 +1,5 @@
+import "list"
+
 import (
 	"strconv"
 	"strings"
@@ -60,7 +62,7 @@ template: {
 				_basePortsMap: {for _basePort in _basePorts {(strings.ToLower(_basePort.protocol) + strconv.FormatInt(_basePort.containerPort, 10)): _basePort}}
 				_portsMap: {for port in _params.ports {(strings.ToLower(port.protocol) + strconv.FormatInt(port.containerPort, 10)): port}}
 				// +patchStrategy=replace
-				ports: [for portVar in _basePorts {
+				ports: list.Concat([[for portVar in _basePorts {
 					containerPort: portVar.containerPort
 					protocol:      portVar.protocol
 					name:          portVar.name
@@ -73,7 +75,7 @@ template: {
 							hostIP: _portsMap[_uniqueKey].hostIP
 						}
 					}
-				}] + [for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {
+				}], [for port in _params.ports if _basePortsMap[strings.ToLower(port.protocol)+strconv.FormatInt(port.containerPort, 10)] == _|_ {
 					if port.containerPort != _|_ {
 						containerPort: port.containerPort
 					}
@@ -86,7 +88,7 @@ template: {
 					if port.hostIP != _|_ {
 						hostIP: port.hostIP
 					}
-				}]
+				}]])
 			}
 		}
 	}

--- a/vela-templates/definitions/internal/trait/env.cue
+++ b/vela-templates/definitions/internal/trait/env.cue
@@ -1,3 +1,5 @@
+import "list"
+
 env: {
 	type: "trait"
 	annotations: {}
@@ -40,7 +42,7 @@ template: {
 			if _baseEnv != _|_ {
 				_baseEnvMap: {for envVar in _baseEnv {(envVar.name): envVar}}
 				// +patchStrategy=replace
-				env: [for envVar in _baseEnv if _delKeys[envVar.name] == _|_ && !_params.replace {
+				env: list.Concat([[for envVar in _baseEnv if _delKeys[envVar.name] == _|_ && !_params.replace {
 					name: envVar.name
 					if _params.env[envVar.name] != _|_ {
 						value: _params.env[envVar.name]
@@ -53,10 +55,10 @@ template: {
 							valueFrom: envVar.valueFrom
 						}
 					}
-				}] + [for k, v in _params.env if _delKeys[k] == _|_ && (_params.replace || _baseEnvMap[k] == _|_) {
+				}], [for k, v in _params.env if _delKeys[k] == _|_ && (_params.replace || _baseEnvMap[k] == _|_) {
 					name:  k
 					value: v
-				}]
+				}]])
 			}
 		}
 	}

--- a/vela-templates/definitions/internal/trait/init-container.cue
+++ b/vela-templates/definitions/internal/trait/init-container.cue
@@ -1,3 +1,5 @@
+import "list"
+
 "init-container": {
 	type: "trait"
 	annotations: {}
@@ -34,10 +36,10 @@ template: {
 			}
 
 			// +patchKey=name
-			volumeMounts: [{
+			volumeMounts: list.Concat([[{
 				name:      parameter.mountName
 				mountPath: parameter.initMountPath
-			}] + parameter.extraVolumeMounts
+			}], parameter.extraVolumeMounts])
 		}]
 		// +patchKey=name
 		volumes: [{

--- a/vela-templates/definitions/internal/workflowstep/apply-deployment.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-deployment.cue
@@ -1,6 +1,4 @@
 import (
-	"strconv"
-	"strings"
 	"vela/kube"
 	"vela/builtin"
 )

--- a/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
@@ -2,7 +2,6 @@ import (
 	"vela/config"
 	"vela/kube"
 	"vela/builtin"
-	"strings"
 )
 
 "apply-terraform-provider": {

--- a/vela-templates/definitions/internal/workflowstep/build-push-image.cue
+++ b/vela-templates/definitions/internal/workflowstep/build-push-image.cue
@@ -2,7 +2,6 @@ import (
 	"vela/builtin"
 	"vela/kube"
 	"vela/util"
-	"encoding/json"
 	"strings"
 )
 

--- a/vela-templates/registry/auto-gen/autoscale.yaml
+++ b/vela-templates/registry/auto-gen/autoscale.yaml
@@ -24,7 +24,6 @@ spec:
     cue:
       template: |
         import "strconv"
-
         outputs: autoscaler: {{
         	apiVersion: "standard.oam.dev/v1alpha1"
         	kind:       "Autoscaler"

--- a/vela-templates/registry/auto-gen/kautoscale.yaml
+++ b/vela-templates/registry/auto-gen/kautoscale.yaml
@@ -15,7 +15,6 @@ spec:
     cue:
       template: |
         import "encoding/json"
-
         patch: metadata: annotations: "my.autoscale.ann": json.Marshal({
         	minReplicas: parameter.min
         	maxReplicas: parameter.max


### PR DESCRIPTION
### Description of your changes

copilot:all

Auto-remediate legacy CUE syntax at render time so clusters running CUE v0.14+ continue to work with existing definitions that use pre-v0.14 syntax, without requiring operators to manually migrate definitions.

**Problem**: CUE v0.14 made list arithmetic (+, *) and unquoted error field labels hard errors. Any definition using this syntax fails to render, breaking applications silently on upgrade.

**Solution**: A compatibility layer (pkg/cue/upgrade) transparently rewrites deprecated syntax at render time. The original template is stored verbatim; the upgraded form is used only at render time. Operators are warned at `vela def apply` time and can identify affected definitions using the new `vela def compat` commands.

**CLI**:
- `vela def upgrade <file>`: rewrites a definition file in-place (or to `-o <output>`) applying all compatibility fixes; `--validate` flag exits with code 1 if the file needs upgrading without modifying it
  - `vela def compatibility-check definitions` (alias: `vela def compat definitions`): scans all definitions across namespaces for legacy CUE syntax, reporting which fixes would be applied and which revisions are affected
  - `vela def compatibility-check applications` (alias: `vela def compat applications`): scans all active ApplicationRevisions and reports which definition snapshots still use legacy syntax that is being auto-upgraded at render time
  - `vela def apply` now warns when a definition contains legacy syntax that will be auto-upgraded

**Known limitation**: Workflow step templates are evaluated by the kubevela/workflow engine independently at execution time and do not go through this layer. Fixing workflow steps requires changes in that repo; this is a planned follow-up.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

  - Unit tests cover the upgrade registry, list-arithmetic and error-field-label rewrites, cache LRU/TTL behaviour, RequiresUpgrade reason format, and Prometheus metric emission
  - E2e test ("test app with legacy CUE syntax renders and becomes healthy") applies a ComponentDefinition, TraitDefinition, and PolicyDefinition all using deprecated + list arithmetic, then asserts the application reaches healthy status and the policy-rendered ConfigMap contains the correct value; verifying the compat layer ran end-to-end across all three definition kinds and all template areas (main template, healthPolicy, customStatus, status details)


### Special notes for your reviewer
**Alpha target / follow-up required**: This PR is being merged to get the feature into alpha for real-world testing. The upgrade registry, CUEUpgradeFunc, Version, and cache currently live in the `kubevela` repo. The intention is to move these to `kubevela/pkg` so the same fixes can be consumed by the `kubevela/workflow` engine and any other downstream repo without duplication. 

Until that move happens, workflow step templates with legacy CUE syntax will still fail at execution time; the workflow engine evaluates CUE independently and does not go through this layer. This is the primary known gap and the motivation for extracting to `pkg`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

