### PR TITLE
Docs: Prevent outputting empty "Component based on the following kinds of resources:" in generating documentation

### DIFF
--- a/references/docgen/markdown.go
+++ b/references/docgen/markdown.go
@@ -236,7 +236,7 @@ func (ref *MarkdownReference) GenerateMarkdownForCap(_ context.Context, c types.
 		var applyto string
 		if len(c.AppliesTo) == 1 && c.AppliesTo[0] == AllComponentTypes {
 			applyto += lang.Get("All Component Types.")
-		} else {
+		} else if len(c.AppliesTo) > 0 {
 			applyto += lang.Get("Component based on the following kinds of resources:") + "\n"
 			for _, ap := range c.AppliesTo {
 				applyto += "- " + ap + "\n"


### PR DESCRIPTION
### Description of your changes

Without this fix, `applyto` is

```
Component based on the following kinds of resources:\n
```

which prevents

```
if applyto == ""
```

from working as seemingly expected.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 

- [ ] Run `make reviewable` to ensure this PR is ready for review.

I get

```
/bin/bash: version: command not found
/bin/bash: version: command not found
/bin/bash: .../kubevela/bin/kustomize: No such file or directory
invalid value "./references/cmd/cli/main.go" for flag -ldflags: missing =<value> in <pattern>=<value>
usage: go build [-o output] [build flags] [packages]
Run 'go help build' for details.
make: *** [makefiles/build.mk:4: vela-cli] Error 2
```

- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

I want to add the label, but I'm not sure what `x.y` is; https://kubevela.io/docs/contributor/code-contribute/#create-a-pull-request mentions both `x.x` and `x.y`, but not `.z` (as per the current releases), so would `release-v1.10.9` work?

### How has this code been tested

n/a.

### Special notes for your reviewer

n/a.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

