### PR TITLE
Fix: redact sensitiveCtx values from spec snapshots in the policy ConfigMap

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -29,8 +29,15 @@ rules:
     resources: ["users", "groups", "serviceaccounts"]
     verbs: ["impersonate"]
   - apiGroups: [""]
-    resources: ["namespaces", "secrets", "services"]
+    resources: ["namespaces", "services"]
     verbs: ["get", "watch", "list"]
+  # Secrets are read-only except for the Application-owned Secret that stores
+  # sensitive policy context (kubevela#6840). create/update/patch are required to
+  # persist that Secret; delete is intentionally omitted (it is garbage-collected
+  # via the Application owner reference).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["configmaps", "events"]
     verbs: ["*"]

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
@@ -325,12 +325,12 @@ func (h *AppHandler) writePolicyObservabilityConfigMap(ctx monitorContext.Contex
 	// Sensitive policy context (values a policy derived from Secrets and routed
 	// through output.sensitiveCtx) is persisted to an Application-owned Secret so
 	// it never lands in the plaintext observability ConfigMap. See kubevela#6840.
-	// This write is fail-safe: on error the sensitive data is simply not persisted
-	// anywhere — it is never written to the ConfigMap as a fallback.
-	if secretData := collectSensitivePolicyContext(results); len(secretData) > 0 {
-		if err := createOrUpdatePolicySecret(ctx, h.Client, app, secretData); err != nil {
-			ctx.Info("Failed to store sensitive policy Secret; sensitive context omitted from persistence", "error", err)
-		}
+	// Always reconcile (even when empty) so that removing sensitiveCtx, disabling a
+	// policy, or deleting the last policy CLEARS previously stored credentials
+	// instead of leaving them behind. Fail-safe: on error sensitive data is simply
+	// not persisted — it is never written to the ConfigMap as a fallback.
+	if err := reconcilePolicySecret(ctx, h.Client, app, collectSensitivePolicyContext(results)); err != nil {
+		ctx.Info("Failed to reconcile sensitive policy Secret; sensitive context not persisted", "error", err)
 	}
 }
 
@@ -1335,70 +1335,94 @@ func policySecretName(namespace, appName string) string {
 	return prefix + truncated + "-" + hash
 }
 
-// createOrUpdatePolicySecret persists sensitive policy context to an
-// Application-owned Secret. The Secret carries an owner reference to the
-// Application so it is garbage-collected when the Application is deleted, and the
-// same labels as the observability ConfigMap for discoverability. It mirrors
-// createOrUpdateDiffsConfigMap but writes an Opaque Secret instead of a ConfigMap.
-func createOrUpdatePolicySecret(ctx context.Context, cli client.Client, app *v1beta1.Application, data map[string][]byte) error {
-	secretName := policySecretName(app.Namespace, app.Name)
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: app.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					// Use hardcoded values since TypeMeta is cleared by k8s client after Create/Get
-					APIVersion:         v1beta1.SchemeGroupVersion.String(),
-					Kind:               v1beta1.ApplicationKind,
-					Name:               app.Name,
-					UID:                app.UID,
-					Controller:         ptrBool(true),
-					BlockOwnerDeletion: ptrBool(true),
-				},
-			},
+// policySecretOwnerRefs returns the owner reference tying the sensitive-context
+// Secret to its Application so the Secret is garbage-collected on delete.
+func policySecretOwnerRefs(app *v1beta1.Application) []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		{
+			// Use hardcoded values since TypeMeta is cleared by k8s client after Create/Get
+			APIVersion:         v1beta1.SchemeGroupVersion.String(),
+			Kind:               v1beta1.ApplicationKind,
+			Name:               app.Name,
+			UID:                app.UID,
+			Controller:         ptrBool(true),
+			BlockOwnerDeletion: ptrBool(true),
 		},
-		Type: corev1.SecretTypeOpaque,
-		Data: data,
 	}
+}
 
-	meta.AddLabels(secret, map[string]string{
-		oam.LabelAppName:                   app.Name,
-		oam.LabelAppNamespace:              app.Namespace,
-		oam.LabelAppUID:                    string(app.UID),
-		"app.oam.dev/application-policies": "true",
-	})
-	meta.AddAnnotations(secret, map[string]string{
-		oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
-	})
-
-	err := cli.Create(ctx, secret)
-	if err != nil {
-		if client.IgnoreAlreadyExists(err) == nil {
-			existing := &corev1.Secret{}
-			if getErr := cli.Get(ctx, client.ObjectKey{Name: secretName, Namespace: app.Namespace}, existing); getErr != nil {
-				return errors.Wrap(getErr, "failed to get existing Secret")
-			}
-
-			existing.Data = data
-			existing.Type = corev1.SecretTypeOpaque
-			existing.OwnerReferences = secret.OwnerReferences
-			meta.AddLabels(existing, map[string]string{
-				oam.LabelAppUID: string(app.UID),
-			})
-			meta.AddAnnotations(existing, map[string]string{
-				oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
-			})
-			if updateErr := cli.Update(ctx, existing); updateErr != nil {
-				return errors.Wrap(updateErr, "failed to update Secret")
-			}
-		} else {
-			return errors.Wrap(err, "failed to create Secret")
+// appOwnsSecret reports whether the given owner references include a controller
+// reference to this Application (matched by UID so a stale name cannot spoof it).
+func appOwnsSecret(refs []metav1.OwnerReference, app *v1beta1.Application) bool {
+	for _, ref := range refs {
+		if ref.Kind == v1beta1.ApplicationKind && ref.UID == app.UID {
+			return true
 		}
 	}
+	return false
+}
 
-	return nil
+// reconcilePolicySecret makes the Application-owned sensitive-context Secret
+// reflect the CURRENT policy output. It mirrors createOrUpdateDiffsConfigMap but
+// for an Opaque Secret, with two safety properties beyond it:
+//
+//   - When data is empty (no policy contributes sensitive context anymore, e.g.
+//     sensitiveCtx was removed or the last policy was deleted) it clears an
+//     existing Secret's Data instead of leaving stale credentials behind, and
+//     does NOT create a new empty Secret.
+//   - It refuses to mutate a Secret that this Application does not own, so the
+//     controller's broad secret-write permission cannot be leveraged to overwrite
+//     an unrelated Secret that happens to share the deterministic name.
+func reconcilePolicySecret(ctx context.Context, cli client.Client, app *v1beta1.Application, data map[string][]byte) error {
+	secretName := policySecretName(app.Namespace, app.Name)
+
+	existing := &corev1.Secret{}
+	err := cli.Get(ctx, client.ObjectKey{Name: secretName, Namespace: app.Namespace}, existing)
+	if kerrors.IsNotFound(err) {
+		if len(data) == 0 {
+			// Nothing sensitive to persist and no Secret to clean up.
+			return nil
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secretName,
+				Namespace:       app.Namespace,
+				OwnerReferences: policySecretOwnerRefs(app),
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: data,
+		}
+		meta.AddLabels(secret, map[string]string{
+			oam.LabelAppName:                   app.Name,
+			oam.LabelAppNamespace:              app.Namespace,
+			oam.LabelAppUID:                    string(app.UID),
+			"app.oam.dev/application-policies": "true",
+		})
+		meta.AddAnnotations(secret, map[string]string{
+			oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
+		})
+		return errors.Wrap(cli.Create(ctx, secret), "failed to create sensitive policy Secret")
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to get sensitive policy Secret")
+	}
+
+	if !appOwnsSecret(existing.OwnerReferences, app) {
+		return errors.Errorf("refusing to overwrite Secret %s/%s not owned by Application %s", app.Namespace, secretName, app.Name)
+	}
+
+	// data may be empty here: assigning it clears previously stored credentials
+	// when the current policy output no longer contributes any sensitive context.
+	existing.Data = data
+	existing.Type = corev1.SecretTypeOpaque
+	existing.OwnerReferences = policySecretOwnerRefs(app)
+	meta.AddLabels(existing, map[string]string{
+		oam.LabelAppUID: string(app.UID),
+	})
+	meta.AddAnnotations(existing, map[string]string{
+		oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
+	})
+	return errors.Wrap(cli.Update(ctx, existing), "failed to update sensitive policy Secret")
 }
 
 func ptrBool(b bool) *bool { return &b }

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
@@ -321,6 +321,37 @@ func (h *AppHandler) writePolicyObservabilityConfigMap(ctx monitorContext.Contex
 			app.Status.ApplicationPoliciesConfigMap = policyConfigMapName(app.Namespace, app.Name)
 		}
 	}
+
+	// Sensitive policy context (values a policy derived from Secrets and routed
+	// through output.sensitiveCtx) is persisted to an Application-owned Secret so
+	// it never lands in the plaintext observability ConfigMap. See kubevela#6840.
+	// This write is fail-safe: on error the sensitive data is simply not persisted
+	// anywhere — it is never written to the ConfigMap as a fallback.
+	if secretData := collectSensitivePolicyContext(results); len(secretData) > 0 {
+		if err := createOrUpdatePolicySecret(ctx, h.Client, app, secretData); err != nil {
+			ctx.Info("Failed to store sensitive policy Secret; sensitive context omitted from persistence", "error", err)
+		}
+	}
+}
+
+// collectSensitivePolicyContext gathers the sensitive context contributed by each
+// enabled policy into a Secret data map, keyed to mirror the ConfigMap layout
+// (<seq>-<policyName>) so operators can correlate the two. Values are JSON blobs.
+func collectSensitivePolicyContext(results []RenderedPolicyResult) map[string][]byte {
+	secretData := make(map[string][]byte)
+	sequence := 1
+	for _, result := range results {
+		if !result.Enabled {
+			continue
+		}
+		if len(result.SensitiveContext) > 0 {
+			if sensitiveJSON, err := json.MarshalIndent(result.SensitiveContext, "", "  "); err == nil {
+				secretData[fmt.Sprintf("%03d-%s", sequence, result.PolicyName)] = sensitiveJSON
+			}
+		}
+		sequence++
+	}
+	return secretData
 }
 
 // buildPolicyObservabilityData constructs the per-policy data map written to the observability ConfigMap.
@@ -499,6 +530,7 @@ func (h *AppHandler) renderPolicy(ctx monitorContext.Context, app *v1beta1.Appli
 
 	result.Transforms = output
 	result.AdditionalContext = output.Ctx
+	result.SensitiveContext = output.SensitiveCtx
 	return result, nil
 }
 
@@ -630,6 +662,12 @@ type PolicyOutput struct {
 	Labels      map[string]string             `json:"labels,omitempty"`
 	Annotations map[string]string             `json:"annotations,omitempty"`
 	Ctx         map[string]interface{}        `json:"ctx,omitempty"`
+	// SensitiveCtx carries policy context values that were derived from Secrets
+	// (e.g. via kube.#Read of a Secret). It is the sensitivity marker described
+	// in kubevela/kubevela#6840: anything a policy routes through output.sensitiveCtx
+	// is persisted to an Application-owned Secret instead of the plaintext
+	// observability ConfigMap. Non-sensitive context continues to use output.ctx.
+	SensitiveCtx map[string]interface{} `json:"sensitiveCtx,omitempty"`
 }
 
 // extractOutput decodes the output field from rendered CUE. Returns nil if absent.
@@ -645,12 +683,13 @@ func (h *AppHandler) extractOutput(val cue.Value) (*PolicyOutput, error) {
 	}
 
 	allowedFields := map[string]bool{
-		"components":  true,
-		"workflow":    true,
-		"policies":    true,
-		"labels":      true,
-		"annotations": true,
-		"ctx":         true,
+		"components":   true,
+		"workflow":     true,
+		"policies":     true,
+		"labels":       true,
+		"annotations":  true,
+		"ctx":          true,
+		"sensitiveCtx": true,
 	}
 
 	iter, err := outputVal.Fields()
@@ -659,7 +698,7 @@ func (h *AppHandler) extractOutput(val cue.Value) (*PolicyOutput, error) {
 	}
 	for iter.Next() {
 		if fieldName := iter.Selector().String(); !allowedFields[fieldName] {
-			return nil, errors.Errorf("output.%s is not allowed; permitted fields: components, workflow, policies, labels, annotations, ctx", fieldName)
+			return nil, errors.Errorf("output.%s is not allowed; permitted fields: components, workflow, policies, labels, annotations, ctx, sensitiveCtx", fieldName)
 		}
 	}
 
@@ -1274,6 +1313,88 @@ func createOrUpdateDiffsConfigMap(ctx context.Context, cli client.Client, app *v
 			}
 		} else {
 			return errors.Wrap(err, "failed to create ConfigMap")
+		}
+	}
+
+	return nil
+}
+
+// policySecretName returns the Secret name for sensitive policy context, capped at
+// 253 chars. Uses a distinct prefix from policyConfigMapName so the two objects
+// never collide, and a hash suffix when truncation is needed.
+func policySecretName(namespace, appName string) string {
+	const prefix = "application-policies-sensitive-"
+	const maxLen = 253
+	name := prefix + namespace + "-" + appName
+	if len(name) <= maxLen {
+		return name
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(namespace+"/"+appName)))[:8]
+	available := maxLen - len(prefix) - 1 - 8
+	truncated := (namespace + "-" + appName)[:available]
+	return prefix + truncated + "-" + hash
+}
+
+// createOrUpdatePolicySecret persists sensitive policy context to an
+// Application-owned Secret. The Secret carries an owner reference to the
+// Application so it is garbage-collected when the Application is deleted, and the
+// same labels as the observability ConfigMap for discoverability. It mirrors
+// createOrUpdateDiffsConfigMap but writes an Opaque Secret instead of a ConfigMap.
+func createOrUpdatePolicySecret(ctx context.Context, cli client.Client, app *v1beta1.Application, data map[string][]byte) error {
+	secretName := policySecretName(app.Namespace, app.Name)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: app.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					// Use hardcoded values since TypeMeta is cleared by k8s client after Create/Get
+					APIVersion:         v1beta1.SchemeGroupVersion.String(),
+					Kind:               v1beta1.ApplicationKind,
+					Name:               app.Name,
+					UID:                app.UID,
+					Controller:         ptrBool(true),
+					BlockOwnerDeletion: ptrBool(true),
+				},
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	meta.AddLabels(secret, map[string]string{
+		oam.LabelAppName:                   app.Name,
+		oam.LabelAppNamespace:              app.Namespace,
+		oam.LabelAppUID:                    string(app.UID),
+		"app.oam.dev/application-policies": "true",
+	})
+	meta.AddAnnotations(secret, map[string]string{
+		oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
+	})
+
+	err := cli.Create(ctx, secret)
+	if err != nil {
+		if client.IgnoreAlreadyExists(err) == nil {
+			existing := &corev1.Secret{}
+			if getErr := cli.Get(ctx, client.ObjectKey{Name: secretName, Namespace: app.Namespace}, existing); getErr != nil {
+				return errors.Wrap(getErr, "failed to get existing Secret")
+			}
+
+			existing.Data = data
+			existing.Type = corev1.SecretTypeOpaque
+			existing.OwnerReferences = secret.OwnerReferences
+			meta.AddLabels(existing, map[string]string{
+				oam.LabelAppUID: string(app.UID),
+			})
+			meta.AddAnnotations(existing, map[string]string{
+				oam.AnnotationLastAppliedTime: time.Now().Format(time.RFC3339),
+			})
+			if updateErr := cli.Update(ctx, existing); updateErr != nil {
+				return errors.Wrap(updateErr, "failed to update Secret")
+			}
+		} else {
+			return errors.Wrap(err, "failed to create Secret")
 		}
 	}
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_policies.go
@@ -314,6 +314,12 @@ func (h *AppHandler) writePolicyObservabilityConfigMap(ctx monitorContext.Contex
 		configMapData["info"] = string(infoJSON)
 	}
 
+	// A policy may template a sensitiveCtx value into the spec itself (component
+	// properties, workflow inputs, ...). The spec snapshots above (rendered_spec,
+	// applied_spec, per-policy spec diffs) would then leak it, so scrub every
+	// value marked sensitive from all ConfigMap payloads before persisting.
+	redactSensitiveValues(configMapData, results)
+
 	if len(configMapData) > 0 {
 		if err := createOrUpdateDiffsConfigMap(ctx, h.Client, app, configMapData); err != nil {
 			ctx.Info("Failed to store policy ConfigMap", "error", err)
@@ -331,6 +337,64 @@ func (h *AppHandler) writePolicyObservabilityConfigMap(ctx monitorContext.Contex
 	// not persisted — it is never written to the ConfigMap as a fallback.
 	if err := reconcilePolicySecret(ctx, h.Client, app, collectSensitivePolicyContext(results)); err != nil {
 		ctx.Info("Failed to reconcile sensitive policy Secret; sensitive context not persisted", "error", err)
+	}
+}
+
+// sensitiveRedactionPlaceholder replaces sensitiveCtx-derived values in
+// observability ConfigMap payloads.
+const sensitiveRedactionPlaceholder = "[redacted:sensitiveCtx]"
+
+// minSensitiveRedactionLen guards against mangling the surrounding JSON: leaf
+// values shorter than this (e.g. "1", "on") are too generic to substring-match
+// safely and are left alone. Real credentials are comfortably longer.
+const minSensitiveRedactionLen = 4
+
+// collectSensitiveLeafStrings walks a sensitiveCtx map and returns every string
+// leaf long enough to redact, including nested maps and slices.
+func collectSensitiveLeafStrings(v interface{}, out *[]string) {
+	switch val := v.(type) {
+	case string:
+		if len(val) >= minSensitiveRedactionLen {
+			*out = append(*out, val)
+		}
+	case map[string]interface{}:
+		for _, nested := range val {
+			collectSensitiveLeafStrings(nested, out)
+		}
+	case []interface{}:
+		for _, nested := range val {
+			collectSensitiveLeafStrings(nested, out)
+		}
+	}
+}
+
+// redactSensitiveValues removes every sensitiveCtx-marked string from the
+// ConfigMap payloads. Values are matched both raw and JSON-escaped, since the
+// payloads are JSON documents and a secret containing quotes or backslashes
+// appears escaped there.
+func redactSensitiveValues(configMapData map[string]string, results []RenderedPolicyResult) {
+	var sensitive []string
+	for _, result := range results {
+		if result.Enabled && len(result.SensitiveContext) > 0 {
+			collectSensitiveLeafStrings(result.SensitiveContext, &sensitive)
+		}
+	}
+	if len(sensitive) == 0 {
+		return
+	}
+
+	for key, payload := range configMapData {
+		for _, s := range sensitive {
+			payload = strings.ReplaceAll(payload, s, sensitiveRedactionPlaceholder)
+			if escaped, err := json.Marshal(s); err == nil {
+				// Trim the surrounding quotes json.Marshal adds to a bare string.
+				escapedBody := string(escaped[1 : len(escaped)-1])
+				if escapedBody != s {
+					payload = strings.ReplaceAll(payload, escapedBody, sensitiveRedactionPlaceholder)
+				}
+			}
+		}
+		configMapData[key] = payload
 	}
 }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/application_policy_cache.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/application_policy_cache.go
@@ -53,6 +53,7 @@ type RenderedPolicyResult struct {
 	Source            string                 // PolicySourceGlobal or PolicySourceExplicit
 	Transforms        interface{}            // *PolicyOutput
 	AdditionalContext map[string]interface{} // output.ctx
+	SensitiveContext  map[string]interface{} // output.sensitiveCtx; persisted to an Application-owned Secret, never the ConfigMap
 	SkipReason        string
 	IsError           bool // true when SkipReason is due to an error, false for config.enabled=false
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
@@ -163,6 +163,79 @@ func TestPolicyContext_SensitiveCtxNotInConfigMap(t *testing.T) {
 	}
 }
 
+// TestPolicyContext_SensitiveCtxClearedWhenEmpty verifies that once sensitive
+// context stops being produced (sensitiveCtx removed / policy disabled), the
+// previously stored credentials are cleared from the owned Secret rather than
+// lingering indefinitely.
+func TestPolicyContext_SensitiveCtxClearedWhenEmpty(t *testing.T) {
+	cli := secretLeakTestClient(t)
+	h := &AppHandler{Client: cli}
+	app := secretLeakTestApp()
+
+	// First reconcile: policy contributes a secret → Secret is populated.
+	withSensitive := []RenderedPolicyResult{{
+		PolicyName:       "read-db-secret",
+		Enabled:          true,
+		Transforms:       &PolicyOutput{SensitiveCtx: map[string]interface{}{"dbPassword": leakedSecretValue}},
+		SensitiveContext: map[string]interface{}{"dbPassword": leakedSecretValue},
+	}}
+	monCtx := monitorContext.NewTraceContext(context.Background(), "clear-1")
+	h.writePolicyObservabilityConfigMap(monCtx, app, withSensitive, &v1beta1.ApplicationSpec{}, nil, false, false)
+
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{Name: policySecretName(app.Namespace, app.Name), Namespace: app.Namespace}
+	if err := cli.Get(context.Background(), key, secret); err != nil {
+		t.Fatalf("expected Secret to exist after first reconcile: %v", err)
+	}
+	if !secretContains(secret, leakedSecretValue) {
+		t.Fatalf("expected sensitive value stored after first reconcile")
+	}
+
+	// Second reconcile: policy no longer contributes sensitive context.
+	noSensitive := []RenderedPolicyResult{{
+		PolicyName: "read-db-secret",
+		Enabled:    true,
+		Transforms: &PolicyOutput{Ctx: map[string]interface{}{"dbHost": "db.internal"}},
+	}}
+	monCtx = monitorContext.NewTraceContext(context.Background(), "clear-2")
+	h.writePolicyObservabilityConfigMap(monCtx, app, noSensitive, &v1beta1.ApplicationSpec{}, nil, false, false)
+
+	if err := cli.Get(context.Background(), key, secret); err != nil {
+		t.Fatalf("expected Secret to still exist (cleared, not deleted): %v", err)
+	}
+	if len(secret.Data) != 0 {
+		t.Fatalf("expected Secret Data to be cleared, still had %d entries", len(secret.Data))
+	}
+}
+
+// TestPolicyContext_DoesNotOverwriteForeignSecret verifies the controller refuses
+// to clobber a Secret it does not own even on a name collision.
+func TestPolicyContext_DoesNotOverwriteForeignSecret(t *testing.T) {
+	app := secretLeakTestApp()
+	foreign := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policySecretName(app.Namespace, app.Name),
+			Namespace: app.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"unrelated": []byte("keep-me")},
+	}
+	cli := secretLeakTestClient(t, foreign)
+
+	err := reconcilePolicySecret(context.Background(), cli, app, map[string][]byte{"001-p": []byte("new")})
+	if err == nil {
+		t.Fatalf("expected reconcile to refuse overwriting a non-owned Secret")
+	}
+
+	got := &corev1.Secret{}
+	if getErr := cli.Get(context.Background(), client.ObjectKey{Name: foreign.Name, Namespace: foreign.Namespace}, got); getErr != nil {
+		t.Fatalf("foreign Secret should still exist: %v", getErr)
+	}
+	if string(got.Data["unrelated"]) != "keep-me" {
+		t.Fatalf("foreign Secret data must be untouched")
+	}
+}
+
 // TestPolicyContext_NoSecretWhenNoSensitiveData ensures we don't create empty
 // Secrets when no policy contributes sensitive context (no needless RBAC use).
 func TestPolicyContext_NoSecretWhenNoSensitiveData(t *testing.T) {

--- a/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
@@ -18,6 +18,7 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -33,6 +34,7 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	monitorContext "github.com/kubevela/pkg/monitor/context"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 )
 
@@ -233,6 +235,82 @@ func TestPolicyContext_DoesNotOverwriteForeignSecret(t *testing.T) {
 	}
 	if string(got.Data["unrelated"]) != "keep-me" {
 		t.Fatalf("foreign Secret data must be untouched")
+	}
+}
+
+// TestPolicyContext_SensitiveValueRedactedFromSpecSnapshots covers the second
+// leak channel: a policy templates a sensitiveCtx value into the spec itself, so
+// the rendered_spec/applied_spec snapshots in the observability ConfigMap would
+// carry it. The redaction pass must scrub it from every ConfigMap payload while
+// the Secret keeps the real value.
+func TestPolicyContext_SensitiveValueRedactedFromSpecSnapshots(t *testing.T) {
+	cli := secretLeakTestClient(t)
+	h := &AppHandler{Client: cli}
+	app := secretLeakTestApp()
+
+	// Simulate the policy having injected the secret into component properties.
+	renderedSpec := &v1beta1.ApplicationSpec{
+		Components: []common.ApplicationComponent{{
+			Name: "web",
+			Type: "webservice",
+			Properties: &runtime.RawExtension{
+				Raw: []byte(`{"env":[{"name":"DB_PASSWORD","value":"` + leakedSecretValue + `"}]}`),
+			},
+		}},
+	}
+	app.Spec = *renderedSpec.DeepCopy()
+
+	results := []RenderedPolicyResult{{
+		PolicyName: "inject-db-secret",
+		Enabled:    true,
+		Transforms: &PolicyOutput{
+			SensitiveCtx: map[string]interface{}{
+				"dbPassword": leakedSecretValue,
+				"nested":     map[string]interface{}{"token": leakedSecretValue},
+				"tiny":       "ok", // below redaction length, must not mangle JSON
+			},
+		},
+		SensitiveContext: map[string]interface{}{
+			"dbPassword": leakedSecretValue,
+			"nested":     map[string]interface{}{"token": leakedSecretValue},
+			"tiny":       "ok",
+		},
+	}}
+
+	monCtx := monitorContext.NewTraceContext(context.Background(), "redact-spec")
+	h.writePolicyObservabilityConfigMap(monCtx, app, results, renderedSpec, nil, false, false)
+
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policyConfigMapName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, cm); err != nil {
+		t.Fatalf("expected observability ConfigMap to exist: %v", err)
+	}
+	if configMapContains(cm, leakedSecretValue) {
+		t.Fatalf("SECURITY REGRESSION: sensitive value leaked into spec snapshots in ConfigMap %q", cm.Name)
+	}
+	if !configMapContains(cm, sensitiveRedactionPlaceholder) {
+		t.Fatalf("expected redaction placeholder in spec snapshots")
+	}
+	// Redaction must not corrupt the JSON payloads.
+	for key, payload := range cm.Data {
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+			t.Fatalf("ConfigMap key %q no longer valid JSON after redaction: %v", key, err)
+		}
+	}
+
+	// The Secret still holds the real value.
+	secret := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policySecretName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected sensitive-context Secret to exist: %v", err)
+	}
+	if !secretContains(secret, leakedSecretValue) {
+		t.Fatalf("expected Secret to keep the unredacted sensitive value")
 	}
 }
 

--- a/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/secret_context_leak_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	monitorContext "github.com/kubevela/pkg/monitor/context"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+)
+
+// secretLeakTestClient builds a fake client and an AppHandler for exercising the
+// policy observability persistence path in isolation (no envtest / API server).
+func secretLeakTestClient(t *testing.T, objs ...runtime.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add clientgo scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+}
+
+func secretLeakTestApp() *v1beta1.Application {
+	return &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "leak-app",
+			Namespace: "leak-ns",
+			UID:       types.UID("app-uid-1234"),
+		},
+	}
+}
+
+// The literal secret value that a policy reads out of a Kubernetes Secret (e.g. via
+// kube.#Read) and surfaces into policy context. It must never appear in a ConfigMap.
+const leakedSecretValue = "s3cr3t-db-password-DO-NOT-LEAK"
+
+// TestPolicyContext_SecretLeaksIntoConfigMap documents the vulnerability from
+// kubevela/kubevela#6840: before the fix there was NO way to keep policy context
+// out of the plaintext observability ConfigMap, so a secret value surfaced through
+// output.ctx is persisted verbatim where any user with ConfigMap read access can
+// see it. This test asserts the leak on the plain-ctx (non-sensitive) channel and
+// therefore stays green after the fix — it is the reference "before" behavior.
+func TestPolicyContext_SecretLeaksIntoConfigMap(t *testing.T) {
+	cli := secretLeakTestClient(t)
+	h := &AppHandler{Client: cli}
+	app := secretLeakTestApp()
+
+	// A policy that read a Secret and (incorrectly) placed the value in output.ctx.
+	results := []RenderedPolicyResult{
+		{
+			PolicyName: "read-db-secret",
+			Enabled:    true,
+			Transforms: &PolicyOutput{
+				Ctx: map[string]interface{}{"dbPassword": leakedSecretValue},
+			},
+			AdditionalContext: map[string]interface{}{"dbPassword": leakedSecretValue},
+		},
+	}
+
+	monCtx := monitorContext.NewTraceContext(context.Background(), "leak-repro")
+	h.writePolicyObservabilityConfigMap(monCtx, app, results, &v1beta1.ApplicationSpec{}, nil, false, false)
+
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policyConfigMapName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, cm); err != nil {
+		t.Fatalf("expected observability ConfigMap to exist: %v", err)
+	}
+
+	if !configMapContains(cm, leakedSecretValue) {
+		t.Fatalf("expected the plain output.ctx value to be present in the ConfigMap (documents the leak channel)")
+	}
+	t.Logf("LEAK CONFIRMED: secret value present in ConfigMap %q via output.ctx", cm.Name)
+}
+
+// TestPolicyContext_SensitiveCtxNotInConfigMap verifies the fix: a policy that
+// routes secret-derived values through output.sensitiveCtx keeps them OUT of the
+// ConfigMap and stores them in an Application-owned Secret instead.
+func TestPolicyContext_SensitiveCtxNotInConfigMap(t *testing.T) {
+	cli := secretLeakTestClient(t)
+	h := &AppHandler{Client: cli}
+	app := secretLeakTestApp()
+
+	results := []RenderedPolicyResult{
+		{
+			PolicyName: "read-db-secret",
+			Enabled:    true,
+			Transforms: &PolicyOutput{
+				// Non-sensitive context stays in ctx (still allowed in the ConfigMap).
+				Ctx:          map[string]interface{}{"dbHost": "db.internal"},
+				SensitiveCtx: map[string]interface{}{"dbPassword": leakedSecretValue},
+			},
+			AdditionalContext: map[string]interface{}{"dbHost": "db.internal"},
+			SensitiveContext:  map[string]interface{}{"dbPassword": leakedSecretValue},
+		},
+	}
+
+	monCtx := monitorContext.NewTraceContext(context.Background(), "leak-fixed")
+	h.writePolicyObservabilityConfigMap(monCtx, app, results, &v1beta1.ApplicationSpec{}, nil, false, false)
+
+	// 1. The ConfigMap must NOT contain the sensitive value...
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policyConfigMapName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, cm); err != nil {
+		t.Fatalf("expected observability ConfigMap to exist: %v", err)
+	}
+	if configMapContains(cm, leakedSecretValue) {
+		t.Fatalf("SECURITY REGRESSION: sensitive value leaked into ConfigMap %q", cm.Name)
+	}
+	// ...but non-sensitive context is still persisted for observability.
+	if !configMapContains(cm, "db.internal") {
+		t.Fatalf("expected non-sensitive ctx value to remain in the ConfigMap")
+	}
+
+	// 2. The sensitive value must be stored in an Application-owned Secret.
+	secret := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policySecretName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, secret); err != nil {
+		t.Fatalf("expected sensitive-context Secret to exist: %v", err)
+	}
+	if !secretContains(secret, leakedSecretValue) {
+		t.Fatalf("expected sensitive value to be stored in the Secret")
+	}
+
+	// 3. The Secret must be owned by the Application (garbage-collected on delete).
+	if !ownedByApplication(secret.OwnerReferences, app) {
+		t.Fatalf("expected Secret to carry an owner reference to the Application for GC")
+	}
+	if secret.Type != corev1.SecretTypeOpaque {
+		t.Fatalf("expected Opaque Secret, got %q", secret.Type)
+	}
+}
+
+// TestPolicyContext_NoSecretWhenNoSensitiveData ensures we don't create empty
+// Secrets when no policy contributes sensitive context (no needless RBAC use).
+func TestPolicyContext_NoSecretWhenNoSensitiveData(t *testing.T) {
+	cli := secretLeakTestClient(t)
+	h := &AppHandler{Client: cli}
+	app := secretLeakTestApp()
+
+	results := []RenderedPolicyResult{
+		{
+			PolicyName:        "plain-policy",
+			Enabled:           true,
+			Transforms:        &PolicyOutput{Ctx: map[string]interface{}{"region": "us-east-1"}},
+			AdditionalContext: map[string]interface{}{"region": "us-east-1"},
+		},
+	}
+
+	monCtx := monitorContext.NewTraceContext(context.Background(), "no-sensitive")
+	h.writePolicyObservabilityConfigMap(monCtx, app, results, &v1beta1.ApplicationSpec{}, nil, false, false)
+
+	secret := &corev1.Secret{}
+	err := cli.Get(context.Background(), client.ObjectKey{
+		Name:      policySecretName(app.Namespace, app.Name),
+		Namespace: app.Namespace,
+	}, secret)
+	if err == nil {
+		t.Fatalf("did not expect a sensitive-context Secret when no sensitive data is present")
+	}
+}
+
+// TestExtractOutput_AllowsSensitiveCtx verifies the CUE contract accepts the new
+// output.sensitiveCtx marker field.
+func TestExtractOutput_AllowsSensitiveCtx(t *testing.T) {
+	h := &AppHandler{}
+	val := compileCUEForTest(t, `output: { ctx: { a: "1" }, sensitiveCtx: { token: "abc" } }`)
+	out, err := h.extractOutput(val)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("expected non-nil output")
+	}
+	if got := out.SensitiveCtx["token"]; got != "abc" {
+		t.Fatalf("expected sensitiveCtx.token=abc, got %v", got)
+	}
+}
+
+func compileCUEForTest(t *testing.T, src string) cue.Value {
+	t.Helper()
+	val := cuecontext.New().CompileString(src)
+	if err := val.Err(); err != nil {
+		t.Fatalf("failed to compile CUE: %v", err)
+	}
+	return val
+}
+
+func configMapContains(cm *corev1.ConfigMap, needle string) bool {
+	for _, v := range cm.Data {
+		if strings.Contains(v, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func secretContains(secret *corev1.Secret, needle string) bool {
+	for _, v := range secret.Data {
+		if strings.Contains(string(v), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func ownedByApplication(refs []metav1.OwnerReference, app *v1beta1.Application) bool {
+	for _, ref := range refs {
+		if ref.Kind == v1beta1.ApplicationKind && ref.Name == app.Name && ref.UID == app.UID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Scrub `sensitiveCtx`-marked values out of the `rendered_spec` / `applied_spec` /
per-policy spec diff payloads before they're written to the policy observability
ConfigMap.

## Why

#7249 gives policies a place to put Secret-derived values (`output.sensitiveCtx`) so they land in an Application-owned Secret instead of the ConfigMap. That covers the context channel, but there's a second way the same value can reach the
ConfigMap: a policy can template it straight into the spec component properties, workflow step inputs, whatever.

`writePolicyObservabilityConfigMap` snapshots both the rendered and applied spec into the ConfigMap (`application_policies.go:283,286`), plus per-policy before/after diffs. So a policy that reads a Secret and injects it into a
component's env would still leak it in plaintext, even with the Secret routing in place. Same issue as #6840, different path in.

## Approach

- Added a redaction pass that runs on the assembled ConfigMap data right before  it's persisted. It collects every string leaf from each enabled policy's
  `SensitiveContext` (walking nested maps and slices) and replaces occurrences with `[redacted:sensitiveCtx]`.
- Matches both the raw value and its JSON-escaped form, since the payloads are JSON documents and a secret containing quotes/backslashes shows up escaped there.
- Skips leaves shorter than 4 chars. Something like `"on"` or `"1"` is too generic to substring-match safely and would corrupt the surrounding JSON. Real credentials are comfortably longer than that.
- The Secret still stores the unredacted values, so nothing is actually lost it just moves behind the RBAC boundary where it belongs.

## Verification

- `go build` / `go vet` / `gofmt` clean
- New test `TestPolicyContext_SensitiveValueRedactedFromSpecSnapshots`: injects the ecret into component properties, then checks it's gone from the ConfigMap, the placeholder is present, every payload still parses as valid JSON, and the Secret
keeps the real value.
- All 7 tests in `secret_context_leak_test.go` pass.
- Full application package suite green with envtest (~85s), no regressions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

