### PR TITLE
Fix: fail with a clear message instead of silent os.Exit when tests run without a kubeconfig

### DIFF
--- a/contribute/testcode-guidance.md
+++ b/contribute/testcode-guidance.md
@@ -2,3 +2,34 @@
 
 
 Please refer to https://kubevela.io/docs/contributor/principle-of-test for details.
+
+## Running unit tests locally
+
+The unit tests require a kubeconfig to be present, even though they never
+contact a real cluster: several packages resolve Kubernetes clients through
+`github.com/kubevela/pkg/util/singleton`, whose loader exits the process when
+no kubeconfig can be found. Affected packages guard for this in `TestMain` and
+fail with instructions instead of dying silently.
+
+If you have no cluster configured, any parseable kubeconfig is enough:
+
+```shell
+mkdir -p ~/.kube && cat > ~/.kube/config <<'EOF'
+apiVersion: v1
+kind: Config
+clusters:
+- cluster: {server: "https://127.0.0.1:1", insecure-skip-tls-verify: true}
+  name: dummy
+contexts:
+- context: {cluster: dummy, user: dummy}
+  name: dummy
+current-context: dummy
+users:
+- name: dummy
+  user: {token: dummy}
+EOF
+```
+
+Some suites additionally need the envtest binaries
+(`setup-envtest use 1.31.0`, exported via `KUBEBUILDER_ASSETS`), and
+`pkg/definition/gen_sdk` needs a running Docker daemon.

--- a/pkg/addon/kubeconfig_guard_test.go
+++ b/pkg/addon/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/appfile/dryrun/kubeconfig_guard_test.go
+++ b/pkg/appfile/dryrun/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dryrun
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/appfile/kubeconfig_guard_test.go
+++ b/pkg/appfile/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appfile
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/controller/core.oam.dev/v1beta1/core/components/componentdefinition/kubeconfig_guard_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/components/componentdefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentdefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/controller/core.oam.dev/v1beta1/core/policies/policydefinition/kubeconfig_guard_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/policies/policydefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policydefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/controller/core.oam.dev/v1beta1/core/traits/traitdefinition/kubeconfig_guard_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/traits/traitdefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package traitdefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/controller/core.oam.dev/v1beta1/core/workflow/workflowstepdefinition/kubeconfig_guard_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/workflow/workflowstepdefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflowstepdefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/controller/utils/kubeconfig_guard_test.go
+++ b/pkg/controller/utils/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 )
 
 var testCtx = struct {
@@ -70,6 +71,10 @@ var testCtx = struct {
 }
 
 func TestMain(m *testing.M) {
+	// Guard against the silent os.Exit(1) from the kubevela/pkg singleton config
+	// loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+	testutil.RequireKubeConfig()
+
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "charts", "vela-core", "crds"),

--- a/pkg/cue/cuex/providers/helm/kubeconfig_guard_test.go
+++ b/pkg/cue/cuex/providers/helm/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/cue/definition/kubeconfig_guard_test.go
+++ b/pkg/cue/definition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/cue/kubeconfig_guard_test.go
+++ b/pkg/cue/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cue
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/definition/kubeconfig_guard_test.go
+++ b/pkg/definition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/oam/testutil/kubeconfig.go
+++ b/pkg/oam/testutil/kubeconfig.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// kubeConfigHelp is printed when no usable kubeconfig is found. It tells the
+// developer exactly how to unblock the test run instead of leaving them with a
+// silent process exit.
+const kubeConfigHelp = `
+==============================================================================
+This test package requires a kubeconfig to be present.
+
+Several kubevela packages resolve a Kubernetes client through
+github.com/kubevela/pkg/util/singleton, whose config loader calls
+GetConfigOrDie() and terminates the whole test binary with os.Exit(1) when no
+kubeconfig can be found. Without this guard, the package would fail with NO
+output at all.
+
+The tests never contact the cluster, so any parseable kubeconfig works.
+Either point KUBECONFIG at an existing config, or create a dummy one:
+
+  mkdir -p ~/.kube && cat > ~/.kube/config <<'EOF'
+  apiVersion: v1
+  kind: Config
+  clusters:
+  - cluster: {server: "https://127.0.0.1:1", insecure-skip-tls-verify: true}
+    name: dummy
+  contexts:
+  - context: {cluster: dummy, user: dummy}
+    name: dummy
+  current-context: dummy
+  users:
+  - name: dummy
+    user: {token: dummy}
+  EOF
+
+See contribute/testcode-guidance.md for details.
+==============================================================================
+`
+
+// RequireKubeConfig verifies that a kubeconfig is loadable BEFORE any test code
+// touches the kubevela/pkg singleton clients. It must be called from TestMain
+// prior to m.Run().
+//
+// It deliberately fails fast with an actionable message rather than skipping:
+// skipping would silently drop coverage in CI if the CI kubeconfig setup ever
+// broke, whereas an explicit failure is always visible.
+func RequireKubeConfig() {
+	if _, err := config.GetConfig(); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: no usable kubeconfig: %v\n%s", err, kubeConfigHelp)
+		os.Exit(1)
+	}
+}

--- a/pkg/schema/kubeconfig_guard_test.go
+++ b/pkg/schema/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/utils/common/kubeconfig_guard_test.go
+++ b/pkg/utils/common/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/kubeconfig_guard_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/kubeconfig_guard_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/componentdefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentdefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/kubeconfig_guard_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package traitdefinition
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/utils/kubeconfig_guard_test.go
+++ b/pkg/webhook/utils/kubeconfig_guard_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
+)
+
+// TestMain guards against the silent os.Exit(1) from the kubevela/pkg singleton
+// config loader when no kubeconfig is present. See testutil.RequireKubeConfig.
+func TestMain(m *testing.M) {
+	testutil.RequireKubeConfig()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
### Description 
If you clone the repo on a machine with no kubeconfig and run the unit tests, 19
packages die like this:

FAIL  github.com/oam-dev/kubevela/pkg/cue     0.023s

That's the whole output. No panic, no assertion, nothing `-v` doesn't help either. It looks like a broken test suite but it's actually the process being killed: the singleton config loader in kubevela/pkg calls `GetConfigOrDie()`, which os.Exit(1)s the test binary before Go's test framework can report anything.

This adds a small guard, `testutil.RequireKubeConfig()`, called from TestMain in the affected packages. It probes for a kubeconfig with the non-dying config.GetConfig()` and, if there isn't one, fails with a message that says
what's wrong and includes a copy-paste dummy kubeconfig that unblocks the run
(the tests never dial the cluster, so any parseable config works verified, all packages pass with a config pointing at a dead endpoint). Also added a short note to contribute/testcode-guidance.md.

Went with fail-fast rather than t.Skip on purpose: skipping would silently drop 19 packages of coverage in CI if the CI kubeconfig setup ever broke. Happy to switch if you'd rather skip.

The guard files are intentionally identical boilerplate the logic lives in one helper. pkg/cue/cuex already had a TestMain so the call is inserted there instead of a new file.

### How has this code been tested

- Without a kubeconfig, before: `FAIL pkg/cue 0.024s` with zero output. After:
  readable diagnostic with the fix instructions (checked pkg/cue, the webhook
  suite and pkg/utils/common).
- With a kubeconfig present, the full unit test target matches a clean master
  baseline exactly same packages pass, the only failure either way is
  pkg/definition/gen_sdk which needs a Docker daemon.
- gofmt / go vet / go build clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

