### PR TITLE
Fix: skip TestAuthn due to unreliable external registry endpoints

### DIFF
--- a/pkg/utils/registries/secret_authenticator_test.go
+++ b/pkg/utils/registries/secret_authenticator_test.go
@@ -60,6 +60,13 @@ func TestSecretAuthenticator(t *testing.T) {
 }
 
 func TestAuthn(t *testing.T) {
+	// This test authenticates against live external registries
+	// (dockerhub.qingcloud.com and index.docker.io). Those endpoints are no
+	// longer reliable and stopped serving a valid registry response, which made
+	// the test fail intermittently and aborted the whole unit-test run. Skip it
+	// until it is rewritten against an in-process mock registry.
+	t.Skip("skipping: depends on unreliable external registry endpoints")
+
 	testCases := []struct {
 		name          string
 		imageRegistry *ImageRegistry


### PR DESCRIPTION
## Change

Skip `TestAuthn` with an explanatory `t.Skip()` until it can be rewritten
against an in-process mock registry. `testing.Short()` is not usable here
because CI runs plain `go test` (no `-short`).

Scope is intentionally minimal:
- Only `TestAuthn` is skipped — it is the only test that dials the network.
- `TestSecretAuthenticator` is left running; it only calls `Authorization()`
  (pure string handling, no network).

With the test skipped, `make test` completes, coverage uploads, and the
`Unit-Test` / codecov checks recover.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

