### PR TITLE
Fix: reject invalid conflictsWith label selectors

### DIFF
--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation.go
@@ -548,7 +548,9 @@ func traitConflictRuleMatches(rule string, target *v1beta1.TraitDefinition) bool
 	case strings.HasPrefix(rule, "labelSelector:"):
 		selector, err := labels.Parse(strings.TrimPrefix(rule, "labelSelector:"))
 		if err != nil {
-			return false
+			// TraitDefinition admission rejects malformed selectors. Fail closed
+			// here in case a legacy invalid definition is already stored.
+			return true
 		}
 		return selector.Matches(labels.Set(target.GetLabels()))
 	case rule == target.Name:

--- a/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/application/validation_conflicts_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Trait conflict validation", func() {
 			Entry("group wildcard ignored for empty reference", "*.k8s.io", cueTrait, false),
 			Entry("label selector match", "labelSelector:team=platform", cueTrait, true),
 			Entry("label selector miss", "labelSelector:team=edge", cueTrait, false),
-			Entry("invalid label selector", "labelSelector:@@@", cueTrait, false),
+			Entry("invalid label selector fails closed", "labelSelector:@@@", cueTrait, true),
 		)
 	})
 

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -175,9 +177,23 @@ func RegisterValidatingHandler(mgr manager.Manager, _ controller.Args) {
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 		Validators: []TraitDefValidator{
 			TraitDefValidatorFn(ValidateDefinitionReference),
+			TraitDefValidatorFn(ValidateConflictsWith),
 			// add more validators here
 		},
 	}})
+}
+
+// ValidateConflictsWith validates label selector rules in spec.conflictsWith.
+func ValidateConflictsWith(_ context.Context, td v1beta1.TraitDefinition) error {
+	for _, rule := range td.Spec.ConflictsWith {
+		if !strings.HasPrefix(rule, "labelSelector:") {
+			continue
+		}
+		if _, err := labels.Parse(strings.TrimPrefix(rule, "labelSelector:")); err != nil {
+			return fmt.Errorf("invalid spec.conflictsWith rule %q: %w", rule, err)
+		}
+	}
+	return nil
 }
 
 // ValidateDefinitionReference validates whether the trait definition is valid if

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/trait_definition_validating_handler_test.go
@@ -342,4 +342,36 @@ var _ = Describe("Test TraitDefinition validating handler", func() {
 			Expect(resp.Allowed).Should(BeTrue())
 		})
 	})
+
+	Context("Test conflictsWith admission validation", func() {
+		DescribeTable("validates label selector rules on create and update",
+			func(operation admissionv1.Operation, rules []string, allowed bool) {
+				handler.Validators = []TraitDefValidator{
+					TraitDefValidatorFn(ValidateConflictsWith),
+				}
+				traitDef := v1beta1.TraitDefinition{
+					Spec: v1beta1.TraitDefinitionSpec{ConflictsWith: rules},
+				}
+				raw, err := json.Marshal(traitDef)
+				Expect(err).Should(BeNil())
+				request := admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: operation,
+						Resource:  reqResource,
+						Object:    runtime.RawExtension{Raw: raw},
+					},
+				}
+
+				response := handler.Handle(context.TODO(), request)
+
+				Expect(response.Allowed).Should(Equal(allowed))
+				if !allowed {
+					Expect(response.Result.Message).Should(ContainSubstring(`invalid spec.conflictsWith rule "labelSelector:@@@"`))
+				}
+			},
+			Entry("allows a valid selector on create", admissionv1.Create, []string{"labelSelector:team=platform"}, true),
+			Entry("rejects an invalid selector on create", admissionv1.Create, []string{"labelSelector:@@@"}, false),
+			Entry("rejects an invalid selector on update", admissionv1.Update, []string{"labelSelector:@@@"}, false),
+		)
+	})
 })

--- a/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validator_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/traitdefinition/validator_test.go
@@ -19,14 +19,51 @@ package traitdefinition
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
+
+func TestValidateConflictsWith(t *testing.T) {
+	tests := map[string]struct {
+		rules       []string
+		wantErrText string
+	}{
+		"definition rules": {
+			rules: []string{"scaler", "services.k8s.io", "*.networking.k8s.io"},
+		},
+		"valid label selector": {
+			rules: []string{"labelSelector:team=platform,tier in (api,worker)"},
+		},
+		"invalid label selector": {
+			rules:       []string{"labelSelector:@@@"},
+			wantErrText: `invalid spec.conflictsWith rule "labelSelector:@@@"`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateConflictsWith(context.Background(), v1beta1.TraitDefinition{
+				Spec: v1beta1.TraitDefinitionSpec{ConflictsWith: tt.rules},
+			})
+			if tt.wantErrText == "" {
+				if err != nil {
+					t.Fatalf("ValidateConflictsWith() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("ValidateConflictsWith() error = %v, want error containing %q", err, tt.wantErrText)
+			}
+		})
+	}
+}
 
 func TestValidateDefinitionReference(t *testing.T) {
 	cases := map[string]struct {


### PR DESCRIPTION
### Description of your changes

Reject malformed `labelSelector:` entries in `TraitDefinition.spec.conflictsWith` during both create and update admission. The validation error identifies the invalid rule, while Application conflict matching now fails closed for malformed selectors in legacy stored definitions.

Adds focused validator, webhook admission, and conflict-matching coverage.

Fixes #7315

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. No docs update is needed because the existing documented selector syntax and API are unchanged.
- [ ] Run `make reviewable` to ensure this PR is ready for review. The focused formatting, vet, and tests below were run locally; full repository checks are delegated to CI because the local environment is Windows.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary. No backport is requested.

### How has this code been tested

- `go test ./pkg/webhook/core.oam.dev/v1beta1/traitdefinition -run '^TestValidateConflictsWith$' -count=1`
- Focused TraitDefinition Ginkgo admission specs: valid create plus invalid create/update (3/3 passed)
- Focused Application trait-conflict specs (19/19 passed; the Windows-only envtest teardown subsequently reports unsupported process signaling)
- `go vet ./pkg/webhook/core.oam.dev/v1beta1/traitdefinition ./pkg/webhook/core.oam.dev/v1beta1/application`
- `gofmt` and `git diff --check`

### Special notes for your reviewer

This is the follow-up identified during review of #7303. New definitions are rejected at admission; the matcher fallback protects clusters that already contain a malformed definition.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

