### PR TITLE
Fix: prevent panics in ParseGitlab on malformed addon registry URLs

### DIFF
--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -317,10 +317,10 @@ func NewAsyncReader(baseURL, bucket, repo, subPath, token string, rdType ReaderT
 			return nil, errors.New("addon registry invalid")
 		}
 		_, content, err := utils.ParseGitlab(u.String(), repo)
-		content.GitlabContent.Path = subPath
 		if err != nil {
 			return nil, err
 		}
+		content.GitlabContent.Path = subPath
 		gitlabHelper, err := createGitlabHelper(content, token)
 		if err != nil {
 			return nil, errors.New("addon registry connect fail")

--- a/pkg/utils/parse.go
+++ b/pkg/utils/parse.go
@@ -232,6 +232,9 @@ func ParseGitlab(addr, repo string) (string, *Content, error) {
 
 	arr := strings.Split(addr, repo)
 	owner := strings.Split(arr[0], URL.Host+"/")
+	if len(owner) < 2 || len(owner[1]) == 0 {
+		return "", nil, errors.New(errInvalidFormatMsg + addr)
+	}
 	if !strings.Contains(arr[1], "/") {
 		// https://example.gitlab.com/<owner>/<repo>
 		return TypeGitlab, &Content{
@@ -246,6 +249,9 @@ func ParseGitlab(addr, repo string) (string, *Content, error) {
 
 	// https://example.gitlab.com/<owner>/<repo>/tree/<branch>
 	l := strings.Split(arr[1], "/")
+	if len(l) < 3 {
+		return "", nil, errors.New(errInvalidFormatMsg + addr)
+	}
 
 	return TypeGitlab, &Content{
 		GitlabContent: GitlabContent{

--- a/pkg/utils/parse_test.go
+++ b/pkg/utils/parse_test.go
@@ -174,6 +174,24 @@ func TestParseGitlab(t *testing.T) {
 			repo:    "repo",
 			wantErr: true,
 		},
+		{
+			name:    "invalid gitlab url repo at path root without owner",
+			addr:    "https://gitlab.com/catalog",
+			repo:    "catalog",
+			wantErr: true,
+		},
+		{
+			name:    "invalid gitlab url tree branch missing",
+			addr:    "https://gitlab.com/kubevela/catalog/tree",
+			repo:    "catalog",
+			wantErr: true,
+		},
+		{
+			name:    "invalid gitlab url repo only in host",
+			addr:    "https://catalog.gitlab.com/kubevela/foo",
+			repo:    "catalog",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description of your changes

`utils.ParseGitlab` indexes the results of splitting the registry address
without bounds checks, so a malformed (but repo-name-matching) GitLab registry
URL crashes the controller/CLI instead of returning an error. Three inputs
panic today:

| addr | repo | panic |
|---|---|---|
| `https://gitlab.com/catalog` | `catalog` | `slice bounds out of range [:-1]` |
| `https://gitlab.com/kubevela/catalog/tree` | `catalog` | `index out of range [2]` |
| `https://catalog.gitlab.com/kubevela/foo` | `catalog` | `index out of range [1]` |

This adds length/empty guards that return the existing invalid-format error
(`errInvalidFormatMsg`, the same path `Parse` already uses) for the empty owner
slice, the short host split, and the missing tree-branch segment. Behaviour for
all currently-valid inputs is unchanged.

It also fixes the caller `NewAsyncReader` (`pkg/addon/source.go`), which
dereferenced the returned `content` before checking `err`: on any `ParseGitlab`
error `content` is nil, so the assignment nil-panicked before the error could be
returned. The error check now precedes the dereference, matching the gitee
branch directly above it.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. No docs change: pure error-handling fix, no new feature or configuration option.
- [x] Run `make reviewable` to ensure this PR is ready for review. gofmt clean, go vet clean, golangci-lint reports zero non-typecheck findings on the changed packages.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. Happy to add if a maintainer wants this backported.

### How has this code been tested

`TestParseGitlab` is extended with the three malformed cases (`wantErr: true`):
they panic on master and pass after the fix. `go test ./pkg/utils/ -run
'TestParseGitlab|TestParse$'` passes (7 `ParseGitlab` subtests + 11 `Parse`).
`go build`, `gofmt -l`, and `go vet` are clean. The caller-area addon tests
(`TestGitLabReaderNotPanic`, `TestGitlabReader_*`, `TestGitLabItem`) pass.

### Special notes for your reviewer

The `NewAsyncReader` reorder is not covered by an automated test (the gitlab
branch of `TestNewAsyncReader` is `t.Skip`'d upstream because it needs a live
API). It is a trivial 2-line move that mirrors the gitee branch directly above
it, and the `ParseGitlab` error path that produced the nil `content` is now
covered by the new table cases.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

