### PR TITLE
Fix(cli): guard top info helpers against nil rest.Config

### DIFF
--- a/references/cli/top/model/info.go
+++ b/references/cli/top/model/info.go
@@ -86,6 +86,9 @@ func (i *Info) ClusterNum() string {
 
 // K8SVersion return k8s version info
 func K8SVersion(cfg *rest.Config) string {
+	if cfg == nil {
+		return Unknown
+	}
 	c, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return Unknown
@@ -141,6 +144,9 @@ func ApplicationRunningNum(cfg *rest.Config) string {
 }
 
 func velaCorePodUsage(cfg *rest.Config) (*v1beta1.PodMetrics, error) {
+	if cfg == nil {
+		return nil, errors.New("no rest.Config available")
+	}
 	ctx := context.Background()
 	c, err := metrics.NewForConfig(cfg)
 	if err != nil {
@@ -194,6 +200,9 @@ func VelaCoreRatio(c client.Client, cfg *rest.Config) (string, string, string, s
 }
 
 func velaCLusterGatewayPodUsage(cfg *rest.Config) (*v1beta1.PodMetrics, error) {
+	if cfg == nil {
+		return nil, errors.New("no rest.Config available")
+	}
 	ctx := context.Background()
 	c, err := metrics.NewForConfig(cfg)
 	if err != nil {

--- a/references/cli/top/model/info_test.go
+++ b/references/cli/top/model/info_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+
+	clicommon "github.com/oam-dev/kubevela/references/common"
 )
 
 func TestInfo_CurrentContext(t *testing.T) {
@@ -44,6 +46,26 @@ func TestInfo_VelaCoreVersion(t *testing.T) {
 
 func TestInfo_GOLangVersion(t *testing.T) {
 	assert.Contains(t, GOLangVersion(), "go")
+}
+
+func TestInfo_K8SVersion_NilConfig(t *testing.T) {
+	assert.Equal(t, Unknown, K8SVersion(nil))
+}
+
+func TestInfo_VelaCoreRatio_NilConfig(t *testing.T) {
+	cpuL, memL, cpuR, memR := VelaCoreRatio(nil, nil)
+	assert.Equal(t, clicommon.MetricsNA, cpuL)
+	assert.Equal(t, clicommon.MetricsNA, memL)
+	assert.Equal(t, clicommon.MetricsNA, cpuR)
+	assert.Equal(t, clicommon.MetricsNA, memR)
+}
+
+func TestInfo_CLusterGatewayRatio_NilConfig(t *testing.T) {
+	cpuL, memL, cpuR, memR := CLusterGatewayRatio(nil, nil)
+	assert.Equal(t, clicommon.MetricsNA, cpuL)
+	assert.Equal(t, clicommon.MetricsNA, memL)
+	assert.Equal(t, clicommon.MetricsNA, cpuR)
+	assert.Equal(t, clicommon.MetricsNA, memR)
 }
 
 var _ = Describe("test info", func() {


### PR DESCRIPTION
### Description of your changes

copilot:all

K8SVersion, velaCorePodUsage and velaCLusterGatewayPodUsage in references/cli/top/model/info.go pass *rest.Config straight into kubernetes.NewForConfig / metrics.NewForConfig without a nil check. client-go panics on a nil config rather than returning an error, so any caller that reaches these with nil crashes instead of getting the Unknown / N/A fallback the rest of those functions already return on failure.

To be clear about scope, this is not reachable from the CLI today. launchUI resolves the client and config first and returns early if either fails, so vela top with no kubeconfig exits with "invalid configuration: no configuration has been provided" long before App.Init runs. The panic only shows up if something calls App.Init or InfoBoard.Init with a nil *rest.Config directly, which is what the new tests do.

So this is defensive hardening plus test coverage for that path, not a user-visible bug fix. Happy to close it if you'd rather not carry guards for a case no caller can hit right now.

### How has this code been tested

Added three unit tests in references/cli/top/model/info_test.go covering nil config for K8SVersion, VelaCoreRatio and CLusterGatewayRatio. Reverted the guards locally to confirm each one panics with the client-go nil pointer dereference, and passes with them in place. Ran the references/cli/top/... suite, no other changes in behavior.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. Not applicable, no user facing change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.