### PR TITLE
Refactor: unify provider credential fields in apply-terraform-provide…

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
+++ b/charts/vela-core/templates/defwithtemplate/apply-terraform-provider.yaml
@@ -84,21 +84,20 @@ spec:
         		$params: continue: read.$returns.value.status.state == "ready"
         	}
         }
-        providerBasic: {
+        #AlibabaProvider: {
         	accessKey!: string
         	secretKey!: string
         	region!:    string
-        }
-        #AlibabaProvider: {
-        	providerBasic
-        	type: "alibaba"
-        	name: *"alibaba-provider" | string
+        	type:       "alibaba"
+        	name:       *"alibaba-provider" | string
         }
         #AWSProvider: {
-        	providerBasic
-        	token: *"" | string
-        	type:  "aws"
-        	name:  *"aws-provider" | string
+        	accessKey!: string
+        	secretKey!: string
+        	region!:    string
+        	token:      *"" | string
+        	type:       "aws"
+        	name:       *"aws-provider" | string
         }
         #AzureProvider: {
         	subscriptionID: string
@@ -108,9 +107,11 @@ spec:
         	name:           *"azure-provider" | string
         }
         #BaiduProvider: {
-        	providerBasic
-        	type: "baidu"
-        	name: *"baidu-provider" | string
+        	accessKey!: string
+        	secretKey!: string
+        	region!:    string
+        	type:       "baidu"
+        	name:       *"baidu-provider" | string
         }
         #ECProvider: {
         	type:   "ec"

--- a/pkg/definition/gen_sdk/testdata/apply-terraform-provider.cue
+++ b/pkg/definition/gen_sdk/testdata/apply-terraform-provider.cue
@@ -80,21 +80,20 @@ template: {
 			$params: continue: read.$returns.value.status.state == "ready"
 		}
 	}
-	providerBasic: {
+	#AlibabaProvider: {
 		accessKey!: string
 		secretKey!: string
 		region!:    string
-	}
-	#AlibabaProvider: {
-		providerBasic
-		type: "alibaba"
-		name: *"alibaba-provider" | string
+		type:       "alibaba"
+		name:       *"alibaba-provider" | string
 	}
 	#AWSProvider: {
-		providerBasic
-		token: *"" | string
-		type:  "aws"
-		name:  *"aws-provider" | string
+		accessKey!: string
+		secretKey!: string
+		region!:    string
+		token:      *"" | string
+		type:       "aws"
+		name:       *"aws-provider" | string
 	}
 	#AzureProvider: {
 		subscriptionID: string
@@ -104,9 +103,11 @@ template: {
 		name:           *"azure-provider" | string
 	}
 	#BaiduProvider: {
-		providerBasic
-		type: "baidu"
-		name: *"baidu-provider" | string
+		accessKey!: string
+		secretKey!: string
+		region!:    string
+		type:       "baidu"
+		name:       *"baidu-provider" | string
 	}
 	#ECProvider: {
 		type:   "ec"

--- a/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
+++ b/vela-templates/definitions/internal/workflowstep/apply-terraform-provider.cue
@@ -84,21 +84,20 @@ template: {
 			$params: continue: read.$returns.value.status.state == "ready"
 		}
 	}
-	providerBasic: {
+	#AlibabaProvider: {
 		accessKey!: string
 		secretKey!: string
 		region!:    string
-	}
-	#AlibabaProvider: {
-		providerBasic
-		type: "alibaba"
-		name: *"alibaba-provider" | string
+		type:       "alibaba"
+		name:       *"alibaba-provider" | string
 	}
 	#AWSProvider: {
-		providerBasic
-		token: *"" | string
-		type:  "aws"
-		name:  *"aws-provider" | string
+		accessKey!: string
+		secretKey!: string
+		region!:    string
+		token:      *"" | string
+		type:       "aws"
+		name:       *"aws-provider" | string
 	}
 	#AzureProvider: {
 		subscriptionID: string
@@ -108,9 +107,11 @@ template: {
 		name:           *"azure-provider" | string
 	}
 	#BaiduProvider: {
-		providerBasic
-		type: "baidu"
-		name: *"baidu-provider" | string
+		accessKey!: string
+		secretKey!: string
+		region!:    string
+		type:       "baidu"
+		name:       *"baidu-provider" | string
 	}
 	#ECProvider: {
 		type:   "ec"


### PR DESCRIPTION

`apply-terraform-provider`'s `parameter` is a disjunction of provider structs, three of which embed a shared `providerBasic`. CUE's OpenAPI generator cannot resolve an embedding that sits inside a disjunct, so the controller cannot write the capability schema:

```
failed to generate OpenAPI v3 JSON schema for capability apply-terraform-provider:
unsupported op . for object type ({accessKey!: string, secretKey!: string, region!: string})
```

The definition applies but never syncs, so every `vela-core` install carries it at `Synced: False` with no schema ConfigMap. Inlining the three credential fields into each provider struct fixes it. No parameter is added, removed or renamed.


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. No user-facing parameter change.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Verified against `cuelang.org/go v0.14.1` (pinned on master) through the same call `GenOpenAPI` makes — `openapi.Gen` with `ExpandReferences: true` over a `#parameter`-wrapped value. Fails on master, returns a valid schema with this change.

Also checked end to end on a k3d cluster running kubevela/vela-core v1.11.0. As shipped, the definition sits at Synced=False with the error above and no workflowstep-schema-apply-terraform-provider ConfigMap. After applying the definition from this branch, it reports Synced=True and the schema ConfigMap is written.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

