### PR TITLE
Fix: support configurable timeout via request.timeout in http builtin

### DIFF
--- a/pkg/builtin/http/http.go
+++ b/pkg/builtin/http/http.go
@@ -59,6 +59,16 @@ func (c *HTTPCmd) Run(meta *registry.Meta) (res interface{}, err error) {
 		}
 	)
 	if obj := meta.Obj.LookupPath(value.FieldPath("request")); obj.Exists() {
+		// Allow CUE authors to override the default 3s timeout via request.timeout
+		// (e.g., timeout: "30s"). Expects a string duration parseable by time.ParseDuration.
+		// Only positive durations are accepted; zero or negative values are ignored.
+		if v := obj.LookupPath(value.FieldPath("timeout")); v.Exists() {
+			if timeoutStr, parseErr := v.String(); parseErr == nil {
+				if d, parseErr := time.ParseDuration(timeoutStr); parseErr == nil && d > 0 {
+					client.Timeout = d
+				}
+			}
+		}
 		if v := obj.LookupPath(value.FieldPath("body")); v.Exists() {
 			r, err = v.Reader()
 			if err != nil {

--- a/pkg/builtin/http/http_test.go
+++ b/pkg/builtin/http/http_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
@@ -97,6 +98,110 @@ func TestHTTPCmdRun(t *testing.T) {
 
 	assert.Equal(t, "{\"token\":\"test-token-no-header\"}", body)
 
+}
+
+func TestHTTPCmdRunWithCustomTimeout(t *testing.T) {
+	// Start a slow server that takes 200ms to respond
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on ephemeral port: %v", err)
+	}
+	ts.Listener.Close()
+	ts.Listener = l
+	ts.Start()
+	defer ts.Close()
+
+	// Derive the server URL from the listener address
+	serverURL := fmt.Sprintf("http://%s/api/v1/slow", l.Addr().String())
+
+	// Without custom timeout (default 3s) — should succeed since server responds in 200ms
+	reqDefault := cuecontext.New().CompileString(fmt.Sprintf(`{
+		method: "GET"
+		url: "%s"
+	}`, serverURL))
+	runner, _ := newHTTPCmd(cue.Value{})
+	got, err := runner.Run(&registry.Meta{Obj: reqDefault.Value()})
+	assert.NoError(t, err)
+	body := (got.(map[string]interface{}))["body"].(string)
+	assert.Equal(t, `{"status":"ok"}`, body)
+
+	// With explicit timeout of 1s — should also succeed
+	reqCustom := cuecontext.New().CompileString(fmt.Sprintf(`{
+		method: "GET"
+		url: "%s"
+		request: {
+			timeout: "1s"
+		}
+	}`, serverURL))
+	got, err = runner.Run(&registry.Meta{Obj: reqCustom.Value()})
+	assert.NoError(t, err)
+	body = (got.(map[string]interface{}))["body"].(string)
+	assert.Equal(t, `{"status":"ok"}`, body)
+
+	// With a very short timeout of 50ms — should fail
+	reqShort := cuecontext.New().CompileString(fmt.Sprintf(`{
+		method: "GET"
+		url: "%s"
+		request: {
+			timeout: "50ms"
+		}
+	}`, serverURL))
+	_, err = runner.Run(&registry.Meta{Obj: reqShort.Value()})
+	assert.Error(t, err, "expected timeout error with 50ms deadline on a 200ms server")
+}
+
+func TestHTTPCmdRunWithInvalidTimeout(t *testing.T) {
+	s := NewMock()
+	defer s.Close()
+
+	runner, _ := newHTTPCmd(cue.Value{})
+
+	// Invalid timeout value should be silently ignored and use the default 3s
+	reqInvalid := cuecontext.New().CompileString(`{
+		method: "GET"
+		url: "http://127.0.0.1:8090/api/v1/token?val=test-token"
+		request: {
+			timeout: "not-a-duration"
+			header: {
+				"Accept-Language": "en,nl"
+			}
+		}
+	}`)
+	got, err := runner.Run(&registry.Meta{Obj: reqInvalid.Value()})
+	assert.NoError(t, err)
+	body := (got.(map[string]interface{}))["body"].(string)
+	assert.Equal(t, `{"token":"test-token"}`, body)
+
+	// Zero timeout should be rejected and fall back to default 3s
+	reqZero := cuecontext.New().CompileString(`{
+		method: "GET"
+		url: "http://127.0.0.1:8090/api/v1/token?val=test-zero"
+		request: {
+			timeout: "0s"
+		}
+	}`)
+	got, err = runner.Run(&registry.Meta{Obj: reqZero.Value()})
+	assert.NoError(t, err)
+	body = (got.(map[string]interface{}))["body"].(string)
+	assert.Equal(t, `{"token":"test-zero"}`, body)
+
+	// Negative timeout should be rejected and fall back to default 3s
+	reqNegative := cuecontext.New().CompileString(`{
+		method: "GET"
+		url: "http://127.0.0.1:8090/api/v1/token?val=test-negative"
+		request: {
+			timeout: "-5s"
+		}
+	}`)
+	got, err = runner.Run(&registry.Meta{Obj: reqNegative.Value()})
+	assert.NoError(t, err)
+	body = (got.(map[string]interface{}))["body"].(string)
+	assert.Equal(t, `{"token":"test-negative"}`, body)
 }
 
 func TestHTTPSRun(t *testing.T) {


### PR DESCRIPTION
## About

The `http` builtin task has a hardcoded 3-second client timeout with no way to override it. Slow external services or large payloads always fail with a `context deadline exceeded` error.

This PR adds support for the `request.timeout` field to override the default timeout.

## Why this approach over #7121

Per the review feedback on #7121:
- Uses `request.timeout` instead of top-level `timeout` (matches existing `#HTTPDo` schema in `kubevela/workflow`)
- No unrelated CI/Go version changes
- Silent fallback to default 3s for backward compatibility (invalid values don't break existing workflows)

## Changes

**pkg/builtin/http/http.go**
- Read optional `request.timeout` field from CUE task value
- Accepts Go duration string (`"30s"`, `"2m"`, `"500ms"`)
- Falls back to 3s default when absent or invalid (backward compatible)

**pkg/builtin/http/http_test.go**
- `TestHTTPCmdRunWithCustomTimeout`: valid timeout, short timeout (fails as expected)
- `TestHTTPCmdRunWithInvalidTimeout`: invalid duration string silently uses default

## Usage

```cue
myStep: op.#HTTPDo & {
  method: "GET"
  url: "https://slow-api.example.com/data"
  request: {
    timeout: "30s"
  }
}
```

## Testing

```bash
go test ./pkg/builtin/http/... -v
```

All tests pass.

Closes #7119
Supersedes #7121


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

