### PR TITLE
Fix: preserve existing caBundle during upgrade of cluster-gateway API…

### DIFF
--- a/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
@@ -162,9 +162,18 @@ spec:
   versionPriority: 10
   insecureSkipTLSVerify: {{ not .Values.multicluster.clusterGateway.secureTLS.enabled }}
   {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
-  caBundle: Cg==
+  {{- /* Preserve an already-valid caBundle on upgrade so we don't reset it to the
+         Cg== placeholder before the patch Job re-runs 
+         $apiSvc is the existing APIService looked up above; fall back to the
+         placeholder only on fresh install or when it still holds the placeholder. */}}
+  {{- $caBundle := "Cg==" }}
+  {{- if and $apiSvc $apiSvc.spec (hasKey $apiSvc.spec "caBundle") (ne $apiSvc.spec.caBundle "Cg==") }}
+  {{- $caBundle = $apiSvc.spec.caBundle }}
+  {{- end }}
+  caBundle: {{ $caBundle }}
   {{ end }}
 {{ end }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
The cluster-gateway `APIService` (`v1alpha1.cluster.core.oam.dev`) template hardcodes
`caBundle: Cg==` (base64 for a newline) and relies on cert-manager injection or the
post-install/upgrade patch Job to replace it with the real CA.

Unlike the webhook configurations — which were fixed in #6919 — this template does **not**
preserve an already-valid `caBundle` across upgrades. On every `helm upgrade` it re-renders
the placeholder, so a working CA gets reset to `Cg==`. When the patch Job doesn't re-run
(e.g. it's disabled, fails, or the reset wins the race), the kube-apiserver can no longer
verify the aggregated server and **every gateway-proxied request fails** with:

unable to load root certificates: unable to parse bytes as PEM block

This PR applies the same pattern #6919 used for the webhooks: it reuses the `$apiSvc`
`lookup` that the template already performs and preserves an existing valid `caBundle`
across upgrades, falling back to the `Cg==` placeholder only on fresh install (or when the
live value is still the placeholder). No new resources or RBAC are needed — the
cluster-gateway patch Job and its RBAC already exist, and Helm's `lookup` runs client-side.

Fixes #7214

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. — N/A, no user-facing behavior/config change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Reproduced and verified end-to-end on a k3d cluster (k3s v1.31, Helm v4):

**Before (the bug in #7214):**
- Installed vela-core with `multicluster` + `secureTLS` enabled. The patch Job populated a
  valid CA (756 bytes) into the APIService, and
  `GET /apis/cluster.core.oam.dev/v1alpha1/clustergateways` returned a `ClusterGatewayList`.
- On `helm upgrade`, the APIService template re-rendered the hardcoded placeholder, **resetting
  the working `caBundle` back to `Cg==`**. The kube-apiserver could then no longer verify the
  aggregated server, and every gateway-proxied request failed with:
  unable to load root certificates: unable to parse bytes as PEM block
This is the core bug: the template does not preserve the caBundle across upgrades (unlike the
webhook templates fixed in #6919), so a valid CA is lost whenever the patch Job doesn't
immediately re-run.

**After (this fix):**
- On `helm upgrade`, the existing valid `caBundle` is **preserved** — it stays the real 756-byte
CA (not `Cg==`), and proxying continues to return the `ClusterGatewayList`.
- Because the chart now renders the value that's already present, there is also no `.spec.caBundle`
server-side-apply conflict on Helm 4.
- `helm template` (no cluster, so `lookup` returns nil) correctly falls back to `Cg==`, leaving
fresh installs unchanged.

**After (this fix):**
- On `helm upgrade`, the existing valid `caBundle` is **preserved** — it stays the real 756-byte
  CA (not `Cg==`), so the kube-apiserver keeps trusting the gateway and
  `GET /apis/cluster.core.oam.dev/v1alpha1/clustergateways` continues to return a
  `ClusterGatewayList`. The upgrade no longer loses the CA (Helm 3 or Helm 4).
- (On Helm 4 specifically: since the chart now renders the value already present, there is also
  no longer any server-side-apply conflict on `.spec.caBundle`.)
- `helm template` (no cluster, so `lookup` returns nil) correctly falls back to `Cg==`, leaving
  fresh installs unchanged.

### Special notes for your reviewer

- Single-file change; it reuses the `$apiSvc` `lookup` already defined a few lines above for
  adoption, so there's no extra cluster round-trip.
- Deliberately **not** mirroring #6919's patch-Job/RBAC/rollback changes: cluster-gateway
  already ships its own patch Job with the needed RBAC (`cluster-gateway/job-patch.yaml`), and
  the preserve logic needs no new permissions since `lookup` is client-side.
- Under Helm 4 (server-side apply) the pre-fix symptom is an upgrade **conflict** on
  `.spec.caBundle`; under Helm 3 (3-way merge) it's a **silent reset** to `Cg==`. This fix
  resolves both, because the chart now renders the value already present instead of a
  different one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

