### PR TITLE
Fix: add ValidateTraitParams to improve trait parameter error messages

### DIFF
--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -296,7 +296,10 @@ func ValidateTraitParams(ctxData velaprocess.ContextData, tr *Trait) error {
 // trait's parameter schema that are absent from the supplied params map.
 func enforceTraitRequiredParams(paramVal cue.Value, params map[string]any, traitName string) error {
 	reqFields, err := requiredFields(paramVal)
-	if err != nil || len(reqFields) == 0 {
+	if err != nil {
+		return err
+	}
+	if len(reqFields) == 0 {
 		return nil
 	}
 	var missing []string

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -109,6 +109,9 @@ func (p *Parser) ValidateCUESchematicAppfile(a *Appfile) error {
 				// references to fields that are populated/injected during runtime only
 				continue
 			}
+			if err := ValidateTraitParams(ctxData, tr); err != nil {
+				return err
+			}
 			if err := tr.EvalContext(pCtx); err != nil {
 				return errors.WithMessagef(err, "cannot evaluate trait %q", tr.Name)
 			}
@@ -223,6 +226,51 @@ func (p *Parser) ValidateComponentParams(ctxData velaprocess.ContextData, wl *Co
 					"component %q", wl.Name)
 			}
 		}
+	}
+
+	return nil
+}
+
+
+// ValidateTraitParams validates a Trait's parameter values against the CUE schema
+// before EvalContext is called, surfacing clear messages like
+// `trait "foo": parameter constraint violation: parameter.maxReplicas: conflicting values "ten" and int`
+// instead of the cryptic CUE disjunction errors produced by EvalContext.
+func ValidateTraitParams(ctxData velaprocess.ContextData, tr *Trait) error {
+	if tr.FullTemplate == nil || tr.FullTemplate.TemplateStr == "" {
+		return nil
+	}
+
+	ctx := velaprocess.NewContext(ctxData)
+	baseCtx, err := ctx.BaseContextFile()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	paramSnippet, err := cueParamBlock(tr.Params)
+	if err != nil {
+		return errors.WithMessagef(err, "trait %q: invalid params", tr.Name)
+	}
+
+	templateStr, _ := upgrade.EnsureCueVersionCompatibility(tr.FullTemplate.TemplateStr, tr.Name, upgrade.TraitKind, upgrade.TemplateAreaMain)
+
+	cueSrc := strings.Join([]string{
+		renderTemplate(templateStr),
+		paramSnippet,
+		baseCtx,
+	}, "\n")
+
+	val, err := velacuex.WorkloadCompiler.Get().CompileString(ctx.GetCtx(), cueSrc)
+	if err != nil {
+		// Compile errors may be caused by provider imports not available during
+		// standalone compilation; log and skip rather than blocking admission.
+		klog.V(4).Infof("trait %q: CUE compile error during param validation (skipping): %v", tr.Name, err)
+		return nil
+	}
+
+	paramVal := val.LookupPath(value.FieldPath(velaprocess.ParameterFieldName))
+	if err := paramVal.Validate(cue.Concrete(false)); err != nil {
+		return errors.WithMessagef(err, "trait %q: parameter constraint violation", tr.Name)
 	}
 
 	return nil

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -279,41 +279,10 @@ func ValidateTraitParams(ctxData velaprocess.ContextData, tr *Trait) error {
 
 	paramVal := val.LookupPath(value.FieldPath(velaprocess.ParameterFieldName))
 
-	// Check for required params (no default, not optional) that are absent from
-	// the supplied values — cue.Concrete(false) alone does not catch these.
-	if err := enforceTraitRequiredParams(paramVal, tr.Params, tr.Name); err != nil {
-		return err
-	}
-
 	if err := paramVal.Validate(cue.Concrete(false)); err != nil {
 		return errors.WithMessagef(err, "trait %q: parameter constraint violation", tr.Name)
 	}
 
-	return nil
-}
-
-// enforceTraitRequiredParams reports any non-optional, non-defaulted fields in the
-// trait's parameter schema that are absent from the supplied params map.
-func enforceTraitRequiredParams(paramVal cue.Value, params map[string]any, traitName string) error {
-	reqFields, err := requiredFields(paramVal)
-	if err != nil {
-		return err
-	}
-	if len(reqFields) == 0 {
-		return nil
-	}
-	var missing []string
-	for _, f := range reqFields {
-		if _, ok := params[f]; !ok {
-			missing = append(missing, f)
-		}
-	}
-	if len(missing) > 0 {
-		sort.Strings(missing)
-		return errors.WithMessagef(
-			fmt.Errorf("missing required parameters: %s", strings.Join(missing, ", ")),
-			"trait %q", traitName)
-	}
 	return nil
 }
 

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -253,6 +253,11 @@ func ValidateTraitParams(ctxData velaprocess.ContextData, tr *Trait) error {
 
 	templateStr, _ := upgrade.EnsureCueVersionCompatibility(tr.FullTemplate.TemplateStr, tr.Name, upgrade.TraitKind, upgrade.TemplateAreaMain)
 
+	// Compile template-only first (no user params) to distinguish provider-import
+	// errors (expected in standalone validation) from user-param type errors.
+	templateOnlySrc := strings.Join([]string{renderTemplate(templateStr), baseCtx}, "\n")
+	_, templateCompileErr := velacuex.WorkloadCompiler.Get().CompileString(ctx.GetCtx(), templateOnlySrc)
+
 	cueSrc := strings.Join([]string{
 		renderTemplate(templateStr),
 		paramSnippet,
@@ -261,17 +266,51 @@ func ValidateTraitParams(ctxData velaprocess.ContextData, tr *Trait) error {
 
 	val, err := velacuex.WorkloadCompiler.Get().CompileString(ctx.GetCtx(), cueSrc)
 	if err != nil {
-		// Compile errors may be caused by provider imports not available during
-		// standalone compilation; log and skip rather than blocking admission.
+		if templateCompileErr == nil {
+			// Template compiled fine without user params, so the error originates
+			// from a type conflict in the supplied parameter values.
+			return errors.WithMessagef(err, "trait %q: invalid parameter value", tr.Name)
+		}
+		// Template itself had compile errors regardless of user params (e.g. a missing
+		// provider import); log and skip to avoid false positives.
 		klog.V(4).Infof("trait %q: CUE compile error during param validation (skipping): %v", tr.Name, err)
 		return nil
 	}
 
 	paramVal := val.LookupPath(value.FieldPath(velaprocess.ParameterFieldName))
+
+	// Check for required params (no default, not optional) that are absent from
+	// the supplied values — cue.Concrete(false) alone does not catch these.
+	if err := enforceTraitRequiredParams(paramVal, tr.Params, tr.Name); err != nil {
+		return err
+	}
+
 	if err := paramVal.Validate(cue.Concrete(false)); err != nil {
 		return errors.WithMessagef(err, "trait %q: parameter constraint violation", tr.Name)
 	}
 
+	return nil
+}
+
+// enforceTraitRequiredParams reports any non-optional, non-defaulted fields in the
+// trait's parameter schema that are absent from the supplied params map.
+func enforceTraitRequiredParams(paramVal cue.Value, params map[string]any, traitName string) error {
+	reqFields, err := requiredFields(paramVal)
+	if err != nil || len(reqFields) == 0 {
+		return nil
+	}
+	var missing []string
+	for _, f := range reqFields {
+		if _, ok := params[f]; !ok {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return errors.WithMessagef(
+			fmt.Errorf("missing required parameters: %s", strings.Join(missing, ", ")),
+			"trait %q", traitName)
+	}
 	return nil
 }
 

--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -231,7 +231,6 @@ func (p *Parser) ValidateComponentParams(ctxData velaprocess.ContextData, wl *Co
 	return nil
 }
 
-
 // ValidateTraitParams validates a Trait's parameter values against the CUE schema
 // before EvalContext is called, surfacing clear messages like
 // `trait "foo": parameter constraint violation: parameter.maxReplicas: conflicting values "ten" and int`

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -383,6 +383,36 @@ func TestValidateTraitParams(t *testing.T) {
 			params:    map[string]interface{}{},
 			wantErr:   "",
 		},
+		{
+			name:      "required param with no default left out",
+			traitName: "scaler",
+			template: `
+			parameter: {
+				maxReplicas: int
+			}
+			patch: {
+				spec: replicas: parameter.maxReplicas
+			}
+			`,
+			params:  map[string]interface{}{},
+			wantErr: "missing required parameters",
+		},
+		{
+			name:      "wrong type for defaulted parameter",
+			traitName: "scaler",
+			template: `
+			parameter: {
+				maxReplicas: int | *2
+			}
+			patch: {
+				spec: replicas: parameter.maxReplicas
+			}
+			`,
+			params: map[string]interface{}{
+				"maxReplicas": "not-an-int",
+			},
+			wantErr: "parameter constraint violation",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -320,14 +320,13 @@ func TestParser_ValidateComponentParams(t *testing.T) {
 	}
 }
 
-
 func TestValidateTraitParams(t *testing.T) {
 	testCases := []struct {
-		name     string
+		name      string
 		traitName string
-		template string
-		params   map[string]interface{}
-		wantErr  string
+		template  string
+		params    map[string]interface{}
+		wantErr   string
 	}{
 		{
 			name:      "valid trait params",

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -320,6 +320,99 @@ func TestParser_ValidateComponentParams(t *testing.T) {
 	}
 }
 
+
+func TestValidateTraitParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		traitName string
+		template string
+		params   map[string]interface{}
+		wantErr  string
+	}{
+		{
+			name:      "valid trait params",
+			traitName: "scaler",
+			template: `
+			parameter: {
+				maxReplicas: int | *10
+			}
+			patch: {
+				spec: replicas: parameter.maxReplicas
+			}
+			`,
+			params: map[string]interface{}{
+				"maxReplicas": 5,
+			},
+			wantErr: "",
+		},
+		{
+			name:      "wrong type for int parameter",
+			traitName: "scaler",
+			template: `
+			parameter: {
+				maxReplicas: int
+			}
+			patch: {
+				spec: replicas: parameter.maxReplicas
+			}
+			`,
+			params: map[string]interface{}{
+				"maxReplicas": "ten",
+			},
+			wantErr: "parameter constraint violation",
+		},
+		{
+			name:      "constraint violation negative int",
+			traitName: "scaler",
+			template: `
+			parameter: {
+				maxReplicas: int & >0
+			}
+			patch: {
+				spec: replicas: parameter.maxReplicas
+			}
+			`,
+			params: map[string]interface{}{
+				"maxReplicas": -1,
+			},
+			wantErr: "parameter constraint violation",
+		},
+		{
+			name:      "nil FullTemplate is skipped",
+			traitName: "empty-trait",
+			template:  "",
+			params:    map[string]interface{}{},
+			wantErr:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &Appfile{
+				Name:      "myapp",
+				Namespace: "test-ns",
+			}
+			ctxData := GenerateContextDataFromAppFile(app, "mycomp")
+			var fullTemplate *Template
+			if tc.template != "" {
+				fullTemplate = &Template{TemplateStr: tc.template}
+			}
+			tr := &Trait{
+				Name:         tc.traitName,
+				FullTemplate: fullTemplate,
+				Params:       tc.params,
+			}
+			err := ValidateTraitParams(ctxData, tr)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidationHelpers(t *testing.T) {
 	t.Run("renderTemplate", func(t *testing.T) {
 		tmpl := "output: {}"

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -384,7 +384,7 @@ func TestValidateTraitParams(t *testing.T) {
 			wantErr:   "",
 		},
 		{
-			name:      "required param with no default left out",
+			name:      "required param with no default left out — no error at validation time",
 			traitName: "scaler",
 			template: `
 			parameter: {
@@ -394,8 +394,13 @@ func TestValidateTraitParams(t *testing.T) {
 				spec: replicas: parameter.maxReplicas
 			}
 			`,
+			// Trait validation checks type/constraint violations only; whether a
+			// required param was supplied is not enforced here because traits may
+			// receive params from the runtime context (component values, workflow
+			// step inputs) that are not available during static validation. Enforcing
+			// required-ness at this layer causes false-positive rejections in e2e.
 			params:  map[string]interface{}{},
-			wantErr: "missing required parameters",
+			wantErr: "",
 		},
 		{
 			name:      "wrong type for defaulted parameter",


### PR DESCRIPTION
## Problem Statement

Trait parameter type violations return cryptic CUE disjunction errors:
```
cannot evaluate trait "def-name": invalid template of trait def-name after merge with parameter and context: parameter.maxReplicas: 2 errors in empty disjunction: (and 30 more errors)
```

## Related Issue

Fixes #7014

## Proposed Changes

Add `ValidateTraitParams` to `pkg/appfile/validate.go`, modelled on the existing `ValidateComponentParams` (added in #6984 for components). The function validates the trait's parameter values against the CUE schema before `EvalContext` is called, surfacing clear messages like `trait "foo": parameter constraint violation: parameter.maxReplicas: conflicting values "ten" and int`.

## Format

fix(appfile): add ValidateTraitParams for clear trait error messages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

