### PR TITLE
Fix: stop issue-commands bot failing on expired workflow PAT

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -69,10 +69,12 @@ jobs:
           path.write_text(updated)
           print(f"patched {path}")
           PY
+      # Node 14 matches the vintage package-lock in kubevela-github-actions@v0.4.2.
+      # Newer npm (Node 20+) rejects npm ci because that lockfile is out of sync.
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version: "20"
+          node-version: "14"
       - name: Install Dependencies
         run: npm ci --production --prefix ./actions
       - name: Run Commands

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -13,27 +13,72 @@ jobs:
   bot:
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
-          repository: "oam-dev/kubevela-github-actions"
+          repository: "kubevela/kubevela-github-actions"
           path: ./actions
           ref: v0.4.2
+      # GH_KUBEVELA_COMMAND_WORKFLOW has been invalid since ~2026-04-24 (401 Bad
+      # credentials on GET /user). Prefer a still-valid override secret when present,
+      # otherwise use the workflow GITHUB_TOKEN which already has issues/PR write.
+      - name: Resolve bot token
+        id: token
+        env:
+          OVERRIDE_TOKEN: ${{ secrets.GH_KUBEVELA_COMMAND_WORKFLOW }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          token="${OVERRIDE_TOKEN:-}"
+          if [ -n "${token}" ]; then
+            code=$(curl -sS -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/user || true)
+            if [ "${code}" != "200" ]; then
+              echo "Override token rejected (HTTP ${code}); falling back to github.token" >&2
+              token="${FALLBACK_TOKEN}"
+            fi
+          else
+            echo "Override token unset; using github.token" >&2
+            token="${FALLBACK_TOKEN}"
+          fi
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "${GITHUB_OUTPUT}"
+      # Action constructor always calls users.getAuthenticated(); GITHUB_TOKEN is not a
+      # user PAT so that call 401/403s. Patch to a static actor name for error reporting.
+      - name: Patch commands action for github.token
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+          path = Path("actions/common/Action.js")
+          text = path.read_text()
+          pattern = re.compile(
+              r"this\.username\s*=\s*new github_1\.GitHub\(this\.token\)\.users\.getAuthenticated\(\)\.then\(\(v\)\s*=>\s*v\.data\.name\);"
+          )
+          new = "this.username = Promise.resolve(process.env.GITHUB_ACTOR || 'github-actions[bot]');"
+          updated, n = pattern.subn(new, text, count=1)
+          if n != 1:
+              raise SystemExit(f"expected getAuthenticated() assignment not found in {path}")
+          path.write_text(updated)
+          print(f"patched {path}")
+          PY
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version: "14"
-          cache: "npm"
-          cache-dependency-path: ./actions/package-lock.json
+          node-version: "20"
       - name: Install Dependencies
         run: npm ci --production --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands
         with:
-          token: ${{ secrets.GH_KUBEVELA_COMMAND_WORKFLOW }}
+          token: ${{ steps.token.outputs.token }}
           configPath: issue-commands
 
   backport:
@@ -124,18 +169,31 @@ jobs:
                 head_sha: pr.head.sha,
               })
               console.log("runs for " + workflow_id + ": ", JSON.stringify(runs))
-              runs.workflow_runs.forEach((workflow_run) => {
-                if (workflow_run.status === "in_progress") return
-                let handler = github.rest.actions.reRunWorkflow
-                if (action === "/retest-failed") handler = github.rest.actions.reRunWorkflowFailedJobs
-                handler({
+              // Only consider the newest completed run per workflow; skip in-progress
+              // and treat "cannot be retried" as a soft failure so a stale/success run
+              // does not fail the whole issue-commands workflow.
+              const candidates = runs.workflow_runs
+                .filter((workflow_run) => workflow_run.status !== "in_progress")
+                .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+              const workflow_run = candidates[0]
+              if (!workflow_run) {
+                console.log("no retriable runs for " + workflow_id)
+                continue
+              }
+              let handler = github.rest.actions.reRunWorkflow
+              if (action === "/retest-failed") handler = github.rest.actions.reRunWorkflowFailedJobs
+              try {
+                await handler({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   run_id: workflow_run.id
                 })
-              })
+                console.log("re-ran " + workflow_id + " run " + workflow_run.id)
+              } catch (err) {
+                console.log("skip re-run of " + workflow_id + " run " + workflow_run.id + ": " + err.message)
+              }
             }
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: comment_id,

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -171,11 +171,13 @@ jobs:
                 head_sha: pr.head.sha,
               })
               console.log("runs for " + workflow_id + ": ", JSON.stringify(runs))
-              // Only consider the newest completed run per workflow; skip in-progress
-              // and treat "cannot be retried" as a soft failure so a stale/success run
-              // does not fail the whole issue-commands workflow.
+              // Only consider the newest completed run per workflow. Skip queued/
+              // in_progress/requested/waiting/pending so we do not call re-run APIs
+              // on unfinished runs (4xx, now swallowed) and still fall back to an
+              // older completed failed run. Soft-fail "cannot be retried" so a
+              // stale/success run does not fail the whole issue-commands workflow.
               const candidates = runs.workflow_runs
-                .filter((workflow_run) => workflow_run.status !== "in_progress")
+                .filter((workflow_run) => workflow_run.status === "completed")
                 .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
               const workflow_run = candidates[0]
               if (!workflow_run) {


### PR DESCRIPTION
### Description of your changes

copilot:all

Fixes #7304

The `issue-commands` workflow has been failing on every issue label/comment since ~2026-04-24 because `secrets.GH_KUBEVELA_COMMAND_WORKFLOW` returns 401 Bad credentials on `GET /user`.

This PR:
- Validates the override secret and falls back to `github.token` when it is missing or rejected
- Adds `contents: read` on the bot job so config can be loaded with `GITHUB_TOKEN`
- Patches the vendored triage action so it does not call `users.getAuthenticated()` (incompatible with `GITHUB_TOKEN`)
- Points the actions checkout at `kubevela/kubevela-github-actions`
- Hardens `/retest` so a non-retriable workflow run does not fail the whole job

Maintainers can later rotate or delete `GH_KUBEVELA_COMMAND_WORKFLOW`; the workflow no longer depends on it being valid.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Reproduced upstream failure logs: `RequestError [HttpError]: Bad credentials` on `GET /user` in the bot job (example: https://github.com/kubevela/kubevela/actions/runs/31579250411).
- Applied the change on fork `roguepikachu/kubevela`, temporarily set the fork default branch to this fix branch (required for `issues`/`issue_comment` workflows), labeled a test issue, and confirmed a green run: https://github.com/roguepikachu/kubevela/actions/runs/31581051466
- Observed token fallback (`Override token unset; using github.token`), successful Action.js patch, `npm ci`, and `Run Commands` completion.

### Special notes for your reviewer

- No application/runtime code changes; CI workflow only.
- After merge, optionally remove or rotate the dead `GH_KUBEVELA_COMMAND_WORKFLOW` repo secret.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

