### PR TITLE
Fix: reject invalid labelSelector in TraitDefinition conflictsWith

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -42,6 +44,11 @@ const (
 	errValidateDefRef = "error occurs when validating definition reference"
 
 	failInfoDefRefOmitted = "if definition reference is omitted, patch or output with GVK is required"
+
+	// conflictsWithLabelSelectorPrefix is the prefix for label-selector rules in
+	// TraitDefinition.spec.conflictsWith. Must stay in sync with Application
+	// admission matching (traitConflictRuleMatches).
+	conflictsWithLabelSelectorPrefix = "labelSelector:"
 )
 
 var traitDefGVR = v1beta1.TraitDefinitionGVR
@@ -175,6 +182,7 @@ func RegisterValidatingHandler(mgr manager.Manager, _ controller.Args) {
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 		Validators: []TraitDefValidator{
 			TraitDefValidatorFn(ValidateDefinitionReference),
+			TraitDefValidatorFn(ValidateConflictsWith),
 			// add more validators here
 		},
 	}})
@@ -199,6 +207,22 @@ func ValidateDefinitionReference(_ context.Context, td v1beta1.TraitDefinition) 
 	if capability.CueTemplate == "" {
 		return errors.New(failInfoDefRefOmitted)
 
+	}
+	return nil
+}
+
+// ValidateConflictsWith validates TraitDefinition.spec.conflictsWith rules.
+// labelSelector: values must be parseable by labels.Parse so a typo cannot become
+// a silent no-op at Application admission (see #7315).
+func ValidateConflictsWith(_ context.Context, td v1beta1.TraitDefinition) error {
+	for i, rule := range td.Spec.ConflictsWith {
+		if !strings.HasPrefix(rule, conflictsWithLabelSelectorPrefix) {
+			continue
+		}
+		selector := strings.TrimPrefix(rule, conflictsWithLabelSelectorPrefix)
+		if _, err := labels.Parse(selector); err != nil {
+			return fmt.Errorf("spec.conflictsWith[%d]: invalid labelSelector %q: %w", i, selector, err)
+		}
 	}
 	return nil
 }

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validator_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validator_test.go
@@ -19,12 +19,14 @@ package traitdefinition
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -82,4 +84,69 @@ metadata:
   name: scaler
 spec:
 %s`, t)
+}
+
+func TestValidateConflictsWith(t *testing.T) {
+	cases := map[string]struct {
+		conflictsWith []string
+		wantErr       bool
+		errContains   string
+	}{
+		"Empty": {
+			conflictsWith: nil,
+			wantErr:       false,
+		},
+		"NonSelectorRules": {
+			// name / CRD / group rules are not validated here
+			conflictsWith: []string{"service", "services.k8s.io", "*.networking.k8s.io", "*"},
+			wantErr:       false,
+		},
+		"ValidLabelSelector": {
+			conflictsWith: []string{"labelSelector:feature=expose"},
+			wantErr:       false,
+		},
+		"ValidLabelSelectorWithSpaces": {
+			conflictsWith: []string{"labelSelector: team in (platform, sre)"},
+			wantErr:       false,
+		},
+		"InvalidLabelSelector": {
+			conflictsWith: []string{"labelSelector:@@@"},
+			wantErr:       true,
+			errContains:   `spec.conflictsWith[0]: invalid labelSelector "@@@"`,
+		},
+		"InvalidAmongValid": {
+			conflictsWith: []string{
+				"scaler",
+				"labelSelector:feature=expose",
+				"labelSelector:!!!bad",
+			},
+			wantErr:     true,
+			errContains: `spec.conflictsWith[2]: invalid labelSelector "!!!bad"`,
+		},
+		"EmptySelectorExpression": {
+			// empty selector is valid (matches everything) per labels.Parse
+			conflictsWith: []string{"labelSelector:"},
+			wantErr:       false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			td := v1beta1.TraitDefinition{}
+			td.Spec.ConflictsWith = tc.conflictsWith
+			err := ValidateConflictsWith(context.Background(), td)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Description of your changes

Fixes #7315

`TraitDefinition.spec.conflictsWith` entries of the form `labelSelector:…` are only meaningful if the selector string is parseable. Today a broken selector is ignored at Application admission (`labels.Parse` error → match false), so a typo makes the rule a silent no-op.

This PR validates every `labelSelector:` rule when the TraitDefinition is created or updated:

- admit valid selectors (`labelSelector:feature=expose`, set-based expressions, empty selector)
- deny unparseable ones (`labelSelector:@@@`) with a clear error naming the index and expression
- leave non-selector rules (`service`, `services.k8s.io`, `*.networking.k8s.io`, `*`) unchanged

Registered as a `TraitDefValidator` next to the existing definition-reference check.

**Note:** Application-side fail-closed matching (optional follow-up from #7315) depends on #7303 landing `traitConflictRuleMatches`. Definition-time rejection is the primary user-facing fix and lands independently.

### Checklist

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. I see no docs related to my features. You can ignore this item if you don't have docs related feature/bug fix.
- [x] Run `make reviewable` to ensure this PR is ready for review (local unit tests for this package; full `make reviewable` may run in CI).
- [ ] Added `type: feature`/`type: bug`/`type: documentation`/`type: field-report` label to this PR.
- [x] Add an explanation what the PR does / why we need it.
- [x] Add an explanation of the code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

