### PR TITLE
Fix: defkit health conditions erroring when status is absent

### DIFF
--- a/pkg/definition/defkit/health_expr.go
+++ b/pkg/definition/defkit/health_expr.go
@@ -89,7 +89,12 @@ func (c *ConditionExpr) varName() string {
 
 func (c *ConditionExpr) Preamble() string {
 	varName := c.varName()
-	return fmt.Sprintf(`%s: [ for c in context.output.status.conditions if c.type == "%s" { c } ]`,
+	// context.output.status.conditions may not exist yet (e.g. right after creation),
+	// which would make the comprehension source bottom. The `*X | []` disjunction
+	// discards that bottom disjunct and falls back to an empty list instead of
+	// propagating the error. c.type is filtered defensively for the same reason:
+	// a condition entry without a type would otherwise make the comparison bottom.
+	return fmt.Sprintf(`%s: [ for c in *context.output.status.conditions | [] if c.type != _|_ if c.type == "%s" { c } ]`,
 		varName, c.condType)
 }
 
@@ -98,12 +103,15 @@ func (c *ConditionExpr) ToCUE() string {
 	if c.checkExists {
 		return fmt.Sprintf("len(%s) > 0", varName)
 	}
+	// Filter rather than index %s[0]: && does not short-circuit in CUE, so an
+	// out-of-range index on an empty list would propagate as bottom even when
+	// len(%s) > 0 is false.
 	if c.expectedReason != "" {
-		return fmt.Sprintf(`len(%s) > 0 && %s[0].status == "%s" && %s[0].reason == "%s"`,
-			varName, varName, c.expectedStatus, varName, c.expectedReason)
+		return fmt.Sprintf(`len([ for c in %s if c.status == "%s" if c.reason == "%s" { c } ]) > 0`,
+			varName, c.expectedStatus, c.expectedReason)
 	}
-	return fmt.Sprintf(`len(%s) > 0 && %s[0].status == "%s"`,
-		varName, varName, c.expectedStatus)
+	return fmt.Sprintf(`len([ for c in %s if c.status == "%s" { c } ]) > 0`,
+		varName, c.expectedStatus)
 }
 
 // --- Phase Expressions ---

--- a/pkg/definition/defkit/health_expr.go
+++ b/pkg/definition/defkit/health_expr.go
@@ -105,12 +105,14 @@ func (c *ConditionExpr) ToCUE() string {
 	}
 	// Filter rather than index %s[0]: && does not short-circuit in CUE, so an
 	// out-of-range index on an empty list would propagate as bottom even when
-	// len(%s) > 0 is false.
+	// len(%s) > 0 is false. c.status/c.reason are guarded with != _|_ for the
+	// same reason c.type is guarded in Preamble: a condition entry missing
+	// that field would otherwise make the comparison bottom instead of false.
 	if c.expectedReason != "" {
-		return fmt.Sprintf(`len([ for c in %s if c.status == "%s" if c.reason == "%s" { c } ]) > 0`,
+		return fmt.Sprintf(`len([ for c in %s if c.status != _|_ if c.status == "%s" if c.reason != _|_ if c.reason == "%s" { c } ]) > 0`,
 			varName, c.expectedStatus, c.expectedReason)
 	}
-	return fmt.Sprintf(`len([ for c in %s if c.status == "%s" { c } ]) > 0`,
+	return fmt.Sprintf(`len([ for c in %s if c.status != _|_ if c.status == "%s" { c } ]) > 0`,
 		varName, c.expectedStatus)
 }
 

--- a/pkg/definition/defkit/health_expr_test.go
+++ b/pkg/definition/defkit/health_expr_test.go
@@ -19,6 +19,8 @@ package defkit
 import (
 	"strings"
 	"testing"
+
+	"github.com/oam-dev/kubevela/pkg/cue/definition/health"
 )
 
 func TestConditionIsTrue(t *testing.T) {
@@ -336,6 +338,74 @@ func TestComplexComposition(t *testing.T) {
 	}
 	if !strings.Contains(policy, "!(") {
 		t.Errorf("Missing Not() expression")
+	}
+}
+
+// TestConditionExprHandlesMissingStatus reproduces the fixtures from the
+// GitHub issue: a health policy built with AllTrue must evaluate to false
+// (not a CUE evaluation error) when status or status.conditions is absent,
+// and must skip condition entries that have no type instead of erroring.
+func TestConditionExprHandlesMissingStatus(t *testing.T) {
+	h := Health()
+	policy := h.Policy(h.And(
+		h.Exists("status"),
+		h.Exists("status.conditions"),
+		h.AllTrue("Ready", "Synced"),
+	))
+
+	cases := []struct {
+		name   string
+		output map[string]interface{}
+		want   bool
+	}{
+		{
+			name:   "no status",
+			output: map[string]interface{}{},
+			want:   false,
+		},
+		{
+			name:   "empty status",
+			output: map[string]interface{}{"status": map[string]interface{}{}},
+			want:   false,
+		},
+		{
+			name: "ready and synced",
+			output: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+			}}},
+			want: true,
+		},
+		{
+			name: "ready false",
+			output: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "False"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+			}}},
+			want: false,
+		},
+		{
+			name: "condition entry without type",
+			output: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+				map[string]interface{}{"status": "True"},
+			}}},
+			want: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			templateContext := map[string]interface{}{"output": c.output}
+			got, err := health.CheckHealth(templateContext, policy, nil)
+			if err != nil {
+				t.Fatalf("CheckHealth returned an error instead of a health verdict: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("expected healthy=%v, got %v", c.want, got)
+			}
+		})
 	}
 }
 

--- a/pkg/definition/defkit/health_expr_test.go
+++ b/pkg/definition/defkit/health_expr_test.go
@@ -393,6 +393,14 @@ func TestConditionExprHandlesMissingStatus(t *testing.T) {
 			}}},
 			want: true,
 		},
+		{
+			name: "matched condition without status",
+			output: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+			}}},
+			want: false,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
### Description of your changes

copilot:all

Fixes #

`defkit.ConditionExpr` (used by `HealthPolicyExpr`/`AllTrue`/`AnyTrue`) generates a CUE
comprehension over `context.output.status.conditions` to build health policies. When
`status` or `status.conditions` doesn't exist yet — e.g. during the first few reconciles
after a Crossplane claim is created — that comprehension source is CUE bottom (`_|_`).
CUE's `&&` does not short-circuit, so the bottom propagates through the whole `isHealth`
expression even past `Exists()` guards meant to protect it. A condition entry without a
`type` field hit the same problem. Separately, `ToCUE()` indexed the filtered list at
`[0]`, which also errors on an empty list regardless of a preceding `len(...) > 0` check,
for the same non-short-circuit reason.

The fix:
- `Preamble()` now sources the comprehension from `*context.output.status.conditions | []`.
  CUE disjunctions discard any operand that evaluates to bottom, so this falls back to an
  empty list instead of erroring when status/conditions are absent, while still ranging
  over the real list when it exists. `if c.type != _|_` skips condition entries missing
  a `type` field instead of letting the comparison go bottom.
- `ToCUE()` now checks status/reason by filtering the (always-concrete) condition list
  with `len([for c in ... if ...]) > 0` instead of indexing `[0]`, so there's never an
  out-of-range index to evaluate.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go build ./...` passes.
- `go test ./pkg/definition/defkit/... ./pkg/cue/definition/health/...` passes.
- Added `TestConditionExprHandlesMissingStatus` in `pkg/definition/defkit/health_expr_test.go`,
  which builds the exact policy shape from the issue repro
  (`h.And(h.Exists("status"), h.Exists("status.conditions"), h.AllTrue("Ready","Synced"))`)
  and runs it through the real production evaluation path (`health.CheckHealth`, the same
  function `GetStatus` calls) against the issue's 5 fixtures: no status, empty status,
  Ready+Synced true, Ready false, and a condition entry missing `type`.
  I verified this is a genuine regression test, not a tautology: stashing only the
  `health_expr.go` change (keeping the new test) reproduces the exact errors from the
  issue (`_readyCond: undefined field: status`, `...: undefined field: conditions`,
  `...: undefined field: type`) on 3 of the 5 subtests; unstashing makes all 5 pass.
- No live cluster / e2e run: this is pure CUE-string-generation logic with no Kubernetes
  API interaction, so the unit tests above exercise the actual `cuecontext` CUE evaluator
  end to end and are the appropriate validation tier for this change.

### Special notes for your reviewer

Impact is precise, not dramatic: before this fix, `GetStatus` (`pkg/cue/definition/health/health.go`)
already returned `healthy=false` on this error path — it just also logged
`"failed to check health"` on every reconcile during the affected window, and the error
was propagated up as a warning rather than a clean `false`. This is a recovered/logged
evaluation error that produced log spam and an imprecise error path, not an incorrect
final health verdict, a panic, or an outage. The end-user-visible behavior (resource
reads as not-ready while status is absent) is unchanged; the fix removes the spurious
error and makes the "absent status = unhealthy" case go through the normal, quiet path.

```release-note
Fixed `defkit` health policies built with `ConditionExpr`/`AllTrue`/`AnyTrue` erroring
instead of evaluating to unhealthy when the target resource has no `status` or
`status.conditions` yet.
```

Fixes #7284

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

