### PR TITLE
chore: add the template for the enhancement issue [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us improve
 title: ""
-labels: kind/bug
+labels: type/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,28 @@
+---
+name: "✨ Enhancement request"
+about: Suggest an improvement to an existing feature
+title: "[Enhancement]"
+labels: type/enhancement
+assignees: ''
+
+---
+
+**Which existing feature or component would you like to improve?**
+<!--
+Name the feature, component, or API (e.g. "Application rollout", "vela CLI output", "CUE template rendering").
+-->
+
+**What is the current limitation or pain point?**
+<!--
+A clear and concise description of what is missing or frustrating today.
+-->
+
+**Describe the improvement you'd like**
+<!--
+A clear and concise description of what you want to happen instead.
+-->
+
+**Additional context**
+<!--
+Add any other context or screenshots about the enhancement request here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: "\U0001F680 Feature request"
 about: Suggest an idea for this project
 title: "[Feature]"
-labels: kind/feature
+labels: type/feature
 assignees: ''
 
 ---


### PR DESCRIPTION
Tracking issue: https://github.com/kubevela/kubevela/issues/7244


### Description of your changes

- This PR add the template for the enhancement issue type. 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

