### PR TITLE
Fix(addon): correct metadata.yaml filename in addon validation errors

### DIFF
--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -531,10 +531,10 @@ func validateAddonPackage(addonPkg *InstallPackage) error {
 		return fmt.Errorf("the addon package doesn't have `metadata.yaml`")
 	}
 	if addonPkg.Name == "" {
-		return fmt.Errorf("`matadata.yaml` must define the name of addon")
+		return fmt.Errorf("`metadata.yaml` must define the name of addon")
 	}
 	if addonPkg.Version == "" {
-		return fmt.Errorf("`matadata.yaml` must define the version of addon")
+		return fmt.Errorf("`metadata.yaml` must define the version of addon")
 	}
 	return nil
 }

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -468,10 +468,10 @@ func TestCheckAddonPackageValid(t *testing.T) {
 		err:      fmt.Errorf("the addon package doesn't have `metadata.yaml`"),
 	}, {
 		testCase: Meta{Version: "v1.4.0"},
-		err:      fmt.Errorf("`matadata.yaml` must define the name of addon"),
+		err:      fmt.Errorf("`metadata.yaml` must define the name of addon"),
 	}, {
 		testCase: Meta{Name: "test-addon"},
-		err:      fmt.Errorf("`matadata.yaml` must define the version of addon"),
+		err:      fmt.Errorf("`metadata.yaml` must define the version of addon"),
 	}, {
 		testCase: Meta{Name: "test-addon", Version: "1.4.5"},
 		err:      nil,


### PR DESCRIPTION


`validateAddonPackage` reports the required addon manifest as `matadata.yaml` in
two of its error messages, when the real filename is `metadata.yaml`. An addon
author whose `metadata.yaml` is missing the `name` or `version` field is told to
fix `matadata.yaml`, a file that does not exist, so the diagnostic points them at
the wrong thing.

The correct spelling is already used everywhere else, including the sibling error
on the missing-manifest branch of this same function:

```go
// pkg/addon/utils.go, validateAddonPackage
return fmt.Errorf("the addon package doesn't have `metadata.yaml`") // correct
...
return fmt.Errorf("`matadata.yaml` must define the name of addon")    // typo
return fmt.Errorf("`matadata.yaml` must define the version of addon") // typo
```

and by the constant that names the file:

```go
// pkg/addon/addon.go
MetadataFileName string = "metadata.yaml"
```

This corrects the two misspelled literals so all three error messages agree with
the constant and with the rest of the package. There is no behavior, signature,
or logic change; the messages are the only thing that differs.

Fixes #

I have:

- [x] Read and followed KubeVela's contribution process.
- [ ] Related Docs updated properly. (Not applicable: no user-facing docs
  reference these internal error strings; this is an internal message correction.)
- [x] Run `make reviewable` to ensure this PR is ready for review. (Ran the
  relevant subset: `gofmt`, `go vet ./pkg/addon/`, `go build ./pkg/addon/`, and the
  addon unit tests, all clean/passing. See "How has this code been tested".)
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
  (Deferred to a maintainer: a cosmetic message fix likely does not need a
  backport, but happy to add labels if wanted.)

### How has this code been tested

`TestCheckAddonPackageValid` in `pkg/addon/utils_test.go` already exercises the
empty-name and empty-version branches and asserts the exact error string via
`reflect.DeepEqual`, so the two assertions were updated in lockstep with the
source. This keeps the test as a real guard: reverting only the source (keeping
the test asserting `metadata.yaml`) makes the test fail on exactly those two
branches, and restoring it passes again.

Commands run locally (Go 1.26):

- `gofmt -l pkg/addon/utils.go pkg/addon/utils_test.go` - clean
- `go vet ./pkg/addon/` - clean
- `go build ./pkg/addon/` - ok
- `go test ./pkg/addon/ -run TestCheckAddonPackageValid -count=1` - PASS

### Special notes for your reviewer

Minimal, message-only change (4 lines: 2 source + 2 test). A separate,
pre-existing comment typo (`meatadata` in an `addon.go` comment) was intentionally
left untouched to keep this PR scoped to the user-facing validation errors. Happy
to fold that in or split it out if you prefer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

