### PR TITLE
Fix: nil pointer panic in getMatchingDefinitionRevision on malformed revision version

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -354,10 +354,10 @@ func getMatchingDefinitionRevision(exactRevisionName, definitionName string, rev
 		if strings.HasPrefix(revision.Name, revisionPrefix) {
 			version := strings.Split(revision.Name, definitionName+"-")[1]
 			v, err := semver.NewVersion(version)
-			orignalVersions[v.String()] = version
 			if err != nil {
 				return "", err
 			}
+			orignalVersions[v.String()] = version
 			definitionVersions = append(definitionVersions, v)
 		}
 	}

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -992,6 +992,11 @@ func TestGetLatestDefinitionRevisionName(t *testing.T) {
 		defRevisionList.DeepCopyInto(list.(*v1beta1.DefinitionRevisionList))
 		return nil
 	}}
+	malformedListCli := test.MockClient{MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		defRevisionList := getMalformedComponentDefRevisionList()
+		defRevisionList.DeepCopyInto(list.(*v1beta1.DefinitionRevisionList))
+		return nil
+	}}
 
 	testcases := []struct {
 		name                    string
@@ -1052,6 +1057,15 @@ func TestGetLatestDefinitionRevisionName(t *testing.T) {
 			expectedDefRevisionName: "",
 			client:                  &traitListCli,
 			err:                     fmt.Errorf("error finding definition revision for Name: scaler-trait, Type: Trait"),
+		},
+		{
+			name:                    "Malformed Component version segment returns error not panic",
+			inputRevisionName:       "configmap-component-v1",
+			definitionName:          "configmap-component",
+			definitionType:          "Component",
+			expectedDefRevisionName: "",
+			client:                  &malformedListCli,
+			err:                     fmt.Errorf("error finding definition revision for Name: configmap-component, Type: Component"),
 		},
 	}
 	ctx := context.Background()
@@ -1219,6 +1233,21 @@ func getComponentDefRevisionList() v1beta1.DefinitionRevisionList {
 		},
 	}
 	return compRevisionList
+}
+
+func getMalformedComponentDefRevisionList() v1beta1.DefinitionRevisionList {
+	compDefRevision := componentDefinitionRevision.DeepCopy()
+	compDefRevision.Name = "configmap-component-v1.bad"
+
+	return v1beta1.DefinitionRevisionList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DefinitionRevision",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		Items: []v1beta1.DefinitionRevision{
+			*compDefRevision,
+		},
+	}
 }
 
 func getTraitDefRevisionList() v1beta1.DefinitionRevisionList {

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -997,6 +997,11 @@ func TestGetLatestDefinitionRevisionName(t *testing.T) {
 		defRevisionList.DeepCopyInto(list.(*v1beta1.DefinitionRevisionList))
 		return nil
 	}}
+	emptyVersionListCli := test.MockClient{MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		defRevisionList := getEmptyVersionComponentDefRevisionList()
+		defRevisionList.DeepCopyInto(list.(*v1beta1.DefinitionRevisionList))
+		return nil
+	}}
 
 	testcases := []struct {
 		name                    string
@@ -1065,6 +1070,15 @@ func TestGetLatestDefinitionRevisionName(t *testing.T) {
 			definitionType:          "Component",
 			expectedDefRevisionName: "",
 			client:                  &malformedListCli,
+			err:                     fmt.Errorf("error finding definition revision for Name: configmap-component, Type: Component"),
+		},
+		{
+			name:                    "Empty Component version segment returns error not panic",
+			inputRevisionName:       "configmap-component-v1",
+			definitionName:          "configmap-component",
+			definitionType:          "Component",
+			expectedDefRevisionName: "",
+			client:                  &emptyVersionListCli,
 			err:                     fmt.Errorf("error finding definition revision for Name: configmap-component, Type: Component"),
 		},
 	}
@@ -1238,6 +1252,21 @@ func getComponentDefRevisionList() v1beta1.DefinitionRevisionList {
 func getMalformedComponentDefRevisionList() v1beta1.DefinitionRevisionList {
 	compDefRevision := componentDefinitionRevision.DeepCopy()
 	compDefRevision.Name = "configmap-component-v1.bad"
+
+	return v1beta1.DefinitionRevisionList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DefinitionRevision",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		Items: []v1beta1.DefinitionRevision{
+			*compDefRevision,
+		},
+	}
+}
+
+func getEmptyVersionComponentDefRevisionList() v1beta1.DefinitionRevisionList {
+	compDefRevision := componentDefinitionRevision.DeepCopy()
+	compDefRevision.Name = "configmap-component-"
 
 	return v1beta1.DefinitionRevisionList{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
### Description of your changes

`getMatchingDefinitionRevision` (`pkg/oam/util/helper.go`) dereferenced the
parsed semver result before checking the parse error:

```go
v, err := semver.NewVersion(version)
orignalVersions[v.String()] = version   // v.String() runs before err is checked
if err != nil {
    return "", err
}
```

When a `DefinitionRevision` name carries the expected prefix (`<name>-`) but the
version segment is not valid semver, `semver.NewVersion` returns `(nil, err)`, so
`v.String()` panics with a nil pointer dereference instead of returning the error.
This path runs whenever `GetLatestDefinitionRevisionName` resolves a definition
revision (the `autoUpdate` / `@vX` definition-resolution lane), so a single
malformed revision name crashes the caller rather than surfacing an error.

The fix moves the existing `if err != nil { return "", err }` check ahead of the
map write. Valid input is unaffected; the only change is that a bad version now
returns the error as the code already intended.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

(This is an internal robustness fix with no new feature or configuration option,
so no docs change is needed. I ran the targeted checks below rather than the full
`make reviewable` chain.)

### How has this code been tested

Added a table case to `TestGetLatestDefinitionRevisionName` in
`pkg/oam/util/helper_test.go` with a revision named `configmap-component-v1.bad`
(prefix matches, version segment is invalid semver). Before the fix this case
panics at `semver.(*Version).String` (`helper.go:357`); after it, the call returns
`error finding definition revision for Name: configmap-component, Type: Component`
(the generic error is expected because `GetLatestDefinitionRevisionName` swallows
the inner semver error and falls through both namespaces, matching the existing
trait/component cases).

```
go test ./pkg/oam/util/... -count=1                                  # PASS (mock client, no cluster/envtest)
go vet ./pkg/oam/util/                                               # clean
gofmt -l pkg/oam/util/helper.go pkg/oam/util/helper_test.go          # empty
goimports -local github.com/oam-dev/kubevela -l <changed files>      # empty
```

### Special notes for your reviewer

Single-line reorder plus one test. No signature, behavior, or error-string change
for valid input; the only difference is that a malformed version segment now
returns the error instead of triggering a nil pointer dereference.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

