### PR TITLE
Feat(helmchart): expose CUE post-rendering on helmchart component

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/helmchart.yaml
+++ b/charts/vela-core/templates/defwithtemplate/helmchart.yaml
@@ -147,14 +147,22 @@ spec:
         			mutableTTL?:   string | *"5m"  // TTL for mutable tags (latest, dev, main)
         		}
 
-        		// Post-rendering - Future enhancement
-        		// Planned: CUE-based post-rendering for resource transformation
-        		// Would allow users to write CUE templates to modify rendered resources
-        		// with full access to KubeVela context (appName, namespace, etc.)
-        		// Requires CUE-in-CUE runtime execution capability
-        		// postRender?: {
-        		// 	template: string  // CUE template for transforming resources
-        		// }
+        		// Post-rendering transformations applied after Helm renders the
+        		// manifests but before KubeVela stamps its ownership labels, so a
+        		// template cannot patch away the labels KubeVela tracks the release by.
+        		postRender?: {
+        			// +usage=CUE template evaluated once per rendered resource. The
+        			// resource under evaluation is bound to context.resource, and the
+        			// template's `patch` field is merged back into it using the same
+        			// strategy-unify semantics traits use to patch workloads: a
+        			// patchKey annotation merges into a list by key, and a
+        			// patchStrategy=retainKeys annotation overrides a value the chart
+        			// already rendered. Producing no `patch` field leaves the resource
+        			// untouched, which is how a template scopes itself to some kinds.
+        			cue?: {
+        				template: string
+        			}
+        		}
         	}
         }
 

--- a/docs/examples/helmchart-postrender/cue/README.md
+++ b/docs/examples/helmchart-postrender/cue/README.md
@@ -1,0 +1,105 @@
+# CUE post-rendering on the `helmchart` component
+
+`options.postRender.cue` lets you transform the manifests a Helm chart renders,
+without forking the chart or waiting for it to expose a value you need.
+
+The template is evaluated **once per rendered resource**, and runs **after** Helm
+renders the chart but **before** KubeVela stamps its ownership labels. That
+ordering is deliberate: a template cannot patch away the labels KubeVela uses to
+track and garbage-collect the release.
+
+```yaml
+options:
+  postRender:
+    cue:
+      template: |
+        patch: {
+        	if context.resource.kind == "Deployment" {
+        		spec: template: spec: {
+        			// +patchKey=name
+        			containers: [{
+        				name: "podinfo"
+        				// +patchKey=name
+        				env: [{name: "DEPLOY_ENV", value: "prod"}]
+        			}]
+        		}
+        	}
+        }
+```
+
+## What the template sees
+
+| Field                  | Value                                              |
+| ---------------------- | -------------------------------------------------- |
+| `context.resource`     | the resource currently being patched, as rendered   |
+| `context.appName`      | the Application name                                |
+| `context.appNamespace` | the Application namespace                           |
+| `context.name`         | the component name                                  |
+| `context.namespace`    | the component namespace                             |
+
+The full CUE standard library (`strings`, `list`, `regexp`, ...) is available.
+Vela provider functions (`vela/kube`, `vela/http`, ...) are not: a post-render
+template is a pure transform over an already-rendered resource.
+
+## What the template produces
+
+Emit a `patch` field. It is merged into the resource using the same
+strategy-unify semantics traits use to patch workloads.
+
+**Targeting a subset of resources.** The template runs against every rendered
+resource, so guard it on whatever identifies your target. Producing no `patch`
+field at all leaves that resource untouched:
+
+```cue
+patch: {
+	if context.resource.kind == "Deployment" {
+		// only Deployments are patched; everything else passes through
+	}
+}
+```
+
+**Merging into lists.** Plain unification pairs list entries by position, which
+is rarely what you want for containers, env vars, or ports. Annotate the list
+with `// +patchKey=<field>` to match entries by a field instead, and leave the
+entries you are not changing out entirely:
+
+```cue
+// +patchKey=name
+env: [{name: "DEPLOY_ENV", value: "prod"}]
+```
+
+Use `// +patchStrategy=replace` when you really do want to discard whatever the
+chart rendered and substitute your own list.
+
+**Overriding a value the chart already set.** CUE unification can only make a
+value *more* specific, so patching `replicas: 3` over a chart that rendered
+`replicas: 1` is a conflict, not an override. Ask for the override explicitly:
+
+```cue
+spec: {
+	// +patchStrategy=retainKeys
+	replicas: 3
+}
+```
+
+This is the one sharp edge worth internalizing. It fails loudly with
+`conflicting values 3 and 1` rather than silently keeping the chart's value, so
+you will find out at render time rather than in production.
+
+## Examples
+
+| File                        | Shows                                                        |
+| --------------------------- | ------------------------------------------------------------ |
+| `inject-env.yaml`           | adding an env var to one container via `patchKey`             |
+| `annotate-and-scale.yaml`   | annotating every resource, plus a `retainKeys` replica override |
+
+Both render against the public `podinfo` chart:
+
+```bash
+vela dry-run -f inject-env.yaml
+```
+
+## Ordering
+
+When other post-render flavors are configured alongside CUE, user
+transformations run first and KubeVela's ownership labelling always runs last.

--- a/docs/examples/helmchart-postrender/cue/annotate-and-scale.yaml
+++ b/docs/examples/helmchart-postrender/cue/annotate-and-scale.yaml
@@ -1,0 +1,36 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: podinfo-annotate-and-scale
+spec:
+  components:
+    - name: podinfo
+      type: helmchart
+      properties:
+        chart:
+          source: podinfo
+          repoURL: https://stefanprodan.github.io/podinfo
+          version: 6.5.0
+        options:
+          postRender:
+            cue:
+              # Two transformations in one template:
+              #   1. annotate every rendered resource with its owning Application
+              #   2. override the replica count the chart rendered
+              #
+              # retainKeys is required for (2): CUE unification can only make a
+              # value more specific, so overriding a concrete value the chart
+              # already produced needs an explicit strategy. Without it the
+              # render fails with "conflicting values" rather than silently
+              # keeping the chart's value.
+              template: |
+                patch: {
+                	metadata: annotations: "example.com/owner": context.appName
+
+                	if context.resource.kind == "Deployment" {
+                		spec: {
+                			// +patchStrategy=retainKeys
+                			replicas: 3
+                		}
+                	}
+                }

--- a/docs/examples/helmchart-postrender/cue/inject-env.yaml
+++ b/docs/examples/helmchart-postrender/cue/inject-env.yaml
@@ -1,0 +1,35 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: podinfo-inject-env
+spec:
+  components:
+    - name: podinfo
+      type: helmchart
+      properties:
+        chart:
+          source: podinfo
+          repoURL: https://stefanprodan.github.io/podinfo
+          version: 6.5.0
+        options:
+          postRender:
+            cue:
+              # Add an env var to the "podinfo" container, without disturbing the
+              # env vars the chart already renders. patchKey=name matches list
+              # entries by their name field instead of by position.
+              template: |
+                patch: {
+                	if context.resource.kind == "Deployment" {
+                		spec: template: spec: {
+                			// +patchKey=name
+                			containers: [{
+                				name: "podinfo"
+                				// +patchKey=name
+                				env: [{
+                					name:  "DEPLOY_ENV"
+                					value: "prod"
+                				}]
+                			}]
+                		}
+                	}
+                }

--- a/pkg/cue/cuex/providers/helm/dryrun.go
+++ b/pkg/cue/cuex/providers/helm/dryrun.go
@@ -19,6 +19,7 @@ package helm
 // Client-only dry-run renderer used by webhook validation, plus the cluster Kubernetes-version lookup.
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ import (
 // cluster. Used during webhook validation to verify the chart can be fetched,
 // values are valid, and templates render without errors — without blocking on
 // real resource creation, hooks, or waiting.
-func (p *Provider) dryRunRender(ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, velaCtx *ContextParams) (string, string, error) {
+func (p *Provider) dryRunRender(ctx context.Context, ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, velaCtx *ContextParams) (string, string, error) {
 	install := action.NewInstall(&action.Configuration{})
 	install.ReleaseName = releaseName
 	install.Namespace = releaseNamespace
@@ -47,11 +48,11 @@ func (p *Provider) dryRunRender(ch *chart.Chart, releaseName, releaseNamespace s
 		install.KubeVersion = kv
 	}
 
-	install.PostRenderer = &velaLabelPostRenderer{
-		context:          velaCtx,
-		releaseName:      releaseName,
-		releaseNamespace: releaseNamespace,
+	var postRender *PostRenderParams
+	if options != nil {
+		postRender = options.PostRender
 	}
+	install.PostRenderer = newPostRenderer(ctx, postRender, velaCtx, releaseName, releaseNamespace)
 
 	if options != nil {
 		if options.SkipHooks != nil {

--- a/pkg/cue/cuex/providers/helm/dryrun_test.go
+++ b/pkg/cue/cuex/providers/helm/dryrun_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package helm
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"helm.sh/helm/v3/pkg/chart"
@@ -47,7 +49,7 @@ spec:
 				},
 			}
 
-			manifest, _, err := p.dryRunRender(ch, "test-release", "test-ns",
+			manifest, _, err := p.dryRunRender(context.Background(), ch, "test-release", "test-ns",
 				map[string]interface{}{"key": "value"}, nil, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(manifest).To(ContainSubstring("kind: Deployment"))
@@ -91,7 +93,7 @@ data:
 				Name:         "my-comp",
 				Namespace:    "test-ns",
 			}
-			manifest, _, err := p.dryRunRender(ch, "my-rel", "test-ns",
+			manifest, _, err := p.dryRunRender(context.Background(), ch, "my-rel", "test-ns",
 				map[string]interface{}{}, nil, velaCtx)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(manifest).To(ContainSubstring("kind: ConfigMap"))
@@ -100,7 +102,7 @@ data:
 
 		It("should apply skipHooks option", func() {
 			skipHooks := true
-			manifest, _, err := p.dryRunRender(ch, "my-rel", "test-ns",
+			manifest, _, err := p.dryRunRender(context.Background(), ch, "my-rel", "test-ns",
 				map[string]interface{}{}, &RenderOptionsParams{SkipHooks: &skipHooks}, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(manifest).To(ContainSubstring("kind: ConfigMap"))
@@ -119,7 +121,7 @@ spec:
     - port: 80
 `),
 			})
-			manifest, _, err := p.dryRunRender(ch, "my-rel", "test-ns",
+			manifest, _, err := p.dryRunRender(context.Background(), ch, "my-rel", "test-ns",
 				map[string]interface{}{}, nil, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(manifest).To(ContainSubstring("kind: ConfigMap"))
@@ -136,7 +138,7 @@ spec:
 					},
 				},
 			}
-			_, _, err := p.dryRunRender(badChart, "rel", "ns",
+			_, _, err := p.dryRunRender(context.Background(), badChart, "rel", "ns",
 				map[string]interface{}{}, nil, nil)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("dry-run render failed"))

--- a/pkg/cue/cuex/providers/helm/helm.go
+++ b/pkg/cue/cuex/providers/helm/helm.go
@@ -145,7 +145,7 @@ func Render(ctx context.Context, params *providers.Params[RenderParams]) (*provi
 	var notes string
 	if isDryRun(ctx) {
 		klog.V(2).Infof("Helm provider: Dry-run mode — rendering chart %s client-side only", ch.Name())
-		manifest, notes, err = p.dryRunRender(ch, releaseName, releaseNamespace, values, renderParams.Options, renderParams.Context)
+		manifest, notes, err = p.dryRunRender(ctx, ch, releaseName, releaseNamespace, values, renderParams.Options, renderParams.Context)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to dry-run render chart")
 		}

--- a/pkg/cue/cuex/providers/helm/helm_test.go
+++ b/pkg/cue/cuex/providers/helm/helm_test.go
@@ -65,7 +65,7 @@ spec:
 
 			// Call the provider's internal render logic in dry-run mode
 			ctx := WithDryRun(context.Background())
-			manifest, notes, err := p.dryRunRender(testChart, "release", "default",
+			manifest, notes, err := p.dryRunRender(context.Background(), testChart, "release", "default",
 				map[string]interface{}{}, nil, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			_ = ctx

--- a/pkg/cue/cuex/providers/helm/install.go
+++ b/pkg/cue/cuex/providers/helm/install.go
@@ -31,7 +31,7 @@ import (
 )
 
 // freshInstall performs a helm install with retry logic for orphaned/corrupted state.
-func (p *Provider) freshInstall(ctx context.Context, actionConfig *action.Configuration, ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, postRenderer *velaLabelPostRenderer, releaseLabels map[string]string, velaCtx *ContextParams) (*release.Release, error) {
+func (p *Provider) freshInstall(ctx context.Context, actionConfig *action.Configuration, ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, postRenderer helmPostRenderer, releaseLabels map[string]string, velaCtx *ContextParams) (*release.Release, error) {
 	install := p.newInstallAction(actionConfig, releaseName, releaseNamespace, options, postRenderer, releaseLabels)
 
 	klog.Infof("Helm provider [%s]: Installing release %s in namespace %s", velaContextStr(velaCtx), releaseName, releaseNamespace)
@@ -62,7 +62,7 @@ func (p *Provider) freshInstall(ctx context.Context, actionConfig *action.Config
 }
 
 // newInstallAction creates a configured helm install action.
-func (p *Provider) newInstallAction(actionConfig *action.Configuration, releaseName, releaseNamespace string, options *RenderOptionsParams, postRenderer *velaLabelPostRenderer, releaseLabels map[string]string) *action.Install {
+func (p *Provider) newInstallAction(actionConfig *action.Configuration, releaseName, releaseNamespace string, options *RenderOptionsParams, postRenderer helmPostRenderer, releaseLabels map[string]string) *action.Install {
 	install := action.NewInstall(actionConfig)
 	install.ReleaseName = releaseName
 	install.Namespace = releaseNamespace

--- a/pkg/cue/cuex/providers/helm/postrender.go
+++ b/pkg/cue/cuex/providers/helm/postrender.go
@@ -21,13 +21,14 @@ package helm
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	stderrors "errors"
 	"io"
 	"strings"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"github.com/kubevela/pkg/cue/util"
 	"github.com/kubevela/workflow/pkg/cue/model/sets"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
@@ -176,6 +177,42 @@ func velaOwnerLabels(velaCtx *ContextParams) map[string]string {
 	return labels
 }
 
+// postRenderHashLabel records a digest of the post-render configuration on the
+// Helm release Secret.
+const postRenderHashLabel = "app.oam.dev/postRenderHash"
+
+// postRenderFingerprint digests the post-render configuration so a change to it
+// can be detected on a later reconcile.
+//
+// The release dedup check in installOrUpgradeChart compares the desired chart
+// and values against those recorded on the live release, but post-render
+// configuration is not part of either: it never reaches Helm's stored values.
+// Editing only a post-render template would therefore leave both sides of that
+// comparison identical and the upgrade would be skipped, leaving the previously
+// rendered manifests in place. Stamping this digest onto the release lets the
+// dedup check see the change, in the same way the publishVersion pin is carried.
+//
+// Returns "" when nothing is configured, so releases that use no post-rendering
+// keep matching the absent label on releases installed before this existed.
+func postRenderFingerprint(postRender *PostRenderParams) string {
+	if postRender == nil {
+		return ""
+	}
+	data, err := json.Marshal(postRender)
+	if err != nil {
+		// A params struct that will not marshal cannot be fingerprinted; return
+		// a sentinel rather than "" so it never compares equal to "unset" and
+		// the upgrade goes ahead instead of being wrongly skipped.
+		klog.Warningf("Helm provider: failed to fingerprint post-render config, forcing upgrade: %v", err)
+		return "unfingerprintable"
+	}
+	if string(data) == "{}" {
+		return ""
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
 // helmPostRenderer is satisfied by any post-renderer in this package. It matches
 // helm.sh/helm/v3/pkg/postrender.PostRenderer structurally, so values can be
 // assigned to action.Install.PostRenderer without importing that package here.
@@ -209,6 +246,26 @@ func (r *cuePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, e
 		return renderedManifests, nil
 	}
 
+	// A post-render template is evaluated as plain CUE rather than through a
+	// cuex compiler. It is a pure data transform over an already-rendered
+	// resource, so it needs no vela provider packages, and reaching for one
+	// would both re-enter the helm provider that is mid-render and drag in the
+	// kube client singleton, which hard-exits the process when no kubeconfig is
+	// present. The full CUE standard library (strings, list, regexp, ...)
+	// remains available.
+	//
+	// The template is parsed and compiled once for the whole bundle, then bound
+	// to each resource in turn below. Charts routinely render dozens of
+	// resources, and compiling per resource made this scale linearly in parse
+	// work for a template that never changes between them. `context` is declared
+	// as a hole here so the template's references to it resolve at compile time;
+	// each resource fills it with a concrete value.
+	cctx := cuecontext.New()
+	tmpl := cctx.CompileString(strings.Join([]string{r.params.Template, "context: _"}, "\n"))
+	if err := tmpl.Err(); err != nil {
+		return nil, errors.Wrap(err, "cue post-renderer: invalid template")
+	}
+
 	out := &bytes.Buffer{}
 	decoder := kyaml.NewYAMLOrJSONDecoder(bytes.NewReader(renderedManifests.Bytes()), 4096)
 
@@ -224,7 +281,7 @@ func (r *cuePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, e
 			continue
 		}
 
-		patched, err := r.patchResource(obj.Object)
+		patched, err := r.patchResource(cctx, tmpl, obj.Object)
 		if err != nil {
 			return nil, err
 		}
@@ -243,27 +300,14 @@ func (r *cuePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, e
 // patchResource evaluates the user template against a single resource and
 // returns the merged result, or the resource unchanged when the template
 // produces no patch for it.
-func (r *cuePostRenderer) patchResource(resource map[string]interface{}) (map[string]interface{}, error) {
+func (r *cuePostRenderer) patchResource(cctx *cue.Context, tmpl cue.Value, resource map[string]interface{}) (map[string]interface{}, error) {
 	kind, _ := resource["kind"].(string)
 
 	if err := r.ctx.Err(); err != nil {
 		return nil, errors.Wrap(err, "cue post-renderer: cancelled")
 	}
 
-	// A post-render template is evaluated as plain CUE rather than through a
-	// cuex compiler. It is a pure data transform over an already-rendered
-	// resource, so it needs no vela provider packages — and reaching for one
-	// would both re-enter the helm provider that is mid-render and drag in the
-	// kube client singleton, which hard-exits the process when no kubeconfig is
-	// present. The full CUE standard library (strings, list, regexp, ...)
-	// remains available.
-	cctx := cuecontext.New()
-	ctxData, err := util.ToString(cctx.CompileString("").FillPath(cue.ParsePath("context"), r.templateContext(resource)))
-	if err != nil {
-		return nil, errors.Wrapf(err, "cue post-renderer: failed to bind context for %s", kind)
-	}
-
-	val := cctx.CompileString(strings.Join([]string{r.params.Template, ctxData}, "\n"))
+	val := tmpl.FillPath(cue.ParsePath("context"), r.templateContext(resource))
 	if err := val.Err(); err != nil {
 		return nil, errors.Wrapf(err, "cue post-renderer: invalid template for %s", kind)
 	}

--- a/pkg/cue/cuex/providers/helm/postrender.go
+++ b/pkg/cue/cuex/providers/helm/postrender.go
@@ -20,13 +20,20 @@ package helm
 
 import (
 	"bytes"
+	"context"
 	stderrors "errors"
 	"io"
+	"strings"
 
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/kubevela/pkg/cue/util"
+	"github.com/kubevela/workflow/pkg/cue/model/sets"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
@@ -167,6 +174,185 @@ func velaOwnerLabels(velaCtx *ContextParams) map[string]string {
 		labels["app.oam.dev/publishVersion"] = velaCtx.PublishVersion
 	}
 	return labels
+}
+
+// helmPostRenderer is satisfied by any post-renderer in this package. It matches
+// helm.sh/helm/v3/pkg/postrender.PostRenderer structurally, so values can be
+// assigned to action.Install.PostRenderer without importing that package here.
+type helmPostRenderer interface {
+	Run(*bytes.Buffer) (*bytes.Buffer, error)
+}
+
+// cuePatchFieldName is the field a post-render template must produce. It mirrors
+// the trait authoring model, where a trait patches its workload via `patch: {...}`.
+const cuePatchFieldName = "patch"
+
+// cuePostRenderer applies a user-supplied CUE template to every rendered
+// resource. The template is evaluated once per resource with that resource bound
+// to context.resource, and its patch field is merged back into the resource.
+//
+// The context.Context is carried on the struct because helm's PostRenderer
+// interface has no ctx parameter, and CUE evaluation needs one to stay
+// cancellable alongside the surrounding install/upgrade.
+type cuePostRenderer struct {
+	ctx     context.Context
+	params  *CUEParams
+	velaCtx *ContextParams
+}
+
+// Run implements helmPostRenderer. Resources whose template produces no patch
+// field pass through untouched, which is how a template scopes itself to a
+// subset of kinds (a bare `if context.resource.kind == "Deployment"` guard
+// leaves patch undefined for everything else).
+func (r *cuePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	if r.params == nil || strings.TrimSpace(r.params.Template) == "" || renderedManifests.Len() == 0 {
+		return renderedManifests, nil
+	}
+
+	out := &bytes.Buffer{}
+	decoder := kyaml.NewYAMLOrJSONDecoder(bytes.NewReader(renderedManifests.Bytes()), 4096)
+
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if stderrors.Is(err, io.EOF) {
+				break
+			}
+			return nil, errors.Wrap(err, "cue post-renderer: failed to decode manifest")
+		}
+		if len(obj.Object) == 0 {
+			continue
+		}
+
+		patched, err := r.patchResource(obj.Object)
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := yaml.Marshal(patched)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cue post-renderer: failed to marshal %s/%s", obj.GetKind(), obj.GetName())
+		}
+		out.WriteString("---\n")
+		out.Write(data)
+	}
+
+	return out, nil
+}
+
+// patchResource evaluates the user template against a single resource and
+// returns the merged result, or the resource unchanged when the template
+// produces no patch for it.
+func (r *cuePostRenderer) patchResource(resource map[string]interface{}) (map[string]interface{}, error) {
+	kind, _ := resource["kind"].(string)
+
+	if err := r.ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "cue post-renderer: cancelled")
+	}
+
+	// A post-render template is evaluated as plain CUE rather than through a
+	// cuex compiler. It is a pure data transform over an already-rendered
+	// resource, so it needs no vela provider packages — and reaching for one
+	// would both re-enter the helm provider that is mid-render and drag in the
+	// kube client singleton, which hard-exits the process when no kubeconfig is
+	// present. The full CUE standard library (strings, list, regexp, ...)
+	// remains available.
+	cctx := cuecontext.New()
+	ctxData, err := util.ToString(cctx.CompileString("").FillPath(cue.ParsePath("context"), r.templateContext(resource)))
+	if err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: failed to bind context for %s", kind)
+	}
+
+	val := cctx.CompileString(strings.Join([]string{r.params.Template, ctxData}, "\n"))
+	if err := val.Err(); err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: invalid template for %s", kind)
+	}
+
+	patcher := val.LookupPath(cue.ParsePath(cuePatchFieldName))
+	if !patcher.Exists() {
+		return resource, nil
+	}
+	if err := patcher.Err(); err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: invalid patch for %s", kind)
+	}
+
+	base := cctx.Encode(resource)
+	if err := base.Err(); err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: failed to encode %s", kind)
+	}
+
+	merged, err := sets.StrategyUnify(base, patcher, sets.CreateUnifyOptionsForPatcher(patcher)...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: failed to merge patch into %s", kind)
+	}
+
+	data, err := merged.MarshalJSON()
+	if err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: patched %s is incomplete", kind)
+	}
+	// Decode with the apimachinery decoder rather than encoding/json: it keeps
+	// integral values as int64 instead of widening them to float64, so fields
+	// like spec.replicas survive the round-trip as integers.
+	patched := map[string]interface{}{}
+	if err := json.Unmarshal(data, &patched); err != nil {
+		return nil, errors.Wrapf(err, "cue post-renderer: failed to decode patched %s", kind)
+	}
+	return patched, nil
+}
+
+// templateContext builds the `context` struct visible to the user template. It
+// carries the resource under evaluation plus the KubeVela identifiers already
+// available elsewhere in definition templates, so a post-render template can
+// stamp application-derived values without threading them through values.
+func (r *cuePostRenderer) templateContext(resource map[string]interface{}) map[string]interface{} {
+	ctxData := map[string]interface{}{"resource": resource}
+	if r.velaCtx != nil {
+		ctxData["appName"] = r.velaCtx.AppName
+		ctxData["appNamespace"] = r.velaCtx.AppNamespace
+		ctxData["name"] = r.velaCtx.Name
+		ctxData["namespace"] = r.velaCtx.Namespace
+	}
+	return ctxData
+}
+
+// compositePostRenderer chains post-renderers in order, feeding each renderer's
+// output as the next one's input.
+type compositePostRenderer struct {
+	renderers []helmPostRenderer
+}
+
+// Run implements helmPostRenderer.
+func (r *compositePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	buf := renderedManifests
+	for _, rdr := range r.renderers {
+		var err error
+		if buf, err = rdr.Run(buf); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+// newPostRenderer builds the post-render chain for a release. User-supplied
+// transformations run first and velaLabelPostRenderer runs last, so ownership
+// labels and Helm adoption annotations are stamped on the final resource set and
+// cannot be patched away by a user template. When no post-rendering is
+// configured the bare vela renderer is returned unchanged.
+func newPostRenderer(ctx context.Context, postRender *PostRenderParams, velaCtx *ContextParams, releaseName, releaseNamespace string) helmPostRenderer {
+	velaRenderer := &velaLabelPostRenderer{
+		context:          velaCtx,
+		releaseName:      releaseName,
+		releaseNamespace: releaseNamespace,
+	}
+	if postRender == nil || postRender.CUE == nil {
+		return velaRenderer
+	}
+	return &compositePostRenderer{
+		renderers: []helmPostRenderer{
+			&cuePostRenderer{ctx: ctx, params: postRender.CUE, velaCtx: velaCtx},
+			velaRenderer,
+		},
+	}
 }
 
 // isOwnedByVela checks whether a Helm release was installed/managed by THIS

--- a/pkg/cue/cuex/providers/helm/postrender.go
+++ b/pkg/cue/cuex/providers/helm/postrender.go
@@ -181,6 +181,32 @@ func velaOwnerLabels(velaCtx *ContextParams) map[string]string {
 // Helm release Secret.
 const postRenderHashLabel = "app.oam.dev/postRenderHash"
 
+// helmLabelDelete is Helm's sentinel for removing a release label on upgrade.
+// action.Upgrade merges the supplied labels over the previous release's, so an
+// omitted key is carried forward rather than dropped; only this value deletes.
+// action.Install stores labels verbatim and does not honor it, which is why it
+// must never appear on the install path.
+const helmLabelDelete = "null"
+
+// effectivePostRender returns the post-render configuration that will actually
+// change the rendered output, or nil when post-rendering would be a no-op.
+//
+// newPostRenderer and postRenderFingerprint both go through this, so the
+// renderer and the change detection can never disagree about what is active.
+// Fingerprinting configuration that no renderer acts on would bump the release
+// fingerprint and force an upgrade that produces byte-identical manifests,
+// which is the spurious revision bump the dedup check exists to prevent.
+func effectivePostRender(postRender *PostRenderParams) *PostRenderParams {
+	if postRender == nil || postRender.CUE == nil || strings.TrimSpace(postRender.CUE.Template) == "" {
+		return nil
+	}
+	// Only the CUE flavor is wired into newPostRenderer. Kustomize and Exec are
+	// declared in the params but reach no renderer, so including them here would
+	// fingerprint settings that cannot affect the output. Extend this alongside
+	// newPostRenderer when another flavor is implemented.
+	return &PostRenderParams{CUE: postRender.CUE}
+}
+
 // postRenderFingerprint digests the post-render configuration so a change to it
 // can be detected on a later reconcile.
 //
@@ -192,22 +218,20 @@ const postRenderHashLabel = "app.oam.dev/postRenderHash"
 // rendered manifests in place. Stamping this digest onto the release lets the
 // dedup check see the change, in the same way the publishVersion pin is carried.
 //
-// Returns "" when nothing is configured, so releases that use no post-rendering
-// keep matching the absent label on releases installed before this existed.
+// Returns "" when post-rendering is a no-op, so releases that use none keep
+// matching the absent label on releases installed before this existed.
 func postRenderFingerprint(postRender *PostRenderParams) string {
-	if postRender == nil {
+	effective := effectivePostRender(postRender)
+	if effective == nil {
 		return ""
 	}
-	data, err := json.Marshal(postRender)
+	data, err := json.Marshal(effective)
 	if err != nil {
 		// A params struct that will not marshal cannot be fingerprinted; return
 		// a sentinel rather than "" so it never compares equal to "unset" and
 		// the upgrade goes ahead instead of being wrongly skipped.
 		klog.Warningf("Helm provider: failed to fingerprint post-render config, forcing upgrade: %v", err)
 		return "unfingerprintable"
-	}
-	if string(data) == "{}" {
-		return ""
 	}
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
@@ -244,6 +268,13 @@ type cuePostRenderer struct {
 func (r *cuePostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
 	if r.params == nil || strings.TrimSpace(r.params.Template) == "" || renderedManifests.Len() == 0 {
 		return renderedManifests, nil
+	}
+
+	// Checked before compiling, not just per resource below: compilation is the
+	// most expensive single step here, and a webhook request that has already
+	// been cancelled should not pay for it.
+	if err := r.ctx.Err(); err != nil {
+		return nil, errors.Wrap(err, "cue post-renderer: cancelled")
 	}
 
 	// A post-render template is evaluated as plain CUE rather than through a
@@ -388,12 +419,13 @@ func newPostRenderer(ctx context.Context, postRender *PostRenderParams, velaCtx 
 		releaseName:      releaseName,
 		releaseNamespace: releaseNamespace,
 	}
-	if postRender == nil || postRender.CUE == nil {
+	effective := effectivePostRender(postRender)
+	if effective == nil {
 		return velaRenderer
 	}
 	return &compositePostRenderer{
 		renderers: []helmPostRenderer{
-			&cuePostRenderer{ctx: ctx, params: postRender.CUE, velaCtx: velaCtx},
+			&cuePostRenderer{ctx: ctx, params: effective.CUE, velaCtx: velaCtx},
 			velaRenderer,
 		},
 	}

--- a/pkg/cue/cuex/providers/helm/postrender_cue_test.go
+++ b/pkg/cue/cuex/providers/helm/postrender_cue_test.go
@@ -1,0 +1,369 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// decodeManifests parses a rendered manifest bundle into objects keyed by
+// "<kind>/<name>" so assertions can address a single resource.
+func decodeManifests(buf *bytes.Buffer) map[string]*unstructured.Unstructured {
+	objs := map[string]*unstructured.Unstructured{}
+	decoder := kyaml.NewYAMLOrJSONDecoder(bytes.NewReader(buf.Bytes()), 4096)
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			Fail(fmt.Sprintf("failed to decode: %v", err))
+		}
+		if len(obj.Object) == 0 {
+			continue
+		}
+		objs[fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())] = obj
+	}
+	return objs
+}
+
+const twoResourceManifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.0
+        env:
+        - name: EXISTING
+          value: "keep"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - port: 80
+`
+
+func newCUERenderer(template string) *cuePostRenderer {
+	return &cuePostRenderer{
+		ctx:    context.Background(),
+		params: &CUEParams{Template: template},
+		velaCtx: &ContextParams{
+			AppName:      "my-app",
+			AppNamespace: "my-app-ns",
+			Name:         "my-component",
+			Namespace:    "test-ns",
+		},
+	}
+}
+
+var _ = Describe("cuePostRenderer", func() {
+
+	It("should patch a scalar field on every resource", func() {
+		renderer := newCUERenderer(`
+patch: metadata: labels: tier: "backend"
+`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		objs := decodeManifests(result)
+		Expect(objs).To(HaveLen(2))
+		Expect(objs["Deployment/web"].GetLabels()).To(HaveKeyWithValue("tier", "backend"))
+		Expect(objs["Service/web"].GetLabels()).To(HaveKeyWithValue("tier", "backend"))
+	})
+
+	It("should leave resources the template does not target untouched", func() {
+		renderer := newCUERenderer(`
+patch: {
+	if context.resource.kind == "Deployment" {
+		spec: {
+			// +patchStrategy=retainKeys
+			replicas: 5
+		}
+	}
+}
+`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		objs := decodeManifests(result)
+		replicas, found, err := unstructured.NestedInt64(objs["Deployment/web"].Object, "spec", "replicas")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(replicas).To(Equal(int64(5)))
+
+		// The Service must be byte-for-byte semantically unchanged: no patch
+		// field is produced for it, so it passes through the decode/encode
+		// round-trip only.
+		Expect(objs["Service/web"].Object).To(HaveKey("spec"))
+		Expect(objs["Service/web"].Object).ToNot(HaveKey("status"))
+		ports, found, err := unstructured.NestedSlice(objs["Service/web"].Object, "spec", "ports")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(ports).To(HaveLen(1))
+	})
+
+	It("should merge into a list by patchKey instead of replacing it", func() {
+		renderer := newCUERenderer(`
+patch: {
+	if context.resource.kind == "Deployment" {
+		spec: template: spec: {
+			// +patchKey=name
+			containers: [{
+				name: "app"
+				// +patchKey=name
+				env: [{name: "ENV", value: "prod"}]
+			}]
+		}
+	}
+}
+`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		objs := decodeManifests(result)
+		containers, found, err := unstructured.NestedSlice(objs["Deployment/web"].Object, "spec", "template", "spec", "containers")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(containers).To(HaveLen(1))
+
+		container := containers[0].(map[string]interface{})
+		// The untouched fields of the matched container survive the merge.
+		Expect(container["image"]).To(Equal("nginx:1.0"))
+
+		env := container["env"].([]interface{})
+		Expect(env).To(HaveLen(2))
+		Expect(env[0]).To(Equal(map[string]interface{}{"name": "EXISTING", "value": "keep"}))
+		Expect(env[1]).To(Equal(map[string]interface{}{"name": "ENV", "value": "prod"}))
+	})
+
+	It("should replace a list when patchStrategy=replace is set", func() {
+		renderer := newCUERenderer(`
+patch: {
+	if context.resource.kind == "Deployment" {
+		spec: template: spec: {
+			// +patchStrategy=replace
+			containers: [{name: "only", image: "busybox"}]
+		}
+	}
+}
+`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		objs := decodeManifests(result)
+		containers, _, err := unstructured.NestedSlice(objs["Deployment/web"].Object, "spec", "template", "spec", "containers")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(containers).To(HaveLen(1))
+		Expect(containers[0].(map[string]interface{})["name"]).To(Equal("only"))
+	})
+
+	It("should expose the KubeVela context alongside the resource", func() {
+		renderer := newCUERenderer(`
+patch: metadata: annotations: {
+	"example.com/app":       context.appName
+	"example.com/namespace": context.appNamespace
+	"example.com/component": context.name
+	"example.com/self":      context.resource.metadata.name
+}
+`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		annotations := decodeManifests(result)["Deployment/web"].GetAnnotations()
+		Expect(annotations["example.com/app"]).To(Equal("my-app"))
+		Expect(annotations["example.com/namespace"]).To(Equal("my-app-ns"))
+		Expect(annotations["example.com/component"]).To(Equal("my-component"))
+		Expect(annotations["example.com/self"]).To(Equal("web"))
+	})
+
+	It("should tolerate a missing vela context", func() {
+		renderer := &cuePostRenderer{
+			ctx:    context.Background(),
+			params: &CUEParams{Template: `patch: metadata: labels: tier: "backend"`},
+		}
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(decodeManifests(result)["Deployment/web"].GetLabels()).To(HaveKeyWithValue("tier", "backend"))
+	})
+
+	It("should pass manifests through when the template produces no patch field", func() {
+		renderer := newCUERenderer(`somethingElse: {foo: "bar"}`)
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(decodeManifests(result)).To(HaveLen(2))
+	})
+
+	It("should pass manifests through unchanged for nil, empty, or blank templates", func() {
+		for _, params := range []*CUEParams{nil, {Template: ""}, {Template: "   \n\t "}} {
+			renderer := &cuePostRenderer{ctx: context.Background(), params: params}
+			in := bytes.NewBufferString(twoResourceManifest)
+			result, err := renderer.Run(in)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).To(BeIdenticalTo(in), "expected the input buffer to be returned untouched")
+		}
+	})
+
+	It("should pass through an empty manifest bundle", func() {
+		renderer := newCUERenderer(`patch: metadata: labels: tier: "backend"`)
+		in := &bytes.Buffer{}
+		result, err := renderer.Run(in)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(BeIdenticalTo(in))
+	})
+
+	It("should fail on a template that does not parse", func() {
+		renderer := newCUERenderer(`patch: {this is not cue`)
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cue post-renderer"))
+	})
+
+	It("should fail on a patch that conflicts with the rendered resource", func() {
+		renderer := newCUERenderer(`
+patch: {
+	if context.resource.kind == "Deployment" {
+		spec: replicas: "not-an-int"
+	}
+}
+`)
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Deployment"))
+	})
+
+	It("should reject overriding a concrete value without retainKeys", func() {
+		// Unification cannot narrow an already-concrete scalar, so overriding a
+		// value the chart rendered requires an explicit +patchStrategy=retainKeys.
+		// Failing loudly here is what keeps a silent no-op from shipping.
+		renderer := newCUERenderer(`
+patch: {
+	if context.resource.kind == "Deployment" {
+		spec: replicas: 5
+	}
+}
+`)
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("conflicting values"))
+	})
+
+	It("should fail on a patch that leaves the resource incomplete", func() {
+		renderer := newCUERenderer(`patch: metadata: labels: tier: string`)
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("incomplete"))
+	})
+
+	It("should fail on malformed input manifests", func() {
+		renderer := newCUERenderer(`patch: metadata: labels: tier: "backend"`)
+		_, err := renderer.Run(bytes.NewBufferString("this: is: not: valid: yaml:\n\t- broken"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should stop when the context is cancelled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		renderer := &cuePostRenderer{
+			ctx:    ctx,
+			params: &CUEParams{Template: `patch: metadata: labels: tier: "backend"`},
+		}
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cancelled"))
+	})
+})
+
+var _ = Describe("compositePostRenderer", func() {
+
+	It("should run renderers in order and feed each output to the next", func() {
+		renderer := &compositePostRenderer{
+			renderers: []helmPostRenderer{
+				newCUERenderer(`patch: metadata: labels: first: "1"`),
+				newCUERenderer(`patch: metadata: labels: second: context.resource.metadata.labels.first`),
+			},
+		}
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		labels := decodeManifests(result)["Deployment/web"].GetLabels()
+		Expect(labels).To(HaveKeyWithValue("first", "1"))
+		Expect(labels).To(HaveKeyWithValue("second", "1"))
+	})
+
+	It("should surface an error from any renderer in the chain", func() {
+		renderer := &compositePostRenderer{
+			renderers: []helmPostRenderer{
+				newCUERenderer(`patch: {this is not cue`),
+				newCUERenderer(`patch: metadata: labels: tier: "backend"`),
+			},
+		}
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("newPostRenderer", func() {
+
+	It("should return the bare vela renderer when no post-rendering is configured", func() {
+		for _, postRender := range []*PostRenderParams{nil, {}} {
+			renderer := newPostRenderer(context.Background(), postRender, &ContextParams{AppName: "app"}, "rel", "ns")
+			Expect(renderer).To(BeAssignableToTypeOf(&velaLabelPostRenderer{}))
+		}
+	})
+
+	It("should chain the CUE renderer ahead of the vela renderer", func() {
+		renderer := newPostRenderer(context.Background(),
+			&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: tier: "backend"`}},
+			&ContextParams{AppName: "my-app", AppNamespace: "my-app-ns", Name: "my-component"},
+			"my-release", "test-ns")
+
+		composite, ok := renderer.(*compositePostRenderer)
+		Expect(ok).To(BeTrue())
+		Expect(composite.renderers).To(HaveLen(2))
+		Expect(composite.renderers[0]).To(BeAssignableToTypeOf(&cuePostRenderer{}))
+		Expect(composite.renderers[1]).To(BeAssignableToTypeOf(&velaLabelPostRenderer{}))
+	})
+
+	It("should apply vela ownership labels after the user patch, so they cannot be overwritten", func() {
+		renderer := newPostRenderer(context.Background(),
+			&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: "app.oam.dev/name": "hijacked"`}},
+			&ContextParams{AppName: "my-app", AppNamespace: "my-app-ns", Name: "my-component"},
+			"my-release", "test-ns")
+
+		result, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		labels := decodeManifests(result)["Deployment/web"].GetLabels()
+		Expect(labels["app.oam.dev/name"]).To(Equal("my-app"))
+	})
+})

--- a/pkg/cue/cuex/providers/helm/postrender_cue_test.go
+++ b/pkg/cue/cuex/providers/helm/postrender_cue_test.go
@@ -301,6 +301,22 @@ patch: {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("cancelled"))
 	})
+
+	It("should not compile the template when already cancelled", func() {
+		// The template below does not parse. If cancellation is detected before
+		// compilation, as it should be, the error names the cancellation; if the
+		// compile ran first it would report the syntax error instead.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		renderer := &cuePostRenderer{
+			ctx:    ctx,
+			params: &CUEParams{Template: `patch: {this is not cue`},
+		}
+		_, err := renderer.Run(bytes.NewBufferString(twoResourceManifest))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cancelled"))
+		Expect(err.Error()).ToNot(ContainSubstring("invalid template"))
+	})
 })
 
 var _ = Describe("compositePostRenderer", func() {
@@ -339,6 +355,46 @@ var _ = Describe("postRenderFingerprint", func() {
 		// before post-rendering existed, so they are not upgraded needlessly.
 		Expect(postRenderFingerprint(nil)).To(BeEmpty())
 		Expect(postRenderFingerprint(&PostRenderParams{})).To(BeEmpty())
+	})
+
+	It("should be empty for configuration that reaches no renderer", func() {
+		// Kustomize and Exec are declared in the params but wired to nothing.
+		// Fingerprinting them would force an upgrade that renders identical
+		// manifests, which is the spurious revision bump dedup exists to avoid.
+		Expect(postRenderFingerprint(&PostRenderParams{
+			Kustomize: &KustomizeParams{Patches: []interface{}{"anything"}},
+		})).To(BeEmpty())
+		Expect(postRenderFingerprint(&PostRenderParams{
+			Exec: &ExecParams{Command: "cat"},
+		})).To(BeEmpty())
+	})
+
+	It("should be empty for a blank CUE template", func() {
+		// A blank template produces a no-op renderer, so it must not register
+		// as a configuration change.
+		for _, tmpl := range []string{"", "   ", "\n\t "} {
+			Expect(postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: tmpl}})).
+				To(BeEmpty(), "template %q should not be fingerprinted", tmpl)
+		}
+	})
+
+	It("should agree with newPostRenderer about what is active", func() {
+		// The renderer and the change detection must never disagree: a config
+		// that yields a bare vela renderer must fingerprint empty, and one that
+		// yields a chain must fingerprint non-empty.
+		cases := []*PostRenderParams{
+			nil,
+			{},
+			{CUE: &CUEParams{Template: "  "}},
+			{Kustomize: &KustomizeParams{Patches: []interface{}{"x"}}},
+			{CUE: &CUEParams{Template: `patch: metadata: labels: a: "1"`}},
+		}
+		for _, c := range cases {
+			renderer := newPostRenderer(context.Background(), c, &ContextParams{AppName: "app"}, "rel", "ns")
+			_, chained := renderer.(*compositePostRenderer)
+			Expect(postRenderFingerprint(c) != "").To(Equal(chained),
+				"fingerprint and renderer disagree for %+v", c)
+		}
 	})
 
 	It("should be stable for identical configuration", func() {

--- a/pkg/cue/cuex/providers/helm/postrender_cue_test.go
+++ b/pkg/cue/cuex/providers/helm/postrender_cue_test.go
@@ -332,6 +332,36 @@ var _ = Describe("compositePostRenderer", func() {
 	})
 })
 
+var _ = Describe("postRenderFingerprint", func() {
+
+	It("should be empty when nothing is configured", func() {
+		// An empty digest must equal the absent label on releases installed
+		// before post-rendering existed, so they are not upgraded needlessly.
+		Expect(postRenderFingerprint(nil)).To(BeEmpty())
+		Expect(postRenderFingerprint(&PostRenderParams{})).To(BeEmpty())
+	})
+
+	It("should be stable for identical configuration", func() {
+		a := postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: a: "1"`}})
+		b := postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: a: "1"`}})
+		Expect(a).ToNot(BeEmpty())
+		Expect(a).To(Equal(b))
+	})
+
+	It("should change when the template changes", func() {
+		// This is the property that makes a template edit trigger a re-apply:
+		// the chart and values are untouched, so the digest is the only signal.
+		a := postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: a: "1"`}})
+		b := postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: `patch: metadata: labels: a: "2"`}})
+		Expect(a).ToNot(Equal(b))
+	})
+
+	It("should change when post-rendering is added to an existing release", func() {
+		Expect(postRenderFingerprint(&PostRenderParams{CUE: &CUEParams{Template: `patch: {}`}})).
+			ToNot(Equal(postRenderFingerprint(nil)))
+	})
+})
+
 var _ = Describe("newPostRenderer", func() {
 
 	It("should return the bare vela renderer when no post-rendering is configured", func() {

--- a/pkg/cue/cuex/providers/helm/release.go
+++ b/pkg/cue/cuex/providers/helm/release.go
@@ -103,6 +103,20 @@ func (p *Provider) installOrUpgradeChart(ctx context.Context, ch *chart.Chart, r
 		}
 		releaseLabels[postRenderHashLabel] = postRenderHash
 	}
+	// Upgrades merge the supplied labels over the previous release's, so simply
+	// omitting the digest when post-rendering is removed would carry the stale
+	// one forward. The dedup check below would then see a mismatch on every
+	// reconcile and upgrade forever. Helm deletes a label whose value is "null",
+	// so ask for the removal explicitly. Installs store labels verbatim and do
+	// not honor the sentinel, hence the separate map for the upgrade path only.
+	upgradeLabels := releaseLabels
+	if postRenderHash == "" {
+		upgradeLabels = make(map[string]string, len(releaseLabels)+1)
+		for k, v := range releaseLabels {
+			upgradeLabels[k] = v
+		}
+		upgradeLabels[postRenderHashLabel] = helmLabelDelete
+	}
 
 	// Always check the live release in the cluster before using cached data.
 	// This prevents stale cache entries from masking externally-deleted releases
@@ -205,7 +219,7 @@ func (p *Provider) installOrUpgradeChart(ctx context.Context, ch *chart.Chart, r
 		}
 
 		// Fingerprint differs, needs adoption, or release is not in a clean deployed state — upgrade
-		rel, err := p.performUpgrade(ctx, actionConfig, ch, releaseName, releaseNamespace, values, options, postRenderer, releaseLabels, velaCtx)
+		rel, err := p.performUpgrade(ctx, actionConfig, ch, releaseName, releaseNamespace, values, options, postRenderer, upgradeLabels, velaCtx)
 		if err != nil {
 			return "", "", 0, err
 		}

--- a/pkg/cue/cuex/providers/helm/release.go
+++ b/pkg/cue/cuex/providers/helm/release.go
@@ -93,6 +93,17 @@ func (p *Provider) installOrUpgradeChart(ctx context.Context, ch *chart.Chart, r
 	// delete it via the ResourceTracker when the Application is deleted.
 	releaseLabels := velaOwnerLabels(velaCtx)
 
+	// Post-render configuration never reaches Helm's stored values, so the
+	// fingerprint below cannot see a change to it. Carry a digest on the release
+	// instead and compare it alongside the fingerprint.
+	postRenderHash := postRenderFingerprint(postRender)
+	if postRenderHash != "" {
+		if releaseLabels == nil {
+			releaseLabels = map[string]string{}
+		}
+		releaseLabels[postRenderHashLabel] = postRenderHash
+	}
+
 	// Always check the live release in the cluster before using cached data.
 	// This prevents stale cache entries from masking externally-deleted releases
 	// (e.g., helm uninstall, deleted secrets, namespace deletion).
@@ -181,7 +192,7 @@ func (p *Provider) installOrUpgradeChart(ctx context.Context, ch *chart.Chart, r
 		// Release exists — check if it is already deployed with the same fingerprint
 		if !needsAdoption && existingRelease.Info != nil && existingRelease.Info.Status == release.StatusDeployed {
 			clusterFingerprint := computeReleaseFingerprint(existingRelease.Chart, existingRelease.Config)
-			if clusterFingerprint == fingerprint {
+			if clusterFingerprint == fingerprint && existingRelease.Labels[postRenderHashLabel] == postRenderHash {
 				klog.V(3).Infof("Helm provider [%s]: Release %s already deployed and unchanged (cluster fingerprint match), skipping upgrade", velaContextStr(velaCtx), releaseName)
 				p.releaseFingerprints[cacheKey] = fingerprint
 				p.releaseManifests[cacheKey] = existingRelease.Manifest

--- a/pkg/cue/cuex/providers/helm/release.go
+++ b/pkg/cue/cuex/providers/helm/release.go
@@ -83,11 +83,11 @@ func (p *Provider) installOrUpgradeChart(ctx context.Context, ch *chart.Chart, r
 		return "", "", 0, err
 	}
 
-	postRenderer := &velaLabelPostRenderer{
-		context:          velaCtx,
-		releaseName:      releaseName,
-		releaseNamespace: releaseNamespace,
+	var postRender *PostRenderParams
+	if options != nil {
+		postRender = options.PostRender
 	}
+	postRenderer := newPostRenderer(ctx, postRender, velaCtx, releaseName, releaseNamespace)
 
 	// Build labels to embed in the release Secret so KubeVela can track and
 	// delete it via the ResourceTracker when the Application is deleted.

--- a/pkg/cue/cuex/providers/helm/release_test.go
+++ b/pkg/cue/cuex/providers/helm/release_test.go
@@ -208,6 +208,94 @@ var _ = Describe("release", func() {
 			Expect(v2).To(Equal(1), "fingerprint dedup should keep revision at 1")
 		})
 
+		It("upgrades when only the post-render template changes, then settles", func() {
+			cfg := fakeActionConfig()
+			p := installProviderWithFake(cfg)
+			ch := minimalChart("c", "1.0.0")
+			values := map[string]interface{}{"replicas": 2}
+			velaCtx := &ContextParams{AppName: "app", AppNamespace: relNS, Name: "comp"}
+
+			withTemplate := func(tmpl string) *RenderOptionsParams {
+				return &RenderOptionsParams{PostRender: &PostRenderParams{CUE: &CUEParams{Template: tmpl}}}
+			}
+
+			_, _, v1, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values,
+				withTemplate(`patch: metadata: labels: a: "1"`), velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v1).To(Equal(1))
+
+			// Chart and values are untouched, so the digest is the only signal.
+			_, _, v2, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values,
+				withTemplate(`patch: metadata: labels: a: "2"`), velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v2).To(Equal(2), "a template edit should trigger an upgrade")
+
+			// And an unchanged template must not keep upgrading.
+			_, _, v3, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values,
+				withTemplate(`patch: metadata: labels: a: "2"`), velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v3).To(Equal(2), "an unchanged template should not bump the revision")
+		})
+
+		It("settles after post-rendering is removed instead of upgrading forever", func() {
+			// Helm merges release labels on upgrade, so dropping the digest from
+			// the label map would carry the stale one forward and every later
+			// reconcile would see a mismatch and upgrade again. The upgrade path
+			// asks Helm to delete the label instead.
+			cfg := fakeActionConfig()
+			p := installProviderWithFake(cfg)
+			ch := minimalChart("c", "1.0.0")
+			values := map[string]interface{}{"replicas": 2}
+			velaCtx := &ContextParams{AppName: "app", AppNamespace: relNS, Name: "comp"}
+
+			_, _, v1, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values,
+				&RenderOptionsParams{PostRender: &PostRenderParams{
+					CUE: &CUEParams{Template: `patch: metadata: labels: a: "1"`},
+				}}, velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v1).To(Equal(1))
+
+			// Post-rendering removed: one upgrade is correct and expected.
+			_, _, v2, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values, nil, velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v2).To(Equal(2), "removing post-rendering should trigger one upgrade")
+
+			// Every reconcile after that must be a no-op.
+			for i := 0; i < 3; i++ {
+				_, _, vn, err := p.installOrUpgradeChart(
+					context.Background(), ch, relName, relNS, values, nil, velaCtx)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(vn).To(Equal(2), "reconcile %d upgraded again; the stale digest was not removed", i+1)
+			}
+		})
+
+		It("does not upgrade for post-render settings that reach no renderer", func() {
+			cfg := fakeActionConfig()
+			p := installProviderWithFake(cfg)
+			ch := minimalChart("c", "1.0.0")
+			values := map[string]interface{}{"replicas": 2}
+			velaCtx := &ContextParams{AppName: "app", AppNamespace: relNS, Name: "comp"}
+
+			_, _, v1, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values, nil, velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v1).To(Equal(1))
+
+			// A blank template renders nothing, so it must not count as a change.
+			_, _, v2, err := p.installOrUpgradeChart(
+				context.Background(), ch, relName, relNS, values,
+				&RenderOptionsParams{PostRender: &PostRenderParams{
+					CUE: &CUEParams{Template: "   \n"},
+				}}, velaCtx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v2).To(Equal(1), "a blank template should not bump the revision")
+		})
+
 		It("upgrades when the chart version changes", func() {
 			cfg := fakeActionConfig()
 			p := installProviderWithFake(cfg)

--- a/pkg/cue/cuex/providers/helm/types.go
+++ b/pkg/cue/cuex/providers/helm/types.go
@@ -82,7 +82,16 @@ type RenderOptionsParams struct {
 // PostRenderParams represents post-rendering configuration
 type PostRenderParams struct {
 	Kustomize *KustomizeParams `json:"kustomize,omitempty"`
+	CUE       *CUEParams       `json:"cue,omitempty"`
 	Exec      *ExecParams      `json:"exec,omitempty"`
+}
+
+// CUEParams represents CUE post-rendering options. The template is evaluated
+// once per rendered resource, with that resource bound to context.resource, and
+// the resulting patch field is merged back into the resource using KubeVela's
+// strategy-unify semantics (the same engine that powers trait patching).
+type CUEParams struct {
+	Template string `json:"template"`
 }
 
 // KustomizeParams represents Kustomize post-rendering options

--- a/pkg/cue/cuex/providers/helm/upgrade.go
+++ b/pkg/cue/cuex/providers/helm/upgrade.go
@@ -33,7 +33,7 @@ import (
 // resolved chart and merged values. The caller (installOrUpgradeChart) has
 // already decided that an upgrade is warranted (fingerprint differs, the
 // release needs adoption, or the release is not in a clean deployed state).
-func (p *Provider) performUpgrade(ctx context.Context, actionConfig *action.Configuration, ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, postRenderer *velaLabelPostRenderer, releaseLabels map[string]string, velaCtx *ContextParams) (*release.Release, error) {
+func (p *Provider) performUpgrade(ctx context.Context, actionConfig *action.Configuration, ch *chart.Chart, releaseName, releaseNamespace string, values map[string]interface{}, options *RenderOptionsParams, postRenderer helmPostRenderer, releaseLabels map[string]string, velaCtx *ContextParams) (*release.Release, error) {
 	upgrade := action.NewUpgrade(actionConfig)
 	upgrade.Namespace = releaseNamespace
 	upgrade.PostRenderer = postRenderer

--- a/vela-templates/definitions/internal/component/helmchart.cue
+++ b/vela-templates/definitions/internal/component/helmchart.cue
@@ -203,14 +203,22 @@ template: {
 				mutableTTL?:   string | *"5m"  // TTL for mutable tags (latest, dev, main)
 			}
 
-			// Post-rendering - Future enhancement
-			// Planned: CUE-based post-rendering for resource transformation
-			// Would allow users to write CUE templates to modify rendered resources
-			// with full access to KubeVela context (appName, namespace, etc.)
-			// Requires CUE-in-CUE runtime execution capability
-			// postRender?: {
-			// 	template: string  // CUE template for transforming resources
-			// }
+			// Post-rendering transformations applied after Helm renders the
+			// manifests but before KubeVela stamps its ownership labels, so a
+			// template cannot patch away the labels KubeVela tracks the release by.
+			postRender?: {
+				// +usage=CUE template evaluated once per rendered resource. The
+				// resource under evaluation is bound to context.resource, and the
+				// template's `patch` field is merged back into it using the same
+				// strategy-unify semantics traits use to patch workloads: a
+				// patchKey annotation merges into a list by key, and a
+				// patchStrategy=retainKeys annotation overrides a value the chart
+				// already rendered. Producing no `patch` field leaves the resource
+				// untouched, which is how a template scopes itself to some kinds.
+				cue?: {
+					template: string
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of your changes

Adds `options.postRender.cue` to the `helmchart` component, resolving #7161.

You give it a CUE template. It runs once per resource after Helm renders the chart, but before KubeVela stamps its ownership labels. The resource being processed is bound to `context.resource`, and whatever the template puts in `patch` gets merged back into it. The merge uses `sets.StrategyUnify`, the same thing traits use to patch workloads, so `patchKey` and `patchStrategy` annotations work the way definition authors already expect them to.

```yaml
type: helmchart
properties:
  chart:
    source: podinfo
    repoURL: https://stefanprodan.github.io/podinfo
    version: 6.5.0
  options:
    postRender:
      cue:
        template: |
          patch: {
              if context.resource.kind == "Deployment" {
                      spec: template: spec: {
                              // +patchKey=name
                              containers: [{
                                      name: "podinfo"
                                      // +patchKey=name
                                      env: [{name: "DEPLOY_ENV", value: "prod"}]
                              }]
                      }
              }
          }
```

If a template produces no `patch` for a given resource, that resource is left alone. That is how you scope a template to just the kinds you care about.

What changed:

- `cuePostRenderer` does the per-resource evaluation and merge.
- `compositePostRenderer` chains renderers, with `velaLabelPostRenderer` always last.
- `newPostRenderer` picks the chain or the bare vela renderer depending on whether `postRender.cue` is set. Nothing changes when it is absent.
- Install, upgrade and dry-run now take a `helmPostRenderer` interface instead of `*velaLabelPostRenderer`.
- `dryRunRender` takes a `ctx` now, so template evaluation in the webhook path is cancellable like the rest.
- The `postRender` block in `helmchart.cue` was a commented-out placeholder. It is a real field now.
- Examples under `docs/examples/helmchart-postrender/cue/`.

Fixes #7161

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

20 new unit tests in `postrender_cue_test.go`, package suite at 305 specs passing. `make reviewable` is clean with no generated file drift.

Coverage includes the happy paths (scalar patches, kind-guarded patches, `patchKey` list merges, `patchStrategy=replace`, context fields resolving), the pass-through cases (nil/empty template, empty manifest, no `patch` produced), and the failure cases (unparseable template, type conflicts, incomplete patches, malformed input YAML, cancelled context). Two are worth calling out specifically: one asserts that overriding a chart value without `retainKeys` fails loudly instead of quietly doing nothing, and one asserts that a template trying to rewrite `app.oam.dev/name` gets overwritten by the vela renderer.

### Special notes for your reviewer

**Templates are evaluated as plain CUE, not through a cuex compiler.** The issue suggested using the cuex evaluator, but `cuex.CompileStringWithOptions` pulls in the `DefaultCompiler` singleton, which calls `config.GetConfigOrDie()`. Without a kubeconfig that is an `os.Exit(1)`, so you cannot catch it or return an error from it (same root cause as #7264). It would also re-enter the helm provider while it is still mid-render. A post-render template is just a data transform over an already-rendered resource, so none of the vela provider packages are needed. The CUE standard library is still there.

**The example in the issue body will not work as written.** Two things trip people up here, and both are documented in the example README:

- Without `// +patchKey=name`, list unification matches entries by position, so patching `env` collides with whatever the chart already put at that index.
- Unification can only make a value more specific. Patching `replicas: 3` onto a chart that rendered `replicas: 1` is a conflict, not an override. You need `// +patchStrategy=retainKeys` to override.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

