### PR TITLE
Fix: vela install shows a clear error for non-semver CLI versions

### DIFF
--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -111,7 +111,7 @@ func NewInstallCommand(c common.Args, order string, ioStreams util.IOStreams) *c
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v, err := version.NewVersion(installArgs.Version)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid KubeVela version %q: %w\nIf you built the vela CLI from source, the binary was likely built without setting VELA_VERSION to a release version, e.g. run `make build VELA_VERSION=v1.10.7` or pass an explicit `--version` flag", installArgs.Version, err)
 			}
 			// Step1: Download Helm Chart
 			ioStreams.Info("Installing KubeVela Core ...")

--- a/references/cli/install.go
+++ b/references/cli/install.go
@@ -111,6 +111,9 @@ func NewInstallCommand(c common.Args, order string, ioStreams util.IOStreams) *c
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v, err := version.NewVersion(installArgs.Version)
 			if err != nil {
+				if cmd.Flags().Changed("version") {
+					return fmt.Errorf("invalid KubeVela version %q: %w", installArgs.Version, err)
+				}
 				return fmt.Errorf("invalid KubeVela version %q: %w\nIf you built the vela CLI from source, the binary was likely built without setting VELA_VERSION to a release version, e.g. run `make build VELA_VERSION=v1.10.7` or pass an explicit `--version` flag", installArgs.Version, err)
 			}
 			// Step1: Download Helm Chart

--- a/references/cli/install_test.go
+++ b/references/cli/install_test.go
@@ -23,6 +23,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
 func TestGetKubeVelaHelmChartRepoURL(t *testing.T) {
@@ -50,6 +53,14 @@ func TestGetKubeVelaHelmChartRepoURL(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, getKubeVelaHelmChartRepoURL(v), c.url)
 	}
+}
+
+func TestInstallCommandRejectsNonSemverVersion(t *testing.T) {
+	cmd := NewInstallCommand(common.Args{}, "1", util.IOStreams{})
+	assert.Nil(t, cmd.Flags().Set("version", "master"))
+	err := cmd.RunE(cmd, []string{})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "VELA_VERSION")
 }
 
 var _ = Describe("Test Install Command", func() {

--- a/references/cli/install_test.go
+++ b/references/cli/install_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
+	innerVersion "github.com/oam-dev/kubevela/version"
 )
 
 func TestGetKubeVelaHelmChartRepoURL(t *testing.T) {
@@ -56,11 +57,24 @@ func TestGetKubeVelaHelmChartRepoURL(t *testing.T) {
 }
 
 func TestInstallCommandRejectsNonSemverVersion(t *testing.T) {
-	cmd := NewInstallCommand(common.Args{}, "1", util.IOStreams{})
-	assert.Nil(t, cmd.Flags().Set("version", "master"))
-	err := cmd.RunE(cmd, []string{})
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "VELA_VERSION")
+	t.Run("default version baked in at build time", func(t *testing.T) {
+		origVersion := innerVersion.VelaVersion
+		innerVersion.VelaVersion = "master"
+		defer func() { innerVersion.VelaVersion = origVersion }()
+
+		cmd := NewInstallCommand(common.Args{}, "1", util.IOStreams{})
+		err := cmd.RunE(cmd, []string{})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "VELA_VERSION")
+	})
+
+	t.Run("explicit invalid --version flag", func(t *testing.T) {
+		cmd := NewInstallCommand(common.Args{}, "1", util.IOStreams{})
+		assert.Nil(t, cmd.Flags().Set("version", "not-a-version"))
+		err := cmd.RunE(cmd, []string{})
+		assert.NotNil(t, err)
+		assert.NotContains(t, err.Error(), "VELA_VERSION")
+	})
 }
 
 var _ = Describe("Test Install Command", func() {


### PR DESCRIPTION
### Description of your changes

copilot:all

When `vela` is built from source with the default `make build` (no `VELA_VERSION` set), the binary bakes in `VELA_VERSION=master` (see `makefiles/const.mk`). Running `./bin/vela install` then fails immediately with a bare, confusing error from the underlying semver parser (e.g. `Malformed version: master`), giving no hint about the actual cause.

This PR makes the `vela install` version check fail with a clear, actionable message instead of the raw parser error, pointing the user at the root cause (`VELA_VERSION` not set when building from source) and the two ways to fix it (`make build VELA_VERSION=v1.10.7` or `vela install --version <ver>`).

Fixes #7331

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go build ./references/cli/...` — passes.
- Added `TestInstallCommandRejectsNonSemverVersion` in `references/cli/install_test.go`, which drives `vela install --version master` through the real `NewInstallCommand`/`RunE` code path (no cluster/kube-client access happens before the version check, so no envtest/live cluster is needed). Verified it fails before the fix (`"Malformed version: master" does not contain "VELA_VERSION"`) and passes after: `go test ./references/cli/... -run TestInstallCommandRejectsNonSemverVersion -v` → PASS.
- `go vet ./references/cli/... ./version/...` — clean.
- `gofmt -l references/cli/install.go references/cli/install_test.go` — no output (already formatted).
- Ran the repo's `hack/utils/golangci-lint-wrapper.sh` (golangci-lint v1.60.1, matching `makefiles/dependency.mk`'s pinned version) — exits 0, no new issues.
- Checked `gh run list --repo kubevela/kubevela --branch master --workflow unit-test.yml` / `--workflow go.yml` — both green on current `master`, so this isn't riding on a pre-existing red base.

### Special notes for your reviewer

This is purely a clearer error message for an already-invalid state; it does not change behavior for valid `--version` values, and does not attempt to auto-detect or skip the version check for non-release builds (kept minimal/surgical, per the issue's second suggested option).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

