### PR TITLE
fix: podDisruptive has no controller effect in TraitDefinition

### DIFF
--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -115,7 +115,13 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
-	// PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+	// PodDisruptive specifies whether applying this trait will cause the pod to restart.
+	// When set to true, the controller computes a hash of the trait's rendered output and
+	// injects it into the workload's spec.template.metadata.annotations. If the trait output
+	// changes on a subsequent reconcile, the hash changes and Kubernetes performs a rolling
+	// update of the pods. This works for any workload kind that has a spec.template path
+	// (e.g. Deployment, StatefulSet, DaemonSet). The field is ignored if the workload does
+	// not have a spec.template path.
 	// +optional
 	PodDisruptive bool `json:"podDisruptive,omitempty"`
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/generator.go
@@ -18,6 +18,8 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/rand"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -480,7 +483,98 @@ func renderComponentsAndTraits(manifest *types.ComponentManifest, appRev *v1beta
 		}
 	}
 	readyTraits = redirectTraitToLocalIfNeed(appRev, readyTraits)
+
+	// Apply podDisruptive logic: if any trait has PodDisruptive=true, compute a hash of
+	// the disruptive trait outputs and inject it into the workload's pod template annotations.
+	// This ensures that when a disruptive trait's output changes, the pod template changes
+	// and Kubernetes performs a rolling update.
+	if err := applyPodDisruptiveHash(readyWorkload, readyTraits, appRev); err != nil {
+		return nil, nil, errors.WithMessage(err, "apply pod disruptive hash")
+	}
+
 	return readyWorkload, readyTraits, nil
+}
+
+// applyPodDisruptiveHash computes a combined hash of all disruptive trait outputs and
+// injects it into the workload's spec.template.metadata.annotations. When the trait
+// output changes, the hash changes and Kubernetes triggers a rolling update.
+func applyPodDisruptiveHash(workload *unstructured.Unstructured, traits []*unstructured.Unstructured, appRev *v1beta1.ApplicationRevision) error {
+	if workload == nil || len(traits) == 0 {
+		return nil
+	}
+
+	// Check if the workload has a spec.template path (e.g. Deployment, StatefulSet, DaemonSet)
+	// If not, we cannot inject the hash into the pod template.
+	specTemplate, found, err := unstructured.NestedMap(workload.Object, "spec", "template")
+	if err != nil || !found {
+		return nil
+	}
+
+	// Collect hashes from all disruptive traits
+	var disruptiveHashes []string
+	for _, trait := range traits {
+		traitType := trait.GetLabels()[oam.TraitTypeLabel]
+		if traitType == "" {
+			continue
+		}
+
+		// Handle version-prefixed trait types (same pattern as getTraitDispatchStage)
+		lookupType := traitType
+		if strings.Contains(traitType, "-") {
+			splitName := traitType[0:strings.LastIndex(traitType, "-")]
+			if _, ok := appRev.Spec.TraitDefinitions[splitName]; ok {
+				lookupType = splitName
+			}
+		}
+
+		// Look up the TraitDefinition to check if it's disruptive
+		traitDef, ok := appRev.Spec.TraitDefinitions[lookupType]
+		if !ok {
+			continue
+		}
+		if !traitDef.Spec.PodDisruptive {
+			continue
+		}
+
+		// Compute a hash of the trait's rendered content
+		hash := util.ComputeHash(trait)
+		disruptiveHashes = append(disruptiveHashes, hash)
+	}
+
+	if len(disruptiveHashes) == 0 {
+		return nil
+	}
+
+	// Combine all disruptive trait hashes into a single combined hash
+	hasher := fnv.New32a()
+	for _, h := range disruptiveHashes {
+		_, _ = hasher.Write([]byte(h))
+	}
+	combinedHash := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+
+	// Inject the combined hash into the pod template annotations
+	if specTemplate["metadata"] == nil {
+		specTemplate["metadata"] = map[string]interface{}{}
+	}
+	templateMetadata, ok := specTemplate["metadata"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	if templateMetadata["annotations"] == nil {
+		templateMetadata["annotations"] = map[string]interface{}{}
+	}
+	annotations, ok := templateMetadata["annotations"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	annotations[oam.AnnotationPodDisruptiveHash] = combinedHash
+
+	// Write back the modified template
+	if err := unstructured.SetNestedMap(workload.Object, specTemplate, "spec", "template"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // componentOutputsConsumed returns true if any other component depends on outputs produced

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -226,6 +226,11 @@ const (
 	// "1m", "15m", "30s").  Values below 10s are ignored and fall back to the
 	// global default.  Invalid values are also ignored.
 	AnnotationReconcileInterval = "app.oam.dev/reconcile-interval"
+
+	// AnnotationPodDisruptiveHash is the annotation key used on workload's pod template
+	// metadata to store a hash of disruptive trait outputs. When the trait output changes,
+	// the hash changes and Kubernetes triggers a rolling update of the pods.
+	AnnotationPodDisruptiveHash = "app.oam.dev/pod-disruptive-hash"
 )
 
 const (

--- a/ter
+++ b/ter
@@ -1,0 +1,15 @@
+* [33m5f1ff057[m[33m ([m[1;31morigin/fix/oci-ttl[m[33m)[m fix: treat sha256 OCI digests as immutable in isMutableVersion
+* [33m5a44b5f1[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmaster[m[33m, [m[1;31morigin/master[m[33m, [m[1;31morigin/HEAD[m[33m)[m Feat: auto remediate cue issues (#7199)
+* [33m5d19a031[m Fix: do not log or persist credentials embedded in Terraform module remote URLs (#7201)
+* [33maaa1b050[m Chore: update kubevela/workflow to v0.6.4 (#7200)
+* [33ma10dba6d[m Fix: resolve gosec G304 lint failure in Terraform module cache check (#7190)
+* [33mf6a64398[m Merge commit from fork
+* [33m8598986e[m feat(helm): set User-Agent when downloading Helm repo index.yaml (#7162)
+* [33m24ae77d3[m Fix(controller): set Ready condition to False on reconcile failure (#7168)
+* [33mc3e510a0[m Chore: (deps): Bump imjasonh/setup-crane from 0.3 to 0.4 (#6851)
+* [33ma24d3a9c[m Fix: defkit changes for resource builder docs (#7136)
+* [33m3eaf62b2[m Fix(helmchart): wire options correctly (#7151) and decompose provider (#7154)
+* [33mbcf6af97[m Feat: helm chart auth (#7148)
+* [33m5664912a[m Feat: support per-application reconciliation interval override via annotation (#7089)
+* [33mc81b1413[m Fix: handle optional collections in CUE strict mode in defkit (#7102)
+* [33m28892ccc[m Feat: implement valuesFrom support for helmchart component and update… (#7099)


### PR DESCRIPTION
### Description of your changes

This PR clarifies the behavior of the podDisruptive field in TraitDefinition.

Currently, podDisruptive: true is treated as metadata only and has no effect on the controller reconciliation logic. The controller does not read or act on this field, and therefore it does not trigger pod restarts.

This PR:

Documents the actual runtime behavior of podDisruptive
Resolves the mismatch between documentation claims and implementation
Clarifies that pod restarts only occur when the rendered workload template changes (e.g., via spec.template updates), not due to this field

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #7204 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Verified by reproducing the behavior using a TraitDefinition with podDisruptive: true that modifies ConfigMap data without affecting spec.template. Pod UID remains unchanged before and after updates, confirming no restart is triggered by this field.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
The current implementation does not include any controller logic tied to podDisruptive. This PR focuses on aligning documentation with actual behavior and highlighting the discrepancy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

