### PR TITLE
Fix: do not exit the process when building a CUE compiler without a kubeconfig

### DIFF
--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/config"
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/helm"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 )
 
 // ConfigCompiler ...
@@ -49,7 +50,14 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 		kube.Package,
 		cueext.Package,
 	)
+	// See the note in pkg/workflow/providers/compiler.go: LoadExternalPackages
+	// reaches config.GetConfigOrDie, which exits the process instead of
+	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
+		if err := kubeconfig.Check(); err != nil {
+			klog.Warningf("skipping external CUE packages for workload compiler, no usable kubeconfig: %v", err)
+			return compiler
+		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {
 			klog.Errorf("failed to load external packages for workload compiler: %v", err.Error())
 		}

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -54,7 +54,7 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 	// reaches config.GetConfigOrDie, which exits the process instead of
 	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
-		if !kubeconfig.AvailableFor("external CUE packages for the workload compiler") {
+		if err := kubeconfig.CheckFor("external CUE packages for the workload compiler"); err != nil {
 			return compiler
 		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -54,8 +54,7 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 	// reaches config.GetConfigOrDie, which exits the process instead of
 	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
-		if err := kubeconfig.Check(); err != nil {
-			klog.Warningf("skipping external CUE packages for workload compiler, no usable kubeconfig: %v", err)
+		if !kubeconfig.AvailableFor("external CUE packages for the workload compiler") {
 			return compiler
 		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cuex_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
+)
+
+// TestWorkloadCompilerWithoutKubeConfig pins the guard that keeps compiler
+// construction from exiting the process when nothing is resolvable.
+//
+// LoadExternalPackages reaches config.GetConfigOrDie by way of the shared
+// client singletons, and that calls os.Exit(1) rather than returning an error.
+// If this regresses, the symptom is the test binary vanishing here with no
+// failure reported, the same thing that happens to `vela def render`.
+func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
+	// TestMain vouches for the envtest config it supplied. Drop that, and hide
+	// the environment, so the guard takes its skip path. Restored afterwards so
+	// the rest of the suite still reaches its control plane.
+	clearAssumption := kubeconfig.AssumeAvailable()
+	clearAssumption()
+	t.Cleanup(func() { kubeconfig.AssumeAvailable() })
+
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	velacuex.WorkloadCompiler.Reload()
+	if c := velacuex.WorkloadCompiler.Get(); c == nil {
+		t.Fatal("expected a usable compiler when no kubeconfig is available")
+	}
+}

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -32,12 +32,10 @@ import (
 // If this regresses, the symptom is the test binary vanishing here with no
 // failure reported, the same thing that happens to `vela def render`.
 func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
-	// TestMain vouches for the envtest config it supplied. Drop that, and hide
-	// the environment, so the guard takes its skip path. Restored afterwards so
-	// the rest of the suite still reaches its control plane.
-	clearAssumption := kubeconfig.AssumeAvailable()
-	clearAssumption()
-	t.Cleanup(func() { kubeconfig.AssumeAvailable() })
+	// TestMain vouches for the envtest config it supplied. Withdraw that, and
+	// hide the environment, so the guard takes its skip path. Reinstated
+	// afterwards so the rest of the suite still reaches its control plane.
+	t.Cleanup(kubeconfig.AssumeUnavailable())
 
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -35,7 +35,17 @@ func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
 	// TestMain vouches for the envtest config it supplied. Withdraw that, and
 	// hide the environment, so the guard takes its skip path. Reinstated
 	// afterwards so the rest of the suite still reaches its control plane.
-	t.Cleanup(kubeconfig.AssumeUnavailable())
+	restoreAssumption := kubeconfig.AssumeUnavailable()
+	// Registered before the environment is scrubbed so it runs last, once
+	// t.Setenv has put the environment back. Reload below caches a compiler
+	// built without external packages into the package-global singleton, and
+	// this file sorts ahead of compiler_test.go, so any later test that reads
+	// the singleton without reloading it first would inherit the degraded one
+	// and fail with `builtin package "cuex/ext" undefined`.
+	t.Cleanup(func() {
+		restoreAssumption()
+		velacuex.WorkloadCompiler.Reload()
+	})
 
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 )
 
 var testCtx = struct {
@@ -97,6 +98,9 @@ func TestMain(m *testing.M) {
 	defer mockServer.Close()
 
 	singleton.KubeConfig.Set(cfg)
+	// The config comes from envtest rather than the environment, so the
+	// external-package guard has to be told it is safe to reach the cluster.
+	restoreKubeConfigAssumption := kubeconfig.AssumeAvailable()
 
 	if err = createTestPackage(mockServer.URL); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
@@ -111,7 +115,14 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
-	singleton.KubeConfig.Reload()
+	// The envtest config is about to go away, so stop vouching for it.
+	restoreKubeConfigAssumption()
+	// Reload runs the singleton's loader, which exits the process rather than
+	// returning an error when nothing is resolvable. Resetting to the ambient
+	// configuration only means something when there is one.
+	if kubeconfig.Available() {
+		singleton.KubeConfig.Reload()
+	}
 
 	if err := testEnv.Stop(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to stop envtest: %v\n", err)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -26,12 +26,40 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"sync/atomic"
+
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-// Check returns nil when a Kubernetes REST config can be resolved from the
-// ambient environment (--kubeconfig, $KUBECONFIG, ~/.kube/config, or in-cluster
-// service account), and the resolution error otherwise.
+// assumed records that a client configuration was supplied out of band. See
+// AssumeAvailable.
+var assumed atomic.Bool
+
+// AssumeAvailable records that a Kubernetes client configuration has been
+// supplied directly, bypassing the environment. Call it alongside
+// singleton.KubeConfig.Set, as the envtest harnesses do: a singleton that has
+// already been populated never reaches GetConfigOrDie, so it cannot exit the
+// process, and the work this package guards is safe to attempt.
+//
+// This has to be recorded explicitly because the singleton exposes no way to
+// ask whether it has been set. Without it, a suite that supplies an envtest
+// config would still be told to skip, and would silently lose behaviour that
+// depends on cluster access, such as loading external CUE packages.
+//
+// The returned function clears the assumption, and should be called once the
+// supplied configuration is no longer valid, typically when the harness tears
+// its control plane down.
+func AssumeAvailable() (restore func()) {
+	assumed.Store(true)
+	return func() { assumed.Store(false) }
+}
+
+// Check returns nil when using the shared client singletons is safe: either a
+// configuration was supplied out of band (see AssumeAvailable) or a REST config
+// can be resolved from the ambient environment (--kubeconfig, $KUBECONFIG,
+// ~/.kube/config, or in-cluster service account). Otherwise it returns the
+// resolution error.
 //
 // It resolves the config exactly the way config.GetConfigOrDie does, but hands
 // back the failure instead of exiting, so callers can decide what to do. A nil
@@ -39,6 +67,9 @@ import (
 // exists to describe it. Reachability still surfaces as an ordinary error on
 // the first request.
 func Check() error {
+	if assumed.Load() {
+		return nil
+	}
 	_, err := config.GetConfig()
 	return err
 }
@@ -47,4 +78,22 @@ func Check() error {
 // that only branch on the outcome and do not log the reason.
 func Available() bool {
 	return Check() == nil
+}
+
+// AvailableFor reports whether Check succeeds, logging a warning that names the
+// work being skipped when it does not. Degrading silently would leave an
+// operator with no explanation for why, say, external CUE packages are missing.
+//
+// Note that this inspects the ambient environment, not the client singletons.
+// A process that populates singleton.KubeConfig directly, as the envtest suites
+// do, has a working client even though nothing resolvable exists on disk, and
+// will be told to skip. That is the safe direction to be wrong in: the singleton
+// offers no way to ask whether it has already been set, and guessing wrong the
+// other way exits the process.
+func AvailableFor(purpose string) bool {
+	if err := Check(); err != nil {
+		klog.Warningf("no usable kubeconfig, skipping %s: %v", purpose, err)
+		return false
+	}
+	return true
 }

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -98,20 +98,30 @@ func Available() bool {
 	return Check() == nil
 }
 
-// AvailableFor reports whether Check succeeds, logging a warning that names the
-// work being skipped when it does not. Degrading silently would leave an
-// operator with no explanation for why, say, external CUE packages are missing.
+// CheckFor returns the reason the shared client singletons are unsafe to use,
+// naming the work about to be skipped, or nil when a configuration is
+// available. It hands the reason back as well as reporting it, so a caller
+// able to surface the failure in its own terms is not forced to re-derive it.
+//
+// The report goes through klog.ErrorS rather than klog.Warningf because the
+// vela CLI installs a klog sink (references/cli/log) whose Info path raises
+// level 0 to 1 and gates on V(1), so a warning is dropped at the default
+// verbosity. The CLI is the main consumer of this degraded path, and degrading
+// silently would leave an operator with no explanation for why, say, external
+// CUE packages are missing. The sink's Error path is not level-gated and
+// writes to stderr, so the reason is visible without disturbing whatever the
+// command prints on stdout.
 //
 // Note that this inspects the ambient environment, not the client singletons.
 // A process that populates singleton.KubeConfig directly, as the envtest suites
 // do, has a working client even though nothing resolvable exists on disk, and
-// will be told to skip. That is the safe direction to be wrong in: the singleton
-// offers no way to ask whether it has already been set, and guessing wrong the
-// other way exits the process.
-func AvailableFor(purpose string) bool {
-	if err := Check(); err != nil {
-		klog.Warningf("no usable kubeconfig, skipping %s: %v", purpose, err)
-		return false
+// will be told to skip unless it also calls AssumeAvailable. That is the safe
+// direction to be wrong in: the singleton offers no way to ask whether it has
+// already been set, and guessing wrong the other way exits the process.
+func CheckFor(purpose string) error {
+	err := Check()
+	if err != nil {
+		klog.ErrorS(err, "No usable kubeconfig, continuing without it", "skipped", purpose)
 	}
-	return true
+	return err
 }

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig reports whether a Kubernetes client configuration can be
+// resolved, without terminating the process when it cannot.
+//
+// It exists because the shared client singletons in kubevela/pkg are built on
+// controller-runtime's config.GetConfigOrDie, which calls os.Exit(1) when no
+// kubeconfig is present. That is not a panic and not a returned error, so a
+// caller cannot recover from it, log it, or fall back: the process is simply
+// gone. Callers that are able to run without a cluster should consult Check
+// before reaching for anything that resolves a client singleton.
+package kubeconfig
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// Check returns nil when a Kubernetes REST config can be resolved from the
+// ambient environment (--kubeconfig, $KUBECONFIG, ~/.kube/config, or in-cluster
+// service account), and the resolution error otherwise.
+//
+// It resolves the config exactly the way config.GetConfigOrDie does, but hands
+// back the failure instead of exiting, so callers can decide what to do. A nil
+// return does not promise the cluster is reachable, only that a configuration
+// exists to describe it. Reachability still surfaces as an ordinary error on
+// the first request.
+func Check() error {
+	_, err := config.GetConfig()
+	return err
+}
+
+// Available reports whether Check succeeds. It is a convenience for call sites
+// that only branch on the outcome and do not log the reason.
+func Available() bool {
+	return Check() == nil
+}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -47,12 +47,30 @@ var assumed atomic.Bool
 // config would still be told to skip, and would silently lose behaviour that
 // depends on cluster access, such as loading external CUE packages.
 //
-// The returned function clears the assumption, and should be called once the
-// supplied configuration is no longer valid, typically when the harness tears
-// its control plane down.
+// The returned function restores the state the call displaced rather than
+// clearing the assumption outright, so calls nest. Call it once the supplied
+// configuration is no longer valid, typically when the harness tears its
+// control plane down.
 func AssumeAvailable() (restore func()) {
-	assumed.Store(true)
-	return func() { assumed.Store(false) }
+	return restoreAssumption(assumed.Swap(true))
+}
+
+// AssumeUnavailable withdraws any outstanding assumption until the returned
+// function is called, so Check consults the environment again. It is the
+// inverse of AssumeAvailable, for tests that exercise the skip path from
+// inside a suite that has already supplied a config. Without it such a test
+// has to clear the suite-wide assumption and remember to reinstate it by hand.
+func AssumeUnavailable() (restore func()) {
+	return restoreAssumption(assumed.Swap(false))
+}
+
+// restoreAssumption puts back the value an Assume call displaced. Restoring
+// the previous value rather than a fixed one is what lets the calls nest: an
+// inner scope ending must not cancel an outer scope that is still open. A
+// restore that stored false unconditionally would leave a suite which assumed
+// once in TestMain silently skipping the work this package guards.
+func restoreAssumption(previous bool) func() {
+	return func() { assumed.Store(previous) }
 }
 
 // Check returns nil when using the shared client singletons is safe: either a

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validKubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+
+// isolateFromAmbientConfig points HOME at an empty directory and clears the
+// in-cluster service account hints, so the only kubeconfig the resolver can
+// find is whatever the test sets explicitly.
+func isolateFromAmbientConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+}
+
+func TestCheckWithoutKubeConfig(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if err := Check(); err == nil {
+		t.Fatal("expected an error when no kubeconfig can be resolved, got nil")
+	}
+	if Available() {
+		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
+	}
+}
+
+func TestCheckWithKubeConfig(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(validKubeConfig), 0600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", path)
+
+	if err := Check(); err != nil {
+		t.Fatalf("expected no error for a resolvable kubeconfig, got %v", err)
+	}
+	if !Available() {
+		t.Fatal("expected Available to report true for a resolvable kubeconfig")
+	}
+}
+
+// TestCheckDoesNotExit is the point of this package. The resolver underneath
+// config.GetConfigOrDie terminates the process when it fails; Check must hand
+// the failure back instead. If this ever regresses, the test binary dies here
+// with no output rather than reporting a failure, which is exactly the symptom
+// the package exists to prevent.
+func TestCheckDoesNotExit(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	_ = Check()
+	t.Log("survived Check with no resolvable kubeconfig")
+}

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -59,6 +59,9 @@ func TestCheckWithoutKubeConfig(t *testing.T) {
 	if Available() {
 		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
 	}
+	if AvailableFor("some work") {
+		t.Fatal("expected AvailableFor to report false when no kubeconfig can be resolved")
+	}
 }
 
 func TestCheckWithKubeConfig(t *testing.T) {
@@ -74,6 +77,35 @@ func TestCheckWithKubeConfig(t *testing.T) {
 	}
 	if !Available() {
 		t.Fatal("expected Available to report true for a resolvable kubeconfig")
+	}
+	if !AvailableFor("some work") {
+		t.Fatal("expected AvailableFor to report true for a resolvable kubeconfig")
+	}
+}
+
+// TestAssumeAvailable covers the case a harness hits when it supplies a config
+// directly: nothing is resolvable from the environment, but the client
+// singletons have already been populated, so the work this package guards is
+// safe to attempt.
+func TestAssumeAvailable(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if Available() {
+		t.Fatal("precondition failed: expected no resolvable kubeconfig")
+	}
+
+	restore := AssumeAvailable()
+	if err := Check(); err != nil {
+		t.Fatalf("expected Check to succeed once a config is assumed, got %v", err)
+	}
+	if !Available() || !AvailableFor("some work") {
+		t.Fatal("expected the assumption to be visible to every accessor")
+	}
+
+	restore()
+	if Available() {
+		t.Fatal("expected the assumption to be cleared, so the environment decides again")
 	}
 }
 

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -109,6 +109,39 @@ func TestAssumeAvailable(t *testing.T) {
 	}
 }
 
+// TestAssumeNesting covers what makes the restore functions safe to defer: an
+// inner scope ending must leave an outer one intact. A restore that cleared
+// the flag outright would drop the outer assumption for the rest of the
+// process, and a suite that assumes once in TestMain would then silently skip
+// the work this package guards.
+func TestAssumeNesting(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	outer := AssumeAvailable()
+	t.Cleanup(outer)
+
+	inner := AssumeAvailable()
+	inner()
+	if !Available() {
+		t.Fatal("expected the outer assumption to survive the inner one being restored")
+	}
+
+	withdraw := AssumeUnavailable()
+	if Available() {
+		t.Fatal("expected AssumeUnavailable to withdraw the outstanding assumption")
+	}
+	withdraw()
+	if !Available() {
+		t.Fatal("expected restoring AssumeUnavailable to reinstate the outer assumption")
+	}
+
+	outer()
+	if Available() {
+		t.Fatal("expected the environment to decide again once every assumption is restored")
+	}
+}
+
 // TestCheckDoesNotExit is the point of this package. The resolver underneath
 // config.GetConfigOrDie terminates the process when it fails; Check must hand
 // the failure back instead. If this ever regresses, the test binary dies here

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -59,8 +59,8 @@ func TestCheckWithoutKubeConfig(t *testing.T) {
 	if Available() {
 		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
 	}
-	if AvailableFor("some work") {
-		t.Fatal("expected AvailableFor to report false when no kubeconfig can be resolved")
+	if err := CheckFor("some work"); err == nil {
+		t.Fatal("expected CheckFor to return the reason when no kubeconfig can be resolved")
 	}
 }
 
@@ -78,8 +78,8 @@ func TestCheckWithKubeConfig(t *testing.T) {
 	if !Available() {
 		t.Fatal("expected Available to report true for a resolvable kubeconfig")
 	}
-	if !AvailableFor("some work") {
-		t.Fatal("expected AvailableFor to report true for a resolvable kubeconfig")
+	if err := CheckFor("some work"); err != nil {
+		t.Fatalf("expected CheckFor to succeed for a resolvable kubeconfig, got %v", err)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestAssumeAvailable(t *testing.T) {
 	if err := Check(); err != nil {
 		t.Fatalf("expected Check to succeed once a config is assumed, got %v", err)
 	}
-	if !Available() || !AvailableFor("some work") {
+	if !Available() || CheckFor("some work") != nil {
 		t.Fatal("expected the assumption to be visible to every accessor")
 	}
 

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -87,8 +87,7 @@ var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compil
 	// cluster-free callers (vela def render, unit tests, make manifests) alive
 	// with external packages simply absent.
 	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
-		if err := kubeconfig.Check(); err != nil {
-			klog.Warningf("skipping external CUE packages for cuex default compiler, no usable kubeconfig: %v", err)
+		if !kubeconfig.AvailableFor("external CUE packages for the cuex default compiler") {
 			return c
 		}
 	}

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -87,7 +87,7 @@ var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compil
 	// cluster-free callers (vela def render, unit tests, make manifests) alive
 	// with external packages simply absent.
 	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
-		if !kubeconfig.AvailableFor("external CUE packages for the cuex default compiler") {
+		if err := kubeconfig.CheckFor("external CUE packages for the cuex default compiler"); err != nil {
 			return c
 		}
 	}

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubevela/workflow/pkg/providers/time"
 	"github.com/kubevela/workflow/pkg/providers/util"
 
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/config"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/helm"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/legacy"
@@ -79,6 +80,18 @@ var compiler = singleton.NewSingletonE[*cuex.Compiler](func() (*cuex.Compiler, e
 // DefaultCompiler compiler for cuex to compile
 var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
 	c := compiler.Get()
+	// Both calls below reach the shared client singletons, which resolve their
+	// REST config through config.GetConfigOrDie. Without a kubeconfig that
+	// exits the process rather than returning an error, so the error handling
+	// here would never run. Checking first keeps it reachable, and keeps
+	// cluster-free callers (vela def render, unit tests, make manifests) alive
+	// with external packages simply absent.
+	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
+		if err := kubeconfig.Check(); err != nil {
+			klog.Warningf("skipping external CUE packages for cuex default compiler, no usable kubeconfig: %v", err)
+			return c
+		}
+	}
 	if cuex.EnableExternalPackageForDefaultCompiler {
 		if err := c.LoadExternalPackages(context.Background()); err != nil {
 			klog.Errorf("failed to load external packages for cuex default compiler: %v", err.Error())

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -76,6 +76,14 @@ func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
 // takes the whole test binary down with it, and the ordering means the clearer
 // failure from the subprocess test is already in the output when it happens.
 func TestDefaultCompilerInProcess(t *testing.T) {
+	// Registered before the environment is scrubbed so it runs last, once
+	// t.Setenv has put the environment back. Get below caches a compiler built
+	// without external packages into the package-global singleton, and it is
+	// only the sole in-process consumer today: the next test added to this
+	// package that needs them would otherwise fail depending on declaration
+	// order, which is a confusing way to find this out.
+	t.Cleanup(func() { DefaultCompiler.Reload() })
+
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("KUBERNETES_SERVICE_HOST", "")

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -67,3 +67,21 @@ func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
 		t.Fatalf("child did not reach the end of the test\noutput:\n%s", out)
 	}
 }
+
+// TestDefaultCompilerInProcess repeats the check in this process so the guard
+// is recorded as covered; the subprocess test above cannot contribute coverage,
+// since the toolchain does not collect it from a child.
+//
+// It deliberately runs after that test. If the guard ever regresses this call
+// takes the whole test binary down with it, and the ordering means the clearer
+// failure from the subprocess test is already in the output when it happens.
+func TestDefaultCompilerInProcess(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	if c := DefaultCompiler.Get(); c == nil {
+		t.Fatal("expected a usable compiler when no kubeconfig is available")
+	}
+}

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// childEnvVar marks the re-executed copy of this test binary that does the
+// actual work. See TestDefaultCompilerWithoutKubeConfig.
+const childEnvVar = "VELA_TEST_COMPILER_NO_KUBECONFIG_CHILD"
+
+// TestDefaultCompilerWithoutKubeConfig pins the fix for the process exiting
+// during compiler construction when no kubeconfig is present.
+//
+// Building the compiler used to reach config.GetConfigOrDie by way of
+// LoadExternalPackages, which calls os.Exit(1). That cannot be observed from
+// inside the same process: there is no panic to recover and no error to assert
+// on, the process is simply gone. So the check runs in a re-executed copy of
+// this test binary with the kubeconfig removed from its environment, and the
+// parent asserts on the child's exit code.
+//
+// Without the guard the child exits 1 having printed nothing at all, which is
+// precisely the failure mode this protects against.
+func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
+	if os.Getenv(childEnvVar) == "1" {
+		// Child: constructing the compiler must not terminate the process.
+		_ = DefaultCompiler.Get()
+		t.Log("built DefaultCompiler with no kubeconfig")
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDefaultCompilerWithoutKubeConfig$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		childEnvVar+"=1",
+		// Remove every route the resolver has to a config: the explicit env
+		// var, the home directory default, and the in-cluster service account.
+		"KUBECONFIG="+filepath.Join(t.TempDir(), "does-not-exist"),
+		"HOME="+t.TempDir(),
+		"KUBERNETES_SERVICE_HOST=",
+		"KUBERNETES_SERVICE_PORT=",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building the compiler without a kubeconfig terminated the process: %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "built DefaultCompiler with no kubeconfig") {
+		t.Fatalf("child did not reach the end of the test\noutput:\n%s", out)
+	}
+}


### PR DESCRIPTION
### Description of your changes


Fixes #7328

Building either CUE compiler used to terminate the process when no kubeconfig could be resolved. `LoadExternalPackages` reaches `config.GetConfigOrDie` through the shared client singletons, and that calls `os.Exit(1)`. Not a panic, not a returned error, so the error handling already present at the call site could never run:

```go
if err := c.LoadExternalPackages(context.Background()); err != nil {
    klog.Errorf("failed to load external packages for cuex default compiler: %v", err.Error())
}
```

That branch was unreachable dead code without a kubeconfig. The process died inside `singleton.DynamicClient.Get()` before `LoadExternalPackages` could return anything.

This adds a small `pkg/utils/kubeconfig` package that resolves the config the same way `GetConfigOrDie` does but hands back the error, and checks it before reaching for external packages in both compilers. With no kubeconfig, external CUE packages are skipped with a warning and the compiler comes back usable. With one present, behaviour is unchanged: the load is attempted and any failure is logged exactly as before.

Before:

```
$ KUBECONFIG=/nonexistent vela def render .../helmchart.cue -o out.yaml
$ echo $?
1                     # no output, no message, out.yaml never written
```

After:

```
$ KUBECONFIG=/nonexistent vela def render .../helmchart.cue -o out.yaml
$ echo $?
0
$ head -3 out.yaml
# Code generated by KubeVela templates. DO NOT EDIT.
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
```

Also guards `ListenExternalPackages`, which reaches the same singleton from inside a goroutine. It is off by default, but enabling it without a kubeconfig would kill the process from a background goroutine.

Fixes #7328

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`make reviewable` passes with no generated-file drift. `pkg/cue/...`, `pkg/definition`, `pkg/utils/kubeconfig` and `pkg/workflow/providers` all pass.

Unit tests for the resolver cover the missing, present, and does-not-exit cases, isolating `HOME` and the in-cluster service account env vars so only the explicitly-set kubeconfig is visible.

The regression test in `pkg/workflow/providers/compiler_test.go` needed a different approach. An `os.Exit` cannot be observed from inside the process that makes it: there is nothing to recover and nothing to assert on. So the test re-executes the test binary as a child with every route to a config removed, and the parent asserts on the child's exit code.

Verified it actually catches the bug by reverting the guard and rerunning:

```
--- FAIL: TestDefaultCompilerWithoutKubeConfig (0.04s)
    compiler_test.go:64: building the compiler without a kubeconfig terminated the process: exit status 1
        output:
        === RUN   TestDefaultCompilerWithoutKubeConfig
```

The child's output ends right there, which is the symptom itself: the test started and the process vanished.

Manually confirmed both directions end to end. Without a kubeconfig, `vela def render` now exits 0 and writes correct output. With a kubeconfig pointing at an unreachable server, it still logs `Failed to load external packages ... connection refused` and exits 0, same as before this change.

### Special notes for your reviewer

**This fixes the reachable symptom, not the root cause.** The `os.Exit(1)` is in `config.GetConfigOrDie`, reached via `singleton.KubeConfig` in kubevela/pkg. Fixing it properly means changing that singleton to return an error, which is a breaking API change for every consumer and belongs in its own discussion in that repo. The check here is deliberately narrow: it sits at the two places this repo constructs a compiler, and does not try to wrap the singletons.

**Relationship to PR # 7264** Same root cause, different surface. # 7264 makes test suites fail loudly instead of exiting silently; this makes production paths survive. Neither subsumes the other. Some test suites will still exit silently after this lands, for example `pkg/cue/cuex/providers/helm`, where a `BeforeEach` calls `singleton.KubeClient.Get()` directly to capture the original client. That is # 7264's territory and I have deliberately not touched test files here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

