### PR TITLE
Chore: mirror vela-core chart to GHCR as an OCI artifact

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -65,3 +65,93 @@ jobs:
           chart_version=${{ steps.get_version.outputs.VERSION }}
           git commit -m "update vela-core chart ${chart_version}"
           git push https://x-access-token:${{ steps.get_app_token.outputs.token }}@github.com/kubevela/charts.git
+
+  # Publishes the same chart to GHCR as an OCI artifact. This is an additive
+  # mirror: the classic HTTP repo at kubevela.github.io/charts is untouched and
+  # remains the primary. The mirror keeps charts installable when that domain or
+  # its DNS is unavailable, and gives users a second option.
+  publish-charts-ghcr:
+    permissions:
+      contents: read
+      packages: write
+    env:
+      HELM_CHART: charts/vela-core
+      HELM_CHART_NAME: vela-core
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      # OCI push requires Helm 3.8 or newer. The publish-charts job above pins
+      # 3.4.0, so this job installs its own version rather than changing it.
+      - name: Install Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
+        with:
+          version: v3.16.2
+
+      # Mirrors the publish-charts job so both channels ship the same
+      # generated chart README rather than whatever is committed in the tree.
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '14'
+
+      - name: Generate helm doc
+        run: |
+          make helm-doc-gen
+
+      - name: Resolve the version
+        id: get_version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${REF_NAME}"
+          case "${VERSION}" in
+            v*) ;;
+            *) echo "expected a v-prefixed tag, got ${VERSION}" >&2; exit 1 ;;
+          esac
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "SEMVER=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Tag helm chart image
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          SEMVER: ${{ steps.get_version.outputs.SEMVER }}
+        run: |
+          # Anchored to the image tag field so an unrelated "latest" elsewhere
+          # in values.yaml is never rewritten. Chart.yaml keeps the global
+          # substitution because both version and appVersion are stamped.
+          sed -i "s|^  tag: latest|  tag: ${VERSION}|" $HELM_CHART/values.yaml
+          sed -i "s/0.1.0/${SEMVER}/g" $HELM_CHART/Chart.yaml
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GHCR_USER}" --password-stdin
+
+      - name: Package and push to GHCR
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          owner_lc=$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')
+          helm package $HELM_CHART --destination ./dist
+          helm push ./dist/${HELM_CHART_NAME}-*.tgz "oci://ghcr.io/${owner_lc}/charts"
+
+      # Verified without credentials on purpose. A newly created GHCR package is
+      # private, and GitHub exposes no API to change that (a PATCH against the
+      # packages endpoint returns 404), so it cannot be provisioned here. An
+      # anonymous check turns that into a visible failure at publish time
+      # instead of a 403 for every user trying to pull the chart.
+      - name: Verify the chart is pullable without credentials
+        env:
+          OWNER: ${{ github.repository_owner }}
+          SEMVER: ${{ steps.get_version.outputs.SEMVER }}
+        run: |
+          owner_lc=$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')
+          echo '{}' > "${RUNNER_TEMP}/anon-registry.json"
+          if ! helm show chart "oci://ghcr.io/${owner_lc}/charts/${HELM_CHART_NAME}" \
+              --version "${SEMVER}" --registry-config "${RUNNER_TEMP}/anon-registry.json"; then
+            echo "::error::Chart pushed but not pullable anonymously. Set the package ghcr.io/${owner_lc}/charts/${HELM_CHART_NAME} to public in the package settings, then re-run."
+            exit 1
+          fi


### PR DESCRIPTION
### Description of your changes

Publishes the vela-core chart to GHCR as an OCI artifact, in addition to the existing repo at `kubevela.github.io/charts`.

The chart is currently available from one place only, served through the `kubevela.io` domain. When that domain is unavailable, users have no alternative source. This adds a second job so the chart can also be pulled from `ghcr.io/${owner}/charts`.

The change is additive. The existing `publish-charts` job and the HTTP repo are untouched and stay primary.

Fixes #7271

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Verified on a fork. The job packaged the chart, pushed it to `ghcr.io/<owner>/charts`, and the workflow's own verify step pulled it back with a matching digest. An anonymous `helm show chart` then succeeded with no credentials and no `helm repo add`, confirming the fallback works without depending on `kubevela.io` resolving.

Run: https://github.com/roguepikachu/kubevela/actions/runs/30464465936

One difference worth stating plainly: that run was triggered with a temporary `workflow_dispatch` version input, which has since been removed so the trigger block stays exactly as it was. The shipped job derives the version from the tag ref instead. Everything after version resolution, meaning the stamping, packaging, push, and verify, is unchanged from what that run exercised. Happy to cut a throwaway tag on the fork and re-run if you would prefer a tag-driven run on record.

### Special notes for your reviewer

- **Additive by design.** The HTTP repo remains primary. The intent is a second channel, not a migration.
- **Separate Helm install.** OCI push needs Helm 3.8 or newer, while `publish-charts` pins 3.4.0. Bumping that pin in place would change the existing publish path, so the new job installs its own 3.16.2 and the two stay independent.
- **Injection safety.** Every value used in a `run:` body is passed through `env:` and referenced as a quoted shell variable. There is no `${{ }}` interpolation inside any script body.
- **Package visibility.** A newly created GHCR package is private, and GitHub exposes no API to change that (a `PATCH` against the packages endpoint returns 404), so it cannot be provisioned from a step. The first publish therefore needs the package set public once in the org's package settings. To stop that being forgotten silently, the verify step runs **anonymously**, against an empty registry config so the earlier login is not reused, and fails the job with an actionable error if the chart is not publicly pullable. A private package then fails for the maintainer cutting the release rather than for every user.
- **README parity.** The job runs `make helm-doc-gen` before packaging, matching `publish-charts`, so both channels ship the same generated chart README rather than whatever is committed in the tree.
- **Unchecked boxes above.** `make reviewable` targets Go code and this change touches only a workflow file, so it is not meaningful here. A docs update for the OCI install path belongs in the kubevela.io repo and I am happy to raise it separately once the direction is agreed. No backport labels, since this only affects future releases.
- **Pre-existing, not addressed here.** The existing `publish-charts` job is not safe to run via `workflow_dispatch`. It derives the version from `GITHUB_REF`, which on a manual run yields a value containing slashes and breaks its `sed`. Left alone to keep this diff narrow, happy to fix in a follow-up.
