### PR TITLE
Fix: Update default registry definition.

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -244,3 +244,42 @@ jobs:
     secrets:
       registry-username: ${{ secrets.DOCKER_USERNAME }}
       registry-password: ${{ secrets.DOCKER_PASSWORD }}
+
+  generate-definitions:
+    name: Generate Definitions
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: "1.23.8"
+
+      - name: Build vela CLI
+        run: |
+          make vela-cli
+
+      - name: Render registry definitions with vela binary
+        run: |
+          ./bin/vela def render vela-templates/definitions/registry -o vela-templates/registry/auto-gen --message "Definition source cue file: vela-templates/definitions/registry/{{INPUT_FILENAME}}"
+
+      - name: Commit and push generated definitions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "135009839+kubevela[bot]@users.noreply.github.com"
+          git config --global user.name "kubevela[bot]"
+          git add vela-templates/registry/auto-gen
+          if git diff --quiet --cached; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: Update generated registry definitions."
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:refs/heads/master

--- a/references/cli/registry.go
+++ b/references/cli/registry.go
@@ -277,7 +277,7 @@ func NewRegistry(ctx context.Context, token, registryName string, regURL string)
 // ListRegistryConfig will get all registry config stored in local
 // this will return at least one config, which is DefaultRegistry
 func ListRegistryConfig() ([]RegistryConfig, error) {
-	defaultRegistryConfig := RegistryConfig{Name: DefaultRegistry, URL: "oss://registry.kubevela.net/"}
+	defaultRegistryConfig := RegistryConfig{Name: DefaultRegistry, URL: "https://github.com/kubevela/kubevela/tree/master/vela-templates/registry/auto-gen/"}
 	config, err := system.GetRepoConfig()
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func ListRegistryConfig() ([]RegistryConfig, error) {
 	}
 	haveDefault := false
 	for _, r := range regConfigs {
-		if r.URL == defaultRegistryConfig.URL {
+		if r.Name == defaultRegistryConfig.Name {
 			haveDefault = true
 			break
 		}

--- a/references/cli/registry.go
+++ b/references/cli/registry.go
@@ -277,7 +277,7 @@ func NewRegistry(ctx context.Context, token, registryName string, regURL string)
 // ListRegistryConfig will get all registry config stored in local
 // this will return at least one config, which is DefaultRegistry
 func ListRegistryConfig() ([]RegistryConfig, error) {
-	defaultRegistryConfig := RegistryConfig{Name: DefaultRegistry, URL: "https://github.com/kubevela/kubevela/tree/master/vela-templates/registry/auto-gen/"}
+	defaultRegistryConfig := RegistryConfig{Name: DefaultRegistry, URL: "https://github.com/kubevela/kubevela/tree/master/vela-templates/registry/auto-gen"}
 	config, err := system.GetRepoConfig()
 	if err != nil {
 		return nil, err
@@ -297,15 +297,29 @@ func ListRegistryConfig() ([]RegistryConfig, error) {
 	if err = yaml.Unmarshal(data, &regConfigs); err != nil {
 		return nil, err
 	}
+	const oldDefaultURL = "oss://registry.kubevela.net/"
 	haveDefault := false
-	for _, r := range regConfigs {
+	updated := false
+	for i, r := range regConfigs {
 		if r.Name == defaultRegistryConfig.Name {
 			haveDefault = true
+			if r.URL == oldDefaultURL {
+				regConfigs[i].URL = defaultRegistryConfig.URL
+				updated = true
+			}
 			break
+		}
+	}
+	if updated {
+		if err := StoreRepos(regConfigs); err != nil {
+			return nil, errors.Wrap(err, "error updating default registry URL")
 		}
 	}
 	if !haveDefault {
 		regConfigs = append(regConfigs, defaultRegistryConfig)
+		if err := StoreRepos(regConfigs); err != nil {
+			return nil, errors.Wrap(err, "error adding default registry")
+		}
 	}
 	return regConfigs, nil
 }


### PR DESCRIPTION
### Description of your changes

This PR updates the default registry URL from `oss://registry.kubevela.net/` to `https://github.com/kubevela/kubevela/tree/master/vela-templates/registry/auto-gen/` since the certificate has been expired for the older one. Along with this, a new job has been introduced in the `registry` workflow which generates the registry definitions.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #6835 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- Built the modified vela CLI locally and ran `./bin/vela registry ls`.
- Verified that the updated default registry `https://github.com/kubevela/kubevela/tree/master/vela-templates/registry/auto-gen/` was added to the registry configuration, confirming that the new default registry is being picked up by the CLI.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

