### PR TITLE
Fix: vela status reports Healthy on workflowFailed with empty services

### DIFF
--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -493,6 +493,36 @@ func getAppPhaseColor(appPhase commontypes.ApplicationPhase) *color.Color {
 }
 
 func getAppHealth(app *v1beta1.Application) bool {
+	// Terminal / unhealthy application phases must never report as healthy.
+	// This includes cases where no component services were recorded yet (e.g. CUE
+	// parameter errors fail the workflow before any service status is written).
+	// Previously empty Services made this function return true (vacuous truth),
+	// so `vela status` incorrectly showed Healthy: ✅ on workflowFailed apps.
+	switch app.Status.Phase {
+	case commontypes.ApplicationWorkflowFailed,
+		commontypes.ApplicationWorkflowTerminated,
+		commontypes.ApplicationUnhealthy,
+		commontypes.ApplicationDeleting:
+		return false
+	}
+
+	// A failed workflow step means the app is not healthy, even while the
+	// controller is still retrying (phase may still be runningWorkflow).
+	if app.Status.Workflow != nil {
+		for _, step := range app.Status.Workflow.Steps {
+			if step.Phase == workflowv1alpha1.WorkflowStepPhaseFailed {
+				return false
+			}
+		}
+	}
+
+	// No service status yet: cannot claim the application is healthy.
+	// This covers intermediate phases and edge cases where phase is running
+	// but services were never populated.
+	if len(app.Status.Services) == 0 {
+		return false
+	}
+
 	for _, s := range app.Status.Services {
 		if !s.Healthy {
 			return false

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -504,6 +504,9 @@ func getAppHealth(app *v1beta1.Application) bool {
 		commontypes.ApplicationUnhealthy,
 		commontypes.ApplicationDeleting:
 		return false
+	default:
+		// Other phases (starting/rendering/runningWorkflow/running/...) continue
+		// with service and workflow-step health checks below.
 	}
 
 	// A failed workflow step (or substep in a step-group) means the app is not

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -506,12 +506,19 @@ func getAppHealth(app *v1beta1.Application) bool {
 		return false
 	}
 
-	// A failed workflow step means the app is not healthy, even while the
-	// controller is still retrying (phase may still be runningWorkflow).
+	// A failed workflow step (or substep in a step-group) means the app is not
+	// healthy, even while the controller is still retrying (phase may still be
+	// runningWorkflow).
 	if app.Status.Workflow != nil {
-		for _, step := range app.Status.Workflow.Steps {
+		for i := range app.Status.Workflow.Steps {
+			step := &app.Status.Workflow.Steps[i]
 			if step.Phase == workflowv1alpha1.WorkflowStepPhaseFailed {
 				return false
+			}
+			for j := range step.SubStepsStatus {
+				if step.SubStepsStatus[j].Phase == workflowv1alpha1.WorkflowStepPhaseFailed {
+					return false
+				}
 			}
 		}
 	}

--- a/references/cli/status_health_test.go
+++ b/references/cli/status_health_test.go
@@ -19,8 +19,8 @@ package cli
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"

--- a/references/cli/status_health_test.go
+++ b/references/cli/status_health_test.go
@@ -155,6 +155,27 @@ func TestGetAppHealth(t *testing.T) {
 			}},
 			want: true,
 		},
+		{
+			name: "failed substep in step-group must not be healthy even if services healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunningWorkflow,
+				Services: []common.ApplicationComponentStatus{healthyService},
+				Workflow: &common.WorkflowStatus{
+					Steps: []workflowv1alpha1.WorkflowStepStatus{{
+						StepStatus: workflowv1alpha1.StepStatus{
+							Name:  "group",
+							Type:  "step-group",
+							Phase: workflowv1alpha1.WorkflowStepPhaseRunning,
+						},
+						SubStepsStatus: []workflowv1alpha1.StepStatus{{
+							Name:  "child",
+							Phase: workflowv1alpha1.WorkflowStepPhaseFailed,
+						}},
+					}},
+				},
+			}},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/references/cli/status_health_test.go
+++ b/references/cli/status_health_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+func TestGetAppHealth(t *testing.T) {
+	r := require.New(t)
+
+	healthyService := common.ApplicationComponentStatus{
+		Name:    "web",
+		Healthy: true,
+	}
+	unhealthyService := common.ApplicationComponentStatus{
+		Name:    "web",
+		Healthy: false,
+	}
+	unhealthyTrait := common.ApplicationComponentStatus{
+		Name:    "web",
+		Healthy: true,
+		Traits: []common.ApplicationTraitStatus{{
+			Type:    "scaler",
+			Healthy: false,
+		}},
+	}
+
+	tests := []struct {
+		name string
+		app  *v1beta1.Application
+		want bool
+	}{
+		{
+			name: "running with healthy services",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunning,
+				Services: []common.ApplicationComponentStatus{healthyService},
+			}},
+			want: true,
+		},
+		{
+			name: "running with unhealthy service",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunning,
+				Services: []common.ApplicationComponentStatus{unhealthyService},
+			}},
+			want: false,
+		},
+		{
+			name: "running with unhealthy trait",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunning,
+				Services: []common.ApplicationComponentStatus{unhealthyTrait},
+			}},
+			want: false,
+		},
+		{
+			name: "workflowFailed with empty services must not be healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationWorkflowFailed,
+				Services: nil,
+				Workflow: &common.WorkflowStatus{
+					Finished:   true,
+					Terminated: true,
+					Steps: []workflowv1alpha1.WorkflowStepStatus{{
+						StepStatus: workflowv1alpha1.StepStatus{
+							Name:  "web",
+							Phase: workflowv1alpha1.WorkflowStepPhaseFailed,
+						},
+					}},
+				},
+			}},
+			want: false,
+		},
+		{
+			name: "workflowTerminated with empty services must not be healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase: common.ApplicationWorkflowTerminated,
+			}},
+			want: false,
+		},
+		{
+			name: "unhealthy phase must not be healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationUnhealthy,
+				Services: []common.ApplicationComponentStatus{unhealthyService},
+			}},
+			want: false,
+		},
+		{
+			name: "runningWorkflow with failed step and empty services must not be healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase: common.ApplicationRunningWorkflow,
+				Workflow: &common.WorkflowStatus{
+					Steps: []workflowv1alpha1.WorkflowStepStatus{{
+						StepStatus: workflowv1alpha1.StepStatus{
+							Name:  "web",
+							Phase: workflowv1alpha1.WorkflowStepPhaseFailed,
+						},
+					}},
+				},
+			}},
+			want: false,
+		},
+		{
+			name: "runningWorkflow empty services intermediate is not healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunningWorkflow,
+				Services: nil,
+			}},
+			want: false,
+		},
+		{
+			name: "runningWorkflow wait healthy with unhealthy service",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunningWorkflow,
+				Services: []common.ApplicationComponentStatus{unhealthyService},
+			}},
+			want: false,
+		},
+		{
+			name: "running with empty services is not healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationRunning,
+				Services: nil,
+			}},
+			want: false,
+		},
+		{
+			name: "workflowSuspending with healthy services stays healthy",
+			app: &v1beta1.Application{Status: common.AppStatus{
+				Phase:    common.ApplicationWorkflowSuspending,
+				Services: []common.ApplicationComponentStatus{healthyService},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r.Equal(tt.want, getAppHealth(tt.app), tt.name)
+		})
+	}
+}


### PR DESCRIPTION
`getAppHealth()` returned `true` when `status.services` was empty (vacuous truth).
Failed applications that never recorded component status (e.g. missing required
CUE parameters) incorrectly showed `Healthy: ✅` in `vela status`, even when
the phase was `workflowFailed` and the workflow step was `failed`.

This change:
- Treats terminal/unhealthy phases (`workflowFailed`, `workflowTerminated`, `unhealthy`, `deleting`) as not healthy
- Treats any workflow step in `failed` phase as not healthy (covers retry window)
- Treats empty `status.services` as not healthy
- Adds unit tests for these cases

Related (but distinct): #7045

I have:

- [x] Read and followed KubeVela's contribution process.
- [ ] Related Docs updated properly. (N/A — CLI status display fix only)
- [ ] Run `make reviewable` (full target not run locally; package unit tests run)
- [ ] Added backport release-x.y labels to auto-backport this PR if necessary.

### How has this code been tested

```bash
go test ./references/cli/ -run TestGetAppHealth -count=1 -v