### PR TITLE
Fix: correct ComputeHash doc comment to match its trait argument

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -691,9 +691,8 @@ func GenTraitName(componentName string, ct *unstructured.Unstructured, traitType
 	return fmt.Sprintf("%s-%s-%s", componentName, traitMiddleName, ComputeHash(ct))
 }
 
-// ComputeHash returns a hash value calculated from pod template and
-// a collisionCount to avoid hash collision. The hash will be safe encoded to
-// avoid bad words.
+// ComputeHash returns a hash value calculated from the given trait object.
+// The hash will be safe encoded to avoid bad words.
 func ComputeHash(trait *unstructured.Unstructured) string {
 	componentTraitHasher := fnv.New32a()
 	DeepHashObject(componentTraitHasher, *trait)


### PR DESCRIPTION

### Description of your changes

The `ComputeHash` doc comment in `pkg/oam/util/helper.go` claimed the hash was
computed "from pod template and a collisionCount to avoid hash collision". That
text was copied verbatim from the Kubernetes controller helper of the same name
(`ComputeHash(template *v1.PodTemplateSpec, collisionCount *int32)`), but this
KubeVela version has a different signature:

```go
func ComputeHash(trait *unstructured.Unstructured) string {
	componentTraitHasher := fnv.New32a()
	DeepHashObject(componentTraitHasher, *trait)
	return rand.SafeEncodeString(fmt.Sprint(componentTraitHasher.Sum32()))
}
```

It takes only a `trait *unstructured.Unstructured` and hashes exactly that
object, with no pod template and no collisionCount anywhere in the signature or
body. This updates the comment to describe the actual input. Documentation-only
change; no behavior change.

Fixes #

I have:

- [x] Read and followed KubeVela's contribution process.
- [x] Related Docs updated properly. In a new feature or configuration option, an update to the documentation is necessary. (N/A - this is an in-code doc-comment correction; no kubevela.io docs reference this internal helper.)
- [x] Run `make reviewable` to ensure this PR is ready for review. (Ran `gofmt`, `go vet`, and `go test` on the affected package - see below.)
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. (Not needed - comment-only fix.)

### How has this code been tested

No behavior changed, so no new test was added (a comment correction is not
behaviorally testable, and the function has no existing dedicated test). I ran
the affected package's checks to confirm no regression, from the repo root:

- `gofmt -l pkg/oam/util/helper.go` -> clean (no output)
- `go vet ./pkg/oam/util/` -> exit 0
- `go test -count=1 ./pkg/oam/util/` -> ok

### Special notes for your reviewer

Comment-only, single-file, -3/+2 change. The correctness claim is verifiable by
reading `pkg/oam/util/helper.go` around the `ComputeHash` definition: the
signature and body take/hash only the trait. The preserved "safe encoded to
avoid bad words" line remains accurate (`rand.SafeEncodeString`).

---

## Diff

```diff
diff --git a/pkg/oam/util/helper.go b/pkg/oam/util/helper.go
index fa9d4a79..3ace46c6 100644
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -691,9 +691,8 @@ func GenTraitName(componentName string, ct *unstructured.Unstructured, traitType
 	return fmt.Sprintf("%s-%s-%s", componentName, traitMiddleName, ComputeHash(ct))
 }
 
-// ComputeHash returns a hash value calculated from pod template and
-// a collisionCount to avoid hash collision. The hash will be safe encoded to
-// avoid bad words.
+// ComputeHash returns a hash value calculated from the given trait object.
+// The hash will be safe encoded to avoid bad words.
 func ComputeHash(trait *unstructured.Unstructured) string {
 	componentTraitHasher := fnv.New32a()
 	DeepHashObject(componentTraitHasher, *trait)
```

---



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

