### PR TITLE
Potential fix for code scanning alert no. 398: Clear-text logging of sensitive information

### DIFF
--- a/pkg/cue/cuex/providers/config/config.go
+++ b/pkg/cue/cuex/providers/config/config.go
@@ -102,7 +102,7 @@ func HelmRepository(ctx context.Context, validationParams *HelmRepositoryParams)
 	ok, err := helmHelper.ValidateRepo(ctx, helmRepository)
 	if err != nil {
 		message = err.Error()
-		klog.Warningf("validate helm-repository %s failed, err: %v", helmRepository, err)
+		klog.Warningf("validate helm-repository url %q failed, err: %v", helmRepository.URL, err)
 	}
 	return &ValidationReturns{
 		Returns: ResponseVars{


### PR DESCRIPTION
Potential fix for [https://github.com/kubevela/kubevela/security/code-scanning/398](https://github.com/kubevela/kubevela/security/code-scanning/398)

The safest fix is to avoid logging `helmRepository` entirely in the error path and instead log only non-sensitive attributes (for example, repository URL). This preserves functionality (still logs validation failure + error) while eliminating any chance of password leakage.

In `pkg/cue/cuex/providers/config/config.go`, update the warning in `HelmRepository` (around line 105):

- Replace:
  - `klog.Warningf("validate helm-repository %s failed, err: %v", helmRepository, err)`
- With a message that logs non-sensitive context only, e.g. URL:
  - `klog.Warningf("validate helm-repository url %q failed, err: %v", helmRepository.URL, err)`

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

