### PR TITLE
fix: enforce conflictsWith validation for traits

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/kubevela/pkg/controller/sharding"
 	"github.com/kubevela/pkg/util/singleton"
 	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
@@ -36,6 +38,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
 // ValidateWorkflow validates the Application workflow
@@ -439,6 +442,100 @@ func getWorkflowStepFieldPath(loc workflowStepLocation) *field.Path {
 	return field.NewPath("spec", "workflow", "steps").Index(loc.StepIndex).Child("subSteps").Index(loc.SubStepIndex).Child("type")
 }
 
+// ValidateTraitConflicts validates that no two traits attached to the same component declare
+// each other as conflicting via TraitDefinition.spec.conflictsWith.
+func (h *ValidatingHandler) ValidateTraitConflicts(ctx context.Context, app *v1beta1.Application) field.ErrorList {
+	var errs field.ErrorList
+	defCtx := oamutil.SetNamespaceInCtx(ctx, app.Namespace)
+
+	// cache resolved TraitDefinitions across components so each trait type is only fetched once
+	defCache := make(map[string]*v1beta1.TraitDefinition)
+	getTraitDefinition := func(traitType string) *v1beta1.TraitDefinition {
+		if def, ok := defCache[traitType]; ok {
+			return def
+		}
+		def := &v1beta1.TraitDefinition{}
+		if err := oamutil.GetDefinition(defCtx, h.Client, def, traitType); err != nil {
+			// definition existence/permission is validated elsewhere; if it cannot be
+			// resolved here there is nothing to check conflicts against
+			defCache[traitType] = nil
+			return nil
+		}
+		defCache[traitType] = def
+		return def
+	}
+
+	for compIdx, comp := range app.Spec.Components {
+		if len(comp.Traits) < 2 {
+			continue
+		}
+
+		type attachedTrait struct {
+			traitIdx int
+			def      *v1beta1.TraitDefinition
+		}
+		var attached []attachedTrait
+		for i, trait := range comp.Traits {
+			if def := getTraitDefinition(trait.Type); def != nil {
+				attached = append(attached, attachedTrait{traitIdx: i, def: def})
+			}
+		}
+
+		for i := 0; i < len(attached); i++ {
+			for j := i + 1; j < len(attached); j++ {
+				first, second := attached[i], attached[j]
+				if traitConflictsWith(first.def, second.def) || traitConflictsWith(second.def, first.def) {
+					errs = append(errs, field.Invalid(
+						field.NewPath("spec", "components").Index(compIdx).Child("traits").Index(second.traitIdx).Child("type"),
+						second.def.Name,
+						fmt.Sprintf("trait %q conflicts with trait %q on component %q", first.def.Name, second.def.Name, comp.Name)))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// traitConflictsWith reports whether def's conflictsWith rules match target.
+func traitConflictsWith(def, target *v1beta1.TraitDefinition) bool {
+	for _, rule := range def.Spec.ConflictsWith {
+		if traitConflictRuleMatches(rule, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// traitConflictRuleMatches checks a single conflictsWith rule against a TraitDefinition.
+// Supported rule forms (see TraitDefinitionSpec.ConflictsWith docs):
+//   - "*"                    matches any trait
+//   - "<definition-name>"    matches the trait definition's name
+//   - "<crd-name>"           matches the trait's referenced CRD name (definitionRef.name)
+//   - "*.<group>"            matches any CRD in the given API group
+//   - "labelSelector:<expr>" matches the trait definition's labels against a label selector
+func traitConflictRuleMatches(rule string, target *v1beta1.TraitDefinition) bool {
+	switch {
+	case rule == "*":
+		return true
+	case strings.HasPrefix(rule, "labelSelector:"):
+		selector, err := labels.Parse(strings.TrimPrefix(rule, "labelSelector:"))
+		if err != nil {
+			return false
+		}
+		return selector.Matches(labels.Set(target.Labels))
+	case rule == target.Name:
+		return true
+	case target.Spec.Reference.Name != "" && rule == target.Spec.Reference.Name:
+		return true
+	case strings.HasPrefix(rule, "*."):
+		group := strings.TrimPrefix(rule, "*.")
+		return target.Spec.Reference.Name != "" && strings.HasSuffix(target.Spec.Reference.Name, "."+group)
+	default:
+		return false
+	}
+}
+
 // ValidateAnnotations validates whether the application has both autoupdate and publish version annotations
 func (h *ValidatingHandler) ValidateAnnotations(_ context.Context, app *v1beta1.Application) field.ErrorList {
 	var annotationsErrs field.ErrorList
@@ -460,6 +557,7 @@ func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.App
 	errs = append(errs, h.ValidateDefinitionPermissions(ctx, app, req)...)
 	errs = append(errs, h.ValidateWorkflow(ctx, app)...)
 	errs = append(errs, h.ValidateComponents(ctx, app)...)
+	errs = append(errs, h.ValidateTraitConflicts(ctx, app)...)
 	return errs
 }
 

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_handlers_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_handlers_test.go
@@ -416,3 +416,84 @@ func TestValidateAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTraitConflicts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	traitA := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: "default"},
+		Spec: v1beta1.TraitDefinitionSpec{
+			ConflictsWith: []string{"conflict-b"},
+		},
+	}
+	traitB := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: "default"},
+		Spec: v1beta1.TraitDefinitionSpec{
+			ConflictsWith: []string{"conflict-a"},
+		},
+	}
+	traitC := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "scaler", Namespace: "default"},
+		Spec:       v1beta1.TraitDefinitionSpec{},
+	}
+
+	testCases := []struct {
+		name               string
+		traits             []common.ApplicationTrait
+		expectedErrorCount int
+	}{
+		{
+			name: "conflicting traits on same component are rejected",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "conflict-b"},
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "non-conflicting traits are allowed",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "scaler"},
+			},
+			expectedErrorCount: 0,
+		},
+		{
+			name: "single trait cannot conflict",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+			},
+			expectedErrorCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := &ValidatingHandler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).
+					WithObjects(traitA.DeepCopy(), traitB.DeepCopy(), traitC.DeepCopy()).Build(),
+			}
+
+			app := &v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{
+						{
+							Name:   "comp1",
+							Type:   "webservice",
+							Traits: tc.traits,
+						},
+					},
+				},
+			}
+
+			errs := handler.ValidateTraitConflicts(context.Background(), app)
+			assert.Equal(t, tc.expectedErrorCount, len(errs),
+				"Expected %d errors, got %d: %v", tc.expectedErrorCount, len(errs), errs)
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`TraitDefinition.spec.conflictsWith` was declared on the API type and written by the defkit builder, but nothing ever read it. Two traits that declared each other as conflicting could both be attached to the same component and the Application would be admitted and reconciled normally, with both traits applied, contradicting the documented behavior.

This adds a `ValidateTraitConflicts` check to the Application validating webhook, next to `ValidateComponents` and `ValidateDefinitionPermissions`. For each component it resolves the `TraitDefinition`s of the attached traits (checking the app namespace first, then falling back to vela-system, same as other definition lookups in this file) and rejects the Application if any pair of attached traits conflicts, naming the pair and the component in the error.

Rule matching covers the forms documented for `conflictsWith`: exact trait definition name, the referenced CRD name, `*.group` for an API group, `*` for any trait, and `labelSelector:` for label-based matching.

Fixes #7294

### How has this code been tested

Added `TestValidateTraitConflicts` covering a conflicting pair being rejected, non-conflicting traits being allowed, and a single trait being a no-op. Ran `go vet ./pkg/webhook/core.oam.dev/v1beta1/application/...` and `go test ./pkg/webhook/core.oam.dev/v1beta1/application/...`, both pass.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

Scope is limited to the webhook validation path described in the issue. Matching definition name is the core case; the other rule forms are implemented for completeness with the documented syntax but not heavily exercised in tests since the repro and the existing `AppliesToWorkloads` handling only cover the simple name/`*` cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

