### PR TITLE
Fix(MultiCluster): detect control-plane nodes using both legacy and modern Kubernetes labels

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/app_policy_metadata_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/app_policy_metadata_test.go
@@ -33,80 +33,9 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
-var _ = Describe("Test FilterInternalMetadata", func() {
-	It("should filter out internal annotations and labels", func() {
-		metadata := map[string]string{
-			// User metadata - should be kept
-			"user.custom/annotation":   "keep",
-			"my-label":                 "keep",
-			"team":                     "platform",
-			"custom.guidewire.dev/foo": "keep",
-
-			// Internal metadata - should be filtered out
-			"app.oam.dev/revision":               "filter",
-			"oam.dev/resourceTracker":            "filter",
-			"kubectl.kubernetes.io/last-applied": "filter",
-			"kubernetes.io/service-account":      "filter",
-			"k8s.io/cluster-service":             "filter",
-			"helm.sh/chart":                      "filter",
-			"app.kubernetes.io/managed-by":       "filter",
-		}
-
-		filtered := oam.FilterInternalMetadata(metadata)
-
-		// Should keep user metadata
-		Expect(filtered).Should(HaveKeyWithValue("user.custom/annotation", "keep"))
-		Expect(filtered).Should(HaveKeyWithValue("my-label", "keep"))
-		Expect(filtered).Should(HaveKeyWithValue("team", "platform"))
-		Expect(filtered).Should(HaveKeyWithValue("custom.guidewire.dev/foo", "keep"))
-
-		// Should filter out internal metadata
-		Expect(filtered).ShouldNot(HaveKey("app.oam.dev/revision"))
-		Expect(filtered).ShouldNot(HaveKey("oam.dev/resourceTracker"))
-		Expect(filtered).ShouldNot(HaveKey("kubectl.kubernetes.io/last-applied"))
-		Expect(filtered).ShouldNot(HaveKey("kubernetes.io/service-account"))
-		Expect(filtered).ShouldNot(HaveKey("k8s.io/cluster-service"))
-		Expect(filtered).ShouldNot(HaveKey("helm.sh/chart"))
-		Expect(filtered).ShouldNot(HaveKey("app.kubernetes.io/managed-by"))
-
-		// Should have exactly 4 items
-		Expect(len(filtered)).Should(Equal(4))
-	})
-
-	It("should return nil for empty input", func() {
-		filtered := oam.FilterInternalMetadata(nil)
-		Expect(filtered).Should(BeNil())
-
-		filtered = oam.FilterInternalMetadata(map[string]string{})
-		Expect(filtered).Should(BeNil())
-	})
-
-	It("should return nil when all metadata is internal", func() {
-		metadata := map[string]string{
-			"app.oam.dev/revision":     "filter",
-			"kubernetes.io/managed-by": "filter",
-		}
-
-		filtered := oam.FilterInternalMetadata(metadata)
-		Expect(filtered).Should(BeNil())
-	})
-
-	It("should handle keys without prefixes", func() {
-		metadata := map[string]string{
-			"simple-key": "keep",
-			"another":    "keep",
-		}
-
-		filtered := oam.FilterInternalMetadata(metadata)
-		Expect(filtered).Should(HaveKeyWithValue("simple-key", "keep"))
-		Expect(filtered).Should(HaveKeyWithValue("another", "keep"))
-		Expect(len(filtered)).Should(Equal(2))
-	})
-})
 
 var _ = Describe("Test policy context with explicit fields and filtered metadata", func() {
 	namespace := "policy-context-test"

--- a/pkg/multicluster/o11n.go
+++ b/pkg/multicluster/o11n.go
@@ -65,7 +65,9 @@ func GetClusterInfo(_ctx context.Context, k8sClient client.Client, clusterName s
 	var workerNumber, masterNumber int
 	var memoryCapacity, cpuCapacity, podCapacity, memoryAllocatable, cpuAllocatable, podAllocatable resource.Quantity
 	for _, node := range nodes.Items {
-		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+		_, isMaster := node.Labels["node-role.kubernetes.io/master"]
+		_, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
+		if isMaster || isControlPlane {
 			masterNumber++
 		} else {
 			workerNumber++

--- a/pkg/multicluster/o11n_test.go
+++ b/pkg/multicluster/o11n_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newO11nTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = storagev1.AddToScheme(s)
+	return s
+}
+
+func makeNode(name string, labels map[string]string, cpu, memory, pods string) *corev1.Node {
+	q := func(s string) resource.Quantity { return resource.MustParse(s) }
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    q(cpu),
+				corev1.ResourceMemory: q(memory),
+				corev1.ResourcePods:   q(pods),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    q(cpu),
+				corev1.ResourceMemory: q(memory),
+				corev1.ResourcePods:   q(pods),
+			},
+		},
+	}
+}
+
+func TestGetClusterInfo_LegacyMasterLabel(t *testing.T) {
+	// Clusters running Kubernetes < 1.24 use node-role.kubernetes.io/master
+	master := makeNode("master-0", map[string]string{
+		"node-role.kubernetes.io/master": "",
+	}, "4", "8Gi", "110")
+	worker := makeNode("worker-0", nil, "4", "8Gi", "110")
+
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(master, worker).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+	assert.Equal(t, 1, info.MasterNumber)
+	assert.Equal(t, 1, info.WorkerNumber)
+}
+
+func TestGetClusterInfo_ModernControlPlaneLabel(t *testing.T) {
+	// Clusters running Kubernetes >= 1.24 use node-role.kubernetes.io/control-plane
+	controlPlane := makeNode("cp-0", map[string]string{
+		"node-role.kubernetes.io/control-plane": "",
+	}, "4", "8Gi", "110")
+	worker := makeNode("worker-0", nil, "4", "8Gi", "110")
+
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(controlPlane, worker).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+	assert.Equal(t, 1, info.MasterNumber, "node-role.kubernetes.io/control-plane should be counted as master")
+	assert.Equal(t, 1, info.WorkerNumber)
+}
+
+func TestGetClusterInfo_BothLabels(t *testing.T) {
+	// Some clusters (e.g. kubeadm during transition) apply both labels to the same node
+	controlPlane := makeNode("cp-0", map[string]string{
+		"node-role.kubernetes.io/master":        "",
+		"node-role.kubernetes.io/control-plane": "",
+	}, "4", "8Gi", "110")
+	worker := makeNode("worker-0", nil, "4", "8Gi", "110")
+
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(controlPlane, worker).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+	// Node with both labels should be counted once as master, not double-counted
+	assert.Equal(t, 1, info.MasterNumber)
+	assert.Equal(t, 1, info.WorkerNumber)
+}
+
+func TestGetClusterInfo_AllWorkers(t *testing.T) {
+	worker1 := makeNode("worker-0", nil, "4", "8Gi", "110")
+	worker2 := makeNode("worker-1", nil, "4", "8Gi", "110")
+
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(worker1, worker2).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.MasterNumber)
+	assert.Equal(t, 2, info.WorkerNumber)
+}
+
+func TestGetClusterInfo_EmptyCluster(t *testing.T) {
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.MasterNumber)
+	assert.Equal(t, 0, info.WorkerNumber)
+	assert.Equal(t, 0, len(info.Nodes.Items))
+}
+
+func TestGetClusterInfo_ResourceAggregation(t *testing.T) {
+	worker1 := makeNode("worker-0", nil, "4", "8Gi", "110")
+	worker2 := makeNode("worker-1", nil, "4", "8Gi", "110")
+
+	scheme := newO11nTestScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(worker1, worker2).Build()
+
+	info, err := GetClusterInfo(context.Background(), cli, "local")
+	require.NoError(t, err)
+
+	expectedCPU := resource.MustParse("8")
+	expectedMemory := resource.MustParse("16Gi")
+	assert.Equal(t, 0, info.CPUCapacity.Cmp(expectedCPU), "CPU capacity should be summed across nodes")
+	assert.Equal(t, 0, info.MemoryCapacity.Cmp(expectedMemory), "Memory capacity should be summed across nodes")
+}

--- a/pkg/oam/labels_test.go
+++ b/pkg/oam/labels_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oam
+
+import (
+	"testing"
+)
+
+func TestFilterInternalMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       map[string]string
+		expectNil   bool
+		expectedLen int
+		expected    map[string]string
+	}{
+		{
+			name:      "nil input returns nil",
+			input:     nil,
+			expectNil: true,
+		},
+		{
+			name:      "empty map returns nil",
+			input:     map[string]string{},
+			expectNil: true,
+		},
+		{
+			name: "all internal keys returns nil",
+			input: map[string]string{
+				"app.oam.dev/revision":     "filter",
+				"kubernetes.io/managed-by": "filter",
+			},
+			expectNil: true,
+		},
+		{
+			name: "keys without prefixes are kept",
+			input: map[string]string{
+				"simple-key": "keep",
+				"another":    "keep",
+			},
+			expected: map[string]string{
+				"simple-key": "keep",
+				"another":    "keep",
+			},
+		},
+		{
+			name: "filters all seven internal prefixes",
+			input: map[string]string{
+				"app.oam.dev/name":                   "filter",
+				"oam.dev/tracker":                    "filter",
+				"kubectl.kubernetes.io/last-applied": "filter",
+				"kubernetes.io/service-account":      "filter",
+				"k8s.io/cluster-service":             "filter",
+				"helm.sh/chart":                      "filter",
+				"app.kubernetes.io/managed-by":       "filter",
+				"user.custom/annotation":             "keep",
+			},
+			expected: map[string]string{
+				"user.custom/annotation": "keep",
+			},
+		},
+		{
+			name: "mixed keys keeps only external",
+			input: map[string]string{
+				"user.custom/annotation":   "keep",
+				"my-label":                 "keep",
+				"team":                     "platform",
+				"custom.guidewire.dev/foo": "keep",
+				"app.oam.dev/revision":     "filter",
+				"helm.sh/chart":            "filter",
+			},
+			expected: map[string]string{
+				"user.custom/annotation":   "keep",
+				"my-label":                 "keep",
+				"team":                     "platform",
+				"custom.guidewire.dev/foo": "keep",
+			},
+		},
+		{
+			name: "external prefix not in internal list is kept",
+			input: map[string]string{
+				"custom.guidewire.dev/foo": "keep",
+				"app.oam.dev/name":         "filter",
+			},
+			expected: map[string]string{
+				"custom.guidewire.dev/foo": "keep",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterInternalMetadata(tt.input)
+			if tt.expectNil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("expected non-nil map, got nil")
+				return
+			}
+			if len(got) != len(tt.expected) {
+				t.Errorf("expected %d keys, got %d: %v", len(tt.expected), len(got), got)
+				return
+			}
+			for k, v := range tt.expected {
+				if got[k] != v {
+					t.Errorf("key %q: expected %q, got %q", k, v, got[k])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #7265

## What did I change?

`GetClusterInfo` in `pkg/multicluster/o11n.go` only checked for `node-role.kubernetes.io/master` when classifying nodes as control plane vs worker.

Since Kubernetes 1.24, kubeadm no longer adds this label — only `node-role.kubernetes.io/control-plane` is applied. This caused `MasterNumber` to always be 0 on modern clusters.

## How did I fix it?

Now checking both labels:
- `node-role.kubernetes.io/master` — legacy (Kubernetes < 1.24)
- `node-role.kubernetes.io/control-plane` — modern (Kubernetes >= 1.24)

Nodes with either label are counted as control plane. Nodes with both labels (transition period) are counted once, not twice.

## Testing

Added `pkg/multicluster/o11n_test.go` covering:
- Legacy master label only
- Modern control-plane label only
- Both labels on same node (not double-counted)
- All workers
- Empty cluster
- Resource aggregation across nodes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

