### PR TITLE
Chore: avoid Helm <3.9 template crash in cluster-gateway caBundle guard GWCP-106309

### DIFF
--- a/.github/actions/env-setup/action.yaml
+++ b/.github/actions/env-setup/action.yaml
@@ -57,8 +57,10 @@ runs:
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
 
-        # Install helm using the official script
+        # Install helm using the official script, pinned so CI catches
+        # Helm-version-specific template regressions 
         echo "Installing Helm using official script..."
+        export DESIRED_VERSION=v3.6.3
         curl -fsSL --retry 3 -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
         chmod 700 get_helm.sh
         ./get_helm.sh

--- a/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
@@ -162,7 +162,7 @@ spec:
   versionPriority: 10
   insecureSkipTLSVerify: {{ not .Values.multicluster.clusterGateway.secureTLS.enabled }}
   {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
-  {{- /* Preserve an already-valid caBundle on upgrade so we don't reset it to the
+  {{- /* Preserve an already-valid caBundle on upgrade so we don't reset it to  the
          Cg== placeholder before the patch Job re-runs 
          $apiSvc is the existing APIService looked up above; fall back to the
          placeholder only on fresh install or when it still holds the placeholder. */}}

--- a/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway/cluster-gateway.yaml
@@ -167,8 +167,14 @@ spec:
          $apiSvc is the existing APIService looked up above; fall back to the
          placeholder only on fresh install or when it still holds the placeholder. */}}
   {{- $caBundle := "Cg==" }}
-  {{- if and $apiSvc $apiSvc.spec (hasKey $apiSvc.spec "caBundle") (ne $apiSvc.spec.caBundle "Cg==") }}
-  {{- $caBundle = $apiSvc.spec.caBundle }}
+  {{- if $apiSvc }}
+    {{- if $apiSvc.spec }}
+      {{- if hasKey $apiSvc.spec "caBundle" }}
+        {{- if ne $apiSvc.spec.caBundle "Cg==" }}
+          {{- $caBundle = $apiSvc.spec.caBundle }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   {{- end }}
   caBundle: {{ $caBundle }}
   {{ end }}


### PR DESCRIPTION



## Summary

Fixes a template rendering crash on Helm versions `<3.9` caused by eager evaluation in the `cluster-gateway` APIService `caBundle` guard.

## Problem

The existing guard used a single `and`-chained condition:

```gotemplate
{{- if and $apiSvc$apiSvc.spec (hasKey $apiSvc.spec "caBundle") (ne $apiSvc.spec.caBundle "Cg==") }}
```


Helm versions prior to **3.9** evaluate all arguments to `and` eagerly rather than short-circuiting. When `$apiSvc` or `$apiSvc.spec` is `nil` (such as during a fresh install where the APIService does not exist yet), subsequent arguments like `hasKey $apiSvc.spec ...` and `$apiSvc.spec.caBundle` are still evaluated. This results in a nil-dereference panic and crashes the template rendering process.

## Solution

Replaces the single `and` condition with nested `if` blocks:

```gotemplate
{{- if $apiSvc }}
  {{- if $apiSvc.spec }}
    {{- if hasKey $apiSvc.spec "caBundle" }}
      {{- if ne $apiSvc.spec.caBundle "Cg==" }}
        {{- $caBundle =$apiSvc.spec.caBundle }}
      {{- end }}
    {{- end }}
  {{- end }}
{{- end }}

```

By nesting the `if` checks, each condition only executes once the prior condition confirms the value is non-nil. This restores short-circuit behavior and ensures compatibility across both older and newer Helm versions.

## Type of Change

* [x] **Bug fix** (non-breaking change which fixes an issue)

```

```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

