### PR TITLE
Chore: skip image, license, definition and webhook checks on docs-only PRs

### DIFF
--- a/.github/workflows/definition-lint.yml
+++ b/.github/workflows/definition-lint.yml
@@ -19,7 +19,25 @@ env:
   GO_VERSION: '1.23.8'
 
 jobs:
+  detect-noop:
+    permissions:
+      actions: write # for fkirc/skip-duplicate-actions to skip or stop workflow runs
+    runs-on: ubuntu-22.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+        continue-on-error: true
+
   definition-doc:
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Go

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -13,7 +13,25 @@ permissions:
   contents: read
 
 jobs:
+  detect-noop:
+    permissions:
+      actions: write # for fkirc/skip-duplicate-actions to skip or stop workflow runs
+    runs-on: ubuntu-22.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+        continue-on-error: true
+
   license_check:
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
     runs-on: ubuntu-22.04
     name: Check for unapproved licenses
     steps:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -8,7 +8,25 @@ permissions:
   contents: read
 
 jobs:
+  detect-noop:
+    permissions:
+      actions: write # for fkirc/skip-duplicate-actions to skip or stop workflow runs
+    runs-on: ubuntu-22.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+        continue-on-error: true
+
   images:
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
     name: Image Scan
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/webhook-upgrade-validation.yml
+++ b/.github/workflows/webhook-upgrade-validation.yml
@@ -20,7 +20,25 @@ env:
   GO_VERSION: '1.23.8'
 
 jobs:
+  detect-noop:
+    permissions:
+      actions: write # for fkirc/skip-duplicate-actions to skip or stop workflow runs
+    runs-on: ubuntu-22.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+        continue-on-error: true
+
   webhook-upgrade-check:
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Description

`unit-test`, `e2e-test`, `e2e-multicluster-test` and `go` already gate their jobs on a `detect-noop` step, so a pull request touching only markdown skips them.

Four workflows were never given the same treatment and still run in full on docs-only PRs:

| Workflow | Job |
|---|---|
| `definition-lint.yml` | `definition-doc` |
| `license.yml` | `license_check` (Check for unapproved licenses) |
| `trivy-scan.yml` | `images` (Image Scan) |
| `webhook-upgrade-validation.yml` | `webhook-upgrade-check` |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

