### PR TITLE
Chore: bump docker/docker to v28.5.2 and alpine base images to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
 # You can replace distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
-FROM ${BASE_IMAGE:-alpine:3.18}
+FROM ${BASE_IMAGE:-alpine:3.21}
 # This is required by daemon connecting with cri
 RUN apk add --no-cache ca-certificates bash expat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
 # You can replace distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
-FROM ${BASE_IMAGE:-alpine:3.21}
+FROM ${BASE_IMAGE:-alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d}
 # This is required by daemon connecting with cri
 RUN apk add --no-cache ca-certificates bash expat
 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -32,7 +32,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
 
-FROM ${BASE_IMAGE:-alpine:3.15@sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479}
+FROM ${BASE_IMAGE:-alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d}
 # This is required by daemon connecting with cri
 RUN apk add --no-cache ca-certificates bash expat
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -33,7 +33,7 @@ RUN  apk add gcc musl-dev libc-dev ;\
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
 
-FROM ${BASE_IMAGE:-alpine:3.15@sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479}
+FROM ${BASE_IMAGE:-alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d}
 # This is required by daemon connecting with cri
 RUN apk add --no-cache ca-certificates bash expat
 

--- a/go.mod
+++ b/go.mod
@@ -312,7 +312,7 @@ require (
 replace (
 	cloud.google.com/go => cloud.google.com/go v0.100.2
 	github.com/docker/cli => github.com/docker/cli v24.0.9+incompatible
-	github.com/docker/docker => github.com/docker/docker v28.3.3+incompatible
+	github.com/docker/docker => github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/docker-credential-helpers => github.com/docker/docker-credential-helpers v0.7.0
 	github.com/wercker/stern => github.com/oam-dev/stern v1.13.3-0.20250828063553-e1dd6271d131
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.36

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/docker/cli v24.0.9+incompatible h1:OxbimnP/z+qVjDLpq9wbeFU3Nc30XhSe+L
 github.com/docker/cli v24.0.9+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
-github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
+github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=


### PR DESCRIPTION
## What

- `docker/docker` replace directive 28.3.3 → 28.5.2
- alpine base images: `Dockerfile` 3.18 → 3.21, `Dockerfile.cli` and `Dockerfile.e2e` 3.15 → 3.21 (digests re-pinned)

## Why

Routine docker version bump, per @anoop2811's point about keeping these current on a regular basis rather than only reacting to a critical CVE.

Being straight about what this does and doesn't do: the 4 reachable docker/docker vulns (GO-2026-5668 / 5617 / 4887 / 4883) are still reported at 28.5.2, all still `Fixed in: N/A`. There's nothing upstream to close them with yet. Details are in the govulncheck writeup on #6630. This is hygiene, not a fix.

Picked up the alpine base images in the same pass since they're part of the same image build and were well out of date - Dockerfile.cli and Dockerfile.e2e
both still on 3.15, which is past EOL. Happy to split those into a separate PR if you'd rather keep this strictly to the go.mod side.

Left the `docker/cli` v24.0.9 downpin alone. It's pinned down from the v2 graph asks for, which looks deliberate, and it reported 0 reachable vulns so there's no security reason to disturb it.

## Testing

- `go mod tidy` (idempotent), `go mod verify`, `go build ./...`, `go vet
- Unit test target: 91 packages pass. Only failure is `pkg/definition/gen_sdk`,  which needs a live Docker daemon to pull the openapi-generator image, a fails identically on a clean master checkout
- Verified the pinned digest resolves correctly  `alpine:3.21` -> `sha256:48b0309c…` → alpine 3.21.7, and the index covers amd64/arm64/386/arm/  ppc64le/riscv64/s390x for the multi-arch builds
- Built the new base layer locally to confirm the `apk add` step still works on
  3.21: ca-certificates 20260413-r0, bash 5.2.37, expat 2.8.2 all install

Worth flagging that 3.15 -> 3.21 is a six-version jump for the cli/e2e ima (musl, openssl, busybox all move), so the e2e jobs are the real gate here rather
than the unit tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

