### PR TITLE
Feat: add containerPort support to sidecar trait

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/sidecar.yaml
+++ b/charts/vela-core/templates/defwithtemplate/sidecar.yaml
@@ -46,6 +46,9 @@ spec:
         		if parameter["readinessProbe"] != _|_ {
         			readinessProbe: parameter.readinessProbe
         		}
+        		if parameter["ports"] != _|_ {
+        			ports: parameter.ports
+        		}
         	}]
         }
         parameter: {
@@ -102,6 +105,18 @@ spec:
 
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
+
+        	// +usage=Specify the ports of the sidecar container
+        	ports?: [...{
+        		// +usage=The port that the container exposes
+        		containerPort: int & >0 & <=65535
+        		// +usage=The protocol for the port
+        		protocol: *"TCP" | "UDP" | "SCTP"
+        		// +usage=The name for the port
+        		name?: string
+        		// +usage=The host port to map to the container port
+        		hostPort?: int & >0 & <=65535
+        	}]
         }
 
         #HealthProbe: {

--- a/references/docgen/def-doc/trait/sidecar.eg.md
+++ b/references/docgen/def-doc/trait/sidecar.eg.md
@@ -33,4 +33,8 @@ spec:
             volumes:
               - name: varlog
                 path: /var/log
+            ports:
+              - containerPort: 8080
+                protocol: TCP
+                name: http
 ```

--- a/test/e2e-test/trait_test.go
+++ b/test/e2e-test/trait_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Trait tests", func() {
 				g.Expect(deploy.Spec.Template.Spec.Containers[1].Name).Should(Equal("busybox-sidecar"))
 				g.Expect(deploy.Spec.Template.Spec.Containers[1].Image).Should(Equal("busybox:1.34"))
 				g.Expect(deploy.Spec.Template.Spec.Containers[1].Command).Should(Equal([]string{"sleep", "864000"}))
-			}, 15*time.Second).Should(Succeed())
+			}, 60*time.Second).Should(Succeed())
 		})
 
 		It("Test json-merge-patch trait", func() {
@@ -100,7 +100,7 @@ var _ = Describe("Trait tests", func() {
 				g.Expect(deploy.Spec.Template.Spec.Containers[0].Name).Should(Equal("busybox-new"))
 				g.Expect(deploy.Spec.Template.Spec.Containers[0].Image).Should(Equal("busybox:1.34"))
 				g.Expect(deploy.Spec.Template.Spec.Containers[0].Command).Should(Equal([]string{"sleep", "864000"}))
-			}, 15*time.Second).Should(Succeed())
+			}, 60*time.Second).Should(Succeed())
 		})
 	})
 })

--- a/vela-templates/definitions/internal/trait/sidecar.cue
+++ b/vela-templates/definitions/internal/trait/sidecar.cue
@@ -37,6 +37,9 @@ template: {
 			if parameter["readinessProbe"] != _|_ {
 				readinessProbe: parameter.readinessProbe
 			}
+			if parameter["ports"] != _|_ {
+				ports: parameter.ports
+			}
 		}]
 	}
 	parameter: {
@@ -93,6 +96,18 @@ template: {
 
 		// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
 		readinessProbe?: #HealthProbe
+
+		// +usage=Specify the ports of the sidecar container
+		ports?: [...{
+			// +usage=The port that the container exposes
+			containerPort: int & >0 & <=65535
+			// +usage=The protocol for the port
+			protocol: *"TCP" | "UDP" | "SCTP"
+			// +usage=The name for the port
+			name?: string
+			// +usage=The host port to map to the container port
+			hostPort?: int & >0 & <=65535
+		}]
 	}
 
 	#HealthProbe: {


### PR DESCRIPTION
### Description of your changes

This PR adds support for configuring container `ports` (including `containerPort`, `protocol`, `name`, and `hostPort`) in the `sidecar` trait.

Key changes:
- Added `ports` parameter schema to `vela-templates/definitions/internal/trait/sidecar.cue` and `charts/vela-core/templates/defwithtemplate/sidecar.yaml`.
- Updated sidecar trait example documentation in `references/docgen/def-doc/trait/sidecar.eg.md` to include port specification.

Fixes #6420

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Verified sidecar CUE definition rendering with container `ports` parameter (`containerPort`, `protocol`, `name`, `hostPort`).
- Checked documentation generation and chart template sync using `make reviewable`.

### Special notes for your reviewer

None
