### PR TITLE
Fix: storage trait mountToEnv should replace existing env value

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -182,6 +182,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
+        		// +patchStrategy=retainKeys
         		env: envList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -176,6 +176,7 @@ template: {
 
 		containers: [{
 			// +patchKey=name
+			// +patchStrategy=retainKeys
 			env: envList
 			// +patchKey=name
 			volumeDevices: volumeDevicesList


### PR DESCRIPTION
## What

Fixes #6841

When the built-in `storage` trait uses `mountToEnv` to inject an environment variable from a Secret or ConfigMap, and that environment variable already exists on the workload with a plain `value`, the rendered manifest incorrectly contains both `value` and `valueFrom`. Kubernetes rejects this because an env var cannot specify both fields.

## Root cause

The storage trait patches container `env` entries using `+patchKey=name`, which merges fields into existing environment variables with the same name. During the strategic merge, the original `value` field from the workload is preserved while the trait adds `valueFrom`, resulting in an invalid manifest.

## Fix

Add `+patchStrategy=retainKeys` to the `env` patch field in the storage trait definition. For environment variables matched by name, the existing entry is cleared before applying the patch, allowing the trait to fully replace the env var with `{ name, valueFrom }` instead of merging fields.

Unmatched environment variables remain unchanged.

## Changes

* `vela-templates/definitions/internal/trait/storage.cue` - source trait definition
* `charts/vela-core/templates/defwithtemplate/storage.yaml` - generated Helm template kept in sync

## Example

### Before (invalid)

```yaml
env:
  - name: API_ENDPOINT
    value: https://api.example
    valueFrom:
      secretKeyRef:
        name: test
        key: http://example.com/api
```

### After (valid)

```yaml
env:
  - name: API_ENDPOINT
    valueFrom:
      secretKeyRef:
        name: test
        key: http://example.com/api
```

## Test Plan

* [ ] Deploy a component with a pre-existing environment variable that uses `value`.
* [ ] Attach the `storage` trait with `mountToEnv` targeting the same environment variable name.
* [ ] Confirm the rendered Deployment/StatefulSet contains only `valueFrom` for the matched environment variable.
* [ ] Confirm other environment variables on the same container remain unchanged.
* [ ] Repeat the test for both `secret.mountToEnv` and `configMap.mountToEnv`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

