### PR TITLE
Fix: enforce TraitDefinition conflictsWith at admission

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
@@ -494,6 +494,9 @@ func (h *ValidatingHandler) ValidateTraitConflicts(ctx context.Context, app *v1b
 		for i, trait := range comp.Traits {
 			def, err := getTraitDefinition(trait.Type)
 			if err != nil {
+				// Fail closed so unresolved definitions cannot bypass conflict checks, but
+				// log so operators can distinguish transient API/cache failures from policy rejects.
+				klog.Errorf("Failed to resolve TraitDefinition %q for conflict validation: %v", trait.Type, err)
 				errs = append(errs, field.InternalError(
 					field.NewPath("spec", "components").Index(compIdx).Child("traits").Index(i).Child("type"),
 					err))

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
@@ -464,18 +464,21 @@ func (h *ValidatingHandler) ValidateTraitConflicts(ctx context.Context, app *v1b
 
 	// Cache resolved TraitDefinitions across components so each trait type is fetched once.
 	defCache := make(map[string]*v1beta1.TraitDefinition)
-	getTraitDefinition := func(traitType string) *v1beta1.TraitDefinition {
+	getTraitDefinition := func(traitType string) (*v1beta1.TraitDefinition, error) {
 		if def, ok := defCache[traitType]; ok {
-			return def
+			return def, nil
 		}
 		def := &v1beta1.TraitDefinition{}
 		if err := oamutil.GetCapabilityDefinition(defCtx, h.Client, def, traitType, app.GetAnnotations()); err != nil {
-			// Existence/permission are validated elsewhere; unresolved defs are skipped here.
-			defCache[traitType] = nil
-			return nil
+			if errors.IsNotFound(err) {
+				// Existence is validated elsewhere; missing defs are skipped here.
+				defCache[traitType] = nil
+				return nil, nil
+			}
+			return nil, err
 		}
 		defCache[traitType] = def
-		return def
+		return def, nil
 	}
 
 	for compIdx, comp := range app.Spec.Components {
@@ -489,7 +492,14 @@ func (h *ValidatingHandler) ValidateTraitConflicts(ctx context.Context, app *v1b
 		}
 		var attached []attachedTrait
 		for i, trait := range comp.Traits {
-			if def := getTraitDefinition(trait.Type); def != nil {
+			def, err := getTraitDefinition(trait.Type)
+			if err != nil {
+				errs = append(errs, field.InternalError(
+					field.NewPath("spec", "components").Index(compIdx).Child("traits").Index(i).Child("type"),
+					err))
+				continue
+			}
+			if def != nil {
 				attached = append(attached, attachedTrait{traitIdx: i, def: def})
 			}
 		}
@@ -545,7 +555,13 @@ func traitConflictRuleMatches(rule string, target *v1beta1.TraitDefinition) bool
 	case strings.HasPrefix(rule, "*."):
 		group := strings.TrimPrefix(rule, "*.")
 		refName := target.Spec.Reference.Name
-		return refName != "" && strings.HasSuffix(refName, "."+group)
+		if refName == "" {
+			return false
+		}
+		if dot := strings.Index(refName, "."); dot >= 0 {
+			return refName[dot+1:] == group
+		}
+		return false
 	default:
 		return false
 	}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/kubevela/pkg/controller/sharding"
 	"github.com/kubevela/pkg/util/singleton"
 	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
@@ -36,6 +38,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/features"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
 // ValidateWorkflow validates the Application workflow
@@ -452,6 +455,102 @@ func (h *ValidatingHandler) ValidateAnnotations(_ context.Context, app *v1beta1.
 	return annotationsErrs
 }
 
+// ValidateTraitConflicts validates TraitDefinition.spec.conflictsWith for traits
+// attached to the same component. Kept outside ValidateComponents so it still
+// runs when sharding skips component schematic validation.
+func (h *ValidatingHandler) ValidateTraitConflicts(ctx context.Context, app *v1beta1.Application) field.ErrorList {
+	var errs field.ErrorList
+	defCtx := oamutil.SetNamespaceInCtx(ctx, app.Namespace)
+
+	// Cache resolved TraitDefinitions across components so each trait type is fetched once.
+	defCache := make(map[string]*v1beta1.TraitDefinition)
+	getTraitDefinition := func(traitType string) *v1beta1.TraitDefinition {
+		if def, ok := defCache[traitType]; ok {
+			return def
+		}
+		def := &v1beta1.TraitDefinition{}
+		if err := oamutil.GetCapabilityDefinition(defCtx, h.Client, def, traitType, app.GetAnnotations()); err != nil {
+			// Existence/permission are validated elsewhere; unresolved defs are skipped here.
+			defCache[traitType] = nil
+			return nil
+		}
+		defCache[traitType] = def
+		return def
+	}
+
+	for compIdx, comp := range app.Spec.Components {
+		if len(comp.Traits) < 2 {
+			continue
+		}
+
+		type attachedTrait struct {
+			traitIdx int
+			def      *v1beta1.TraitDefinition
+		}
+		var attached []attachedTrait
+		for i, trait := range comp.Traits {
+			if def := getTraitDefinition(trait.Type); def != nil {
+				attached = append(attached, attachedTrait{traitIdx: i, def: def})
+			}
+		}
+
+		for i := 0; i < len(attached); i++ {
+			for j := i + 1; j < len(attached); j++ {
+				first, second := attached[i], attached[j]
+				// Matching is unidirectional: either side declaring the other is enough.
+				if traitConflictsWith(first.def, second.def) || traitConflictsWith(second.def, first.def) {
+					errs = append(errs, field.Invalid(
+						field.NewPath("spec", "components").Index(compIdx).Child("traits").Index(second.traitIdx).Child("type"),
+						second.def.Name,
+						fmt.Sprintf("trait %q conflicts with trait %q on component %q", first.def.Name, second.def.Name, comp.Name)))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// traitConflictsWith reports whether def's conflictsWith rules match target.
+func traitConflictsWith(def, target *v1beta1.TraitDefinition) bool {
+	for _, rule := range def.Spec.ConflictsWith {
+		if traitConflictRuleMatches(rule, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// traitConflictRuleMatches checks a single conflictsWith rule against a TraitDefinition.
+// Supported rule forms (see TraitDefinitionSpec.ConflictsWith docs):
+//   - "*"                    matches any trait
+//   - "<definition-name>"    matches the trait definition's name
+//   - "<crd-name>"           matches the trait's referenced CRD name (definitionRef.name)
+//   - "*.<group>"            matches any CRD in the given API group
+//   - "labelSelector:<expr>" matches the trait definition's labels against a label selector
+func traitConflictRuleMatches(rule string, target *v1beta1.TraitDefinition) bool {
+	switch {
+	case rule == "*":
+		return true
+	case strings.HasPrefix(rule, "labelSelector:"):
+		selector, err := labels.Parse(strings.TrimPrefix(rule, "labelSelector:"))
+		if err != nil {
+			return false
+		}
+		return selector.Matches(labels.Set(target.GetLabels()))
+	case rule == target.Name:
+		return true
+	case target.Spec.Reference.Name != "" && rule == target.Spec.Reference.Name:
+		return true
+	case strings.HasPrefix(rule, "*."):
+		group := strings.TrimPrefix(rule, "*.")
+		refName := target.Spec.Reference.Name
+		return refName != "" && strings.HasSuffix(refName, "."+group)
+	default:
+		return false
+	}
+}
+
 // ValidateCreate validates the Application on creation
 func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.Application, req admission.Request) field.ErrorList {
 	var errs field.ErrorList
@@ -460,6 +559,7 @@ func (h *ValidatingHandler) ValidateCreate(ctx context.Context, app *v1beta1.App
 	errs = append(errs, h.ValidateDefinitionPermissions(ctx, app, req)...)
 	errs = append(errs, h.ValidateWorkflow(ctx, app)...)
 	errs = append(errs, h.ValidateComponents(ctx, app)...)
+	errs = append(errs, h.ValidateTraitConflicts(ctx, app)...)
 	return errs
 }
 

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -18,10 +18,9 @@ package application
 
 import (
 	"context"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -31,199 +30,115 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
-func TestTraitConflictRuleMatches(t *testing.T) {
-	cueTrait := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "scaler",
-			Labels: map[string]string{"team": "platform"},
-		},
-	}
-	crdTrait := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "service"},
-		Spec: v1beta1.TraitDefinitionSpec{
-			Reference: common.DefinitionReference{Name: "services.k8s.io"},
-		},
-	}
-	nestedGroupTrait := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
-		Spec: v1beta1.TraitDefinitionSpec{
-			Reference: common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
-		},
-	}
+var _ = Describe("Trait conflict validation", func() {
+	Describe("traitConflictRuleMatches", func() {
+		cueTrait := &v1beta1.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "scaler",
+				Labels: map[string]string{"team": "platform"},
+			},
+		}
+		crdTrait := &v1beta1.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "service"},
+			Spec: v1beta1.TraitDefinitionSpec{
+				Reference: common.DefinitionReference{Name: "services.k8s.io"},
+			},
+		}
+		nestedGroupTrait := &v1beta1.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+			Spec: v1beta1.TraitDefinitionSpec{
+				Reference: common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
+			},
+		}
 
-	testCases := []struct {
-		name   string
-		rule   string
-		target *v1beta1.TraitDefinition
-		want   bool
-	}{
-		{name: "wildcard", rule: "*", target: cueTrait, want: true},
-		{name: "definition name match", rule: "scaler", target: cueTrait, want: true},
-		{name: "definition name miss", rule: "ingress", target: cueTrait, want: false},
-		{name: "crd name match", rule: "services.k8s.io", target: crdTrait, want: true},
-		{name: "crd name ignored for empty reference", rule: "services.k8s.io", target: cueTrait, want: false},
-		{name: "group wildcard match", rule: "*.k8s.io", target: crdTrait, want: true},
-		{name: "group wildcard does not match nested group suffix", rule: "*.k8s.io", target: nestedGroupTrait, want: false},
-		{name: "group wildcard miss", rule: "*.networking.k8s.io", target: crdTrait, want: false},
-		{name: "group wildcard ignored for empty reference", rule: "*.k8s.io", target: cueTrait, want: false},
-		{name: "label selector match", rule: "labelSelector:team=platform", target: cueTrait, want: true},
-		{name: "label selector miss", rule: "labelSelector:team=edge", target: cueTrait, want: false},
-		{name: "invalid label selector", rule: "labelSelector:@@@", target: cueTrait, want: false},
-	}
+		DescribeTable("rule matching",
+			func(rule string, target *v1beta1.TraitDefinition, want bool) {
+				Expect(traitConflictRuleMatches(rule, target)).To(Equal(want))
+			},
+			Entry("wildcard", "*", cueTrait, true),
+			Entry("definition name match", "scaler", cueTrait, true),
+			Entry("definition name miss", "ingress", cueTrait, false),
+			Entry("crd name match", "services.k8s.io", crdTrait, true),
+			Entry("crd name ignored for empty reference", "services.k8s.io", cueTrait, false),
+			Entry("group wildcard match", "*.k8s.io", crdTrait, true),
+			Entry("group wildcard does not match nested group suffix", "*.k8s.io", nestedGroupTrait, false),
+			Entry("group wildcard miss", "*.networking.k8s.io", crdTrait, false),
+			Entry("group wildcard ignored for empty reference", "*.k8s.io", cueTrait, false),
+			Entry("label selector match", "labelSelector:team=platform", cueTrait, true),
+			Entry("label selector miss", "labelSelector:team=edge", cueTrait, false),
+			Entry("invalid label selector", "labelSelector:@@@", cueTrait, false),
+		)
+	})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, traitConflictRuleMatches(tc.rule, tc.target))
-		})
-	}
-}
+	Describe("ValidateTraitConflicts", func() {
+		var (
+			scheme         *runtime.Scheme
+			conflictA      *v1beta1.TraitDefinition
+			conflictB      *v1beta1.TraitDefinition
+			scaler         *v1beta1.TraitDefinition
+			service        *v1beta1.TraitDefinition
+			ingress        *v1beta1.TraitDefinition
+			gateway        *v1beta1.TraitDefinition
+			labelConflict  *v1beta1.TraitDefinition
+			nsConflictA    *v1beta1.TraitDefinition
+			baseObjects    []runtime.Object
+		)
 
-func TestValidateTraitConflicts(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, v1beta1.AddToScheme(scheme))
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(v1beta1.AddToScheme(scheme)).To(Succeed())
 
-	conflictA := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: oam.SystemDefinitionNamespace},
-		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"conflict-b"}},
-	}
-	conflictB := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: oam.SystemDefinitionNamespace},
-		Spec:       v1beta1.TraitDefinitionSpec{},
-	}
-	scaler := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "scaler", Namespace: oam.SystemDefinitionNamespace},
-		Spec:       v1beta1.TraitDefinitionSpec{},
-	}
-	service := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: oam.SystemDefinitionNamespace},
-		Spec: v1beta1.TraitDefinitionSpec{
-			Reference: common.DefinitionReference{Name: "services.k8s.io"},
-		},
-	}
-	ingress := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ingress",
-			Namespace: oam.SystemDefinitionNamespace,
-			Labels:    map[string]string{"feature": "expose"},
-		},
-		Spec: v1beta1.TraitDefinitionSpec{
-			Reference:     common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
-			ConflictsWith: []string{"*.networking.k8s.io"},
-		},
-	}
-	gateway := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: oam.SystemDefinitionNamespace},
-		Spec: v1beta1.TraitDefinitionSpec{
-			Reference: common.DefinitionReference{Name: "gateways.networking.k8s.io"},
-		},
-	}
-	labelConflict := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "label-conflict", Namespace: oam.SystemDefinitionNamespace},
-		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"labelSelector:feature=expose"}},
-	}
-	// Namespaced override of conflict-a declares a conflict; the system one does not.
-	nsConflictA := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: "default"},
-		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"scaler"}},
-	}
-
-	baseObjects := []runtime.Object{
-		conflictA.DeepCopy(), conflictB.DeepCopy(), scaler.DeepCopy(),
-		service.DeepCopy(), ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
-	}
-
-	testCases := []struct {
-		name               string
-		objects            []runtime.Object
-		extraObjects       []runtime.Object
-		traits             []common.ApplicationTrait
-		expectedErrorCount int
-	}{
-		{
-			name: "unidirectional definition-name conflict is rejected",
-			traits: []common.ApplicationTrait{
-				{Type: "conflict-a"},
-				{Type: "conflict-b"},
-			},
-			expectedErrorCount: 1,
-		},
-		{
-			name: "non-conflicting traits are allowed",
-			traits: []common.ApplicationTrait{
-				{Type: "conflict-a"},
-				{Type: "scaler"},
-			},
-			expectedErrorCount: 0,
-		},
-		{
-			name: "single trait cannot conflict",
-			traits: []common.ApplicationTrait{
-				{Type: "conflict-a"},
-			},
-			expectedErrorCount: 0,
-		},
-		{
-			name: "crd name conflict is rejected",
-			objects: func() []runtime.Object {
-				objects := make([]runtime.Object, 0, len(baseObjects))
-				for _, o := range baseObjects {
-					if td, ok := o.(*v1beta1.TraitDefinition); ok && td.Name == "conflict-a" {
-						td = td.DeepCopy()
-						td.Spec.ConflictsWith = []string{"services.k8s.io"}
-						objects = append(objects, td)
-						continue
-					}
-					objects = append(objects, o.DeepCopyObject())
-				}
-				return objects
-			}(),
-			traits: []common.ApplicationTrait{
-				{Type: "conflict-a"},
-				{Type: "service"},
-			},
-			expectedErrorCount: 1,
-		},
-		{
-			name: "group wildcard conflict is rejected",
-			traits: []common.ApplicationTrait{
-				{Type: "ingress"},
-				{Type: "gateway"},
-			},
-			expectedErrorCount: 1,
-		},
-		{
-			name: "labelSelector conflict is rejected",
-			traits: []common.ApplicationTrait{
-				{Type: "label-conflict"},
-				{Type: "ingress"},
-			},
-			expectedErrorCount: 1,
-		},
-		{
-			name: "namespaced TraitDefinition overrides system definition",
-			extraObjects: []runtime.Object{
-				nsConflictA.DeepCopy(),
-			},
-			traits: []common.ApplicationTrait{
-				{Type: "conflict-a"},
-				{Type: "scaler"},
-			},
-			// System conflict-a only conflicts with conflict-b. The namespaced
-			// override conflicts with scaler and must win the lookup.
-			expectedErrorCount: 1,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			objects := tc.objects
-			if objects == nil {
-				objects = append([]runtime.Object{}, baseObjects...)
-				if tc.extraObjects != nil {
-					objects = append(objects, tc.extraObjects...)
-				}
+			conflictA = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: oam.SystemDefinitionNamespace},
+				Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"conflict-b"}},
+			}
+			conflictB = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: oam.SystemDefinitionNamespace},
+				Spec:       v1beta1.TraitDefinitionSpec{},
+			}
+			scaler = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "scaler", Namespace: oam.SystemDefinitionNamespace},
+				Spec:       v1beta1.TraitDefinitionSpec{},
+			}
+			service = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: oam.SystemDefinitionNamespace},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Reference: common.DefinitionReference{Name: "services.k8s.io"},
+				},
+			}
+			ingress = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: oam.SystemDefinitionNamespace,
+					Labels:    map[string]string{"feature": "expose"},
+				},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Reference:     common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
+					ConflictsWith: []string{"*.networking.k8s.io"},
+				},
+			}
+			gateway = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: oam.SystemDefinitionNamespace},
+				Spec: v1beta1.TraitDefinitionSpec{
+					Reference: common.DefinitionReference{Name: "gateways.networking.k8s.io"},
+				},
+			}
+			labelConflict = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "label-conflict", Namespace: oam.SystemDefinitionNamespace},
+				Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"labelSelector:feature=expose"}},
+			}
+			nsConflictA = &v1beta1.TraitDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: "default"},
+				Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"scaler"}},
 			}
 
+			baseObjects = []runtime.Object{
+				conflictA.DeepCopy(), conflictB.DeepCopy(), scaler.DeepCopy(),
+				service.DeepCopy(), ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
+			}
+		})
+
+		validateWith := func(objects []runtime.Object, traits []common.ApplicationTrait) int {
 			handler := &ValidatingHandler{
 				Client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build(),
 			}
@@ -233,13 +148,73 @@ func TestValidateTraitConflicts(t *testing.T) {
 					Components: []common.ApplicationComponent{{
 						Name:   "web",
 						Type:   "webservice",
-						Traits: tc.traits,
+						Traits: traits,
 					}},
 				},
 			}
+			return len(handler.ValidateTraitConflicts(context.Background(), app))
+		}
 
-			errs := handler.ValidateTraitConflicts(context.Background(), app)
-			assert.Equal(t, tc.expectedErrorCount, len(errs), "errs=%v", errs)
+		It("rejects unidirectional definition-name conflict", func() {
+			Expect(validateWith(baseObjects, []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "conflict-b"},
+			})).To(Equal(1))
 		})
-	}
-}
+
+		It("allows non-conflicting traits", func() {
+			Expect(validateWith(baseObjects, []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "scaler"},
+			})).To(Equal(0))
+		})
+
+		It("allows a single trait", func() {
+			Expect(validateWith(baseObjects, []common.ApplicationTrait{
+				{Type: "conflict-a"},
+			})).To(Equal(0))
+		})
+
+		It("rejects crd name conflict", func() {
+			objects := make([]runtime.Object, 0, len(baseObjects))
+			for _, o := range baseObjects {
+				if td, ok := o.(*v1beta1.TraitDefinition); ok && td.Name == "conflict-a" {
+					td = td.DeepCopy()
+					td.Spec.ConflictsWith = []string{"services.k8s.io"}
+					objects = append(objects, td)
+					continue
+				}
+				objects = append(objects, o.DeepCopyObject())
+			}
+			Expect(validateWith(objects, []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "service"},
+			})).To(Equal(1))
+		})
+
+		It("rejects group wildcard conflict", func() {
+			Expect(validateWith(baseObjects, []common.ApplicationTrait{
+				{Type: "ingress"},
+				{Type: "gateway"},
+			})).To(Equal(1))
+		})
+
+		It("rejects labelSelector conflict", func() {
+			Expect(validateWith(baseObjects, []common.ApplicationTrait{
+				{Type: "label-conflict"},
+				{Type: "ingress"},
+			})).To(Equal(1))
+		})
+
+		It("prefers namespaced TraitDefinition over system definition", func() {
+			objects := append([]runtime.Object{}, baseObjects...)
+			objects = append(objects, nsConflictA.DeepCopy())
+			// System conflict-a only conflicts with conflict-b. The namespaced
+			// override conflicts with scaler and must win the lookup.
+			Expect(validateWith(objects, []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "scaler"},
+			})).To(Equal(1))
+		})
+	})
+})

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -72,16 +72,16 @@ var _ = Describe("Trait conflict validation", func() {
 
 	Describe("ValidateTraitConflicts", func() {
 		var (
-			scheme         *runtime.Scheme
-			conflictA      *v1beta1.TraitDefinition
-			conflictB      *v1beta1.TraitDefinition
-			scaler         *v1beta1.TraitDefinition
-			service        *v1beta1.TraitDefinition
-			ingress        *v1beta1.TraitDefinition
-			gateway        *v1beta1.TraitDefinition
-			labelConflict  *v1beta1.TraitDefinition
-			nsConflictA    *v1beta1.TraitDefinition
-			baseObjects    []runtime.Object
+			scheme        *runtime.Scheme
+			conflictA     *v1beta1.TraitDefinition
+			conflictB     *v1beta1.TraitDefinition
+			scaler        *v1beta1.TraitDefinition
+			service       *v1beta1.TraitDefinition
+			ingress       *v1beta1.TraitDefinition
+			gateway       *v1beta1.TraitDefinition
+			labelConflict *v1beta1.TraitDefinition
+			nsConflictA   *v1beta1.TraitDefinition
+			baseObjects   []runtime.Object
 		)
 
 		BeforeEach(func() {

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -44,6 +44,12 @@ func TestTraitConflictRuleMatches(t *testing.T) {
 			Reference: common.DefinitionReference{Name: "services.k8s.io"},
 		},
 	}
+	nestedGroupTrait := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Reference: common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
+		},
+	}
 
 	testCases := []struct {
 		name   string
@@ -57,6 +63,7 @@ func TestTraitConflictRuleMatches(t *testing.T) {
 		{name: "crd name match", rule: "services.k8s.io", target: crdTrait, want: true},
 		{name: "crd name ignored for empty reference", rule: "services.k8s.io", target: cueTrait, want: false},
 		{name: "group wildcard match", rule: "*.k8s.io", target: crdTrait, want: true},
+		{name: "group wildcard does not match nested group suffix", rule: "*.k8s.io", target: nestedGroupTrait, want: false},
 		{name: "group wildcard miss", rule: "*.networking.k8s.io", target: crdTrait, want: false},
 		{name: "group wildcard ignored for empty reference", rule: "*.k8s.io", target: cueTrait, want: false},
 		{name: "label selector match", rule: "labelSelector:team=platform", target: cueTrait, want: true},
@@ -127,6 +134,7 @@ func TestValidateTraitConflicts(t *testing.T) {
 
 	testCases := []struct {
 		name               string
+		objects            []runtime.Object
 		extraObjects       []runtime.Object
 		traits             []common.ApplicationTrait
 		expectedErrorCount int
@@ -156,12 +164,14 @@ func TestValidateTraitConflicts(t *testing.T) {
 		},
 		{
 			name: "crd name conflict is rejected",
-			extraObjects: []runtime.Object{
+			objects: []runtime.Object{
 				func() runtime.Object {
 					td := conflictA.DeepCopy()
 					td.Spec.ConflictsWith = []string{"services.k8s.io"}
 					return td
 				}(),
+				conflictB.DeepCopy(), scaler.DeepCopy(), service.DeepCopy(),
+				ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
 			},
 			traits: []common.ApplicationTrait{
 				{Type: "conflict-a"},
@@ -202,15 +212,12 @@ func TestValidateTraitConflicts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			objects := append([]runtime.Object{}, baseObjects...)
-			if tc.name == "crd name conflict is rejected" {
-				objects = []runtime.Object{
-					conflictB.DeepCopy(), scaler.DeepCopy(), service.DeepCopy(),
-					ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
+			objects := tc.objects
+			if objects == nil {
+				objects = append([]runtime.Object{}, baseObjects...)
+				if tc.extraObjects != nil {
+					objects = append(objects, tc.extraObjects...)
 				}
-			}
-			if tc.extraObjects != nil {
-				objects = append(objects, tc.extraObjects...)
 			}
 
 			handler := &ValidatingHandler{
@@ -231,39 +238,4 @@ func TestValidateTraitConflicts(t *testing.T) {
 			assert.Equal(t, tc.expectedErrorCount, len(errs), "errs=%v", errs)
 		})
 	}
-}
-
-func TestValidateTraitConflictsRunsOutsideValidateComponents(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, v1beta1.AddToScheme(scheme))
-
-	conflictA := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: oam.SystemDefinitionNamespace},
-		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"conflict-b"}},
-	}
-	conflictB := &v1beta1.TraitDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: oam.SystemDefinitionNamespace},
-	}
-
-	handler := &ValidatingHandler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(conflictA, conflictB).Build(),
-	}
-	app := &v1beta1.Application{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
-		Spec: v1beta1.ApplicationSpec{
-			Components: []common.ApplicationComponent{{
-				Name: "web",
-				Type: "webservice",
-				Traits: []common.ApplicationTrait{
-					{Type: "conflict-a"},
-					{Type: "conflict-b"},
-				},
-			}},
-		},
-	}
-
-	// ValidateTraitConflicts itself must report the conflict even when component
-	// schematic validation would be skipped under sharding.
-	errs := handler.ValidateTraitConflicts(context.Background(), app)
-	require.Len(t, errs, 1)
 }

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestTraitConflictRuleMatches(t *testing.T) {
+	cueTrait := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "scaler",
+			Labels: map[string]string{"team": "platform"},
+		},
+	}
+	crdTrait := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "service"},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Reference: common.DefinitionReference{Name: "services.k8s.io"},
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		rule   string
+		target *v1beta1.TraitDefinition
+		want   bool
+	}{
+		{name: "wildcard", rule: "*", target: cueTrait, want: true},
+		{name: "definition name match", rule: "scaler", target: cueTrait, want: true},
+		{name: "definition name miss", rule: "ingress", target: cueTrait, want: false},
+		{name: "crd name match", rule: "services.k8s.io", target: crdTrait, want: true},
+		{name: "crd name ignored for empty reference", rule: "services.k8s.io", target: cueTrait, want: false},
+		{name: "group wildcard match", rule: "*.k8s.io", target: crdTrait, want: true},
+		{name: "group wildcard miss", rule: "*.networking.k8s.io", target: crdTrait, want: false},
+		{name: "group wildcard ignored for empty reference", rule: "*.k8s.io", target: cueTrait, want: false},
+		{name: "label selector match", rule: "labelSelector:team=platform", target: cueTrait, want: true},
+		{name: "label selector miss", rule: "labelSelector:team=edge", target: cueTrait, want: false},
+		{name: "invalid label selector", rule: "labelSelector:@@@", target: cueTrait, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, traitConflictRuleMatches(tc.rule, tc.target))
+		})
+	}
+}
+
+func TestValidateTraitConflicts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	conflictA := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: oam.SystemDefinitionNamespace},
+		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"conflict-b"}},
+	}
+	conflictB := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: oam.SystemDefinitionNamespace},
+		Spec:       v1beta1.TraitDefinitionSpec{},
+	}
+	scaler := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "scaler", Namespace: oam.SystemDefinitionNamespace},
+		Spec:       v1beta1.TraitDefinitionSpec{},
+	}
+	service := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: oam.SystemDefinitionNamespace},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Reference: common.DefinitionReference{Name: "services.k8s.io"},
+		},
+	}
+	ingress := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress",
+			Namespace: oam.SystemDefinitionNamespace,
+			Labels:    map[string]string{"feature": "expose"},
+		},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Reference:     common.DefinitionReference{Name: "ingresses.networking.k8s.io"},
+			ConflictsWith: []string{"*.networking.k8s.io"},
+		},
+	}
+	gateway := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: oam.SystemDefinitionNamespace},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Reference: common.DefinitionReference{Name: "gateways.networking.k8s.io"},
+		},
+	}
+	labelConflict := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "label-conflict", Namespace: oam.SystemDefinitionNamespace},
+		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"labelSelector:feature=expose"}},
+	}
+	// Namespaced override of conflict-a declares a conflict; the system one does not.
+	nsConflictA := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: "default"},
+		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"scaler"}},
+	}
+
+	baseObjects := []runtime.Object{
+		conflictA.DeepCopy(), conflictB.DeepCopy(), scaler.DeepCopy(),
+		service.DeepCopy(), ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
+	}
+
+	testCases := []struct {
+		name               string
+		extraObjects       []runtime.Object
+		traits             []common.ApplicationTrait
+		expectedErrorCount int
+	}{
+		{
+			name: "unidirectional definition-name conflict is rejected",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "conflict-b"},
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "non-conflicting traits are allowed",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "scaler"},
+			},
+			expectedErrorCount: 0,
+		},
+		{
+			name: "single trait cannot conflict",
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+			},
+			expectedErrorCount: 0,
+		},
+		{
+			name: "crd name conflict is rejected",
+			extraObjects: []runtime.Object{
+				func() runtime.Object {
+					td := conflictA.DeepCopy()
+					td.Spec.ConflictsWith = []string{"services.k8s.io"}
+					return td
+				}(),
+			},
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "service"},
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "group wildcard conflict is rejected",
+			traits: []common.ApplicationTrait{
+				{Type: "ingress"},
+				{Type: "gateway"},
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "labelSelector conflict is rejected",
+			traits: []common.ApplicationTrait{
+				{Type: "label-conflict"},
+				{Type: "ingress"},
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "namespaced TraitDefinition overrides system definition",
+			extraObjects: []runtime.Object{
+				nsConflictA.DeepCopy(),
+			},
+			traits: []common.ApplicationTrait{
+				{Type: "conflict-a"},
+				{Type: "scaler"},
+			},
+			// System conflict-a only conflicts with conflict-b. The namespaced
+			// override conflicts with scaler and must win the lookup.
+			expectedErrorCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := append([]runtime.Object{}, baseObjects...)
+			if tc.name == "crd name conflict is rejected" {
+				objects = []runtime.Object{
+					conflictB.DeepCopy(), scaler.DeepCopy(), service.DeepCopy(),
+					ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
+				}
+			}
+			if tc.extraObjects != nil {
+				objects = append(objects, tc.extraObjects...)
+			}
+
+			handler := &ValidatingHandler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build(),
+			}
+			app := &v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{{
+						Name:   "web",
+						Type:   "webservice",
+						Traits: tc.traits,
+					}},
+				},
+			}
+
+			errs := handler.ValidateTraitConflicts(context.Background(), app)
+			assert.Equal(t, tc.expectedErrorCount, len(errs), "errs=%v", errs)
+		})
+	}
+}
+
+func TestValidateTraitConflictsRunsOutsideValidateComponents(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	conflictA := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-a", Namespace: oam.SystemDefinitionNamespace},
+		Spec:       v1beta1.TraitDefinitionSpec{ConflictsWith: []string{"conflict-b"}},
+	}
+	conflictB := &v1beta1.TraitDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "conflict-b", Namespace: oam.SystemDefinitionNamespace},
+	}
+
+	handler := &ValidatingHandler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(conflictA, conflictB).Build(),
+	}
+	app := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{{
+				Name: "web",
+				Type: "webservice",
+				Traits: []common.ApplicationTrait{
+					{Type: "conflict-a"},
+					{Type: "conflict-b"},
+				},
+			}},
+		},
+	}
+
+	// ValidateTraitConflicts itself must report the conflict even when component
+	// schematic validation would be skipped under sharding.
+	errs := handler.ValidateTraitConflicts(context.Background(), app)
+	require.Len(t, errs, 1)
+}

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -164,15 +164,19 @@ func TestValidateTraitConflicts(t *testing.T) {
 		},
 		{
 			name: "crd name conflict is rejected",
-			objects: []runtime.Object{
-				func() runtime.Object {
-					td := conflictA.DeepCopy()
-					td.Spec.ConflictsWith = []string{"services.k8s.io"}
-					return td
-				}(),
-				conflictB.DeepCopy(), scaler.DeepCopy(), service.DeepCopy(),
-				ingress.DeepCopy(), gateway.DeepCopy(), labelConflict.DeepCopy(),
-			},
+			objects: func() []runtime.Object {
+				objects := make([]runtime.Object, 0, len(baseObjects))
+				for _, o := range baseObjects {
+					if td, ok := o.(*v1beta1.TraitDefinition); ok && td.Name == "conflict-a" {
+						td = td.DeepCopy()
+						td.Spec.ConflictsWith = []string{"services.k8s.io"}
+						objects = append(objects, td)
+						continue
+					}
+					objects = append(objects, o.DeepCopyObject())
+				}
+				return objects
+			}(),
 			traits: []common.ApplicationTrait{
 				{Type: "conflict-a"},
 				{Type: "service"},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`TraitDefinition.spec.conflictsWith` was declared on the API and emitted by defkit, but never enforced. Applications could attach conflicting traits and still be admitted.

This PR adds admission-time validation in the Application validating webhook:

- Resolve each attached trait with `GetCapabilityDefinition` (app namespace first, then `vela-system`, including `@revision` types)
- Keep the check outside `ValidateComponents` so it still runs under sharding
- Match unidirectionally across the documented rule forms: definition name, CRD name, `*.group`, and `labelSelector:`

**Which issue(s) this PR fixes**:
Fixes #7294

**Bug evidence (required for bug-related PRs)**:

Reproduction from #7294: two TraitDefinitions that list each other in `conflictsWith`, attached to the same component, are admitted and reconcile normally because nothing reads the field. Docs claim KubeVela rejects such Applications.

Relevant prior state:
- Field declaration: `apis/core.oam.dev/v1beta1/core_types.go` (`ConflictsWith`)
- No webhook/controller/CLI consumer existed before this change

**Special notes for your reviewer**:

Followed the guidance on #7294:

- Use `GetCapabilityDefinition` instead of the permission-check lookup path
- Keep validation outside `ValidateComponents`
- Unidirectional matching; CRD/group rules only apply when `spec.reference` is set

Fake-client unit tests cover rule matching and the admission check.

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:
```release-note
Validate TraitDefinition.spec.conflictsWith when admitting Applications so conflicting traits on the same component are rejected.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

