### PR TITLE
Fix(sdk): preserve equals in gen sdk args

### DIFF
--- a/pkg/definition/gen_sdk/gen_sdk.go
+++ b/pkg/definition/gen_sdk/gen_sdk.go
@@ -125,7 +125,7 @@ func NewLanguageArgs(lang string, langArgs []string) (LanguageArgs, error) {
 	availableArgs := LangArgsRegistry[lang]
 	res := languageArgs{}
 	for _, arg := range langArgs {
-		parts := strings.Split(arg, "=")
+		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
 			return nil, errors.Errorf("argument %s is not in the format of key=value", arg)
 		}

--- a/pkg/definition/gen_sdk/gen_sdk_test.go
+++ b/pkg/definition/gen_sdk/gen_sdk_test.go
@@ -249,6 +249,15 @@ var _ = Describe("TestNewLanguageArgs", func() {
 			wantErr: false,
 		},
 		{
+			name: "should preserve equals signs in the value portion",
+			args: args{
+				lang:     "go",
+				langArgs: []string{"GoProxy=https://proxy.example.com?foo=bar=baz"},
+			},
+			want:    map[string]string{"GoProxy": "https://proxy.example.com?foo=bar=baz"},
+			wantErr: false,
+		},
+		{
 			name: "should not set a value for an unknown flag",
 			args: args{
 				lang:     "go",


### PR DESCRIPTION
## Summary

- preserve `=` characters in language-argument values by splitting on the first separator only
- add a regression test for a Go proxy value containing `=`

Fixes #7268

## Verification

- `git diff --check`
- source-level review of the parser change and test

I could not run `go test` in this environment because the bundled toolchain does not include `go`/`gofmt` on PATH.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

