### PR TITLE
Fix: vela cluster join no longer prints false success on declined overwrite

### DIFF
--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -55,6 +55,11 @@ type ContextKey string
 // KubeConfigContext marks the kubeConfig object in context
 const KubeConfigContext ContextKey = "kubeConfig"
 
+// ErrClusterAlreadyExistDeclined is returned by RegisterByVelaSecret when the
+// cluster already exists and ClusterAlreadyExistCallback declines the overwrite.
+// Callers must not treat this as a successful registration.
+var ErrClusterAlreadyExistDeclined = errors.New("declined to overwrite existing cluster")
+
 // KubeClusterConfig info for cluster management
 type KubeClusterConfig struct {
 	FilePath        string
@@ -176,7 +181,7 @@ func (clusterConfig *KubeClusterConfig) RegisterByVelaSecret(ctx context.Context
 			return fmt.Errorf("cluster %s already exists", cluster.Name)
 		}
 		if !clusterConfig.ClusterAlreadyExistCallback(clusterConfig.ClusterName) {
-			return nil
+			return ErrClusterAlreadyExistDeclined
 		}
 		if cluster.Spec.CredentialType == clusterv1alpha1.CredentialTypeInternal || cluster.Spec.CredentialType == clusterv1alpha1.CredentialTypeOCMManagedCluster {
 			return fmt.Errorf("cannot override %s typed cluster", cluster.Spec.CredentialType)

--- a/pkg/multicluster/cluster_management_test.go
+++ b/pkg/multicluster/cluster_management_test.go
@@ -203,11 +203,12 @@ func TestRegisterByVelaSecret(t *testing.T) {
 	t.Cleanup(func() { ClusterGatewaySecretNamespace = oldNS })
 
 	testCases := []struct {
-		name      string
-		cfg       *KubeClusterConfig
-		cli       client.Client
-		expectErr bool
-		verify    func(t *testing.T, cli client.Client, cfg *KubeClusterConfig)
+		name        string
+		cfg         *KubeClusterConfig
+		cli         client.Client
+		expectErr   bool
+		expectErrIs error
+		verify      func(t *testing.T, cli client.Client, cfg *KubeClusterConfig)
 	}{
 		{
 			name: "Token and endpoint",
@@ -291,6 +292,34 @@ func TestRegisterByVelaSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "Declined overwrite returns sentinel error, does not touch existing secret",
+			cfg: func() *KubeClusterConfig {
+				cfg := makeBaseClusterConfig("c-declined")
+				cfg.AuthInfo.Token = "new-token"
+				cfg.ClusterAlreadyExistCallback = func(string) bool { return false }
+				return cfg
+			}(),
+			cli: func() client.Client {
+				clusterName := "c-declined"
+				existing := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      clusterName,
+						Namespace: ClusterGatewaySecretNamespace,
+						Labels:    map[string]string{clustercommon.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeServiceAccountToken)},
+					},
+					Data: map[string][]byte{"token": []byte("old-token"), "endpoint": []byte("https://old-endpoint:6443")},
+				}
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+			}(),
+			expectErr:   true,
+			expectErrIs: ErrClusterAlreadyExistDeclined,
+			verify: func(t *testing.T, cli client.Client, cfg *KubeClusterConfig) {
+				var sec corev1.Secret
+				require.NoError(t, cli.Get(ctx, client.ObjectKey{Name: cfg.ClusterName, Namespace: ClusterGatewaySecretNamespace}, &sec))
+				require.Equal(t, []byte("old-token"), sec.Data["token"])
+			},
+		},
+		{
 			name: "Get error from createOrUpdate",
 			cfg: func() *KubeClusterConfig {
 				cfg := makeBaseClusterConfig("c-get-err")
@@ -322,6 +351,9 @@ func TestRegisterByVelaSecret(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+			if tc.expectErrIs != nil {
+				require.ErrorIs(t, err, tc.expectErrIs)
 			}
 			if tc.verify != nil {
 				tc.verify(t, tc.cli, tc.cfg)

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -221,6 +221,10 @@ func NewClusterJoinCommand(c *common.Args, ioStreams cmdutil.IOStreams) *cobra.C
 					return true
 				}))
 			if err != nil {
+				if errors.Is(err, multicluster.ErrClusterAlreadyExistDeclined) {
+					cmd.Printf("Cancelled, cluster %s was not changed.\n", clusterName)
+					return nil
+				}
 				return err
 			}
 


### PR DESCRIPTION
Motivation:
When `vela cluster join` is used to re-join a cluster name that already
exists and the user answers "n" to the "already exists, overwrite?"
prompt, RegisterByVelaSecret (pkg/multicluster/cluster_management.go)
returns nil for both a declined overwrite and a real successful join.
The join command in references/cli/cluster.go only checks `err != nil`,
so it falls through to the same success path and prints
"Successfully add cluster <name>, endpoint: <new endpoint>" even though
the overwrite never happened and the original cluster's credentials are
untouched. This is a false/misleading CLI message, not data loss: the
existing cluster secret is never modified when the callback declines,
since RegisterByVelaSecret returns before calling
createOrUpdateClusterSecret.

Approach:
- Add a sentinel error, ErrClusterAlreadyExistDeclined, returned by
  RegisterByVelaSecret when ClusterAlreadyExistCallback declines the
  overwrite, instead of returning nil.
- In the `join` command, check errors.Is(err, ErrClusterAlreadyExistDeclined)
  and print "Cancelled, cluster <name> was not changed." instead of
  falling through to the success message, label-adding, and
  topology-policy-update steps meant for an actual join.
- The OCM engine path is unaffected: RegisterClusterManagedByOCM never
  reads ClusterAlreadyExistCallback and already hard-errors on a name
  collision, so it never had this bug.

Validation:
Ran `go build ./...` (passes) and
`go test ./pkg/multicluster/... -run TestRegisterByVelaSecret -v`
(passes), including a new table-driven case that reproduces the bug:
before this change the case failed because RegisterByVelaSecret
returned nil on a declined overwrite; after this change it returns
ErrClusterAlreadyExistDeclined and the pre-existing cluster secret is
verified to be untouched. `go vet ./pkg/multicluster/... ./references/cli/...`
is clean.

Fixes #7273

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

