### PR TITLE
Fix: propagate CUE health-eval errors from GetStatus and mirror trait path fix

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/apply.go
@@ -27,6 +27,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	monitorContext "github.com/kubevela/pkg/monitor/context"
@@ -262,12 +263,15 @@ func (h *AppHandler) collectTraitHealthStatus(comp *appfile.Component, tr *appfi
 		return common.ApplicationTraitStatus{}, nil, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, evaluate status message error", appName, comp.Name, tr.Name)
 	}
 	statusResult, err := tr.EvalStatus(templateContext)
-	if err == nil && statusResult != nil {
+	if err != nil {
+		klog.Warningf("app=%s, comp=%s, trait=%s, evaluate trait status error (best-effort): %v", appName, comp.Name, tr.Name, err)
+	}
+	if statusResult != nil {
 		traitStatus.Healthy = statusResult.Healthy
 		traitStatus.Message = statusResult.Message
 		traitStatus.Details = statusResult.Details
 	}
-	return traitStatus, extractOutputs(templateContext), err
+	return traitStatus, extractOutputs(templateContext), nil
 }
 
 // collectWorkloadHealthStatus collect workload health status
@@ -302,7 +306,7 @@ func (h *AppHandler) collectWorkloadHealthStatus(ctx context.Context, comp *appf
 		}
 		statusResult, err := comp.EvalStatus(templateContext)
 		if err != nil {
-			return false, nil, nil, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, comp.Name)
+			klog.Warningf("app=%s, comp=%s, evaluate workload status error (best-effort): %v", appName, comp.Name, err)
 		}
 		if statusResult != nil {
 			status.Healthy = statusResult.Healthy

--- a/pkg/cue/definition/health/health.go
+++ b/pkg/cue/definition/health/health.go
@@ -18,6 +18,7 @@ package health
 
 import (
 	"encoding/json"
+	goerrors "errors"
 	"slices"
 	"strings"
 
@@ -104,7 +105,7 @@ func GetStatus(templateContext map[string]interface{}, request *StatusRequest) (
 		Healthy: healthy,
 		Message: message,
 		Details: statusMap,
-	}, nil
+	}, goerrors.Join(mapErr, healthErr, msgErr)
 }
 
 func getStatusMessage(templateContext map[string]interface{}, customStatusTemplate string, parameter interface{}) (string, error) {

--- a/pkg/cue/definition/health/health_test.go
+++ b/pkg/cue/definition/health/health_test.go
@@ -1048,3 +1048,20 @@ required: string | *"default"
 		})
 	}
 }
+
+// TestGetStatus_PropagatesHealthEvalError is the regression test from issue #7141:
+// GetStatus must not silently discard a CUE health-policy evaluation error.
+func TestGetStatus_PropagatesHealthEvalError(t *testing.T) {
+	templateContext := map[string]interface{}{
+		"output": map[string]interface{}{
+			"spec":   map[string]interface{}{"replicas": int64(1)},
+			"status": map[string]interface{}{"readyReplicas": int64(1)},
+		},
+	}
+	brokenPolicy := `isHealth: context.output.spec.replicas + "not-a-number" > 0`
+
+	result, err := GetStatus(templateContext, &StatusRequest{Health: brokenPolicy})
+	assert.Error(t, err, "GetStatus must surface the health policy evaluation error")
+	assert.NotNil(t, result, "GetStatus should still return a best-effort result")
+	assert.False(t, result.Healthy)
+}


### PR DESCRIPTION
### Description of your changes

`GetStatus` in `pkg/cue/definition/health/health.go` always returned a `nil` error, even when the CUE health-policy, status-map, or status-message templates failed to evaluate. Callers couldn't distinguish "component is genuinely unhealthy" from "the health check itself errored" — both looked identical (`Healthy: false, err: nil`).

This PR:
- Makes `GetStatus` return `errors.Join(mapErr, healthErr, msgErr)` instead of swallowing them.
- Updates both `collectWorkloadHealthStatus` (component) and `collectTraitHealthStatus` (trait) in `apply.go` to log-and-continue with a best-effort result on eval error, instead of treating it as fatal — so a broken health/status template doesn't abort the whole reconcile.

Fixes #7141

### How has this code been tested

- Added `TestGetStatus_PropagatesHealthEvalError` in `health_test.go`, reproducing the issue's own repro case (a CUE type-error in the health policy) and asserting `GetStatus` now returns a non-nil error.
- Ran the existing `pkg/cue/definition/health` and `pkg/controller/core.oam.dev/v1beta1/application` test suites (including envtest-based integration tests) — all green, no regressions.
- Manually verified via `go vet`/`go build` on all touched packages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

