### PR TITLE
Feat: scope defkit health expressions to outputs and aggregate with Every

### DIFF
--- a/pkg/definition/defkit/health_expr.go
+++ b/pkg/definition/defkit/health_expr.go
@@ -18,8 +18,45 @@ package defkit
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+const defaultHealthRoot = "context.output"
+
+// resolveRoot returns root, or the default primary-output root when it is empty.
+func resolveRoot(root string) string {
+	if root == "" {
+		return defaultHealthRoot
+	}
+	return root
+}
+
+// sanitizeIdent keeps only ASCII alphanumerics, yielding a valid CUE identifier fragment.
+func sanitizeIdent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// sanitizeRoot turns a CUE root path into an identifier fragment for a preamble variable name.
+func sanitizeRoot(root string) string {
+	s := strings.TrimPrefix(root, "context.outputs.")
+	s = strings.TrimPrefix(s, "context.")
+	return sanitizeIdent(s)
+}
+
+// upperFirst upper-cases the first character, leaving the rest unchanged.
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
 
 // HealthExpression is the composable unit for building health policies.
 // All health primitives implement this interface and can be combined
@@ -47,6 +84,8 @@ func HealthPolicy(expr HealthExpression) string {
 
 // ConditionExpr checks a condition in status.conditions[] array.
 type ConditionExpr struct {
+	root           string
+	inline         bool
 	condType       string
 	expectedStatus string
 	expectedReason string
@@ -83,37 +122,54 @@ func (c *ConditionExpr) ReasonIs(reason string) HealthExpression {
 	return c
 }
 
+// varName is the preamble helper name, with the root folded in so distinct scopes do not collide.
 func (c *ConditionExpr) varName() string {
-	return "_" + strings.ToLower(c.condType) + "Cond"
+	if c.root == "" || c.root == defaultHealthRoot {
+		return "_" + strings.ToLower(c.condType) + "Cond"
+	}
+	return "_" + sanitizeRoot(c.root) + upperFirst(strings.ToLower(c.condType)) + "Cond"
 }
 
 func (c *ConditionExpr) Preamble() string {
+	if c.inline {
+		return ""
+	}
 	varName := c.varName()
-	// context.output.status.conditions may not exist yet (e.g. right after creation),
-	// which would make the comprehension source bottom. The `*X | []` disjunction
-	// discards that bottom disjunct and falls back to an empty list instead of
-	// propagating the error. c.type is filtered defensively for the same reason:
-	// a condition entry without a type would otherwise make the comparison bottom.
-	return fmt.Sprintf(`%s: [ for c in *context.output.status.conditions | [] if c.type != _|_ if c.type == "%s" { c } ]`,
-		varName, c.condType)
+	// `*conditions | []` defaults a missing list to empty, so a fresh resource reads unhealthy instead of erroring.
+	return fmt.Sprintf(`%s: [ for c in *%s.status.conditions | [] if c.type != _|_ if c.type == "%s" { c } ]`,
+		varName, resolveRoot(c.root), c.condType)
 }
 
 func (c *ConditionExpr) ToCUE() string {
+	if c.inline {
+		return c.inlineCUE()
+	}
 	varName := c.varName()
 	if c.checkExists {
 		return fmt.Sprintf("len(%s) > 0", varName)
 	}
-	// Filter rather than index %s[0]: && does not short-circuit in CUE, so an
-	// out-of-range index on an empty list would propagate as bottom even when
-	// len(%s) > 0 is false. c.status/c.reason are guarded with != _|_ for the
-	// same reason c.type is guarded in Preamble: a condition entry missing
-	// that field would otherwise make the comparison bottom instead of false.
+	// Filter, don't index [0]: CUE's && isn't short-circuit, so indexing an empty list would error; != _|_ skips incomplete entries.
 	if c.expectedReason != "" {
 		return fmt.Sprintf(`len([ for c in %s if c.status != _|_ if c.status == "%s" if c.reason != _|_ if c.reason == "%s" { c } ]) > 0`,
 			varName, c.expectedStatus, c.expectedReason)
 	}
 	return fmt.Sprintf(`len([ for c in %s if c.status != _|_ if c.status == "%s" { c } ]) > 0`,
 		varName, c.expectedStatus)
+}
+
+// inlineCUE folds all filters into one comprehension so the check can nest inside Every's loop (no hoisted preamble var).
+func (c *ConditionExpr) inlineCUE() string {
+	src := fmt.Sprintf(`*%s.status.conditions | []`, resolveRoot(c.root))
+	if c.checkExists {
+		return fmt.Sprintf(`len([ for c in %s if c.type != _|_ if c.type == %q { c } ]) > 0`,
+			src, c.condType)
+	}
+	filters := fmt.Sprintf(`if c.type != _|_ if c.type == %q if c.status != _|_ if c.status == %q`,
+		c.condType, c.expectedStatus)
+	if c.expectedReason != "" {
+		filters += fmt.Sprintf(` if c.reason != _|_ if c.reason == %q`, c.expectedReason)
+	}
+	return fmt.Sprintf(`len([ for c in %s %s { c } ]) > 0`, src, filters)
 }
 
 // --- Phase Expressions ---
@@ -143,51 +199,53 @@ func (p *phaseExpr) ToCUE() string {
 
 // HealthFieldExpr provides comparison operations on a status field.
 type HealthFieldExpr struct {
+	root string
 	path string
 }
 
 // Eq checks if the field equals the given value.
 func (f *HealthFieldExpr) Eq(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: "==", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: "==", value: value}
 }
 
 // Ne checks if the field does not equal the given value.
 func (f *HealthFieldExpr) Ne(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: "!=", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: "!=", value: value}
 }
 
 // Gt checks if the field is greater than the given value.
 func (f *HealthFieldExpr) Gt(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: ">", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: ">", value: value}
 }
 
 // Gte checks if the field is greater than or equal to the given value.
 func (f *HealthFieldExpr) Gte(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: ">=", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: ">=", value: value}
 }
 
 // Lt checks if the field is less than the given value.
 func (f *HealthFieldExpr) Lt(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: "<", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: "<", value: value}
 }
 
 // Lte checks if the field is less than or equal to the given value.
 func (f *HealthFieldExpr) Lte(value any) HealthExpression {
-	return &fieldCompareExpr{path: f.path, op: "<=", value: value}
+	return &fieldCompareExpr{root: f.root, path: f.path, op: "<=", value: value}
 }
 
 // In checks if the field value is one of the given values.
 func (f *HealthFieldExpr) In(values ...any) HealthExpression {
-	return &fieldInExpr{path: f.path, values: values}
+	return &fieldInExpr{root: f.root, path: f.path, values: values}
 }
 
 // Contains checks if the string field contains the given substring.
 func (f *HealthFieldExpr) Contains(substr string) HealthExpression {
-	return &fieldContainsExpr{path: f.path, substr: substr}
+	return &fieldContainsExpr{root: f.root, path: f.path, substr: substr}
 }
 
 // fieldCompareExpr is a field comparison expression.
 type fieldCompareExpr struct {
+	root  string
 	path  string
 	op    string
 	value any
@@ -198,7 +256,7 @@ func (f *fieldCompareExpr) Preamble() string {
 }
 
 func (f *fieldCompareExpr) ToCUE() string {
-	fullPath := "context.output." + f.path
+	fullPath := resolveRoot(f.root) + "." + f.path
 	// Check if value is a HealthFieldRefExpr
 	if ref, ok := f.value.(*HealthFieldRefExpr); ok {
 		return fmt.Sprintf("%s %s %s", fullPath, f.op, ref.ToCUE())
@@ -208,6 +266,7 @@ func (f *fieldCompareExpr) ToCUE() string {
 
 // fieldInExpr checks if a field is in a set of values.
 type fieldInExpr struct {
+	root   string
 	path   string
 	values []any
 }
@@ -217,7 +276,7 @@ func (f *fieldInExpr) Preamble() string {
 }
 
 func (f *fieldInExpr) ToCUE() string {
-	fullPath := "context.output." + f.path
+	fullPath := resolveRoot(f.root) + "." + f.path
 	parts := make([]string, len(f.values))
 	for i, v := range f.values {
 		parts[i] = fmt.Sprintf("%s == %s", fullPath, formatValue(v))
@@ -227,6 +286,7 @@ func (f *fieldInExpr) ToCUE() string {
 
 // fieldContainsExpr checks if a string field contains a substring.
 type fieldContainsExpr struct {
+	root   string
 	path   string
 	substr string
 }
@@ -236,7 +296,7 @@ func (f *fieldContainsExpr) Preamble() string {
 }
 
 func (f *fieldContainsExpr) ToCUE() string {
-	fullPath := "context.output." + f.path
+	fullPath := resolveRoot(f.root) + "." + f.path
 	return fmt.Sprintf(`strings.Contains(%s, %s)`, fullPath, formatValue(f.substr))
 }
 
@@ -244,6 +304,7 @@ func (f *fieldContainsExpr) ToCUE() string {
 
 // HealthFieldRefExpr represents a reference to another field (for comparisons).
 type HealthFieldRefExpr struct {
+	root string
 	path string
 }
 
@@ -252,13 +313,14 @@ func (f *HealthFieldRefExpr) Preamble() string {
 }
 
 func (f *HealthFieldRefExpr) ToCUE() string {
-	return "context.output." + f.path
+	return resolveRoot(f.root) + "." + f.path
 }
 
 // --- Exists / NotExists ---
 
 // existsExpr checks if a field exists (is not bottom _|_).
 type existsExpr struct {
+	root   string
 	path   string
 	negate bool
 }
@@ -268,7 +330,7 @@ func (e *existsExpr) Preamble() string {
 }
 
 func (e *existsExpr) ToCUE() string {
-	fullPath := "context.output." + e.path
+	fullPath := resolveRoot(e.root) + "." + e.path
 	if e.negate {
 		return fmt.Sprintf("%s == _|_", fullPath)
 	}
@@ -347,6 +409,100 @@ func (a *alwaysExpr) Preamble() string {
 
 func (a *alwaysExpr) ToCUE() string {
 	return "true"
+}
+
+// --- Health scope (output-rooted expressions) ---
+
+// HealthScope roots health expressions at a given output; the zero value targets the primary output.
+type HealthScope struct {
+	root   string
+	inline bool // rooted at a comprehension variable (Every); suppresses ConditionExpr's hoisted preamble
+}
+
+// NewHealthScope returns a scope rooted at the given CUE path.
+func NewHealthScope(root string) *HealthScope {
+	return &HealthScope{root: root}
+}
+
+// Condition creates an expression to check a status condition on this scope.
+func (s *HealthScope) Condition(condType string) *ConditionExpr {
+	return &ConditionExpr{root: s.root, inline: s.inline, condType: condType, expectedStatus: "True"}
+}
+
+// Field creates an expression builder for a field path on this scope.
+func (s *HealthScope) Field(path string) *HealthFieldExpr {
+	return &HealthFieldExpr{root: s.root, path: path}
+}
+
+// FieldRef creates a reference to another field on this scope for field-to-field comparisons.
+func (s *HealthScope) FieldRef(path string) *HealthFieldRefExpr {
+	return &HealthFieldRefExpr{root: s.root, path: path}
+}
+
+// Exists checks if a field exists (is not _|_) on this scope.
+func (s *HealthScope) Exists(path string) HealthExpression {
+	return &existsExpr{root: s.root, path: path}
+}
+
+// NotExists checks if a field does not exist (is _|_) on this scope.
+func (s *HealthScope) NotExists(path string) HealthExpression {
+	return &existsExpr{root: s.root, path: path, negate: true}
+}
+
+// Phase checks if status.phase on this scope matches any of the given phases.
+func (s *HealthScope) Phase(phases ...string) HealthExpression {
+	return &phaseExpr{fieldPath: resolveRoot(s.root) + ".status.phase", phases: phases}
+}
+
+// PhaseField checks a custom phase field path on this scope.
+func (s *HealthScope) PhaseField(path string, phases ...string) HealthExpression {
+	return &phaseExpr{fieldPath: resolveRoot(s.root) + "." + path, phases: phases}
+}
+
+// --- Output collections and aggregation (Every) ---
+
+// OutputCollection selects a set of auxiliary outputs by name prefix.
+type OutputCollection struct {
+	prefix string
+}
+
+// OutputsWithPrefix selects outputs whose name starts with prefix (output groups are numbered slots sharing a prefix).
+func OutputsWithPrefix(prefix string) *OutputCollection {
+	return &OutputCollection{prefix: prefix}
+}
+
+// EveryExpr requires every prefixed output to satisfy the item expression; empty is unhealthy unless AllowEmpty is set.
+type EveryExpr struct {
+	prefix     string
+	itemVar    string
+	itemExpr   HealthExpression
+	allowEmpty bool
+}
+
+// AllowEmpty makes an empty match set healthy, for optional collections.
+func (e *EveryExpr) AllowEmpty() *EveryExpr {
+	e.allowEmpty = true
+	return e
+}
+
+func (e *EveryExpr) itemsVar() string {
+	return "_" + sanitizeIdent(e.prefix) + "Items"
+}
+
+func (e *EveryExpr) Preamble() string {
+	// Built-in =~, not strings.HasPrefix: health CUE compiles without imports. QuoteMeta makes the anchored prefix a literal match.
+	return fmt.Sprintf(`%s: [ for k, v in context.outputs if k =~ %q { v } ]`,
+		e.itemsVar(), "^"+regexp.QuoteMeta(e.prefix))
+}
+
+func (e *EveryExpr) ToCUE() string {
+	items := e.itemsVar()
+	all := fmt.Sprintf(`len([ for %s in %s if %s { %s } ]) == len(%s)`,
+		e.itemVar, items, e.itemExpr.ToCUE(), e.itemVar, items)
+	if e.allowEmpty {
+		return all
+	}
+	return fmt.Sprintf(`len(%s) > 0 && %s`, items, all)
 }
 
 // --- Helper functions ---

--- a/pkg/definition/defkit/health_expr.go
+++ b/pkg/definition/defkit/health_expr.go
@@ -32,13 +32,16 @@ func resolveRoot(root string) string {
 	return root
 }
 
-// sanitizeIdent keeps only ASCII alphanumerics, yielding a valid CUE identifier fragment.
+// sanitizeIdent maps s to a valid CUE identifier fragment. Alphanumerics pass through; other bytes become "_"+hex.
 func sanitizeIdent(s string) string {
 	var b strings.Builder
-	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			b.WriteByte(c)
+			continue
 		}
+		fmt.Fprintf(&b, "_%02x", c)
 	}
 	return b.String()
 }
@@ -491,7 +494,8 @@ func (e *EveryExpr) itemsVar() string {
 
 func (e *EveryExpr) Preamble() string {
 	// Built-in =~, not strings.HasPrefix: health CUE compiles without imports. QuoteMeta makes the anchored prefix a literal match.
-	return fmt.Sprintf(`%s: [ for k, v in context.outputs if k =~ %q { v } ]`,
+	// (*context.outputs | {}) defaults a missing outputs map to empty; getTemplateContext omits it when there are no auxiliary outputs.
+	return fmt.Sprintf(`%s: [ for k, v in (*context.outputs | {}) if k =~ %q { v } ]`,
 		e.itemsVar(), "^"+regexp.QuoteMeta(e.prefix))
 }
 

--- a/pkg/definition/defkit/health_expr_test.go
+++ b/pkg/definition/defkit/health_expr_test.go
@@ -594,7 +594,7 @@ func TestEveryGolden(t *testing.T) {
 		return item.Condition("Ready").IsTrue()
 	})
 	policy := HealthPolicy(expr)
-	expected := "_accessPointItems: [ for k, v in context.outputs if k =~ \"^accessPoint\" { v } ]\n" +
+	expected := "_accessPointItems: [ for k, v in (*context.outputs | {}) if k =~ \"^accessPoint\" { v } ]\n" +
 		"isHealth: len(_accessPointItems) > 0 && len([ for _accessPointItem in _accessPointItems " +
 		"if len([ for c in *_accessPointItem.status.conditions | [] if c.type != _|_ if c.type == \"Ready\" " +
 		"if c.status != _|_ if c.status == \"True\" { c } ]) > 0 { _accessPointItem } ]) == len(_accessPointItems)"
@@ -609,7 +609,7 @@ func TestEveryPrefixPreamble(t *testing.T) {
 		return item.Exists("status.id")
 	})
 	preamble := expr.Preamble()
-	expected := `_accessPointItems: [ for k, v in context.outputs if k =~ "^accessPoint" { v } ]`
+	expected := `_accessPointItems: [ for k, v in (*context.outputs | {}) if k =~ "^accessPoint" { v } ]`
 	if preamble != expected {
 		t.Errorf("got %q, want %q", preamble, expected)
 	}
@@ -844,10 +844,6 @@ func TestConditionReasonEvaluates(t *testing.T) {
 	}
 }
 
-// TestEveryPrefixQuoteMetaEvaluates proves QuoteMeta makes the prefix a LITERAL
-// match: the decoy output "axb1" would match an unescaped "^a.b" regex (dot as
-// wildcard) but must NOT match the escaped "^a\.b". With QuoteMeta the match set
-// is empty, so AllowEmpty => healthy; without it, "axb1" (no status.id) => false.
 func TestEveryPrefixQuoteMetaEvaluates(t *testing.T) {
 	h := Health()
 	policy := HealthPolicy(
@@ -864,6 +860,56 @@ func TestEveryPrefixQuoteMetaEvaluates(t *testing.T) {
 	}
 	if !got {
 		t.Errorf("expected healthy=true (decoy axb1 must not match literal ^a\\.b), got false\npolicy:\n%s", policy)
+	}
+}
+
+func TestEveryNoOutputsContext(t *testing.T) {
+	h := Health()
+	item := func(item *HealthScope) HealthExpression { return item.Condition("Ready").IsTrue() }
+	allowEmpty := HealthPolicy(h.Every(OutputsWithPrefix("replica"), item).AllowEmpty())
+	required := HealthPolicy(h.Every(OutputsWithPrefix("replica"), item))
+
+	// No "outputs" key: mirrors getTemplateContext when a component has no auxiliary outputs.
+	ctx := map[string]interface{}{"output": readyObj()}
+
+	got, err := health.CheckHealth(ctx, allowEmpty, nil)
+	if err != nil {
+		t.Fatalf("AllowEmpty errored with no outputs in context: %v\npolicy:\n%s", err, allowEmpty)
+	}
+	if !got {
+		t.Errorf("AllowEmpty with no outputs should be healthy, got false\npolicy:\n%s", allowEmpty)
+	}
+
+	got, err = health.CheckHealth(ctx, required, nil)
+	if err != nil {
+		t.Fatalf("required Every errored with no outputs in context: %v\npolicy:\n%s", err, required)
+	}
+	if got {
+		t.Errorf("required Every with no outputs should be unhealthy, got true\npolicy:\n%s", required)
+	}
+}
+
+func TestEveryPrefixNoNameCollision(t *testing.T) {
+	h := Health()
+	exists := func(item *HealthScope) HealthExpression { return item.Exists("status.id") }
+	dash := h.Every(OutputsWithPrefix("foo-bar"), exists)
+	plain := h.Every(OutputsWithPrefix("foobar"), exists)
+
+	if dash.itemsVar() == plain.itemsVar() {
+		t.Fatalf("prefixes foo-bar and foobar collided on helper var %q", dash.itemsVar())
+	}
+
+	policy := HealthPolicy(h.And(dash, plain))
+	ctx := map[string]interface{}{"outputs": map[string]interface{}{
+		"foo-bar1": map[string]interface{}{"status": map[string]interface{}{"id": "a"}},
+		"foobar1":  map[string]interface{}{"status": map[string]interface{}{"id": "b"}},
+	}}
+	got, err := health.CheckHealth(ctx, policy, nil)
+	if err != nil {
+		t.Fatalf("colliding-prefix policy errored: %v\npolicy:\n%s", err, policy)
+	}
+	if !got {
+		t.Errorf("expected healthy=true, got false\npolicy:\n%s", policy)
 	}
 }
 

--- a/pkg/definition/defkit/health_expr_test.go
+++ b/pkg/definition/defkit/health_expr_test.go
@@ -474,3 +474,417 @@ func TestComponentHealthPolicyExprComplex(t *testing.T) {
 		t.Errorf("Expected !( in policy, got: %s", policy)
 	}
 }
+
+func TestHealthScopedCondition(t *testing.T) {
+	h := Health()
+	vela := VelaCtx()
+	expr := h.At(vela.Outputs("securityGroup")).Condition("Ready").IsTrue()
+
+	preamble := expr.Preamble()
+	if !strings.Contains(preamble, "context.outputs.securityGroup.status.conditions") {
+		t.Errorf("expected scoped root in preamble, got: %s", preamble)
+	}
+	if !strings.Contains(preamble, "_securityGroupReadyCond") {
+		t.Errorf("expected scoped var name, got: %s", preamble)
+	}
+}
+
+func TestHealthScopedField(t *testing.T) {
+	h := Health()
+	vela := VelaCtx()
+	cue := h.At(vela.Outputs("filesystem")).Field("status.state").Eq("available").ToCUE()
+
+	expected := `context.outputs.filesystem.status.state == "available"`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+}
+
+func TestHealthDefaultRootUnchanged(t *testing.T) {
+	h := Health()
+	cue := h.Field("status.phase").Eq("Running").ToCUE()
+
+	expected := `context.output.status.phase == "Running"`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+}
+
+func TestHealthScopedConditionNoCollision(t *testing.T) {
+	h := Health()
+	vela := VelaCtx()
+	a := h.Condition("Ready").IsTrue()
+	b := h.At(vela.Outputs("securityGroup")).Condition("Ready").IsTrue()
+
+	if a.Preamble() == b.Preamble() {
+		t.Error("scoped and default Ready conditions produced identical preambles")
+	}
+}
+
+func TestHealthAtPrimaryOutput(t *testing.T) {
+	h := Health()
+	vela := VelaCtx()
+	cue := h.At(vela.Output()).Field("status.phase").Eq("Running").ToCUE()
+
+	expected := `context.output.status.phase == "Running"`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+}
+
+func TestHealthAtNilRef(t *testing.T) {
+	h := Health()
+	cue := h.At(nil).Field("status.phase").Eq("Running").ToCUE()
+
+	expected := `context.output.status.phase == "Running"`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+}
+
+func TestEveryEmptyIsUnhealthy(t *testing.T) {
+	h := Health()
+	expr := h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+		return item.Condition("Ready").IsTrue()
+	})
+	cue := expr.ToCUE()
+	if !strings.Contains(cue, "> 0 &&") {
+		t.Errorf("expected empty-match guard (len(...) > 0) in generated CUE, got: %s", cue)
+	}
+	if !strings.HasPrefix(cue, "len(_accessPointItems) > 0") {
+		t.Errorf("expected the guard to lead the expression, got: %s", cue)
+	}
+}
+
+func TestEveryItemExprHasNoPreamble(t *testing.T) {
+	scope := &HealthScope{root: "_x", inline: true}
+	if p := scope.Condition("Ready").IsTrue().Preamble(); p != "" {
+		t.Errorf("inline scope must not emit a preamble, got %q", p)
+	}
+}
+
+func TestEveryInlineConditionMergesFilters(t *testing.T) {
+	scope := &HealthScope{root: "_x", inline: true}
+	cue := scope.Condition("Ready").IsTrue().ToCUE()
+	expected := `len([ for c in *_x.status.conditions | [] if c.type != _|_ if c.type == "Ready" if c.status != _|_ if c.status == "True" { c } ]) > 0`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+}
+
+func TestEveryDistinctPatternsDoNotCollide(t *testing.T) {
+	h := Health()
+	a := h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+		return item.Condition("Ready").IsTrue()
+	})
+	b := h.Every(OutputsWithPrefix("mountTarget"), func(item *HealthScope) HealthExpression {
+		return item.Condition("Ready").IsTrue()
+	})
+	if a.Preamble() == b.Preamble() {
+		t.Errorf("distinct patterns produced identical preambles: %s", a.Preamble())
+	}
+	if a.ToCUE() == b.ToCUE() {
+		t.Errorf("distinct patterns produced identical expressions: %s", a.ToCUE())
+	}
+}
+
+func TestEveryGolden(t *testing.T) {
+	h := Health()
+	expr := h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+		return item.Condition("Ready").IsTrue()
+	})
+	policy := HealthPolicy(expr)
+	expected := "_accessPointItems: [ for k, v in context.outputs if k =~ \"^accessPoint\" { v } ]\n" +
+		"isHealth: len(_accessPointItems) > 0 && len([ for _accessPointItem in _accessPointItems " +
+		"if len([ for c in *_accessPointItem.status.conditions | [] if c.type != _|_ if c.type == \"Ready\" " +
+		"if c.status != _|_ if c.status == \"True\" { c } ]) > 0 { _accessPointItem } ]) == len(_accessPointItems)"
+	if policy != expected {
+		t.Errorf("golden mismatch:\n got: %s\nwant: %s", policy, expected)
+	}
+}
+
+func TestEveryPrefixPreamble(t *testing.T) {
+	h := Health()
+	expr := h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+		return item.Exists("status.id")
+	})
+	preamble := expr.Preamble()
+	expected := `_accessPointItems: [ for k, v in context.outputs if k =~ "^accessPoint" { v } ]`
+	if preamble != expected {
+		t.Errorf("got %q, want %q", preamble, expected)
+	}
+}
+
+func TestEveryAllowEmptyIsHealthy(t *testing.T) {
+	h := Health()
+	expr := h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+		return item.Condition("Ready").IsTrue()
+	}).AllowEmpty()
+	cue := expr.ToCUE()
+	if strings.Contains(cue, "> 0 &&") {
+		t.Errorf("AllowEmpty must drop the empty-match guard, got: %s", cue)
+	}
+	if !strings.HasPrefix(cue, "len([ for _accessPointItem") {
+		t.Errorf("AllowEmpty should lead with the all-match comprehension, got: %s", cue)
+	}
+}
+
+// s3filesPolicy builds the composed health policy that mirrors the real
+// s3-files component (issue #7290): primary Ready, a scoped-condition, a
+// scoped field-existence, an AllowEmpty Every over access points, and a
+// default Every over mount targets.
+func s3filesPolicy() string {
+	h := Health()
+	vela := VelaCtx()
+	expr := h.And(
+		h.Condition("Ready").IsTrue(),
+		h.At(vela.Outputs("securityGroup")).Condition("Ready").IsTrue(),
+		h.At(vela.Outputs("filesystem")).Exists("status.fileSystemID"),
+		h.Every(OutputsWithPrefix("accessPoint"), func(item *HealthScope) HealthExpression {
+			return item.Exists("status.id")
+		}).AllowEmpty(),
+		h.Every(OutputsWithPrefix("mountTarget"), func(item *HealthScope) HealthExpression {
+			return item.Condition("Ready").IsTrue()
+		}),
+	)
+	return HealthPolicy(expr)
+}
+
+func readyObj() map[string]interface{} {
+	return map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "True"},
+	}}}
+}
+
+func notReadyObj() map[string]interface{} {
+	return map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False"},
+	}}}
+}
+
+// TestS3FilesPolicyEvaluates runs the composed policy through vela-core's real
+// evaluator (health.CheckHealth) across the observed cluster states. This
+// proves the generated CUE compiles AND evaluates identically to the
+// hand-written policy it replaces.
+func TestS3FilesPolicyEvaluates(t *testing.T) {
+	policy := s3filesPolicy()
+	cases := []struct {
+		name    string
+		output  map[string]interface{}
+		outputs map[string]interface{}
+		want    bool
+	}{
+		{
+			name:   "all ready",
+			output: readyObj(),
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    map[string]interface{}{"status": map[string]interface{}{"fileSystemID": "fs-1"}},
+				"accessPoint1":  map[string]interface{}{"status": map[string]interface{}{"id": "ap-1"}},
+				"mountTarget1":  readyObj(),
+			},
+			want: true,
+		},
+		{
+			name:   "mount target not ready",
+			output: readyObj(),
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    map[string]interface{}{"status": map[string]interface{}{"fileSystemID": "fs-1"}},
+				"mountTarget1":  readyObj(),
+				"mountTarget2":  notReadyObj(),
+			},
+			want: false,
+		},
+		{
+			name:   "filesystem missing fileSystemID",
+			output: readyObj(),
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    readyObj(), // Ready, but no status.fileSystemID
+				"mountTarget1":  readyObj(),
+			},
+			want: false,
+		},
+		{
+			name:   "access point missing id",
+			output: readyObj(),
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    map[string]interface{}{"status": map[string]interface{}{"fileSystemID": "fs-1"}},
+				"accessPoint1":  map[string]interface{}{}, // exists, no status.id
+				"mountTarget1":  readyObj(),
+			},
+			want: false,
+		},
+		{
+			name:   "no access points requested (AllowEmpty)",
+			output: readyObj(),
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    map[string]interface{}{"status": map[string]interface{}{"fileSystemID": "fs-1"}},
+				"mountTarget1":  readyObj(),
+			},
+			want: true,
+		},
+		{
+			name:   "bucket has no status",
+			output: map[string]interface{}{},
+			outputs: map[string]interface{}{
+				"securityGroup": readyObj(),
+				"filesystem":    map[string]interface{}{"status": map[string]interface{}{"fileSystemID": "fs-1"}},
+				"mountTarget1":  readyObj(),
+			},
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			templateContext := map[string]interface{}{"output": c.output, "outputs": c.outputs}
+			got, err := health.CheckHealth(templateContext, policy, nil)
+			if err != nil {
+				t.Fatalf("CheckHealth errored instead of returning a verdict: %v\npolicy:\n%s", err, policy)
+			}
+			if got != c.want {
+				t.Errorf("healthy=%v, want %v\npolicy:\n%s", got, c.want, policy)
+			}
+		})
+	}
+}
+
+// --- Branch coverage: ConditionExpr variants, inline branches, scoped leaves, QuoteMeta ---
+
+func TestConditionVariantsToCUE(t *testing.T) {
+	h := Health()
+	cases := []struct {
+		name string
+		expr HealthExpression
+		want string
+	}{
+		{"IsFalse", h.Condition("Ready").IsFalse(),
+			`len([ for c in _readyCond if c.status != _|_ if c.status == "False" { c } ]) > 0`},
+		{"Is custom", h.Condition("Ready").Is("Degraded"),
+			`len([ for c in _readyCond if c.status != _|_ if c.status == "Degraded" { c } ]) > 0`},
+		{"ReasonIs", h.Condition("Ready").ReasonIs("LowDisk"),
+			`len([ for c in _readyCond if c.status != _|_ if c.status == "True" if c.reason != _|_ if c.reason == "LowDisk" { c } ]) > 0`},
+		{"Exists", h.Condition("Ready").Exists(),
+			`len(_readyCond) > 0`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.expr.ToCUE(); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestInlineConditionBranches(t *testing.T) {
+	scope := &HealthScope{root: "_x", inline: true}
+
+	reason := scope.Condition("Ready").ReasonIs("LowDisk").ToCUE()
+	wantReason := `len([ for c in *_x.status.conditions | [] if c.type != _|_ if c.type == "Ready" if c.status != _|_ if c.status == "True" if c.reason != _|_ if c.reason == "LowDisk" { c } ]) > 0`
+	if reason != wantReason {
+		t.Errorf("inline ReasonIs:\n got %q\nwant %q", reason, wantReason)
+	}
+
+	exists := scope.Condition("Ready").Exists().ToCUE()
+	wantExists := `len([ for c in *_x.status.conditions | [] if c.type != _|_ if c.type == "Ready" { c } ]) > 0`
+	if exists != wantExists {
+		t.Errorf("inline Exists:\n got %q\nwant %q", exists, wantExists)
+	}
+}
+
+func TestScopedLeavesToCUE(t *testing.T) {
+	h := Health()
+	vela := VelaCtx()
+	x := h.At(vela.Outputs("x"))
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Exists", x.Exists("status.id").ToCUE(), `context.outputs.x.status.id != _|_`},
+		{"NotExists", x.NotExists("status.err").ToCUE(), `context.outputs.x.status.err == _|_`},
+		{"Phase", x.Phase("Running").ToCUE(), `context.outputs.x.status.phase == "Running"`},
+		{"PhaseField", x.PhaseField("status.p", "A", "B").ToCUE(),
+			`context.outputs.x.status.p == "A" || context.outputs.x.status.p == "B"`},
+		{"CrossResourceFieldRef",
+			h.At(vela.Outputs("a")).Field("status.x").Eq(h.At(vela.Outputs("b")).FieldRef("status.y")).ToCUE(),
+			`context.outputs.a.status.x == context.outputs.b.status.y`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("got %q, want %q", c.got, c.want)
+			}
+		})
+	}
+}
+
+func TestConditionReasonEvaluates(t *testing.T) {
+	h := Health()
+	policy := HealthPolicy(h.Condition("Ready").IsTrue().(*ConditionExpr).ReasonIs("AllGood"))
+	cond := func(reason string) map[string]interface{} {
+		return map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "True", "reason": reason},
+		}}}
+	}
+	for _, c := range []struct {
+		reason string
+		want   bool
+	}{{"AllGood", true}, {"SomethingElse", false}} {
+		got, err := health.CheckHealth(map[string]interface{}{"output": cond(c.reason)}, policy, nil)
+		if err != nil {
+			t.Fatalf("CheckHealth error: %v", err)
+		}
+		if got != c.want {
+			t.Errorf("reason=%q: got %v, want %v", c.reason, got, c.want)
+		}
+	}
+}
+
+// TestEveryPrefixQuoteMetaEvaluates proves QuoteMeta makes the prefix a LITERAL
+// match: the decoy output "axb1" would match an unescaped "^a.b" regex (dot as
+// wildcard) but must NOT match the escaped "^a\.b". With QuoteMeta the match set
+// is empty, so AllowEmpty => healthy; without it, "axb1" (no status.id) => false.
+func TestEveryPrefixQuoteMetaEvaluates(t *testing.T) {
+	h := Health()
+	policy := HealthPolicy(
+		h.Every(OutputsWithPrefix("a.b"), func(item *HealthScope) HealthExpression {
+			return item.Exists("status.id")
+		}).AllowEmpty(),
+	)
+	ctx := map[string]interface{}{"outputs": map[string]interface{}{
+		"axb1": map[string]interface{}{"status": map[string]interface{}{}}, // no status.id
+	}}
+	got, err := health.CheckHealth(ctx, policy, nil)
+	if err != nil {
+		t.Fatalf("CheckHealth error: %v\npolicy:\n%s", err, policy)
+	}
+	if !got {
+		t.Errorf("expected healthy=true (decoy axb1 must not match literal ^a\\.b), got false\npolicy:\n%s", policy)
+	}
+}
+
+func TestNewHealthScope(t *testing.T) {
+	s := NewHealthScope("context.outputs.securityGroup")
+	cue := s.Field("status.state").Eq("active").ToCUE()
+	expected := `context.outputs.securityGroup.status.state == "active"`
+	if cue != expected {
+		t.Errorf("got %q, want %q", cue, expected)
+	}
+	// empty root falls back to the primary output
+	if got := NewHealthScope("").Field("status.x").Eq(1).ToCUE(); got != "context.output.status.x == 1" {
+		t.Errorf("empty-root scope: got %q", got)
+	}
+}
+
+func TestUpperFirst(t *testing.T) {
+	if got := upperFirst(""); got != "" {
+		t.Errorf(`upperFirst("") = %q, want ""`, got)
+	}
+	if got := upperFirst("ready"); got != "Ready" {
+		t.Errorf(`upperFirst("ready") = %q, want "Ready"`, got)
+	}
+}

--- a/pkg/definition/defkit/status.go
+++ b/pkg/definition/defkit/status.go
@@ -566,55 +566,61 @@ func CronJobHealth() *HealthBuilder {
 // These methods allow building health checks using composable expressions
 // that are then converted to CUE via HealthyWhenExpr().
 
+// At roots subsequent health expressions at the given context reference; without it they target the primary output.
+func (h *HealthBuilder) At(ref *ContextRef) *HealthScope {
+	if ref == nil {
+		return &HealthScope{}
+	}
+	return &HealthScope{root: ref.Path()}
+}
+
+// Every requires every output in the collection to satisfy fn; it returns the concrete *EveryExpr so AllowEmpty is chainable.
+func (h *HealthBuilder) Every(coll *OutputCollection, fn func(item *HealthScope) HealthExpression) *EveryExpr {
+	itemVar := "_" + sanitizeIdent(coll.prefix) + "Item"
+	scope := &HealthScope{root: itemVar, inline: true}
+	return &EveryExpr{prefix: coll.prefix, itemVar: itemVar, itemExpr: fn(scope)}
+}
+
 // Condition creates an expression to check a status condition.
 // Example: Health().Condition("Ready").IsTrue()
 func (h *HealthBuilder) Condition(condType string) *ConditionExpr {
-	return &ConditionExpr{
-		condType:       condType,
-		expectedStatus: "True", // default
-	}
+	return (&HealthScope{}).Condition(condType)
 }
 
 // Field creates an expression builder for a field path.
 // Example: Health().Field("status.replicas").Gt(0)
 func (h *HealthBuilder) Field(path string) *HealthFieldExpr {
-	return &HealthFieldExpr{path: path}
+	return (&HealthScope{}).Field(path)
 }
 
 // FieldRef creates a reference to another field for field-to-field comparisons.
 // Example: Health().Field("status.readyReplicas").Eq(Health().FieldRef("spec.replicas"))
 func (h *HealthBuilder) FieldRef(path string) *HealthFieldRefExpr {
-	return &HealthFieldRefExpr{path: path}
+	return (&HealthScope{}).FieldRef(path)
 }
 
 // Phase creates an expression to check if status.phase matches any of the given phases.
 // Example: Health().Phase("Running", "Succeeded")
 func (h *HealthBuilder) Phase(phases ...string) HealthExpression {
-	return &phaseExpr{
-		fieldPath: "context.output.status.phase",
-		phases:    phases,
-	}
+	return (&HealthScope{}).Phase(phases...)
 }
 
 // PhaseField creates an expression to check a custom phase field path.
 // Example: Health().PhaseField("status.currentPhase", "Active", "Ready")
 func (h *HealthBuilder) PhaseField(path string, phases ...string) HealthExpression {
-	return &phaseExpr{
-		fieldPath: "context.output." + path,
-		phases:    phases,
-	}
+	return (&HealthScope{}).PhaseField(path, phases...)
 }
 
 // Exists checks if a field exists (is not _|_).
 // Example: Health().Exists("status.loadBalancer.ingress")
 func (h *HealthBuilder) Exists(path string) HealthExpression {
-	return &existsExpr{path: path, negate: false}
+	return (&HealthScope{}).Exists(path)
 }
 
 // NotExists checks if a field does not exist (is _|_).
 // Example: Health().NotExists("status.error")
 func (h *HealthBuilder) NotExists(path string) HealthExpression {
-	return &existsExpr{path: path, negate: true}
+	return (&HealthScope{}).NotExists(path)
 }
 
 // And combines multiple health expressions with AND.


### PR DESCRIPTION
### Description of your changes

 Health expressions in defkit were rooted at `context.output`, with no way to target a named/ auxiliary output (`context.outputs.<name>`) or aggregate over a group of outputs. This adds:

  - **Scoping** — `HealthBuilder.At(ref)` returns a `HealthScope` rooted at the given output; all leaf expressions carry a `root` that defaults to `context.output`. Existing methods delegate to a default-rooted scope, so the generated CUE is byte-identical for current usage (all prior tests pass untouched).
  - **Aggregation** — `Every(OutputsWithPrefix(prefix), fn)` requires every output whose name starts with `prefix` to satisfy `fn`; `.AllowEmpty()` makes an empty match set healthy for optional collections (empty is unhealthy by default). Prefix matching uses the built-in `=~` operator (health CUE is compiled without imports, so `strings.HasPrefix` is unavailable) with the prefix escaped via `regexp.QuoteMeta` for a literal match.

Fixes #7290

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

* Added unit tests covering all the new branches: scoping (`At`, `NewHealthScope`, scoped `Condition`/`Field`/`FieldRef`/`Exists`/`NotExists`/`Phase`/`PhaseField`), cross-resource field refs, condition variants including the inline path, `Every`/`AllowEmpty`, and `QuoteMeta` literal matching. 

* Added real-evaluator tests that run the generated policies through `health.CheckHealth` (the same path used by vela-core) against a set of fixtures covering all-ready resources, missing status fields, unready items, empty collections, and resources with no status. These verify both healthy and unhealthy results.

* Also verified the flow end-to-end on an EKS cluster with ACK controllers. A multi-resource component's health policy was migrated to the builder and successfully reconciled as healthy with both one and two grouped outputs. This also validated the generated CUE and the expected field paths against real resource statuses.

### Example

```go
  h := defkit.Health()
  vela := defkit.VelaCtx()

  policy := h.Policy(h.And(
      h.Condition("Ready").IsTrue(),                                 // primary output
      h.At(vela.Outputs("database")).Condition("Ready").IsTrue(),    // a named output
      h.At(vela.Outputs("database")).Exists("status.endpoint"),      // a published status field
      h.Every(defkit.OutputsWithPrefix("replica"),                   // every output "replica*" is Ready
          func(item *defkit.HealthScope) defkit.HealthExpression {
              return item.Condition("Ready").IsTrue()
          }),
      h.Every(defkit.OutputsWithPrefix("shard"),                     // every output "shard*" has status.id
          func(item *defkit.HealthScope) defkit.HealthExpression {
              return item.Exists("status.id")
          }).AllowEmpty(),                                            // ...healthy if none exist
  ))
  ```

### Special notes for your reviewer

 - **Backward compatibility** is structural: unscoped expressions default their root to `context.output`, so pre-existing tests pass with zero edits.
  - **Prefix vs glob:** output groups are numbered slots sharing a prefix, so prefix selection covers the real cases without a glob/regex layer. A broader `OutputsMatching` selector can be added additively later without breaking the
    prefix API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

