### PR TITLE
Fix: reject non-revision names in ExtractRevision

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -53,6 +54,14 @@ var ExtractComponentName = util.ExtractComponentName
 // ExtractRevision will extract the revision from a revisionName
 func ExtractRevision(revisionName string) (int, error) {
 	splits := strings.Split(revisionName, "-")
+	// check some bad revision name, eg: 5
+	if len(splits) == 1 {
+		return 0, errors.New(util.ErrBadRevision)
+	}
+	// check some bad revision name, eg: myapp-a1
+	if !strings.HasPrefix(splits[len(splits)-1], "v") {
+		return 0, errors.New(util.ErrBadRevision)
+	}
 	// the revision is the last string without the prefix "v"
 	return strconv.Atoi(strings.TrimPrefix(splits[len(splits)-1], "v"))
 }

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -42,7 +42,7 @@ func TestConstructExtract(t *testing.T) {
 			}
 		})
 	}
-	badRevision := []string{"xx", "yy-", "zz-0.1"}
+	badRevision := []string{"xx", "yy-", "zz-0.1", "5", "myapp-a1"}
 	t.Run(fmt.Sprintf("tests %s for extractRevision", badRevision), func(t *testing.T) {
 		for _, revisionName := range badRevision {
 			_, err := ExtractRevision(revisionName)


### PR DESCRIPTION
### Description of your changes

copilot:all

`ExtractRevision` (`pkg/controller/utils/utils.go`) parsed the last hyphen
segment of a revision name as the revision number without first validating the
name's shape. As a result a bareword like `"5"` returned `5, nil`, and any name
whose last segment was not `v`-prefixed (for example `"myapp-a1"`) was silently
mis-parsed instead of being rejected.

This mirrors the guards already present in its robust twin `ExtractRevisionNum`
(`pkg/oam/util/helper.go`): return `ErrBadRevision` when the name has no
delimiter (`len(splits) == 1`) or when the last segment is not `v`-prefixed.
The valid `name-vN` path (trim the `v` prefix, then `strconv.Atoi`) is unchanged.

The colocated `badRevision` test cases are extended with `"5"` and `"myapp-a1"`
so the bareword and non-`v` paths are actually exercised (previously they only
ever errored by `Atoi` accident, never via an explicit guard).

This is a self-identified bug found while reading the revision-parsing helpers;
there is no existing tracking issue.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. <!-- N/A: internal helper hardening, no user-facing API or config change. -->
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go test ./pkg/controller/utils/ -run 'TestConstructExtract|TestGetAppRevison' -count=1 -v` passes,
  including the extended bad-name subtest `tests [xx yy- zz-0.1 5 myapp-a1]`.
- Negative check: reverting only `utils.go` while keeping the new test cases makes
  `TestConstructExtract` fail with `want to get err from 5 but got nil`, confirming
  the test genuinely catches the regression.
- `gofmt -l`, `go vet ./pkg/controller/utils/`, and `go build ./pkg/controller/utils/`
  are all clean.
- The only production caller, `RollbackWorkflow` in
  `pkg/workflow/operation/operation.go`, already wraps and returns the error
  immediately, so erroring on a malformed `rev.Name` is strictly safer than the
  previous silent mis-parse into a wrong rollback target; valid `name-vN`
  revisions are unaffected.

### Special notes for your reviewer

The two new guards are intentionally a line-for-line mirror of the existing
`ExtractRevisionNum` guards in `pkg/oam/util/helper.go`, down to the comment
wording and the `errors.New(util.ErrBadRevision)` sentinel. `ExtractRevision`
hardcodes the `-` delimiter because it is the inverse of `ConstructRevisionName`,
which always joins with `-v`; `ExtractRevisionNum` takes the delimiter as a
parameter. So the adaptation is a faithful port of the same validation, not a
behavioral deviation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

