### PR TITLE
chore: update codeowners 1.10

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,35 +1,35 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*                                  @barnettZQG @wonderflow @leejanee @Somefive @jefree-cat @FogDong @wangyikewxgm @chivalryq @anoop2811
-design/                            @barnettZQG @leejanee @wonderflow @Somefive @jefree-cat @FogDong @anoop2811
+*                                  @barnettZQG @wonderflow @leejanee @Somefive @jefree-cat @FogDong @wangyikewxgm @chivalryq @anoop2811 @briankane @jguionnet
+design/                            @barnettZQG @leejanee @wonderflow @Somefive @jefree-cat @FogDong @anoop2811 @briankane @jguionnet
 
 # Owner of Core Controllers
-pkg/controller/core.oam.dev       @Somefive @FogDong @barnettZQG @wonderflow @wangyikewxgm @chivalryq @anoop2811
+pkg/controller/core.oam.dev       @Somefive @FogDong @barnettZQG @wonderflow @wangyikewxgm @chivalryq @anoop2811 @briankane @jguionnet
 
 # Owner of Standard Controllers
-pkg/controller/standard.oam.dev   @wangyikewxgm @barnettZQG @wonderflow @Somefive @anoop2811 @FogDong
+pkg/controller/standard.oam.dev   @wangyikewxgm @barnettZQG @wonderflow @Somefive @anoop2811 @FogDong @briankane @jguionnet
 
 # Owner of CUE
-pkg/cue                            @leejanee @FogDong @Somefive @anoop2811
-pkg/stdlib                         @leejanee @FogDong @Somefive @anoop2811
+pkg/cue                            @leejanee @FogDong @Somefive @anoop2811 @briankane @jguionnet
+pkg/stdlib                         @leejanee @FogDong @Somefive @anoop2811 @briankane @jguionnet
 
 # Owner of Workflow
-pkg/workflow                       @leejanee @FogDong @Somefive @wangyikewxgm @chivalryq @anoop2811
+pkg/workflow                       @leejanee @FogDong @Somefive @wangyikewxgm @chivalryq @anoop2811 @briankane @jguionnet
 
 # Owner of vela templates
-vela-templates/                     @Somefive @barnettZQG @wonderflow @FogDong @wangyikewxgm @chivalryq @anoop2811
+vela-templates/                     @Somefive @barnettZQG @wonderflow @FogDong @wangyikewxgm @chivalryq @anoop2811 @briankane @jguionnet
 
 # Owner of vela CLI
-references/cli/                     @Somefive @StevenLeiZhang @charlie0129 @wangyikewxgm @chivalryq @anoop2811 @FogDong
+references/cli/                     @Somefive @StevenLeiZhang @charlie0129 @wangyikewxgm @chivalryq @anoop2811 @FogDong @briankane @jguionnet
 
 # Owner of vela addon framework
-pkg/addon/                         @wangyikewxgm @wonderflow @charlie0129 @anoop2811 @FogDong
+pkg/addon/                         @wangyikewxgm @wonderflow @charlie0129 @anoop2811 @FogDong @briankane @jguionnet
 
 # Owner of resource keeper and tracker
-pkg/resourcekeeper                 @Somefive @FogDong @chivalryq @anoop2811
-pkg/resourcetracker                @Somefive @FogDong @chivalryq @anoop2811
+pkg/resourcekeeper                 @Somefive @FogDong @chivalryq @anoop2811 @briankane @jguionnet
+pkg/resourcetracker                @Somefive @FogDong @chivalryq @anoop2811 @briankane @jguionnet
 
-.github/                           @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811
-makefiles                          @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811
-go.*                               @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811
+.github/                           @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811 @briankane @jguionnet
+makefiles                          @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811 @briankane @jguionnet
+go.*                               @chivalryq @wonderflow @Somefive @FogDong @wangyikewxgm @anoop2811 @briankane @jguionnet
 

--- a/pkg/cue/definition/health/health_test.go
+++ b/pkg/cue/definition/health/health_test.go
@@ -781,3 +781,227 @@ func TestContextPassing(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStatusWithDynamicKeys(t *testing.T) {
+	cases := map[string]struct {
+		tpContext map[string]interface{}
+		parameter interface{}
+		statusCue string
+		expStatus map[string]string
+	}{
+		"root-comprehension-generates-dynamic-keys-from-list": {
+			tpContext: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"ingress": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"rules": []interface{}{
+								map[string]interface{}{"host": "foo.example.com"},
+								map[string]interface{}{"host": "bar.example.com"},
+							},
+						},
+					},
+				},
+			},
+			parameter: make(map[string]interface{}),
+			statusCue: strings.TrimSpace(`
+				{for _, rule in context.outputs.ingress.spec.rules {
+					"host.\(rule.host)": rule.host
+				}}
+			`),
+			expStatus: map[string]string{
+				"host.foo.example.com": "foo.example.com",
+				"host.bar.example.com": "bar.example.com",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, status, err := getStatusMap(tc.tpContext, tc.statusCue, tc.parameter)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expStatus, status)
+		})
+	}
+}
+
+func TestGetStatusWithDefinitionAndHiddenLabels(t *testing.T) {
+	testCases := []struct {
+		name            string
+		templateContext map[string]interface{}
+		statusFields    string
+		wantNoErr       bool
+		description     string
+	}{
+		{
+			name: "handles definition labels without panic",
+			templateContext: map[string]interface{}{
+				"output": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			},
+			statusFields: `
+#SomeDefinition: {
+	name: string
+	type: string
+}
+
+status: #SomeDefinition & {
+	name: "test"
+	type: "healthy"
+}
+`,
+			wantNoErr:   true,
+			description: "Should handle definition labels (#SomeDefinition) without panicking",
+		},
+		{
+			name: "handles hidden labels without panic",
+			templateContext: map[string]interface{}{
+				"output": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			},
+			statusFields: `
+_hiddenField: "internal"
+
+status: {
+	name: "test"
+	internal: _hiddenField
+}
+`,
+			wantNoErr:   true,
+			description: "Should handle hidden labels (_hiddenField) without panicking",
+		},
+		{
+			name: "handles pattern labels without panic",
+			templateContext: map[string]interface{}{
+				"output": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			},
+			statusFields: `
+[string]: _
+
+status: {
+	name: "test"
+	healthy: true
+}
+`,
+			wantNoErr:   true,
+			description: "Should handle pattern labels ([string]: _) without panicking",
+		},
+		{
+			name: "handles mixed label types without panic",
+			templateContext: map[string]interface{}{
+				"output": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			},
+			statusFields: `
+#Definition: {
+	field: string
+}
+
+_hidden: "value"
+
+normalField: "visible"
+
+status: {
+	name: normalField
+	type: _hidden
+	def: #Definition & {field: "test"}
+}
+`,
+			wantNoErr:   true,
+			description: "Should handle mixed label types without panicking",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := &StatusRequest{
+				Details:   tc.statusFields,
+				Parameter: map[string]interface{}{},
+			}
+
+			// This should not panic even with definition or hidden labels
+			result, err := GetStatus(tc.templateContext, request)
+
+			if tc.wantNoErr {
+				// We expect no panic and a valid result
+				assert.NotNil(t, result, tc.description)
+				// The function may return an error for invalid CUE, but it shouldn't panic
+				if err != nil {
+					t.Logf("Got expected error (non-panic): %v", err)
+				}
+			} else {
+				assert.Error(t, err, tc.description)
+			}
+		})
+	}
+}
+
+func TestGetStatusMapWithComplexSelectors(t *testing.T) {
+	// Test that getStatusMap doesn't panic with various selector types
+	testCases := []struct {
+		name            string
+		statusFields    string
+		templateContext map[string]interface{}
+		shouldNotPanic  bool
+	}{
+		{
+			name: "definition selector in context",
+			statusFields: `
+#Config: {
+	enabled: bool
+}
+
+config: #Config & {
+	enabled: true
+}
+`,
+			templateContext: map[string]interface{}{},
+			shouldNotPanic:  true,
+		},
+		{
+			name: "hidden field selector",
+			statusFields: `
+_internal: {
+	secret: "hidden"
+}
+
+public: _internal.secret
+`,
+			templateContext: map[string]interface{}{},
+			shouldNotPanic:  true,
+		},
+		{
+			name: "optional field selector",
+			statusFields: `
+optional?: string
+
+required: string | *"default"
+`,
+			templateContext: map[string]interface{}{},
+			shouldNotPanic:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.shouldNotPanic {
+				// The function should not panic
+				assert.NotPanics(t, func() {
+					_, _, _ = getStatusMap(tc.templateContext, tc.statusFields, nil)
+				}, "getStatusMap should not panic with %s", tc.name)
+			}
+		})
+	}
+}

--- a/pkg/definition/ast/transformer.go
+++ b/pkg/definition/ast/transformer.go
@@ -31,7 +31,73 @@ const (
 	customStatus = "attributes.status.customStatus"
 	// localFieldPrefix is the prefix for local fields not output to the status
 	localFieldPrefix = "$"
+	// disableValidationAttr is the CUE field attribute that bypasses validation for status fields.
+	// Usage of this indicates validation is too restrictive and a bug should be opened.
+	disableValidationAttr = "@disableValidation()"
+	// cueAttrPrefix is the line prefix used to persist CUE field attributes
+	// e.g. "// cue-attr:@disableValidation()".
+	cueAttrPrefix = "// cue-attr:"
 )
+
+// injectAttrs serialises all attributes from cue attrs as cue-attr comment lines
+func injectAttrs(litValue string, attrs []*ast.Attribute) string {
+	if len(attrs) == 0 {
+		return litValue
+	}
+
+	trimmed := strings.TrimSpace(litValue)
+
+	var openDelim, closeDelim string
+	switch {
+	case strings.HasPrefix(trimmed, `#"""`) && strings.HasSuffix(trimmed, `"""#`):
+		openDelim, closeDelim = `#"""`, `"""#`
+	case strings.HasPrefix(trimmed, `"""`) && strings.HasSuffix(trimmed, `"""`) && !strings.HasSuffix(trimmed, `"""#`):
+		openDelim, closeDelim = `"""`, `"""`
+	default:
+		return litValue
+	}
+
+	inner := strings.TrimPrefix(trimmed, openDelim)
+	inner = strings.TrimSuffix(inner, closeDelim)
+
+	indent := ""
+	if idx := strings.LastIndex(inner, "\n"); idx >= 0 {
+		indent = inner[idx+1:]
+	}
+
+	var injected strings.Builder
+	for _, a := range attrs {
+		injected.WriteString(indent + cueAttrPrefix + a.Text + "\n")
+	}
+
+	return openDelim + "\n" + injected.String() + inner + closeDelim
+}
+
+// extractAttrs scans unquoted CUE content for cue-attr comment lines, returns the
+// reconstructed attributes and the content with those lines removed.
+func extractAttrs(content string) ([]*ast.Attribute, string) {
+	var attrs []*ast.Attribute
+	var remaining strings.Builder
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if text, ok := strings.CutPrefix(trimmed, cueAttrPrefix); ok {
+			attrs = append(attrs, &ast.Attribute{Text: text})
+		} else {
+			remaining.WriteString(line + "\n")
+		}
+	}
+	return attrs, remaining.String()
+}
+
+// hasDisableValidation reports whether a field carries the @disableValidation() attribute.
+func hasDisableValidation(field *ast.Field) bool {
+	for _, a := range field.Attrs {
+		if a.Text == disableValidationAttr {
+			return true
+		}
+	}
+	return false
+}
 
 // EncodeMetadata encodes native CUE in the metadata fields to a CUE string literal
 func EncodeMetadata(field *ast.Field) error {
@@ -63,6 +129,22 @@ func DecodeMetadata(field *ast.Field) error {
 
 func marshalField[T ast.Node](field *ast.Field, key string, validator func(T) error) error {
 	if statusField, ok := GetFieldByPath(field, key); ok {
+		if hasDisableValidation(statusField) {
+			switch expr := statusField.Value.(type) {
+			case *ast.StructLit:
+				strLit, err := StringifyStructLitAsCueString(expr)
+				if err != nil {
+					return err
+				}
+				strLit.Value = injectAttrs(strLit.Value, statusField.Attrs)
+				UpdateNodeByPath(field, key, strLit)
+			case *ast.BasicLit:
+				if expr.Kind == token.STRING && !strings.Contains(expr.Value, cueAttrPrefix) {
+					expr.Value = injectAttrs(expr.Value, statusField.Attrs)
+				}
+			}
+			return nil
+		}
 		switch expr := statusField.Value.(type) {
 		case *ast.BasicLit:
 			if expr.Kind != token.STRING {
@@ -104,12 +186,19 @@ func unmarshalField[T ast.Node](field *ast.Field, key string, validator func(T) 
 			return fmt.Errorf("%s field is not a string literal", key)
 		}
 
-		err := ValidateCueStringLiteral[T](basicLit, validator)
-		if err != nil {
-			return fmt.Errorf("%s field failed validation: %w", key, err)
+		unquoted := strings.TrimSpace(TrimCueRawString(basicLit.Value))
+
+		// Re-hydrate any attributes that were persisted as cue-attr comment lines
+		if restoredAttrs, cleaned := extractAttrs(unquoted); len(restoredAttrs) > 0 {
+			statusField.Attrs = append(statusField.Attrs, restoredAttrs...)
+			unquoted = strings.TrimSpace(cleaned)
 		}
 
-		unquoted := strings.TrimSpace(TrimCueRawString(basicLit.Value))
+		if !hasDisableValidation(statusField) {
+			if err := ValidateCueStringLiteral[T](basicLit, validator); err != nil {
+				return fmt.Errorf("%s field failed validation: %w", key, err)
+			}
+		}
 
 		structLit, hasImports, hasPackage, parseErr := ParseCueContent(unquoted)
 		if parseErr != nil {
@@ -127,30 +216,128 @@ func unmarshalField[T ast.Node](field *ast.Field, key string, validator func(T) 
 }
 
 func validateStatusField(sl *ast.StructLit) error {
+	localFields := map[string]*ast.StructLit{}
 	for _, elt := range sl.Elts {
 		f, ok := elt.(*ast.Field)
 		if !ok {
-			return fmt.Errorf("status.details contains non-field element")
+			continue
 		}
-
 		label := GetFieldLabel(f.Label)
-
 		if strings.HasPrefix(label, localFieldPrefix) {
-			continue
+			if structVal, ok := f.Value.(*ast.StructLit); ok {
+				localFields[label] = structVal
+			}
 		}
+	}
 
-		switch f.Value.(type) {
-		case *ast.BasicLit,
-			*ast.Ident,
-			*ast.SelectorExpr,
-			*ast.CallExpr,
-			*ast.BinaryExpr:
-			continue
+	for _, elt := range sl.Elts {
+		switch e := elt.(type) {
+		case *ast.Field:
+			label := GetFieldLabel(e.Label)
+			if strings.HasPrefix(label, localFieldPrefix) {
+				continue
+			}
+			if err := validateStatusFieldValue(label, e.Value); err != nil {
+				return err
+			}
+
+		case *ast.Comprehension:
+			if err := validateStatusComprehension(e); err != nil {
+				return err
+			}
+
+		case *ast.EmbedDecl:
+			if err := validateStatusEmbed(e, localFields); err != nil {
+				return err
+			}
+
 		default:
-			return fmt.Errorf("status.details field %q contains unsupported expression type %T", label, f.Value)
+			return fmt.Errorf("status.details contains unsupported element type %T", elt)
 		}
 	}
 	return nil
+}
+
+// validateStatusFieldValue checks that a named details field has a scalar-compatible value.
+func validateStatusFieldValue(label string, val ast.Expr) error {
+	switch val.(type) {
+	case *ast.BasicLit,
+		*ast.Ident,
+		*ast.SelectorExpr,
+		*ast.CallExpr,
+		*ast.BinaryExpr,
+		*ast.UnaryExpr,
+		*ast.Interpolation,
+		*ast.IndexExpr:
+		return nil
+	default:
+		return fmt.Errorf("status.details field %q contains unsupported expression type %T", label, val)
+	}
+}
+
+// validateStatusComprehension checks that a root-level comprehension in details
+// yields string-compatible key/value pairs.
+func validateStatusComprehension(c *ast.Comprehension) error {
+	structVal, ok := c.Value.(*ast.StructLit)
+	if !ok {
+		return fmt.Errorf("status.details comprehension must yield a struct, got %T", c.Value)
+	}
+	for _, elt := range structVal.Elts {
+		f, ok := elt.(*ast.Field)
+		if !ok {
+			return fmt.Errorf("status.details comprehension yields non-field element %T", elt)
+		}
+		// Keys may be interpolations (e.g. "host.\(rule.host)") — use a placeholder
+		label := GetFieldLabel(f.Label)
+		if label == "" {
+			label = "<dynamic>"
+		}
+		if err := validateStatusFieldValue(label, f.Value); err != nil {
+			return fmt.Errorf("status.details comprehension: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateStatusEmbed checks that an embedded expression in details is either a
+// $-prefixed local field or a comprehension block (the {for ...} pattern).
+func validateStatusEmbed(e *ast.EmbedDecl, localFields map[string]*ast.StructLit) error {
+	switch expr := e.Expr.(type) {
+	case *ast.Ident:
+		if !strings.HasPrefix(expr.Name, localFieldPrefix) {
+			return fmt.Errorf("status.details embed must reference a %s-prefixed local field, got identifier %q", localFieldPrefix, expr.Name)
+		}
+		structVal, declared := localFields[expr.Name]
+		if !declared {
+			return nil
+		}
+		for _, elt := range structVal.Elts {
+			f, ok := elt.(*ast.Field)
+			if !ok {
+				continue
+			}
+			label := GetFieldLabel(f.Label)
+			if err := validateStatusFieldValue(label, f.Value); err != nil {
+				return fmt.Errorf("status.details embedded field %q: %w", expr.Name, err)
+			}
+		}
+		return nil
+
+	case *ast.StructLit:
+		for _, elt := range expr.Elts {
+			comp, ok := elt.(*ast.Comprehension)
+			if !ok {
+				return fmt.Errorf("status.details embedded struct contains unsupported element %T", elt)
+			}
+			if err := validateStatusComprehension(comp); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("status.details contains unsupported embed expression type %T", e.Expr)
+	}
 }
 
 func validateCustomStatusField(sl *ast.StructLit) error {

--- a/pkg/definition/ast/transformer_test.go
+++ b/pkg/definition/ast/transformer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ast
 
 import (
+	"strings"
 	"testing"
 
 	"cuelang.org/go/cue/ast"
@@ -76,6 +77,19 @@ func TestMarshalAndUnmarshalMetadata(t *testing.T) {
 				}
 			`,
 			expectContains: "selector",
+		},
+		{
+			name: "unary expression value is valid",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							notFailing: !context.output.status.failing
+						}
+					}
+				}
+			`,
+			expectContains: "notFailing",
 		},
 		{
 			name: "struct value is invalid",
@@ -255,6 +269,484 @@ func TestMarshalAndUnmarshalMetadata(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+
+			if tt.expectContains != "" {
+				statusField, ok := GetFieldByPath(rootField, "attributes.status.details")
+				require.True(t, ok)
+
+				switch v := statusField.Value.(type) {
+				case *ast.BasicLit:
+					require.Contains(t, v.Value, tt.expectContains)
+				case *ast.StructLit:
+					out, err := format.Node(v)
+					require.NoError(t, err)
+					require.Contains(t, string(out), tt.expectContains)
+				default:
+					t.Fatalf("unexpected status value type: %T", v)
+				}
+			}
+		})
+	}
+}
+
+func TestHasDisableValidation(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "field with @disableValidation()",
+			input:    `details: { foo: "bar" } @disableValidation()`,
+			expected: true,
+		},
+		{
+			name:     "field without any attributes",
+			input:    `details: { foo: "bar" }`,
+			expected: false,
+		},
+		{
+			name:     "field with a different attribute",
+			input:    `details: { foo: "bar" } @someOtherAttr()`,
+			expected: false,
+		},
+		{
+			name:     "field with multiple attributes including @disableValidation()",
+			input:    `details: { foo: "bar" } @someOtherAttr() @disableValidation()`,
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := parser.ParseFile("-", tc.input)
+			require.NoError(t, err)
+
+			var field *ast.Field
+			for _, decl := range file.Decls {
+				if f, ok := decl.(*ast.Field); ok {
+					field = f
+					break
+				}
+			}
+			require.NotNil(t, field)
+			assert.Equal(t, tc.expected, hasDisableValidation(field))
+		})
+	}
+}
+
+func TestDisableValidationAttribute(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectContains string
+	}{
+		{
+			name: "details with @disableValidation() bypasses validation and is stringified",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							{for _, rule in context.outputs.ingress.spec.rules {
+								"host.\(rule.host)": rule.host
+							}}
+						} @disableValidation()
+					}
+				}
+			`,
+			expectContains: "host.",
+		},
+		{
+			name: "healthPolicy with @disableValidation() bypasses validation and is stringified",
+			input: `
+				attributes: {
+					status: {
+						healthPolicy: {
+							someComplexField: [for c in context.output.status.conditions { c.status }][0] == "True"
+							isHealth: someComplexField
+						} @disableValidation()
+					}
+				}
+			`,
+			expectContains: "isHealth",
+		},
+		{
+			name: "details stringified format with @disableValidation() bypasses validation on encode and decode",
+			input: `
+				attributes: {
+					status: {
+						details: #"""
+							import "strings"
+							{for _, rule in context.outputs.ingress.spec.rules {
+								"host.\(rule.host)": rule.host
+							}}
+						"""# @disableValidation()
+					}
+				}
+			`,
+			expectContains: "import",
+		},
+		{
+			name: "customStatus with @disableValidation() bypasses validation and is stringified",
+			input: `
+				attributes: {
+					status: {
+						customStatus: {
+							message: [for c in context.output.status.conditions { c.message }][0]
+						} @disableValidation()
+					}
+				}
+			`,
+			expectContains: "message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := parser.ParseFile("-", tt.input)
+			require.NoError(t, err)
+
+			var rootField *ast.Field
+			for _, decl := range file.Decls {
+				if f, ok := decl.(*ast.Field); ok {
+					rootField = f
+					break
+				}
+			}
+			require.NotNil(t, rootField)
+
+			err = EncodeMetadata(rootField)
+			require.NoError(t, err)
+
+			// After encoding, the field value should be a string literal
+			// containing the original content.
+			var fieldPath string
+			switch {
+			case strings.Contains(tt.input, "details:"):
+				fieldPath = "attributes.status.details"
+			case strings.Contains(tt.input, "healthPolicy:"):
+				fieldPath = "attributes.status.healthPolicy"
+			case strings.Contains(tt.input, "customStatus:"):
+				fieldPath = "attributes.status.customStatus"
+			}
+
+			statusField, ok := GetFieldByPath(rootField, fieldPath)
+			require.True(t, ok)
+			basicLit, ok := statusField.Value.(*ast.BasicLit)
+			require.True(t, ok, "expected field to be stringified to *ast.BasicLit after encoding, got %T", statusField.Value)
+			require.Contains(t, basicLit.Value, tt.expectContains)
+		})
+	}
+}
+
+func TestDisableValidationDecodeRoundTrip(t *testing.T) {
+	// Verifies that @disableValidation() skips validation on DecodeMetadata too,
+	// so a stringified field with otherwise-invalid content survives a round trip.
+	input := `
+		attributes: {
+			status: {
+				details: #"""
+					data: { nested: "structure" }
+				"""# @disableValidation()
+			}
+		}
+	`
+	file, err := parser.ParseFile("-", input)
+	require.NoError(t, err)
+
+	var rootField *ast.Field
+	for _, decl := range file.Decls {
+		if f, ok := decl.(*ast.Field); ok {
+			rootField = f
+			break
+		}
+	}
+	require.NotNil(t, rootField)
+
+	// Encode: should pass despite nested struct (validation disabled)
+	require.NoError(t, EncodeMetadata(rootField))
+
+	require.NoError(t, DecodeMetadata(rootField))
+}
+
+func TestDisableValidationYAMLRoundTrip(t *testing.T) {
+	// Simulates the full YAML storage round-trip: encode strips field attributes
+	// (as YAML/gocodec does), but the cue-attr sentinel in the string value means
+	// decode still skips validation correctly.
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "details with struct value and @disableValidation()",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							data: { nested: "structure" }
+						} @disableValidation()
+					}
+				}
+			`,
+		},
+		{
+			name: "details with stringified value and @disableValidation()",
+			input: `
+				attributes: {
+					status: {
+						details: #"""
+							data: { nested: "structure" }
+						"""# @disableValidation()
+					}
+				}
+			`,
+		},
+		{
+			name: "healthPolicy with @disableValidation()",
+			input: `
+				attributes: {
+					status: {
+						healthPolicy: {
+							isHealth: [for c in context.output.status.conditions { c.status }][0] == "True"
+						} @disableValidation()
+					}
+				}
+			`,
+		},
+		{
+			name: "customStatus with @disableValidation()",
+			input: `
+				attributes: {
+					status: {
+						customStatus: {
+							message: [for c in context.output.status.conditions { c.message }][0]
+						} @disableValidation()
+					}
+				}
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := parser.ParseFile("-", tt.input)
+			require.NoError(t, err)
+
+			var rootField *ast.Field
+			for _, decl := range file.Decls {
+				if f, ok := decl.(*ast.Field); ok {
+					rootField = f
+					break
+				}
+			}
+			require.NotNil(t, rootField)
+
+			require.NoError(t, EncodeMetadata(rootField))
+
+			// Simulate YAML storage stripping field attributes from all status sub-fields.
+			for _, path := range []string{
+				"attributes.status.details",
+				"attributes.status.healthPolicy",
+				"attributes.status.customStatus",
+			} {
+				if f, ok := GetFieldByPath(rootField, path); ok {
+					f.Attrs = nil
+				}
+			}
+
+			// Decode must still succeed — the cue-attr sentinel in the string carries
+			// the @disableValidation() intent across the storage boundary.
+			require.NoError(t, DecodeMetadata(rootField))
+		})
+	}
+}
+
+func TestInjectAttrsMultipleAndIdempotent(t *testing.T) {
+	t.Run("multiple attributes are all persisted and restored", func(t *testing.T) {
+		// Use two attributes on the same field; both should survive the YAML round-trip.
+		input := `
+			attributes: {
+				status: {
+					details: {
+						data: { nested: "structure" }
+					} @disableValidation() @someOtherAttr(value)
+				}
+			}
+		`
+		file, err := parser.ParseFile("-", input)
+		require.NoError(t, err)
+
+		var rootField *ast.Field
+		for _, decl := range file.Decls {
+			if f, ok := decl.(*ast.Field); ok {
+				rootField = f
+				break
+			}
+		}
+		require.NotNil(t, rootField)
+
+		require.NoError(t, EncodeMetadata(rootField))
+
+		// Verify both cue-attr lines are present in the stored string.
+		f, ok := GetFieldByPath(rootField, "attributes.status.details")
+		require.True(t, ok)
+		bl, ok := f.Value.(*ast.BasicLit)
+		require.True(t, ok)
+		require.Contains(t, bl.Value, "// cue-attr:@disableValidation()")
+		require.Contains(t, bl.Value, "// cue-attr:@someOtherAttr(value)")
+
+		// Strip field attributes to simulate YAML storage.
+		f.Attrs = nil
+
+		// Decode must restore both attributes and succeed.
+		require.NoError(t, DecodeMetadata(rootField))
+		require.Len(t, f.Attrs, 2)
+	})
+
+	t.Run("encoding an already-stringified field with cue-attr does not double-inject", func(t *testing.T) {
+		// Simulates a second EncodeMetadata call on an already-encoded field.
+		input := `
+			attributes: {
+				status: {
+					details: #"""
+						// cue-attr:@disableValidation()
+						data: { nested: "structure" }
+					"""# @disableValidation()
+				}
+			}
+		`
+		file, err := parser.ParseFile("-", input)
+		require.NoError(t, err)
+
+		var rootField *ast.Field
+		for _, decl := range file.Decls {
+			if f, ok := decl.(*ast.Field); ok {
+				rootField = f
+				break
+			}
+		}
+		require.NotNil(t, rootField)
+
+		require.NoError(t, EncodeMetadata(rootField))
+
+		f, ok := GetFieldByPath(rootField, "attributes.status.details")
+		require.True(t, ok)
+		bl, ok := f.Value.(*ast.BasicLit)
+		require.True(t, ok)
+
+		// Should appear exactly once, not twice.
+		count := strings.Count(bl.Value, "// cue-attr:@disableValidation()")
+		require.Equal(t, 1, count, "cue-attr sentinel should not be duplicated on re-encode")
+	})
+}
+
+func TestComprehensionDynamicKeyErrorMessage(t *testing.T) {
+	// Verifies that a comprehension with an invalid value type reports a
+	// meaningful error rather than an empty label.
+	input := `
+		attributes: {
+			status: {
+				details: {
+					{for _, rule in context.outputs.ingress.spec.rules {
+						"host.\(rule.host)": { nested: "invalid" }
+					}}
+				}
+			}
+		}
+	`
+	file, err := parser.ParseFile("-", input)
+	require.NoError(t, err)
+
+	var rootField *ast.Field
+	for _, decl := range file.Decls {
+		if f, ok := decl.(*ast.Field); ok {
+			rootField = f
+			break
+		}
+	}
+	require.NotNil(t, rootField)
+
+	err = EncodeMetadata(rootField)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<dynamic>")
+}
+
+func TestStatusDetailsWithDynamicKeys(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		expectMarshalErr string
+		expectContains   string
+	}{
+		{
+			name: "root comprehension generates dynamic keys from list",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							{for _, rule in context.outputs.ingress.spec.rules {
+								"host.\(rule.host)": rule.host
+							}}
+						}
+					}
+				}
+			`,
+			expectContains: "host.",
+		},
+		{
+			name: "call expression value with list comprehension arg",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							hosts: strings.Join([for rule in context.outputs.ingress.spec.rules { rule.host }], ",")
+						}
+					}
+				}
+			`,
+			expectContains: "hosts",
+		},
+		{
+			name: "local field embedded at root of details",
+			input: `
+				attributes: {
+					status: {
+						details: {
+							$local: { key: "value" }
+							$local
+						}
+					}
+				}
+			`,
+			expectContains: "key",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := parser.ParseFile("-", tt.input)
+			require.NoError(t, err)
+
+			var rootField *ast.Field
+			for _, decl := range file.Decls {
+				if f, ok := decl.(*ast.Field); ok {
+					rootField = f
+					break
+				}
+			}
+			require.NotNil(t, rootField)
+
+			err = EncodeMetadata(rootField)
+			if tt.expectMarshalErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectMarshalErr)
+				return
+			}
+			require.NoError(t, err)
+
+			err = DecodeMetadata(rootField)
+			require.NoError(t, err)
 
 			if tt.expectContains != "" {
 				statusField, ok := GetFieldByPath(rootField, "attributes.status.details")


### PR DESCRIPTION
### Description of your changes

copilot:all

Updates codeowners in 1.10 branch for merging backports

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

