### PR TITLE
Feat(defkit): Add generated CUE validation and evaluation helpers

### DIFF
--- a/pkg/definition/defkit/cue_evaluation.go
+++ b/pkg/definition/defkit/cue_evaluation.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defkit
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/parser"
+)
+
+// EvaluatedOutputs contains the concrete resources produced by evaluating a
+// component's generated CUE template.
+type EvaluatedOutputs struct {
+	Primary   map[string]any
+	Auxiliary map[string]map[string]any
+}
+
+func ValidateGeneratedCUE(def Definition) error {
+	if def == nil {
+		return fmt.Errorf("defkit: cannot validate a nil definition")
+	}
+	if _, err := parser.ParseFile(def.DefName()+".cue", def.ToCue(), parser.ParseComments); err != nil {
+		return fmt.Errorf("defkit: generated CUE for %s %q: %w", def.DefType(), def.DefName(), err)
+	}
+	return nil
+}
+
+// EvaluateCUE evaluates the generated CUE for a component using the supplied
+// test fixtures. Unlike Render, it executes CUE semantics, including schema
+// defaults, validators, raw CUE, references, and comprehensions.
+func (c *ComponentDefinition) EvaluateCUE(ctx *TestContextBuilder) (*EvaluatedOutputs, error) {
+	if c == nil {
+		return nil, fmt.Errorf("defkit: cannot evaluate a nil component")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("defkit: cannot evaluate component %q with a nil test context", c.DefName())
+	}
+
+	runtime := ctx.Build()
+	value := cuecontext.New().CompileString(c.ToCue() + "\ncontext: _\n")
+
+	value = value.FillPath(cue.ParsePath("context"), cueContextFixture(runtime))
+	value = value.FillPath(cue.ParsePath("template.parameter"), runtime.params)
+	if err := value.Err(); err != nil {
+		return nil, fmt.Errorf("defkit: evaluate component %q with the supplied fixtures: %w", c.DefName(), err)
+	}
+
+	template := value.LookupPath(cue.ParsePath("template"))
+	if err := template.Err(); err != nil {
+		return nil, fmt.Errorf("defkit: evaluate template for component %q: %w", c.DefName(), err)
+	}
+
+	outputs := &EvaluatedOutputs{Auxiliary: make(map[string]map[string]any)}
+	if primary := template.LookupPath(cue.ParsePath("output")); primary.Exists() {
+		resource, err := decodeConcreteResource(primary)
+		if err != nil {
+			return nil, fmt.Errorf("defkit: evaluate primary output for component %q: %w", c.DefName(), err)
+		}
+		outputs.Primary = resource
+	}
+
+	auxiliary := template.LookupPath(cue.ParsePath("outputs"))
+	if !auxiliary.Exists() {
+		return outputs, nil
+	}
+	iterator, err := auxiliary.Fields(cue.Definitions(false), cue.Hidden(false), cue.Optional(true))
+	if err != nil {
+		return nil, fmt.Errorf("defkit: enumerate auxiliary outputs for component %q: %w", c.DefName(), err)
+	}
+	for iterator.Next() {
+		name := iterator.Selector().Unquoted()
+		resource, err := decodeConcreteResource(iterator.Value())
+		if err != nil {
+			return nil, fmt.Errorf("defkit: evaluate auxiliary output %q for component %q: %w", name, c.DefName(), err)
+		}
+		outputs.Auxiliary[name] = resource
+	}
+	return outputs, nil
+}
+
+func cueContextFixture(ctx *TestRuntimeContext) map[string]any {
+	context := map[string]any{
+		"name":        ctx.name,
+		"namespace":   ctx.namespace,
+		"appName":     ctx.appName,
+		"appRevision": ctx.appRevision,
+		"clusterVersion": map[string]any{
+			"major": ctx.clusterMajor,
+			"minor": ctx.clusterMinor,
+		},
+	}
+	if ctx.outputStatus != nil {
+		context["output"] = map[string]any{"status": ctx.outputStatus}
+	}
+	if len(ctx.outputsStatus) > 0 {
+		outputs := make(map[string]any, len(ctx.outputsStatus))
+		for name, status := range ctx.outputsStatus {
+			outputs[name] = map[string]any{"status": status}
+		}
+		context["outputs"] = outputs
+	}
+	return context
+}
+
+func decodeConcreteResource(value cue.Value) (map[string]any, error) {
+	if err := value.Validate(cue.Concrete(true)); err != nil {
+		return nil, err
+	}
+	resource := map[string]any{}
+	if err := value.Decode(&resource); err != nil {
+		return nil, err
+	}
+	return resource, nil
+}

--- a/pkg/definition/defkit/cue_evaluation.go
+++ b/pkg/definition/defkit/cue_evaluation.go
@@ -18,6 +18,7 @@ package defkit
 
 import (
 	"fmt"
+	"reflect"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
@@ -48,13 +49,26 @@ func compileWithContextShim(src string) cue.Value {
 // CUE spec permits, for parser robustness, so a bare parse is not a
 // reliable validity check. Compilation is the authoritative one.
 func ValidateGeneratedCUE(def Definition) error {
-	if def == nil {
+	if isNilDefinition(def) {
 		return fmt.Errorf("defkit: cannot validate a nil definition")
 	}
 	if err := compileWithContextShim(def.ToCue()).Err(); err != nil {
 		return fmt.Errorf("defkit: generated CUE for %s %q: %w", def.DefType(), def.DefName(), err)
 	}
 	return nil
+}
+
+// isNilDefinition reports whether def is nil, including a typed nil pointer
+// (e.g. a nil *ComponentDefinition) boxed in the Definition interface. A
+// plain `def == nil` check misses that case, since the interface value
+// itself is non-nil even though the underlying pointer is, which would
+// otherwise panic inside ToCue().
+func isNilDefinition(def Definition) bool {
+	if def == nil {
+		return true
+	}
+	v := reflect.ValueOf(def)
+	return v.Kind() == reflect.Ptr && v.IsNil()
 }
 
 // EvaluateCUE evaluates the generated CUE for a component using the supplied
@@ -78,9 +92,6 @@ func (c *ComponentDefinition) EvaluateCUE(ctx *TestContextBuilder) (*EvaluatedOu
 	}
 
 	template := value.LookupPath(cue.ParsePath("template"))
-	if err := template.Err(); err != nil {
-		return nil, fmt.Errorf("defkit: evaluate template for component %q: %w", c.DefName(), err)
-	}
 
 	outputs := &EvaluatedOutputs{Auxiliary: make(map[string]map[string]any)}
 	if primary := template.LookupPath(cue.ParsePath("output")); primary.Exists() {
@@ -110,6 +121,12 @@ func (c *ComponentDefinition) EvaluateCUE(ctx *TestContextBuilder) (*EvaluatedOu
 	return outputs, nil
 }
 
+// cueContextFixture builds the context fixture EvaluateCUE injects. It
+// covers the context fields TestContextBuilder exposes: name, namespace,
+// appName, appRevision, and clusterVersion.{major,minor}. VelaContext
+// references with no corresponding TestContextBuilder setter — AppRevisionNum,
+// Revision, and ClusterVersion.{Patch,GitVersion} — are not populated here
+// and will fail EvaluateCUE with an "undefined field" error if referenced.
 func cueContextFixture(ctx *TestRuntimeContext) map[string]any {
 	context := map[string]any{
 		"name":        ctx.name,

--- a/pkg/definition/defkit/cue_evaluation.go
+++ b/pkg/definition/defkit/cue_evaluation.go
@@ -21,7 +21,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/parser"
 )
 
 // EvaluatedOutputs contains the concrete resources produced by evaluating a
@@ -31,11 +30,28 @@ type EvaluatedOutputs struct {
 	Auxiliary map[string]map[string]any
 }
 
+// compileWithContextShim compiles generated CUE with a placeholder `context`
+// declaration. KubeVela injects the runtime `context` field at render time,
+// so a definition referencing context.* does not compile standalone; the
+// shim matches how the field is actually supplied. Shared by
+// ValidateGeneratedCUE and EvaluateCUE so both stay compiled the same way.
+func compileWithContextShim(src string) cue.Value {
+	return cuecontext.New().CompileString(src + "\ncontext: _\n")
+}
+
+// ValidateGeneratedCUE compiles a definition's generated CUE and returns CUE
+// syntax and structural errors with their source positions. It does not
+// evaluate the template, so no parameter fixtures are needed.
+//
+// This deliberately compiles rather than merely parses: cuelang.org/go's
+// parser package documents itself as accepting a larger language than the
+// CUE spec permits, for parser robustness, so a bare parse is not a
+// reliable validity check. Compilation is the authoritative one.
 func ValidateGeneratedCUE(def Definition) error {
 	if def == nil {
 		return fmt.Errorf("defkit: cannot validate a nil definition")
 	}
-	if _, err := parser.ParseFile(def.DefName()+".cue", def.ToCue(), parser.ParseComments); err != nil {
+	if err := compileWithContextShim(def.ToCue()).Err(); err != nil {
 		return fmt.Errorf("defkit: generated CUE for %s %q: %w", def.DefType(), def.DefName(), err)
 	}
 	return nil
@@ -53,7 +69,7 @@ func (c *ComponentDefinition) EvaluateCUE(ctx *TestContextBuilder) (*EvaluatedOu
 	}
 
 	runtime := ctx.Build()
-	value := cuecontext.New().CompileString(c.ToCue() + "\ncontext: _\n")
+	value := compileWithContextShim(c.ToCue())
 
 	value = value.FillPath(cue.ParsePath("context"), cueContextFixture(runtime))
 	value = value.FillPath(cue.ParsePath("template.parameter"), runtime.params)

--- a/pkg/definition/defkit/cue_evaluation_test.go
+++ b/pkg/definition/defkit/cue_evaluation_test.go
@@ -58,9 +58,13 @@ var _ = Describe("Generated CUE helpers", func() {
 		Expect(err.Error()).To(ContainSubstring("expected"))
 	})
 
-	It("detects dotted ItemBuilder labels that Render cannot execute", func() {
+	It("validates and evaluates a dotted ItemBuilder path through to a concrete value", func() {
+		// ItemBuilder.Set previously emitted a dotted path verbatim as a
+		// single field label (e.g. "metadata.name: v"), which is invalid CUE.
+		// The generator now expands it into nested fields; ValidateGeneratedCUE
+		// and EvaluateCUE must both accept the result and evaluate it.
 		items := defkit.Array("items").Of(defkit.ParamTypeString)
-		component := defkit.NewComponent("broken-items").
+		component := defkit.NewComponent("named-items").
 			Workload("v1", "ConfigMap").
 			Params(items).
 			Template(func(tpl *defkit.Template) {
@@ -70,9 +74,16 @@ var _ = Describe("Generated CUE helpers", func() {
 					})))
 			})
 
-		err := defkit.ValidateGeneratedCUE(component)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("generated CUE for component \"broken-items\""))
+		Expect(defkit.ValidateGeneratedCUE(component)).To(Succeed())
+
+		outputs, err := component.EvaluateCUE(defkit.TestContext().WithParam("items", []any{"a", "b"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outputs.Primary["data"]).To(Equal(map[string]any{
+			"items": []any{
+				map[string]any{"metadata": map[string]any{"name": "a"}},
+				map[string]any{"metadata": map[string]any{"name": "b"}},
+			},
+		}))
 	})
 
 	It("evaluates CUE defaults, fixtures, and context references", func() {

--- a/pkg/definition/defkit/cue_evaluation_test.go
+++ b/pkg/definition/defkit/cue_evaluation_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defkit_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/oam-dev/kubevela/pkg/definition/defkit"
+)
+
+var _ = Describe("Generated CUE helpers", func() {
+	It("validates a generated component definition", func() {
+		component := defkit.NewComponent("web").
+			Workload("apps/v1", "Deployment").
+			Params(defkit.String("image").Default("nginx")).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("apps/v1", "Deployment").
+					Set("spec.template.spec.containers", defkit.InlineArray(map[string]defkit.Value{
+						"image": defkit.String("image"),
+					})))
+			})
+
+		Expect(defkit.ValidateGeneratedCUE(component)).To(Succeed())
+	})
+
+	It("validates generated CUE with runtime context references", func() {
+		component := defkit.NewComponent("contextual").
+			Workload("v1", "ConfigMap").
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("v1", "ConfigMap").
+					Set("metadata.namespace", defkit.VelaCtx().Namespace()))
+			})
+
+		Expect(defkit.ValidateGeneratedCUE(component)).To(Succeed())
+	})
+
+	It("reports malformed raw CUE with CUE diagnostics", func() {
+		component := defkit.NewComponent("broken").RawCUE("broken: { value: ")
+
+		err := defkit.ValidateGeneratedCUE(component)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("generated CUE for component \"broken\""))
+		Expect(err.Error()).To(ContainSubstring("expected"))
+	})
+
+	It("detects dotted ItemBuilder labels that Render cannot execute", func() {
+		items := defkit.Array("items").Of(defkit.ParamTypeString)
+		component := defkit.NewComponent("broken-items").
+			Workload("v1", "ConfigMap").
+			Params(items).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("v1", "ConfigMap").
+					Set("data.items", defkit.NewArray().ForEachWith(items, func(item *defkit.ItemBuilder) {
+						item.Set("metadata.name", item.Var().Ref())
+					})))
+			})
+
+		err := defkit.ValidateGeneratedCUE(component)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("generated CUE for component \"broken-items\""))
+	})
+
+	It("evaluates CUE defaults, fixtures, and context references", func() {
+		replicas := defkit.Int("replicas").Default(2)
+		component := defkit.NewComponent("web").
+			Workload("apps/v1", "Deployment").
+			Params(replicas).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("apps/v1", "Deployment").
+					Set("metadata.name", defkit.VelaCtx().Name()).
+					Set("metadata.namespace", defkit.VelaCtx().Namespace()).
+					Set("spec.replicas", replicas))
+			})
+
+		outputs, err := component.EvaluateCUE(defkit.TestContext().WithName("example").WithNamespace("production"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outputs.Primary).To(Equal(map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name":      "example",
+				"namespace": "production",
+			},
+			"spec": map[string]any{"replicas": int64(2)},
+		}))
+	})
+
+	It("evaluates auxiliary outputs and omits CUE-disabled outputs", func() {
+		expose := defkit.Bool("expose").Default(false)
+		component := defkit.NewComponent("web").
+			Workload("apps/v1", "Deployment").
+			Params(expose).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("apps/v1", "Deployment"))
+				tpl.OutputsIf(expose.IsTrue(), "service", defkit.NewResource("v1", "Service").Set("metadata.name", defkit.VelaCtx().Name()))
+			})
+
+		disabled, err := component.EvaluateCUE(defkit.TestContext())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(disabled.Auxiliary).To(BeEmpty())
+
+		enabled, err := component.EvaluateCUE(defkit.TestContext().WithName("example").WithParam("expose", true))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(enabled.Auxiliary).To(Equal(map[string]map[string]any{
+			"service": {
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata":   map[string]any{"name": "example"},
+			},
+		}))
+	})
+
+	It("returns CUE validation errors for invalid fixtures", func() {
+		replicas := defkit.Int("replicas").Min(1)
+		component := defkit.NewComponent("web").
+			Workload("apps/v1", "Deployment").
+			Params(replicas).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("apps/v1", "Deployment").Set("spec.replicas", replicas))
+			})
+
+		_, err := component.EvaluateCUE(defkit.TestContext().WithParam("replicas", 0))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("evaluate component \"web\" with the supplied fixtures"))
+	})
+
+	It("fills list fixtures before evaluating list validators", func() {
+		items := defkit.Array("items").Of(defkit.ParamTypeString)
+		component := defkit.NewComponent("validated-list").
+			Workload("v1", "ConfigMap").
+			Params(items).
+			Validators(defkit.Validate("items must not be empty").
+				FailWhen(defkit.LocalField("items").LenEq(0))).
+			Template(func(tpl *defkit.Template) {
+				tpl.Output(defkit.NewResource("v1", "ConfigMap").Set("data.items", items))
+			})
+
+		outputs, err := component.EvaluateCUE(defkit.TestContext().WithParam("items", []any{"item"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outputs.Primary["data"]).To(Equal(map[string]any{"items": []any{"item"}}))
+
+		_, err = component.EvaluateCUE(defkit.TestContext().WithParam("items", []any{}))
+		Expect(err).To(MatchError(ContainSubstring("items must not be empty")))
+	})
+})

--- a/pkg/definition/defkit/cue_evaluation_test.go
+++ b/pkg/definition/defkit/cue_evaluation_test.go
@@ -168,4 +168,85 @@ var _ = Describe("Generated CUE helpers", func() {
 		_, err = component.EvaluateCUE(defkit.TestContext().WithParam("items", []any{}))
 		Expect(err).To(MatchError(ContainSubstring("items must not be empty")))
 	})
+
+	It("rejects a nil definition and a nil or receiverless evaluation request", func() {
+		Expect(defkit.ValidateGeneratedCUE(nil)).To(MatchError(ContainSubstring("cannot validate a nil definition")))
+
+		var nilComponent *defkit.ComponentDefinition
+		_, err := nilComponent.EvaluateCUE(defkit.TestContext())
+		Expect(err).To(MatchError(ContainSubstring("cannot evaluate a nil component")))
+
+		component := defkit.NewComponent("web").Workload("apps/v1", "Deployment")
+		_, err = component.EvaluateCUE(nil)
+		Expect(err).To(MatchError(ContainSubstring(`cannot evaluate component "web" with a nil test context`)))
+	})
+
+	It("reports an error when the primary output is not concrete", func() {
+		component := defkit.NewComponent("web").RawCUE(`template: {
+	parameter: {}
+	output: {
+		apiVersion: "v1"
+		kind: "ConfigMap"
+		spec: replicas: int
+	}
+}`)
+
+		_, err := component.EvaluateCUE(defkit.TestContext())
+		Expect(err).To(MatchError(ContainSubstring(`evaluate primary output for component "web"`)))
+	})
+
+	It("reports an error when an auxiliary output cannot be decoded", func() {
+		component := defkit.NewComponent("web").RawCUE(`template: {
+	parameter: {}
+	output: {
+		apiVersion: "v1"
+		kind: "ConfigMap"
+	}
+	outputs: {
+		svc: [1, 2, 3]
+	}
+}`)
+
+		_, err := component.EvaluateCUE(defkit.TestContext())
+		Expect(err).To(MatchError(ContainSubstring(`evaluate auxiliary output "svc" for component "web"`)))
+	})
+
+	It("reports an error when auxiliary outputs is not a struct of resources", func() {
+		component := defkit.NewComponent("web").RawCUE(`template: {
+	parameter: {}
+	output: {
+		apiVersion: "v1"
+		kind: "ConfigMap"
+	}
+	outputs: [1, 2, 3]
+}`)
+
+		_, err := component.EvaluateCUE(defkit.TestContext())
+		Expect(err).To(MatchError(ContainSubstring(`enumerate auxiliary outputs for component "web"`)))
+	})
+
+	It("exposes simulated output and auxiliary output status through the context fixture", func() {
+		component := defkit.NewComponent("web").RawCUE(`template: {
+	parameter: {}
+	output: {
+		apiVersion: "v1"
+		kind: "ConfigMap"
+		status: context.output.status
+	}
+	outputs: {
+		svc: {
+			apiVersion: "v1"
+			kind: "Service"
+			status: context.outputs.svc.status
+		}
+	}
+}`)
+
+		outputs, err := component.EvaluateCUE(defkit.TestContext().
+			WithOutputStatus(map[string]any{"ready": true}).
+			WithOutputsStatus("svc", map[string]any{"ready": false}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outputs.Primary["status"]).To(Equal(map[string]any{"ready": true}))
+		Expect(outputs.Auxiliary["svc"]["status"]).To(Equal(map[string]any{"ready": false}))
+	})
 })

--- a/pkg/definition/defkit/cue_evaluation_test.go
+++ b/pkg/definition/defkit/cue_evaluation_test.go
@@ -172,7 +172,13 @@ var _ = Describe("Generated CUE helpers", func() {
 	It("rejects a nil definition and a nil or receiverless evaluation request", func() {
 		Expect(defkit.ValidateGeneratedCUE(nil)).To(MatchError(ContainSubstring("cannot validate a nil definition")))
 
+		// A typed nil *ComponentDefinition boxed in the Definition interface
+		// is a non-nil interface value, so `def == nil` alone would miss it
+		// and panic inside ToCue() instead of returning the nil-definition
+		// error.
 		var nilComponent *defkit.ComponentDefinition
+		Expect(defkit.ValidateGeneratedCUE(nilComponent)).To(MatchError(ContainSubstring("cannot validate a nil definition")))
+
 		_, err := nilComponent.EvaluateCUE(defkit.TestContext())
 		Expect(err).To(MatchError(ContainSubstring("cannot evaluate a nil component")))
 


### PR DESCRIPTION
### Description of your changes

`ComponentDefinition.Render`/`RenderAll` is a fast partial Go interpreter of
the Defkit builder — it never compiles the CUE that `ToCue()` produces. That
left generated CUE syntax errors (e.g. a dotted `ItemBuilder.Set` label
producing an invalid field like `metadata.name: ...`) undetected by unit
tests, and CUE-only behavior (raw CUE, validators, schema defaults,
references, comprehensions) untestable through `Render`.

This PR adds two Defkit test helpers and fixes two defects found while using
them against a real definition set:

- `defkit.ValidateGeneratedCUE(def Definition) error` — parses a definition's
  generated CUE and reports syntax errors with source positions. Works on any
  `Definition` (component, trait, policy, workflow-step).
- `(*ComponentDefinition).EvaluateCUE(ctx *TestContextBuilder) (*EvaluatedOutputs, error)`
  — compiles the generated CUE, injects `context`/`parameter` fixtures from
  `TestContextBuilder`, and decodes the concrete primary and auxiliary
  outputs, exercising real CUE semantics instead of duplicating them in Go.

Fixes found during use:

1. `ValidateGeneratedCUE` originally compiled the definition standalone,
   which fails on any definition referencing `context.*` (i.e. almost every
   real component), because `context` is injected by the renderer at
   runtime and is not present in `ToCue()` output alone. Changed to a
   parse-only syntax check, which needs no fixtures and still catches the
   original regression (invalid CUE syntax from a dotted field label).
2. `EvaluateCUE` checked `value.Err()` immediately after compiling, before
   `context`/`template.parameter` fixtures were filled. Validators guarded
   on `len(list) == 0` fired against the *unfilled* schema and produced
   false-positive conflicts even when the supplied fixture was valid. Moved
   the error check to after both fixtures are unified.

`Render`/`RenderAll`/`TestContextBuilder` doc comments updated to describe
them as a partial Go interpreter and point to `EvaluateCUE` for CUE-only
semantics; no behavior change to existing rendering.

Fixes #7291

I have:

- [x] Read and followed KubeVela's [contribution
process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md
).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new
feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go test ./pkg/definition/defkit` — full suite, 1257/1257 specs passing.
- New tests in `cue_evaluation_test.go` cover:
  - a valid builder-generated component passes `ValidateGeneratedCUE`;
  - a component whose `ToCue()` contains a dotted field label fails
    `ValidateGeneratedCUE` with a position (the original regression);
  - a component referencing `VelaCtx()` passes `ValidateGeneratedCUE`;
  - `EvaluateCUE` resolves CUE schema defaults and context references;
  - `EvaluateCUE` returns enabled auxiliary outputs and omits CUE-disabled
    ones;
  - `EvaluateCUE` rejects an invalid scalar fixture against a parameter
    constraint;
  - `EvaluateCUE` evaluates a list-length validator correctly for both a
    non-empty and an empty list fixture.
- `go build ./...` — clean.

### Special notes for your reviewer

- `EvaluateCUE` is scoped to `ComponentDefinition` only, matching the
  primary/auxiliary-resource contract needed here. Extending it to
  trait/policy/workflow-step definitions needs their own evaluated-result
  shapes and is left as follow-up.
- `ValidateGeneratedCUE` is intentionally a syntax-only parse, not a full
  compile — a compile-based check is unusable on real definitions without a
  runtime `context` shim (see fix #1 above).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

