### PR TITLE
Feat: defkit support structured value schemas for maps with dynamic keys

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -3898,7 +3898,11 @@ func (g *CUEGenerator) formatArrayDefault(val any) string {
 
 // writeMapParam writes a map/object parameter.
 func (g *CUEGenerator) writeMapParam(sb *strings.Builder, p *MapParam, indent, name, optional string, depth int) {
-	// Priority: schemaRef > schema > fields > generic
+	// Priority: schemaRef > schema > value schema (dynamic keys) > fields > generic.
+	// The whole-parameter forms (schemaRef/schema) win over the value forms
+	// (OfSchemaRef/OfObject), which in turn win over the fixed-object form
+	// (WithFields). Setting both a value form and WithFields is contradictory;
+	// the value form is what gets emitted.
 	if schemaRef := p.GetSchemaRef(); schemaRef != "" {
 		// Reference to a helper definition like #HealthProbe
 		sb.WriteString(fmt.Sprintf("%s%s%s: #%s\n", indent, name, optional, schemaRef))
@@ -3908,6 +3912,32 @@ func (g *CUEGenerator) writeMapParam(sb *strings.Builder, p *MapParam, indent, n
 	if schema := p.GetSchema(); schema != "" {
 		// Raw CUE schema - output directly
 		sb.WriteString(fmt.Sprintf("%s%s%s: %s\n", indent, name, optional, schema))
+		return
+	}
+
+	// Values under dynamic keys pointing at a helper definition:
+	// name?: [string]: #Ref
+	if valueSchemaRef := p.GetValueSchemaRef(); valueSchemaRef != "" {
+		sb.WriteString(fmt.Sprintf("%s%s%s: [string]: #%s\n", indent, name, optional, valueSchemaRef))
+		return
+	}
+
+	// Values under dynamic keys with a structured schema:
+	// name?: [string]: { ... }
+	if valueFields := p.GetValueFields(); len(valueFields) > 0 {
+		if p.IsClosed() {
+			sb.WriteString(fmt.Sprintf("%s%s%s: [string]: close({\n", indent, name, optional))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s%s%s: [string]: {\n", indent, name, optional))
+		}
+		for _, field := range valueFields {
+			g.writeParam(sb, field, depth+1)
+		}
+		if p.IsClosed() {
+			sb.WriteString(fmt.Sprintf("%s})\n", indent))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s}\n", indent))
+		}
 		return
 	}
 

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -817,6 +817,116 @@ var _ = Describe("CUEGenerator", func() {
 			Expect(cue).To(ContainSubstring("annotations?:"))
 			Expect(cue).To(ContainSubstring("Labels to apply"))
 		})
+
+		It("should generate a structured value schema under dynamic keys", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.Map("accessPoints").
+						OfObject(
+							defkit.String("path").Required(),
+							defkit.Int("ownerUID").Default(1000),
+							defkit.Int("ownerGID").Default(1000),
+							defkit.String("permissions").Default("0755"),
+						).
+						Optional(),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring("accessPoints?: [string]: {"))
+			Expect(cue).To(ContainSubstring("path!: string"))
+			Expect(cue).To(ContainSubstring("ownerUID: *1000 | int"))
+			Expect(cue).To(ContainSubstring("ownerGID: *1000 | int"))
+			Expect(cue).To(ContainSubstring(`permissions: *"0755" | string`))
+		})
+
+		It("should generate a value schema reference under dynamic keys", func() {
+			comp := defkit.NewComponent("test").
+				Params(defkit.Map("accessPoints").OfSchemaRef("AccessPointConfig").Optional())
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring("accessPoints?: [string]: #AccessPointConfig"))
+		})
+
+		It("should close the value struct when Closed is set alongside OfObject", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.Map("accessPoints").
+						OfObject(defkit.String("path").Required()).
+						Closed().
+						Optional(),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring("accessPoints?: [string]: close({"))
+			Expect(cue).To(ContainSubstring("})"))
+		})
+
+		It("should keep WithFields, Of and StringKeyMap rendering unchanged", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.Map("fixed").WithFields(
+						defkit.String("path"),
+						defkit.Int("uid"),
+					),
+					defkit.Map("scalar").Of(defkit.ParamTypeString),
+					defkit.StringKeyMap("skm"),
+					defkit.Map("wholeRef").WithSchemaRef("HealthProbe"),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			// Fixed object: still a struct on the parameter itself, no [string]: key.
+			Expect(cue).To(ContainSubstring("fixed: {"))
+			Expect(cue).NotTo(ContainSubstring("fixed: [string]:"))
+			// Scalar-valued dynamic maps unchanged.
+			Expect(cue).To(ContainSubstring("scalar: [string]: string"))
+			Expect(cue).To(ContainSubstring("skm: [string]: string"))
+			// WithSchemaRef still applies to the whole parameter.
+			Expect(cue).To(ContainSubstring("wholeRef: #HealthProbe"))
+			Expect(cue).NotTo(ContainSubstring("wholeRef: [string]:"))
+		})
+
+		It("should import packages needed by nested value-schema constraints", func() {
+			comp := defkit.NewComponent("test").
+				Workload("v1", "ConfigMap").
+				Params(
+					defkit.Map("accessPoints").
+						OfObject(defkit.String("path").MinLen(1)).
+						Optional(),
+				)
+
+			cue := defkit.NewCUEGenerator().GenerateFullDefinition(comp)
+
+			// strings.MinRunes is emitted, so "strings" has to be imported or
+			// the generated CUE fails to compile.
+			Expect(cue).To(ContainSubstring("strings.MinRunes(1)"))
+			Expect(cue).To(ContainSubstring(`"strings"`))
+		})
+
+		It("should produce CUE that compiles for the dynamic-key value forms", func() {
+			// Substring assertions cannot tell a missing import from a present
+			// one, so compile the result and let CUE decide.
+			comp := defkit.NewComponent("test").
+				Workload("v1", "ConfigMap").
+				Params(
+					defkit.Map("accessPoints").
+						OfObject(
+							defkit.String("path").Required(),
+							defkit.Int("ownerUID").Default(1000),
+							defkit.String("permissions").Default("0755"),
+						).
+						Optional(),
+					defkit.Map("constrained").
+						OfObject(defkit.String("name").MinLen(3)).
+						Optional(),
+				)
+
+			val := cuecontext.New().CompileString(defkit.NewCUEGenerator().GenerateFullDefinition(comp))
+			Expect(val.Err()).ToNot(HaveOccurred())
+		})
 	})
 
 	Describe("GenerateFullDefinition with template", func() {

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -765,15 +765,22 @@ func (p *ArrayParam) GetMaxItems() *int {
 }
 
 // RequiredImports returns the CUE imports needed by this parameter's constraints.
-// MinItems/MaxItems generate list.MinItems()/list.MaxItems() which require "list".
-// Nested element fields are walked too, so an element constraint such as
-// String("name").MinLen(3) still pulls in "strings".
+// MinItems/MaxItems generate list.MinItems()/list.MaxItems() which require "list",
+// and those are emitted whichever body form wins, so "list" is unconditional.
+//
+// Nested element fields are only reported when they are actually rendered.
+// writeArrayParam ranks schemaRef > schema > fields, so a schema form silences
+// the fields; reporting their imports anyway emits a package the output never
+// references, which CUE rejects as "imported and not used".
 func (p *ArrayParam) RequiredImports() []string {
 	var imports []string
 	if p.minItems != nil || p.maxItems != nil {
 		imports = append(imports, "list")
 	}
-	return dedupeImports(append(imports, nestedParamImports(p.fields)...))
+	if p.schemaRef == "" && p.schema == "" {
+		imports = append(imports, nestedParamImports(p.fields)...)
+	}
+	return dedupeImports(imports)
 }
 
 // nestedParamImports collects the imports declared by nested field parameters.
@@ -786,6 +793,18 @@ func nestedParamImports(params []Param) []string {
 		if ir, ok := param.(ImportRequirer); ok {
 			imports = append(imports, ir.RequiredImports()...)
 		}
+	}
+	return imports
+}
+
+// nestedBranchImports collects the imports declared by params inside conditional
+// branches. Branch bodies are rendered into the struct like ordinary fields, so
+// a constraint such as String("secret").MinLen(3) inside a branch needs its
+// package imported just the same.
+func nestedBranchImports(branches []*ConditionalBranch) []string {
+	var imports []string
+	for _, branch := range branches {
+		imports = append(imports, nestedParamImports(branch.GetParams())...)
 	}
 	return imports
 }
@@ -998,12 +1017,23 @@ func (p *MapParam) GetValueSchemaRef() string {
 }
 
 // RequiredImports returns the CUE imports needed by this parameter's nested
-// fields, covering both the fixed-object form (WithFields) and the
-// dynamic-key value form (OfObject). Without this a nested constraint such as
-// String("name").MinLen(3) renders strings.MinRunes(3) with no import.
+// fields. Without it a nested constraint such as String("name").MinLen(3)
+// renders strings.MinRunes(3) with no import and the definition won't compile.
+//
+// The walk mirrors writeMapParam's priority (schemaRef > schema >
+// valueSchemaRef > valueFields > fields/validators/conditionalFields) and stops
+// at whichever form wins, because only that form's body is rendered. Reporting
+// a losing form's imports emits a package the output never references, which
+// CUE rejects as "imported and not used".
 func (p *MapParam) RequiredImports() []string {
+	if p.schemaRef != "" || p.schema != "" || p.valueSchemaRef != "" {
+		return nil
+	}
+	if len(p.valueFields) > 0 {
+		return dedupeImports(nestedParamImports(p.valueFields))
+	}
 	imports := nestedParamImports(p.fields)
-	imports = append(imports, nestedParamImports(p.valueFields)...)
+	imports = append(imports, nestedBranchImports(p.conditionalFields)...)
 	return dedupeImports(imports)
 }
 

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -773,7 +773,7 @@ func (p *ArrayParam) RequiredImports() []string {
 	if p.minItems != nil || p.maxItems != nil {
 		imports = append(imports, "list")
 	}
-	return append(imports, nestedParamImports(p.fields)...)
+	return dedupeImports(append(imports, nestedParamImports(p.fields)...))
 }
 
 // nestedParamImports collects the imports declared by nested field parameters.
@@ -788,6 +788,26 @@ func nestedParamImports(params []Param) []string {
 		}
 	}
 	return imports
+}
+
+// dedupeImports drops repeated entries while keeping first-occurrence order.
+// Sibling fields commonly need the same package (e.g. two String fields with
+// MinLen both need "strings"), and RequiredImports() is a public API asserted
+// with exact slice equality in existing tests, so callers normalize before
+// returning rather than relying on downstream import collection to dedupe.
+func dedupeImports(imports []string) []string {
+	if len(imports) == 0 {
+		return imports
+	}
+	var deduped []string
+	seen := make(map[string]bool, len(imports))
+	for _, imp := range imports {
+		if !seen[imp] {
+			seen[imp] = true
+			deduped = append(deduped, imp)
+		}
+	}
+	return deduped
 }
 
 // --- ArrayParam Runtime Condition Methods ---
@@ -983,7 +1003,8 @@ func (p *MapParam) GetValueSchemaRef() string {
 // String("name").MinLen(3) renders strings.MinRunes(3) with no import.
 func (p *MapParam) RequiredImports() []string {
 	imports := nestedParamImports(p.fields)
-	return append(imports, nestedParamImports(p.valueFields)...)
+	imports = append(imports, nestedParamImports(p.valueFields)...)
+	return dedupeImports(imports)
 }
 
 // WithSchema sets a raw CUE schema for the map structure.

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -766,11 +766,28 @@ func (p *ArrayParam) GetMaxItems() *int {
 
 // RequiredImports returns the CUE imports needed by this parameter's constraints.
 // MinItems/MaxItems generate list.MinItems()/list.MaxItems() which require "list".
+// Nested element fields are walked too, so an element constraint such as
+// String("name").MinLen(3) still pulls in "strings".
 func (p *ArrayParam) RequiredImports() []string {
+	var imports []string
 	if p.minItems != nil || p.maxItems != nil {
-		return []string{"list"}
+		imports = append(imports, "list")
 	}
-	return nil
+	return append(imports, nestedParamImports(p.fields)...)
+}
+
+// nestedParamImports collects the imports declared by nested field parameters.
+// Only top-level parameters are scanned by the generator, so container params
+// (maps, arrays) have to surface what their children need or the generated CUE
+// references a package it never imports.
+func nestedParamImports(params []Param) []string {
+	var imports []string
+	for _, param := range params {
+		if ir, ok := param.(ImportRequirer); ok {
+			imports = append(imports, ir.RequiredImports()...)
+		}
+	}
+	return imports
 }
 
 // --- ArrayParam Runtime Condition Methods ---
@@ -838,6 +855,8 @@ type MapParam struct {
 	keyType           ParamType
 	valueType         ParamType
 	fields            []Param              // fields for structured map values
+	valueFields       []Param              // schema for values under dynamic keys ([string]: {...})
+	valueSchemaRef    string               // helper definition for values under dynamic keys ([string]: #Ref)
 	schema            string               // raw CUE schema for the map structure
 	schemaRef         string               // reference to a helper definition (e.g., "HealthProbe")
 	closed            bool                 // when true, wraps struct output in close({...})
@@ -903,6 +922,68 @@ func (p *MapParam) WithFields(fields ...Param) *MapParam {
 // GetFields returns the field definitions for map values.
 func (p *MapParam) GetFields() []Param {
 	return p.fields
+}
+
+// OfObject sets a structured schema for the values held under dynamic keys,
+// the Go equivalent of map[string]SomeStruct.
+//
+// This differs from WithFields, which describes a fixed object on the map
+// parameter itself. OfObject describes what each value looks like:
+//
+//	Map("accessPoints").OfObject(
+//		String("path").Required(),
+//		Int("ownerUID").Default(1000),
+//	).Optional()
+//
+// generates:
+//
+//	accessPoints?: [string]: {
+//		path!:     string
+//		ownerUID:  *1000 | int
+//	}
+//
+// Fields keep the defaults, constraints and nesting they would have as
+// ordinary object parameters. Closed() applies to the value struct when
+// OfObject is used, emitting [string]: close({...}).
+func (p *MapParam) OfObject(fields ...Param) *MapParam {
+	p.valueFields = append(p.valueFields, fields...)
+	return p
+}
+
+// GetValueFields returns the schema for values under dynamic keys.
+func (p *MapParam) GetValueFields() []Param {
+	return p.valueFields
+}
+
+// OfSchemaRef points the values under dynamic keys at a reusable helper
+// definition, giving [string]: #Ref.
+//
+//	Map("accessPoints").OfSchemaRef("AccessPointConfig").Optional()
+//
+// generates:
+//
+//	accessPoints?: [string]: #AccessPointConfig
+//
+// This differs from WithSchemaRef, which applies the reference to the whole
+// parameter and yields accessPoints?: #AccessPointConfig instead.
+func (p *MapParam) OfSchemaRef(ref string) *MapParam {
+	p.valueSchemaRef = ref
+	return p
+}
+
+// GetValueSchemaRef returns the helper definition used for values under
+// dynamic keys.
+func (p *MapParam) GetValueSchemaRef() string {
+	return p.valueSchemaRef
+}
+
+// RequiredImports returns the CUE imports needed by this parameter's nested
+// fields, covering both the fixed-object form (WithFields) and the
+// dynamic-key value form (OfObject). Without this a nested constraint such as
+// String("name").MinLen(3) renders strings.MinRunes(3) with no import.
+func (p *MapParam) RequiredImports() []string {
+	imports := nestedParamImports(p.fields)
+	return append(imports, nestedParamImports(p.valueFields)...)
 }
 
 // WithSchema sets a raw CUE schema for the map structure.

--- a/pkg/definition/defkit/param_test.go
+++ b/pkg/definition/defkit/param_test.go
@@ -290,6 +290,30 @@ var _ = Describe("Parameters", func() {
 				defkit.String("name"),
 			).RequiredImports()).To(BeEmpty())
 		})
+
+		It("should not duplicate an import needed by more than one nested field", func() {
+			Expect(defkit.Map("m").WithFields(
+				defkit.String("first").MinLen(3),
+				defkit.String("second").MinLen(3),
+			).RequiredImports()).To(Equal([]string{"strings"}))
+
+			Expect(defkit.Map("m").OfObject(
+				defkit.String("first").MinLen(3),
+				defkit.String("second").MaxLen(63),
+			).RequiredImports()).To(Equal([]string{"strings"}))
+
+			// Same package needed by both WithFields and OfObject on the same map.
+			Expect(defkit.Map("m").WithFields(
+				defkit.String("fixed").MinLen(3),
+			).OfObject(
+				defkit.String("dynamic").MaxLen(63),
+			).RequiredImports()).To(Equal([]string{"strings"}))
+
+			Expect(defkit.Array("labels").WithFields(
+				defkit.String("first").MinLen(3),
+				defkit.String("second").MinLen(3),
+			).MinItems(1).RequiredImports()).To(Equal([]string{"list", "strings"}))
+		})
 	})
 
 	Context("StructParam", func() {

--- a/pkg/definition/defkit/param_test.go
+++ b/pkg/definition/defkit/param_test.go
@@ -314,6 +314,57 @@ var _ = Describe("Parameters", func() {
 				defkit.String("second").MinLen(3),
 			).MinItems(1).RequiredImports()).To(Equal([]string{"list", "strings"}))
 		})
+
+		It("should not report imports for a form the generator will not render", func() {
+			// writeMapParam ranks schemaRef > schema > valueSchemaRef > valueFields >
+			// fields, and returns early. Reporting a losing form's import emits a
+			// package the output never references: "imported and not used".
+			Expect(defkit.Map("m").WithSchemaRef("Ref").OfObject(
+				defkit.String("y").MinLen(3),
+			).RequiredImports()).To(BeEmpty())
+
+			Expect(defkit.Map("m").WithSchema("{...}").WithFields(
+				defkit.String("y").MinLen(3),
+			).RequiredImports()).To(BeEmpty())
+
+			Expect(defkit.Map("m").OfSchemaRef("Ref").OfObject(
+				defkit.String("y").MinLen(3),
+			).RequiredImports()).To(BeEmpty())
+
+			// valueFields wins over fields, so only valueFields is walked.
+			Expect(defkit.Map("m").WithFields(
+				defkit.String("fixed").MinLen(3),
+			).OfObject(
+				defkit.String("dynamic"),
+			).RequiredImports()).To(BeEmpty())
+
+			// list is still needed: MinItems renders whichever array form wins.
+			Expect(defkit.Array("a").WithSchema("[...int]").WithFields(
+				defkit.String("y").MinLen(3),
+			).MinItems(1).RequiredImports()).To(Equal([]string{"list"}))
+
+			Expect(defkit.Array("a").WithSchemaRef("Ref").WithFields(
+				defkit.String("y").MinLen(3),
+			).RequiredImports()).To(BeEmpty())
+		})
+
+		It("should report imports needed by conditional branch params", func() {
+			// Branch bodies are rendered into the struct like ordinary fields.
+			Expect(defkit.Map("cfg").ConditionalFields(
+				defkit.WhenParam(defkit.Bool("flag").Eq(true)).Params(
+					defkit.String("secret").MinLen(3),
+				),
+			).RequiredImports()).To(Equal([]string{"strings"}))
+
+			// deduped against fields needing the same package
+			Expect(defkit.Map("cfg").WithFields(
+				defkit.String("plain").MinLen(3),
+			).ConditionalFields(
+				defkit.WhenParam(defkit.Bool("flag").Eq(true)).Params(
+					defkit.String("secret").MinLen(3),
+				),
+			).RequiredImports()).To(Equal([]string{"strings"}))
+		})
 	})
 
 	Context("StructParam", func() {

--- a/pkg/definition/defkit/param_test.go
+++ b/pkg/definition/defkit/param_test.go
@@ -253,6 +253,43 @@ var _ = Describe("Parameters", func() {
 			Expect(p.IsOptional()).To(BeTrue())
 			Expect(p.ValueType()).To(Equal(defkit.ParamTypeString))
 		})
+
+		It("should store a structured value schema via OfObject", func() {
+			p := defkit.Map("accessPoints").OfObject(
+				defkit.String("path").Required(),
+				defkit.Int("ownerUID").Default(1000),
+			).Optional()
+			Expect(p.GetValueFields()).To(HaveLen(2))
+			Expect(p.GetValueFields()[0].Name()).To(Equal("path"))
+			Expect(p.GetValueFields()[1].Name()).To(Equal("ownerUID"))
+			// OfObject describes the value, not a fixed object on the map itself.
+			Expect(p.GetFields()).To(BeEmpty())
+			Expect(p.IsOptional()).To(BeTrue())
+		})
+
+		It("should store a value schema reference via OfSchemaRef", func() {
+			p := defkit.Map("accessPoints").OfSchemaRef("AccessPointConfig").Optional()
+			Expect(p.GetValueSchemaRef()).To(Equal("AccessPointConfig"))
+			// WithSchemaRef applies to the whole parameter and stays separate.
+			Expect(p.GetSchemaRef()).To(BeEmpty())
+		})
+
+		It("should surface nested field imports from both WithFields and OfObject", func() {
+			// Only top-level params are scanned for imports, so a map has to
+			// report what its children need.
+			Expect(defkit.Map("m").WithFields(
+				defkit.String("name").MinLen(3),
+			).RequiredImports()).To(ContainElement("strings"))
+
+			Expect(defkit.Map("m").OfObject(
+				defkit.String("name").MaxLen(63),
+			).RequiredImports()).To(ContainElement("strings"))
+
+			// No constraints means no imports.
+			Expect(defkit.Map("m").OfObject(
+				defkit.String("name"),
+			).RequiredImports()).To(BeEmpty())
+		})
 	})
 
 	Context("StructParam", func() {


### PR DESCRIPTION
Fixes #7287
### Description of my changes

Two map shapes worked before this: dynamic ka fixed object via `WithFields`. Nothingcovered a dynamic-key map whose values are themselves structured, i.e. `map[string]SomeStruct`. That had to be written
as a raw CUE string through `WithSchema`, whions, defaults and optional markers thebuilders normally produce.

`OfObject` fills that gap:

    Map("accessPoints").OfObject(
        String("path").Required(),
        Int("ownerUID").Default(1000),
    ).Optional()

generates:

    accessPoints?: [string]: {
        path!:     string
        ownerUID:  *1000 | int
    }

`OfSchemaRef` does the same for a reusable definition instead of inline fields:

    Map("accessPoints").OfSchemaRef("AccessPointConfig").Optional()

generates:

    accessPoints?: [string]: #AccessPointConfig

`WithFields` and `WithSchemaRef` are unchanged — those still describe the map parameter itself (`accessPoints: {...}`
/ `accessPoints: #Ref`), not the values unde` now also applies to the value struct when`OfObject` is used, so it emits `[string]: close({...})`.

While wiring this up I ran into a second, older bug it depends on: `MapParam.RequiredImports` and
`ArrayParam.RequiredImports` only ever lookever at nested fields. So something like:

    Map("labels").WithFields(String("env").M

would emit `strings.MinRunes(3)` in the CUE gs"` above it, and the generated definitionwouldn't compile. `OfObject` hits this immediately since its whole point is nested fields, so I fixed both `MapParam` and `ArrayParam` to walk their children's `RithFields` on both types picks up the fixtoo.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevelte-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration
option, an update to the documentation is ne
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels toessary.

### How has this code been tested

Added cases in `param_test.go` for `OfObjectional`/`Closed` interaction, and in`cuegen_test.go` for the generated CUE output and for the import-collection fix (nested `MinLen`/`MaxItems` now produce the right `import` line). `go test .asses.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

