### PR TITLE
Fix: correct GetCondition doc comment to describe value return

### DIFF
--- a/apis/core.oam.dev/condition/condition.go
+++ b/apis/core.oam.dev/condition/condition.go
@@ -122,8 +122,8 @@ func NewConditionedStatus(c ...Condition) *ConditionedStatus {
 	return s
 }
 
-// GetCondition returns the condition for the given ConditionType if exists,
-// otherwise returns nil
+// GetCondition returns the condition for the given ConditionType if it exists,
+// otherwise it returns a Condition of that type with status Unknown.
 func (s *ConditionedStatus) GetCondition(ct ConditionType) Condition {
 	for _, c := range s.Conditions {
 		if c.Type == ct {


### PR DESCRIPTION


`ConditionedStatus.GetCondition` returns a value-typed `Condition`, not a
pointer, so it can never return `nil`. On a missing `ConditionType` it returns a
`Condition` of that type with status `Unknown`:

```go
func (s *ConditionedStatus) GetCondition(ct ConditionType) Condition {
	for _, c := range s.Conditions {
		if c.Type == ct {
			return c
		}
	}

	return Condition{Type: ct, Status: corev1.ConditionUnknown}
}
```

Its doc comment still described the old contract, `otherwise returns nil`, which
dates back to when this file was ported from crossplane-runtime (whose original
returned `*Condition`). The return type was later changed to a value, but the
comment was never updated. A reader following the comment could write
`if cond == nil { ... }`, which would not even compile against the current
signature.

This updates only the doc comment to describe the actual behavior. No code
change.

```diff
-// GetCondition returns the condition for the given ConditionType if exists,
-// otherwise returns nil
+// GetCondition returns the condition for the given ConditionType if it exists,
+// otherwise it returns a Condition of that type with status Unknown.
```

Fixes #

I have:

- [x] Read and followed KubeVela's contribution process.
- [ ] Related Docs updated properly. In a new feature or configuration option, an update to the documentation is necessary. (N/A: no user-facing docs; this is an in-code godoc correction.)
- [x] Run `make reviewable` to ensure this PR is ready for review. (Ran the relevant subset: `gofmt`, `go vet`, `go build`, `go test` on the package and its dependents. See below.)
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. (N/A: comment-only, no behavior change.)

### How has this code been tested

No new test was added: the change is doc-only and the existing
`TestGetCondition/ConditionDoesNotExist` in
`apis/core.oam.dev/condition/condition_test.go` already asserts that an absent
`ConditionType` returns `Condition{Type: ..., Status: corev1.ConditionUnknown}`,
which is exactly the contract the corrected comment now describes.

Verified locally (go1.26.4):

- `gofmt -l apis/core.oam.dev/condition/condition.go` -> clean
- `go vet ./apis/core.oam.dev/condition/...` -> ok
- `go build ./apis/core.oam.dev/condition/...` -> ok
- `go test ./apis/core.oam.dev/condition/...` -> ok
- `go test -v -run TestGetCondition ./apis/core.oam.dev/condition/...` -> PASS

### Special notes for your reviewer

Documentation-comment-only change; there is no behavior change. It corrects a
public-API godoc that has been stale since the crossplane-runtime port (the
`NOTE(negz)` markers elsewhere in the file are from that same origin).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

