### PR TITLE
Feat: support map-to-list comprehensions in ArrayBuilder

### DIFF
--- a/pkg/definition/defkit/array_builder.go
+++ b/pkg/definition/defkit/array_builder.go
@@ -20,20 +20,23 @@ package defkit
 type entryKind int
 
 const (
-	entryStatic      entryKind = iota // always-present item
-	entryConditional                  // conditional item (if cond { item })
-	entryForEach                      // iterated item (for v in source { item })
+	entryStatic         entryKind = iota // always-present item
+	entryConditional                     // conditional item (if cond { item })
+	entryForEach                         // iterated item (for v in source { item })
+	entryForEachWith                     // iterated item using an ItemBuilder
+	entryForEachMapWith                  // map-to-list item using a MapEntryBuilder
 )
 
 // arrayEntry is a single entry in an ArrayBuilder.
 type arrayEntry struct {
-	kind        entryKind
-	element     *ArrayElement // the item fields (for static, conditional, forEach)
-	cond        Condition     // for conditional entries
-	source      Value         // for forEach entries (iteration source)
-	guard       Condition     // for forEach entries (optional guard: if source != _|_)
-	filter      Predicate     // for forEach entries (optional filter: if v.field == value)
-	itemBuilder *ItemBuilder  // for forEachWith entries (complex per-item logic)
+	kind            entryKind
+	element         *ArrayElement    // the item fields (for static, conditional, forEach)
+	cond            Condition        // for conditional entries
+	source          Value            // for forEach entries (iteration source)
+	guard           Condition        // for forEach entries (optional guard: if source != _|_)
+	filter          Predicate        // for forEach entries (optional filter: if v.field == value)
+	itemBuilder     *ItemBuilder     // for forEachWith entries (complex per-item logic)
+	mapEntryBuilder *MapEntryBuilder // for map-to-list entries
 }
 
 // ArrayBuilder builds CUE arrays with static items, conditional items, and for-each items.
@@ -108,9 +111,6 @@ func (a *ArrayBuilder) ForEachGuarded(guard Condition, source Value, elem *Array
 // Entries returns all entries in the array builder.
 func (a *ArrayBuilder) Entries() []arrayEntry { return a.entries }
 
-// entryForEachWith indicates a complex iterated item using an ItemBuilder.
-const entryForEachWith entryKind = 3
-
 // ForEachWith adds a complex iterated item to the array, using an ItemBuilder
 // callback for per-item operations like conditionals, let bindings, and defaults.
 // Uses "v" as the default iteration variable name.
@@ -147,6 +147,34 @@ func (a *ArrayBuilder) ForEachWithGuardedFilteredVar(varName string, guard Condi
 		guard:       guard,
 		filter:      filter,
 		itemBuilder: ib,
+	})
+	return a
+}
+
+// ForEachMapWith adds one array item for every entry in a map-valued source.
+func (a *ArrayBuilder) ForEachMapWith(source Value, fn func(entry *MapEntryBuilder)) *ArrayBuilder {
+	return a.forEachMapWith(nil, source, fn)
+}
+
+// ForEachMapWithGuarded is like ForEachMapWith but only iterates when guard is true.
+func (a *ArrayBuilder) ForEachMapWithGuarded(guard Condition, source Value, fn func(entry *MapEntryBuilder)) *ArrayBuilder {
+	return a.forEachMapWith(guard, source, fn)
+}
+
+func (a *ArrayBuilder) forEachMapWith(guard Condition, source Value, fn func(entry *MapEntryBuilder)) *ArrayBuilder {
+	entryBuilder := &MapEntryBuilder{
+		keyVarName: "k",
+		valueBuilder: ItemBuilder{
+			varName: "v",
+			ops:     make([]itemOp, 0),
+		},
+	}
+	fn(entryBuilder)
+	a.entries = append(a.entries, arrayEntry{
+		kind:            entryForEachMapWith,
+		source:          source,
+		guard:           guard,
+		mapEntryBuilder: entryBuilder,
 	})
 	return a
 }
@@ -263,6 +291,67 @@ func (b *ItemBuilder) Ops() []itemOp { return b.ops }
 
 // VarName returns the iteration variable name.
 func (b *ItemBuilder) VarName() string { return b.varName }
+
+// MapEntryBuilder records operations for an item produced from a map entry.
+// Key and Value expose the two variables bound by the CUE comprehension.
+type MapEntryBuilder struct {
+	keyVarName   string
+	valueBuilder ItemBuilder
+}
+
+// Key returns a reference to the current map key.
+func (b *MapEntryBuilder) Key() *IterVarRef {
+	return &IterVarRef{varName: b.keyVarName}
+}
+
+// Value returns a builder for the current map value.
+func (b *MapEntryBuilder) Value() *IterVarBuilder {
+	return b.valueBuilder.Var()
+}
+
+// Set records an unconditional field assignment.
+func (b *MapEntryBuilder) Set(field string, value Value) {
+	b.valueBuilder.Set(field, value)
+}
+
+// If records a conditional block of operations.
+func (b *MapEntryBuilder) If(cond Condition, fn func()) {
+	b.valueBuilder.If(cond, fn)
+}
+
+// IfSet records a block that runs when a field on the map value is set.
+func (b *MapEntryBuilder) IfSet(field string, fn func()) {
+	b.valueBuilder.IfSet(field, fn)
+}
+
+// IfNotSet records a block that runs when a field on the map value is absent.
+func (b *MapEntryBuilder) IfNotSet(field string, fn func()) {
+	b.valueBuilder.IfNotSet(field, fn)
+}
+
+// Let records a private field binding and returns a reference to it.
+func (b *MapEntryBuilder) Let(name string, value Value) Value {
+	return b.valueBuilder.Let(name, value)
+}
+
+// SetDefault records a CUE default value assignment.
+func (b *MapEntryBuilder) SetDefault(field string, defValue Value, typeName string) {
+	b.valueBuilder.SetDefault(field, defValue, typeName)
+}
+
+// FieldExists returns a condition that checks whether a field on the map value is set.
+func (b *MapEntryBuilder) FieldExists(field string) Condition {
+	return b.valueBuilder.FieldExists(field)
+}
+
+// FieldNotExists returns a condition that checks whether a field on the map value is absent.
+func (b *MapEntryBuilder) FieldNotExists(field string) Condition {
+	return b.valueBuilder.FieldNotExists(field)
+}
+
+func (b *MapEntryBuilder) ops() []itemOp {
+	return b.valueBuilder.Ops()
+}
 
 // IterVarBuilder provides access to iteration variable fields.
 type IterVarBuilder struct {

--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -205,6 +205,8 @@ func (g *CUEGenerator) collectImportsFromValue(v interface{}) {
 	case *ArrayBuilder:
 		for _, entry := range val.Entries() {
 			if entry.itemBuilder != nil {
+				g.collectImportsFromValue(entry.source)
+				g.collectImportsFromValue(entry.guard)
 				g.collectImportsFromItemOps(entry.itemBuilder.Ops())
 			}
 			if entry.mapEntryBuilder != nil {

--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -207,6 +207,11 @@ func (g *CUEGenerator) collectImportsFromValue(v interface{}) {
 			if entry.itemBuilder != nil {
 				g.collectImportsFromItemOps(entry.itemBuilder.Ops())
 			}
+			if entry.mapEntryBuilder != nil {
+				g.collectImportsFromValue(entry.source)
+				g.collectImportsFromValue(entry.guard)
+				g.collectImportsFromItemOps(entry.mapEntryBuilder.ops())
+			}
 		}
 	case *PlusExpr:
 		for _, part := range val.Parts() {
@@ -2507,6 +2512,23 @@ func (g *CUEGenerator) arrayBuilderToCUE(ab *ArrayBuilder, depth int) string {
 			}
 			sb.WriteString(fmt.Sprintf("%s%sfor %s in %s%s {\n", innerIndent, guardPrefix, entry.itemBuilder.VarName(), sourceStr, filterSuffix))
 			g.writeItemBuilderOps(&sb, entry.itemBuilder.Ops(), depth+2)
+			sb.WriteString(fmt.Sprintf("%s},\n", innerIndent))
+
+		case entryForEachMapWith:
+			sourceStr := g.valueToCUE(entry.source)
+			guardPrefix := ""
+			if entry.guard != nil {
+				guardPrefix = "if " + g.conditionToCUE(entry.guard) + " "
+			}
+			sb.WriteString(fmt.Sprintf(
+				"%s%sfor %s, %s in %s {\n",
+				innerIndent,
+				guardPrefix,
+				entry.mapEntryBuilder.keyVarName,
+				entry.mapEntryBuilder.valueBuilder.VarName(),
+				sourceStr,
+			))
+			g.writeItemBuilderOps(&sb, entry.mapEntryBuilder.ops(), depth+2)
 			sb.WriteString(fmt.Sprintf("%s},\n", innerIndent))
 		}
 	}

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -1909,6 +1909,67 @@ var _ = Describe("CUEGenerator", func() {
 		})
 	})
 
+	Describe("ArrayBuilder ForEachWith import collection", func() {
+		It("should collect imports from the iteration source", func() {
+			left := defkit.Array("left").WithFields(
+				defkit.String("name"),
+			)
+			right := defkit.Array("right").WithFields(
+				defkit.String("name"),
+			)
+			comp := defkit.NewComponent("test").
+				Params(left, right).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					items := defkit.NewArray().ForEachWith(
+						defkit.ArrayConcat(left, right),
+						func(item *defkit.ItemBuilder) {
+							item.Set("name", item.Var().Field("name"))
+						},
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.items", items))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`"list"`))
+			Expect(generated).To(ContainSubstring(
+				"for v in list.Concat([parameter.left, parameter.right]) {",
+			))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
+		})
+
+		It("should collect imports from the iteration guard", func() {
+			tags := defkit.Array("tags")
+			ports := defkit.Array("ports").WithFields(
+				defkit.String("name"),
+				defkit.Bool("enabled"),
+			)
+			comp := defkit.NewComponent("test").
+				Params(tags, ports).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					items := defkit.NewArray().ForEachWithGuardedFiltered(
+						tags.Contains("enabled"),
+						defkit.FieldEquals("enabled", true),
+						ports,
+						func(item *defkit.ItemBuilder) {
+							item.Set("name", item.Var().Field("name"))
+						},
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.items", items))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`"list"`))
+			Expect(generated).To(ContainSubstring(
+				`if list.Contains(parameter["tags"], "enabled")`,
+			))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
+		})
+	})
+
 	Describe("Dedupe from Reference source", func() {
 		It("should generate dedup pattern when source is a Reference", func() {
 			ws := defkit.NewWorkflowStep("test").

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package defkit_test
 
 import (
+	"sort"
 	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1748,6 +1752,160 @@ var _ = Describe("CUEGenerator", func() {
 			// Inner braces should contain both the field and the conditional
 			Expect(cue).To(ContainSubstring("name: m.name"))
 			Expect(cue).To(ContainSubstring("if m.subPath != _|_"))
+		})
+	})
+
+	Describe("ArrayBuilder map-to-list comprehensions", func() {
+		It("should expose map keys and values to the item builder", func() {
+			accessPoints := defkit.Map("accessPoints").
+				WithSchema(`[string]: {path: string}`)
+			comp := defkit.NewComponent("test").
+				Params(accessPoints).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					items := defkit.NewArray().ForEachMapWith(
+						accessPoints,
+						func(entry *defkit.MapEntryBuilder) {
+							entry.Set("name", entry.Key())
+							entry.Set("path", entry.Value().Field("path"))
+						},
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.items", items))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(
+				"for k, v in parameter.accessPoints {",
+			))
+			Expect(generated).To(ContainSubstring("name: k"))
+			Expect(generated).To(ContainSubstring("path: v.path"))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
+		})
+
+		It("should support guards and existing item operations", func() {
+			accessPoints := defkit.Map("accessPoints").
+				WithSchema(`[string]: {
+					permissions?: string
+				}`).
+				Optional()
+			comp := defkit.NewComponent("test").
+				Params(accessPoints).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					items := defkit.NewArray().ForEachMapWithGuarded(
+						accessPoints.IsSet(),
+						accessPoints,
+						func(entry *defkit.MapEntryBuilder) {
+							entry.Set("name", defkit.StringsToLower(entry.Key()))
+							fallback := entry.Let("_fallback", defkit.Lit("0755"))
+							entry.IfSet("permissions", func() {
+								entry.Set("permissions", entry.Value().Field("permissions"))
+							})
+							entry.IfNotSet("permissions", func() {
+								entry.Set("permissions", fallback)
+							})
+							entry.SetDefault("ownerUID", defkit.Lit(1000), "int")
+							entry.If(entry.FieldExists("permissions"), func() {
+								entry.Set("configured", defkit.Lit(true))
+							})
+							entry.If(entry.FieldNotExists("permissions"), func() {
+								entry.Set("configured", defkit.Lit(false))
+							})
+						},
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.items", items))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`"strings"`))
+			Expect(generated).To(ContainSubstring(
+				`if parameter["accessPoints"] != _|_ for k, v in parameter.accessPoints {`,
+			))
+			Expect(generated).To(ContainSubstring("name: strings.ToLower(k)"))
+			Expect(generated).To(ContainSubstring("_fallback: \"0755\""))
+			Expect(generated).To(ContainSubstring("if v.permissions != _|_ {"))
+			Expect(generated).To(ContainSubstring("if v.permissions == _|_ {"))
+			Expect(generated).To(ContainSubstring("ownerUID: *1000 | int"))
+			Expect(generated).To(ContainSubstring("configured: true"))
+			Expect(generated).To(ContainSubstring("configured: false"))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
+		})
+
+		It("should evaluate absent, empty, single-entry, and multi-entry maps", func() {
+			accessPoints := defkit.Map("accessPoints").
+				WithSchema(`[string]: {path: string}`).
+				Optional()
+			comp := defkit.NewComponent("test").
+				Params(accessPoints).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					items := defkit.NewArray().ForEachMapWithGuarded(
+						accessPoints.IsSet(),
+						accessPoints,
+						func(entry *defkit.MapEntryBuilder) {
+							entry.Set("name", entry.Key())
+							entry.Set("path", entry.Value().Field("path"))
+						},
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.items", items))
+				})
+
+			base := cuecontext.New().CompileString(comp.ToCue())
+			Expect(base.Err()).NotTo(HaveOccurred())
+
+			fixtures := []struct {
+				name string
+				data map[string]any
+				want []string
+			}{
+				{name: "absent", want: []string{}},
+				{name: "empty", data: map[string]any{}, want: []string{}},
+				{
+					name: "single",
+					data: map[string]any{
+						"reports": map[string]any{"path": "/reports"},
+					},
+					want: []string{"reports:/reports"},
+				},
+				{
+					name: "multiple",
+					data: map[string]any{
+						"reports": map[string]any{"path": "/reports"},
+						"logs":    map[string]any{"path": "/logs"},
+					},
+					want: []string{"logs:/logs", "reports:/reports"},
+				},
+			}
+
+			for _, fixture := range fixtures {
+				value := base
+				if fixture.data != nil {
+					value = value.FillPath(
+						cue.ParsePath("template.parameter.accessPoints"),
+						fixture.data,
+					)
+				}
+				Expect(value.Err()).NotTo(HaveOccurred(), fixture.name)
+
+				var items []struct {
+					Name string `json:"name"`
+					Path string `json:"path"`
+				}
+				err := value.LookupPath(
+					cue.ParsePath("template.output.data.items"),
+				).Decode(&items)
+				Expect(err).NotTo(HaveOccurred(), fixture.name)
+
+				got := make([]string, len(items))
+				for i := range items {
+					got[i] = items[i].Name + ":" + items[i].Path
+				}
+				sort.Strings(got)
+				Expect(got).To(Equal(fixture.want), fixture.name)
+			}
 		})
 	})
 


### PR DESCRIPTION
### Description of your changes

Adds guarded and unguarded map-to-list comprehensions to `ArrayBuilder`.

`ForEachMapWith` and `ForEachMapWithGuarded` expose a `MapEntryBuilder`, allowing the callback to access both the map key and value without raw CUE references:

```go
items := defkit.NewArray().ForEachMapWithGuarded(
    accessPoints.IsSet(),
    accessPoints,
    func(entry *defkit.MapEntryBuilder) {
        entry.Set("name", entry.Key())
        entry.Set("path", entry.Value().Field("path"))
    },
)
 ```

The generated list comprehension binds both variables:

 ```cue
if parameter["accessPoints"] != _|_
for k, v in parameter.accessPoints {
    name: k
    path: v.path
}
 ```

MapEntryBuilder delegates the existing item operations for field assignments, conditional blocks, bindings, and defaults. The generator reuses the existing item-operation renderer and import collector.

Existing ForEachMap behavior is unchanged.

Fixes #7288

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### How has this code been tested

The generated CUE was compiled and evaluated against absent, empty, single-entry, and multi-entry map inputs. Tests also cover key/value references, guarded generation, existing item operations, and import discovery.

### Special notes for your reviewer

This accepts any map-valued Value and does not depend on the structured MapParam schema work in #7287. Tests use the existing WithSchema escape hatch.

Map iteration order is intentionally not asserted.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->