### PR TITLE
Fix: assert the List error in multicluster e2e teardown

### DIFF
--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -112,7 +112,7 @@ var _ = AfterSuite(func() {
 			g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: addon, Namespace: types.DefaultKubeVelaNS}, app)).Should(SatisfyAny(Succeed(), oamutil.NotFoundMatcher{}))
 		}
 		err := k8sClient.List(context.Background(), apps)
-		g.Expect(err, nil)
+		g.Expect(err).Should(Succeed())
 		g.Expect(len(apps.Items)).Should(Equal(0))
 	}, 5*time.Minute).Should(Succeed())
 	Eventually(func(g Gomega) {


### PR DESCRIPTION


copilot:all

In the multicluster e2e `AfterSuite` teardown, the final `Eventually` block
lists all `Application`s and then calls `g.Expect(err, nil)` on the `List`
error. That line asserts nothing: Gomega's `Expect(actual, extra...)` returns
an `Assertion` and only validates the extra arguments once a matcher
(`.Should`/`.To`/etc.) is invoked, so with no matcher chained the `List` error
is silently discarded. If the `List` fails, `apps` is left empty/stale and the
very next `Expect(len(apps.Items)).Should(Equal(0))` can pass for the wrong
reason, masking a real teardown failure.

This replaces `g.Expect(err, nil)` with `g.Expect(err).Should(Succeed())`,
matching the assertion style already used throughout this file (for example the
`k8sClient.List(...).Should(Succeed())` at the top of the same block and the
`g.Expect(err).Should(Succeed())` a few lines below). No product code is
touched and there is no behavior change on the happy path.

Fixes #
<!-- no tracking issue; self-identified test-quality fix -->

I have:

- [x] Read and followed KubeVela's contribution process.
- [ ] Related Docs updated properly. (N/A - test-only change, no user-facing
      behavior or configuration.)
- [x] Run `make reviewable` to ensure this PR is ready for review.
      <!-- see reviewer note: gofmt/goimports/go vet run; full make reviewable


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

