### PR TITLE
Feat: add configurable HTTP timeout to request, webhook, and notification steps

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/notification.yaml
@@ -161,8 +161,14 @@ spec:
         			body: string
         		}
         	}
-        	// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-        	timeout?: string
+        	// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        }
+
+        httpRequestOpts: {
+        	if parameter.timeout != _|_ {
+        		timeout: parameter.timeout
+        	}
         }
 
         block: {
@@ -224,10 +230,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.dingding.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
         		}
@@ -251,10 +254,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.dingding.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
         		}
@@ -271,10 +271,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.lark.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
         		}
@@ -298,10 +295,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.lark.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
 
@@ -319,10 +313,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.slack.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
         		}
@@ -346,10 +337,7 @@ spec:
         					request: {
         						body: json.Marshal(parameter.slack.message)
         						header: "Content-Type": "application/json"
-        						if parameter.timeout != _|_ {
-        							timeout: parameter.timeout
-        						}
-        					}
+        					} & httpRequestOpts
         				}
         			}
         		}

--- a/charts/vela-core/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/notification.yaml
@@ -162,7 +162,7 @@ spec:
         		}
         	}
         	// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        	timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
         }
 
         httpRequestOpts: {

--- a/charts/vela-core/templates/defwithtemplate/notification.yaml
+++ b/charts/vela-core/templates/defwithtemplate/notification.yaml
@@ -161,6 +161,8 @@ spec:
         			body: string
         		}
         	}
+        	// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+        	timeout?: string
         }
 
         block: {
@@ -222,6 +224,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.dingding.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}
@@ -246,6 +251,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.dingding.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}
@@ -263,6 +271,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.lark.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}
@@ -287,6 +298,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.lark.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}
@@ -305,6 +319,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.slack.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}
@@ -329,6 +346,9 @@ spec:
         					request: {
         						body: json.Marshal(parameter.slack.message)
         						header: "Content-Type": "application/json"
+        						if parameter.timeout != _|_ {
+        							timeout: parameter.timeout
+        						}
         					}
         				}
         			}

--- a/charts/vela-core/templates/defwithtemplate/request.yaml
+++ b/charts/vela-core/templates/defwithtemplate/request.yaml
@@ -57,6 +57,6 @@ spec:
         	body?: {...}
         	header?: [string]: string
         	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        	timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
         }
 

--- a/charts/vela-core/templates/defwithtemplate/request.yaml
+++ b/charts/vela-core/templates/defwithtemplate/request.yaml
@@ -56,7 +56,7 @@ spec:
         	method: *"GET" | "POST" | "PUT" | "DELETE"
         	body?: {...}
         	header?: [string]: string
-        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-        	timeout?: string
+        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
         }
 

--- a/charts/vela-core/templates/defwithtemplate/request.yaml
+++ b/charts/vela-core/templates/defwithtemplate/request.yaml
@@ -29,6 +29,9 @@ spec:
         			if parameter.header != _|_ {
         				header: parameter.header
         			}
+        			if parameter.timeout != _|_ {
+        				timeout: parameter.timeout
+        			}
         		}
         	}
         }
@@ -53,5 +56,7 @@ spec:
         	method: *"GET" | "POST" | "PUT" | "DELETE"
         	body?: {...}
         	header?: [string]: string
+        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+        	timeout?: string
         }
 

--- a/charts/vela-core/templates/defwithtemplate/webhook.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webhook.yaml
@@ -37,6 +37,11 @@ spec:
         		value: json.Marshal(parameter.data)
         	}
         }
+        httpRequestOpts: {
+        	if parameter.timeout != _|_ {
+        		timeout: parameter.timeout
+        	}
+        }
         webhook: {
         	if parameter.url.value != _|_ {
         		req: http.#HTTPDo & {
@@ -46,10 +51,7 @@ spec:
         				request: {
         					body: data.value
         					header: "Content-Type": "application/json"
-        					if parameter.timeout != _|_ {
-        						timeout: parameter.timeout
-        					}
-        				}
+        				} & httpRequestOpts
         			}
         		}
         	}
@@ -73,10 +75,7 @@ spec:
         				request: {
         					body: data.value
         					header: "Content-Type": "application/json"
-        					if parameter.timeout != _|_ {
-        						timeout: parameter.timeout
-        					}
-        				}
+        				} & httpRequestOpts
         			}
         		}
         	}
@@ -96,7 +95,7 @@ spec:
         	})
         	// +usage=Specify the data you want to send
         	data?: {...}
-        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-        	timeout?: string
+        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
         }
 

--- a/charts/vela-core/templates/defwithtemplate/webhook.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webhook.yaml
@@ -96,6 +96,6 @@ spec:
         	// +usage=Specify the data you want to send
         	data?: {...}
         	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-        	timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        	timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
         }
 

--- a/charts/vela-core/templates/defwithtemplate/webhook.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webhook.yaml
@@ -46,6 +46,9 @@ spec:
         				request: {
         					body: data.value
         					header: "Content-Type": "application/json"
+        					if parameter.timeout != _|_ {
+        						timeout: parameter.timeout
+        					}
         				}
         			}
         		}
@@ -70,6 +73,9 @@ spec:
         				request: {
         					body: data.value
         					header: "Content-Type": "application/json"
+        					if parameter.timeout != _|_ {
+        						timeout: parameter.timeout
+        					}
         				}
         			}
         		}
@@ -90,5 +96,7 @@ spec:
         	})
         	// +usage=Specify the data you want to send
         	data?: {...}
+        	// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+        	timeout?: string
         }
 

--- a/docs/examples/workflow/notification/app.yaml
+++ b/docs/examples/workflow/notification/app.yaml
@@ -21,6 +21,7 @@ spec:
       - name: notification
         type: notification
         properties:
+          timeout: 30s
           dingding:
             # directly specify the webhook url
             url:

--- a/pkg/workflow/template/http_timeout_step_test.go
+++ b/pkg/workflow/template/http_timeout_step_test.go
@@ -46,8 +46,8 @@ func readWorkflowStepCue(t *testing.T, name string) string {
 
 func assertTimeoutPlumbing(t *testing.T, content, step string) {
 	t.Helper()
-	assert.Contains(t, content, `timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"`,
-		"%s should expose optional timeout parameter with duration validation", step)
+	assert.Contains(t, content, `timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"`,
+		"%s should expose optional timeout parameter with Go ParseDuration-compatible validation", step)
 	assert.Contains(t, content, "Invalid values fail when the step runs",
 		"%s should document runtime failure for invalid timeout values", step)
 }

--- a/pkg/workflow/template/http_timeout_step_test.go
+++ b/pkg/workflow/template/http_timeout_step_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    15|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func workflowstepDefDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	// pkg/workflow/template -> repo root
+	root := filepath.Clean(filepath.Join(filepath.Dir(filename), "../../.."))
+	return filepath.Join(root, "vela-templates/definitions/internal/workflowstep")
+}
+
+func readWorkflowStepCue(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(workflowstepDefDir(t), name)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "read %s", path)
+	return string(data)
+}
+
+func assertTimeoutPlumbing(t *testing.T, content, step string) {
+	t.Helper()
+	assert.Contains(t, content, "timeout?: string",
+		"%s should expose optional timeout parameter", step)
+	assert.Contains(t, content, "if parameter.timeout != _|_",
+		"%s should only set request.timeout when parameter.timeout is provided (default 3s otherwise)", step)
+	assert.Contains(t, content, "timeout: parameter.timeout",
+		"%s should forward timeout to http.#HTTPDo as request.timeout", step)
+}
+
+func TestRequestStepExposesHTTPTimeout(t *testing.T) {
+	content := readWorkflowStepCue(t, "request.cue")
+	assertTimeoutPlumbing(t, content, "request")
+	assert.Equal(t, 1, strings.Count(content, "if parameter.timeout != _|_"),
+		"request should forward timeout in a single HTTPDo request block")
+}
+
+func TestWebhookStepExposesHTTPTimeout(t *testing.T) {
+	content := readWorkflowStepCue(t, "webhook.cue")
+	assertTimeoutPlumbing(t, content, "webhook")
+	assert.Equal(t, 2, strings.Count(content, "if parameter.timeout != _|_"),
+		"webhook should forward timeout for both url.value and url.secretRef HTTPDo paths")
+}
+
+func TestNotificationStepExposesHTTPTimeout(t *testing.T) {
+	content := readWorkflowStepCue(t, "notification.cue")
+	assertTimeoutPlumbing(t, content, "notification")
+	assert.Equal(t, 6, strings.Count(content, "if parameter.timeout != _|_"),
+		"notification should forward timeout for dingding/lark/slack value and secretRef HTTPDo paths")
+	// Email uses email.#SendEmail and must not get HTTP timeout wiring beyond the shared parameter.
+	emailIdx := strings.Index(content, "email0:")
+	require.Greater(t, emailIdx, 0)
+	emailSection := content[emailIdx:]
+	assert.NotContains(t, emailSection, "if parameter.timeout != _|_",
+		"email path should not forward HTTP timeout")
+}

--- a/pkg/workflow/template/http_timeout_step_test.go
+++ b/pkg/workflow/template/http_timeout_step_test.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    15|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -46,17 +46,29 @@ func readWorkflowStepCue(t *testing.T, name string) string {
 
 func assertTimeoutPlumbing(t *testing.T, content, step string) {
 	t.Helper()
-	assert.Contains(t, content, "timeout?: string",
-		"%s should expose optional timeout parameter", step)
-	assert.Contains(t, content, "if parameter.timeout != _|_",
-		"%s should only set request.timeout when parameter.timeout is provided (default 3s otherwise)", step)
-	assert.Contains(t, content, "timeout: parameter.timeout",
-		"%s should forward timeout to http.#HTTPDo as request.timeout", step)
+	assert.Contains(t, content, `timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"`,
+		"%s should expose optional timeout parameter with duration validation", step)
+	assert.Contains(t, content, "Invalid values fail when the step runs",
+		"%s should document runtime failure for invalid timeout values", step)
+}
+
+func assertSharedHTTPRequestOpts(t *testing.T, content, step string, mergeCount int) {
+	t.Helper()
+	assert.Contains(t, content, "httpRequestOpts:",
+		"%s should define shared httpRequestOpts for timeout forwarding", step)
+	assert.Equal(t, 1, strings.Count(content, "if parameter.timeout != _|_"),
+		"%s should forward timeout in one shared httpRequestOpts block", step)
+	assert.Equal(t, mergeCount, strings.Count(content, "& httpRequestOpts"),
+		"%s should merge httpRequestOpts into each HTTPDo request block", step)
 }
 
 func TestRequestStepExposesHTTPTimeout(t *testing.T) {
 	content := readWorkflowStepCue(t, "request.cue")
 	assertTimeoutPlumbing(t, content, "request")
+	assert.Contains(t, content, "if parameter.timeout != _|_",
+		"request should forward timeout in its HTTPDo request block")
+	assert.Contains(t, content, "timeout: parameter.timeout",
+		"request should forward timeout to http.#HTTPDo as request.timeout")
 	assert.Equal(t, 1, strings.Count(content, "if parameter.timeout != _|_"),
 		"request should forward timeout in a single HTTPDo request block")
 }
@@ -64,19 +76,17 @@ func TestRequestStepExposesHTTPTimeout(t *testing.T) {
 func TestWebhookStepExposesHTTPTimeout(t *testing.T) {
 	content := readWorkflowStepCue(t, "webhook.cue")
 	assertTimeoutPlumbing(t, content, "webhook")
-	assert.Equal(t, 2, strings.Count(content, "if parameter.timeout != _|_"),
-		"webhook should forward timeout for both url.value and url.secretRef HTTPDo paths")
+	assertSharedHTTPRequestOpts(t, content, "webhook", 2)
 }
 
 func TestNotificationStepExposesHTTPTimeout(t *testing.T) {
 	content := readWorkflowStepCue(t, "notification.cue")
 	assertTimeoutPlumbing(t, content, "notification")
-	assert.Equal(t, 6, strings.Count(content, "if parameter.timeout != _|_"),
-		"notification should forward timeout for dingding/lark/slack value and secretRef HTTPDo paths")
-	// Email uses email.#SendEmail and must not get HTTP timeout wiring beyond the shared parameter.
+	assertSharedHTTPRequestOpts(t, content, "notification", 6)
+	// Email uses email.#SendEmail and must not merge HTTP timeout opts.
 	emailIdx := strings.Index(content, "email0:")
 	require.Greater(t, emailIdx, 0)
 	emailSection := content[emailIdx:]
-	assert.NotContains(t, emailSection, "if parameter.timeout != _|_",
-		"email path should not forward HTTP timeout")
+	assert.NotContains(t, emailSection, "& httpRequestOpts",
+		"email path should not merge HTTP timeout opts")
 }

--- a/references/docgen/def-doc/workflowstep/notification.eg.md
+++ b/references/docgen/def-doc/workflowstep/notification.eg.md
@@ -22,6 +22,7 @@ spec:
       - name: dingtalk-message
         type: notification
         properties:
+          timeout: 30s
           dingding:
             # the DingTalk webhook address, please refer to: https://developers.dingtalk.com/document/robots/custom-robot-access
             url: 
@@ -35,6 +36,7 @@ spec:
       - name: slack-message
         type: notification
         properties:
+          timeout: 30s
           slack:
             # the Slack webhook address, please refer to: https://api.slack.com/messaging/webhooks
             url:

--- a/references/docgen/def-doc/workflowstep/request.eg.md
+++ b/references/docgen/def-doc/workflowstep/request.eg.md
@@ -12,6 +12,7 @@ spec:
       type: request
       properties:
         url: https://api.github.com/repos/kubevela/workflow
+        timeout: 30s
       outputs:
         - name: stars
           valueFrom: |

--- a/references/docgen/def-doc/workflowstep/webhook.eg.md
+++ b/references/docgen/def-doc/workflowstep/webhook.eg.md
@@ -20,4 +20,5 @@ spec:
         properties:
           url:
             value: <your webhook url>
+          timeout: 30s
 ```

--- a/vela-templates/definitions/internal/workflowstep/notification.cue
+++ b/vela-templates/definitions/internal/workflowstep/notification.cue
@@ -158,8 +158,14 @@ template: {
 				body: string
 			}
 		}
-		// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-		timeout?: string
+		// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	}
+
+	httpRequestOpts: {
+		if parameter.timeout != _|_ {
+			timeout: parameter.timeout
+		}
 	}
 
 	block: {
@@ -221,10 +227,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.dingding.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 			}
@@ -250,10 +253,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.dingding.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 			}
@@ -270,10 +270,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.lark.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 			}
@@ -299,10 +296,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.lark.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 
@@ -320,10 +314,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.slack.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 			}
@@ -349,10 +340,7 @@ template: {
 						request: {
 							body: json.Marshal(parameter.slack.message)
 							header: "Content-Type": "application/json"
-							if parameter.timeout != _|_ {
-								timeout: parameter.timeout
-							}
-						}
+						} & httpRequestOpts
 					}
 				}
 			}

--- a/vela-templates/definitions/internal/workflowstep/notification.cue
+++ b/vela-templates/definitions/internal/workflowstep/notification.cue
@@ -159,7 +159,7 @@ template: {
 			}
 		}
 		// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+		timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
 	}
 
 	httpRequestOpts: {

--- a/vela-templates/definitions/internal/workflowstep/notification.cue
+++ b/vela-templates/definitions/internal/workflowstep/notification.cue
@@ -158,6 +158,8 @@ template: {
 				body: string
 			}
 		}
+		// +usage=The timeout of HTTP notifications (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+		timeout?: string
 	}
 
 	block: {
@@ -219,6 +221,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.dingding.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}
@@ -245,6 +250,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.dingding.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}
@@ -262,6 +270,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.lark.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}
@@ -288,6 +299,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.lark.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}
@@ -306,6 +320,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.slack.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}
@@ -332,6 +349,9 @@ template: {
 						request: {
 							body: json.Marshal(parameter.slack.message)
 							header: "Content-Type": "application/json"
+							if parameter.timeout != _|_ {
+								timeout: parameter.timeout
+							}
 						}
 					}
 				}

--- a/vela-templates/definitions/internal/workflowstep/request.cue
+++ b/vela-templates/definitions/internal/workflowstep/request.cue
@@ -54,7 +54,7 @@ template: {
 		method: *"GET" | "POST" | "PUT" | "DELETE"
 		body?: {...}
 		header?: [string]: string
-		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-		timeout?: string
+		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	}
 }

--- a/vela-templates/definitions/internal/workflowstep/request.cue
+++ b/vela-templates/definitions/internal/workflowstep/request.cue
@@ -55,6 +55,6 @@ template: {
 		body?: {...}
 		header?: [string]: string
 		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+		timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
 	}
 }

--- a/vela-templates/definitions/internal/workflowstep/request.cue
+++ b/vela-templates/definitions/internal/workflowstep/request.cue
@@ -27,6 +27,9 @@ template: {
 				if parameter.header != _|_ {
 					header: parameter.header
 				}
+				if parameter.timeout != _|_ {
+					timeout: parameter.timeout
+				}
 			}
 		}
 	}
@@ -51,5 +54,7 @@ template: {
 		method: *"GET" | "POST" | "PUT" | "DELETE"
 		body?: {...}
 		header?: [string]: string
+		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+		timeout?: string
 	}
 }

--- a/vela-templates/definitions/internal/workflowstep/webhook.cue
+++ b/vela-templates/definitions/internal/workflowstep/webhook.cue
@@ -44,6 +44,9 @@ template: {
 					request: {
 						body: data.value
 						header: "Content-Type": "application/json"
+						if parameter.timeout != _|_ {
+							timeout: parameter.timeout
+						}
 					}
 				}
 			}
@@ -70,6 +73,9 @@ template: {
 					request: {
 						body: data.value
 						header: "Content-Type": "application/json"
+						if parameter.timeout != _|_ {
+							timeout: parameter.timeout
+						}
 					}
 				}
 			}
@@ -90,5 +96,7 @@ template: {
 		})
 		// +usage=Specify the data you want to send
 		data?: {...}
+		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
+		timeout?: string
 	}
 }

--- a/vela-templates/definitions/internal/workflowstep/webhook.cue
+++ b/vela-templates/definitions/internal/workflowstep/webhook.cue
@@ -96,6 +96,6 @@ template: {
 		// +usage=Specify the data you want to send
 		data?: {...}
 		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
-		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+		timeout?: string & =~"^(0|(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+)$"
 	}
 }

--- a/vela-templates/definitions/internal/workflowstep/webhook.cue
+++ b/vela-templates/definitions/internal/workflowstep/webhook.cue
@@ -35,6 +35,11 @@ template: {
 			value: json.Marshal(parameter.data)
 		}
 	}
+	httpRequestOpts: {
+		if parameter.timeout != _|_ {
+			timeout: parameter.timeout
+		}
+	}
 	webhook: {
 		if parameter.url.value != _|_ {
 			req: http.#HTTPDo & {
@@ -44,10 +49,7 @@ template: {
 					request: {
 						body: data.value
 						header: "Content-Type": "application/json"
-						if parameter.timeout != _|_ {
-							timeout: parameter.timeout
-						}
-					}
+					} & httpRequestOpts
 				}
 			}
 		}
@@ -73,10 +75,7 @@ template: {
 					request: {
 						body: data.value
 						header: "Content-Type": "application/json"
-						if parameter.timeout != _|_ {
-							timeout: parameter.timeout
-						}
-					}
+					} & httpRequestOpts
 				}
 			}
 		}
@@ -96,7 +95,7 @@ template: {
 		})
 		// +usage=Specify the data you want to send
 		data?: {...}
-		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted.
-		timeout?: string
+		// +usage=The timeout of this request (Go duration string, e.g. "30s", "2m", "500ms"). Defaults to 3s when omitted. Invalid values fail when the step runs.
+		timeout?: string & =~"^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	}
 }


### PR DESCRIPTION
## About

Built-in workflow steps that invoke `http.#HTTPDo` (`request`, `webhook`, and the HTTP-based channels in `notification`) previously did not expose a configurable timeout, leaving users with the default 3-second HTTP client timeout.

This PR adds an optional `timeout` property (specified as a Go duration string) to these workflow steps and forwards it to `http.#HTTPDo` as `request.timeout`. This follows up on Brian's review comment in #7239.

## Changes

### `vela-templates/definitions/internal/workflowstep/{request,webhook,notification}.cue`

* Add an optional `timeout?: string` field to each workflow step's parameter schema.
* Conditionally forward the value to `$params.request.timeout` when `timeout` is specified.
* For `notification`, apply the timeout only to the HTTP-backed channels (DingTalk, Lark, and Slack). The email implementation remains unchanged.

### `charts/vela-core/templates/defwithtemplate/{request,webhook,notification}.yaml`

* Regenerate the definition templates from the updated CUE sources using `gen_definitions.sh`.

### Documentation

* Update `references/docgen/def-doc/workflowstep/*.eg.md` with `timeout: 30s` examples.
* Update `docs/examples/workflow/notification/app.yaml` to demonstrate the new option.

### Tests

Add `pkg/workflow/template/http_timeout_step_test.go` covering:

* Workflow schemas expose the new `timeout` field.
* Configured `timeout` values are forwarded to `request.timeout`.
* Omitting `timeout` preserves the existing default 3-second timeout by keeping the conditional wiring.
* The email notification path does **not** receive HTTP timeout wiring.

## Usage

```yaml
- name: request
  type: request
  properties:
    url: https://slow-api.example.com/data
    method: GET
    timeout: 30s
```

If `timeout` is omitted, the existing default 3-second HTTP client timeout is preserved.

## Testing

```bash
go test ./pkg/workflow/template/ -run 'Test(Request|Webhook|Notification)StepExposesHTTPTimeout' -v

./vela-templates/gen_definitions.sh

# Definition docgen smoke test
go build -o docgen hack/docgen/def/gen.go

./docgen --type=wf --force-example-doc \
  --path=./wf-def-check.md \
  --def-dir=./vela-templates/definitions/internal/workflowstep/
```

All tests pass.

**Fixes:** #7241


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

