### PR TITLE
Docs: remove dead webhook README links in WEBHOOK_DEBUGGING.md

### DIFF
--- a/docs/WEBHOOK_DEBUGGING.md
+++ b/docs/WEBHOOK_DEBUGGING.md
@@ -186,6 +186,4 @@ make k3d-delete
 
 ## Related Documentation
 
-- [KubeVela Webhook Implementation](../pkg/webhook/README.md)
-- [CUE Template Validation](../pkg/webhook/utils/README.md)
 - [Admission Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)


### PR DESCRIPTION


The "Related Documentation" section of `docs/WEBHOOK_DEBUGGING.md` linked to two
in-repo README files that do not exist:

- `../pkg/webhook/README.md`
- `../pkg/webhook/utils/README.md`

Neither file is present anywhere under `pkg/webhook/` (the guide and both links
were added together in #6932, but those READMEs were never created), so both
bullets are dead relative links.

This removes the two broken links and keeps the valid external
[Admission Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
reference. Removal (rather than repointing) is deliberate: the implementation
files those READMEs would have described, `pkg/webhook/utils/utils.go` and the
`validating_handler.go` handlers, are already linked earlier in the same guide
(in the "Files and Components" section), so repointing would only duplicate
existing references.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

(Note on `make reviewable`: this PR touches only a Markdown file under `docs/`,
with no Go code, generated manifests, or CUE changed, so the reviewable targets
have nothing to act on here. Left unchecked to be honest about not running the
full generator/lint suite for a doc-only change; happy to run it if a maintainer
prefers.)

### How has this code been tested

Doc-only change; no Go build or unit test is affected. Verified by:

- Confirming both link targets are absent: `ls pkg/webhook/README.md pkg/webhook/utils/README.md`
  reports "No such file or directory", and `find pkg/webhook -iname 'readme*'`
  returns nothing.
- A relative-link existence scan over `docs/WEBHOOK_DEBUGGING.md` after the
  change reports zero dead relative links (only the external Kubernetes link
  remains).
- `git diff --check` is clean; the diff is exactly two deletions.

### Special notes for your reviewer

Minimal doc fix (two deletions, one file). The file's original no-trailing-newline
ending is preserved. Backport labels left off since this is a docs-only cleanup;
add one if you would like it in a release branch.

---

## Duplicate / prior-art gate (re-checked at draft time)
- `gh search prs --repo kubevela/kubevela "WEBHOOK_DEBUGGING"` (open and closed) -> 0.
- `gh search prs ... "webhook README broken link"` (open) -> 0.
- `gh search issues ... "WEBHOOK_DEBUGGING"` (open) -> 0.
- `gh api .../commits?path=docs/WEBHOOK_DEBUGGING.md` -> only #6932 ever touched
  the file. No competing fix has landed or is in flight.

## Contributor gates
- PR-title-checker (`thehanimo/pr-title-checker` via `commit-lint.yml`): title
  prefix `Docs: ` is in the allowed list. Passes.
- No markdownlint / link-check / lychee / remark workflow exists in
  `.github/workflows/`, so no doc-lint CI gate applies.
- No DCO-check workflow. The commit is signed off anyway (`-s`) to match the
  prevailing recent-master convention; harmless if unused. EasyCLA may prompt at
  PR time and will need Anas to sign if this is his first PR to the org.
- Commit identity: `Anas Khan <83116240+anxkhn@users.noreply.github.com>`.

## Security / privacy
- Diff, commit subject/body, and branch name (`patch-7`) contain no local paths,
  machine/user names, workspace layout, the word "loop", or task ids (grep scan
  clean).
- No prompt injection encountered in any read material (the doc, task record, and
  workflow/config files were benign technical content).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

