### PR TITLE
Fix: Render structured Defkit literals as valid CUE

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/format"
 )
 
 // sortedKeys returns the keys of a map[string]V in sorted order.
@@ -4014,7 +4017,13 @@ func formatCUEValue(v any) string {
 		return fmt.Sprintf("%v", val)
 	case bool:
 		return fmt.Sprintf("%v", val)
-	default:
-		return fmt.Sprintf("%v", val)
 	}
+
+	value := cuecontext.New().Encode(v)
+	if value.Err() == nil {
+		if encoded, err := format.Node(value.Syntax()); err == nil {
+			return string(encoded)
+		}
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -19,6 +19,7 @@ package defkit_test
 import (
 	"strings"
 
+	"cuelang.org/go/cue/parser"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -30,6 +31,24 @@ var _ = Describe("CUEGenerator", func() {
 
 	BeforeEach(func() {
 		gen = defkit.NewCUEGenerator()
+	})
+
+	It("should render structured literal values as valid CUE", func() {
+		comp := defkit.NewComponent("structured-literal").
+			Workload("v1", "ConfigMap").
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("v1", "ConfigMap").
+					Set("data.config", defkit.Lit([]map[string]any{
+						{
+							"encryption": []map[string]any{{"algorithm": "AES256"}},
+							"enabled":    true,
+						},
+					})))
+			})
+
+		cue := gen.GenerateFullDefinition(comp)
+		_, err := parser.ParseFile("structured-literal.cue", cue)
+		Expect(err).NotTo(HaveOccurred(), cue)
 	})
 
 	Describe("GenerateParameterSchema", func() {


### PR DESCRIPTION
## Summary

- encode `Lit` values with CUE's Go-value encoder instead of Go's display formatting
- format nested maps and slices as valid CUE while preserving the existing fallback for unsupported values
- add a regression that parses a generated component containing a nested structured literal

Fixes #7281.

## Validation

- `go test ./pkg/definition/defkit -run TestDefkit -ginkgo.focus='structured literal values' -count=1`
- `go test ./pkg/definition/defkit -count=1` (1,250 specs)
- `go vet ./pkg/definition/defkit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

