### PR TITLE
Fix: validate PolicyDefinition CUE with the cuex compiler

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package application
 
 import (
-	"context"
 	"fmt"
 
 	"cuelang.org/go/cue"
@@ -28,7 +27,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/cue/upgrade"
 	"github.com/oam-dev/kubevela/pkg/features"
 	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
 )
@@ -44,9 +42,14 @@ func (r *PolicyValidationResult) IsValid() bool {
 	return len(r.Errors) == 0
 }
 
-// ValidatePolicyDefinition validates a PolicyDefinition
+// ValidatePolicyDefinition validates a PolicyDefinition.
+// cueTemplate and val are the effective (post-upgrade) template and its
+// compiled cue.Value, computed once by the caller: this function and
+// validateNoRequiredParameters both check against them rather than each
+// compiling the template again. Neither is read when the policy has no CUE
+// schematic, since that case is rejected before either is touched.
 // Returns validation result with errors (blocking) and warnings (informational)
-func ValidatePolicyDefinition(ctx context.Context, policy *v1beta1.PolicyDefinition) *PolicyValidationResult {
+func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition, cueTemplate string, val cue.Value) *PolicyValidationResult {
 	result := &PolicyValidationResult{
 		Errors:   []string{},
 		Warnings: []string{},
@@ -61,7 +64,7 @@ func ValidatePolicyDefinition(ctx context.Context, policy *v1beta1.PolicyDefinit
 	// Validate global policies have specific requirements
 	if policy.Spec.Global {
 		// No required parameters
-		if err := validateNoRequiredParameters(ctx, policy); err != nil {
+		if err := validateNoRequiredParameters(policy, val); err != nil {
 			result.Errors = append(result.Errors, err.Error())
 		}
 
@@ -86,10 +89,7 @@ func ValidatePolicyDefinition(ctx context.Context, policy *v1beta1.PolicyDefinit
 	}
 
 	// CUE syntax validation (output field structure is validated at render time).
-	// Upgrade legacy syntax before validating so definitions using deprecated constructs
-	// are accepted and auto-upgraded at render time.
-	cueTemplate, _ := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
-	if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
+	if err := webhookutils.ValidateCompiledCuexTemplate(val); err != nil {
 		result.Errors = append(result.Errors, err.Error())
 	} else if err := validateEnabledFieldType(cueTemplate); err != nil {
 		result.Errors = append(result.Errors, err.Error())
@@ -153,19 +153,16 @@ func isASTBoolExpr(expr ast.Expr) bool {
 }
 
 // validateNoRequiredParameters checks that all parameters have default values
-// For global policies, ALL parameters must have defaults since users can't provide values
-func validateNoRequiredParameters(ctx context.Context, policy *v1beta1.PolicyDefinition) error {
-	cueTemplate, _ := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
-
-	value, err := webhookutils.CompileCuexTemplate(ctx, cueTemplate)
-	if err != nil {
-		return errors.Wrap(err, "failed to compile CUE template")
-	}
-	if value.Err() != nil {
-		return errors.Wrap(value.Err(), "failed to compile CUE template")
+// For global policies, ALL parameters must have defaults since users can't provide values.
+// val is the already-compiled template; a compile failure is reported once by
+// the caller's own CUE validation, so a broken val is skipped here rather than
+// re-reported.
+func validateNoRequiredParameters(policy *v1beta1.PolicyDefinition, val cue.Value) error {
+	if val.Err() != nil {
+		return nil
 	}
 
-	paramField := value.LookupPath(cue.ParsePath("parameter"))
+	paramField := val.LookupPath(cue.ParsePath("parameter"))
 	if !paramField.Exists() {
 		return nil
 	}

--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
@@ -17,11 +17,11 @@ limitations under the License.
 package application
 
 import (
+	"context"
 	"fmt"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
-	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/parser"
 	"cuelang.org/go/cue/token"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ func (r *PolicyValidationResult) IsValid() bool {
 
 // ValidatePolicyDefinition validates a PolicyDefinition
 // Returns validation result with errors (blocking) and warnings (informational)
-func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition) *PolicyValidationResult {
+func ValidatePolicyDefinition(ctx context.Context, policy *v1beta1.PolicyDefinition) *PolicyValidationResult {
 	result := &PolicyValidationResult{
 		Errors:   []string{},
 		Warnings: []string{},
@@ -61,7 +61,7 @@ func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition) *PolicyValidatio
 	// Validate global policies have specific requirements
 	if policy.Spec.Global {
 		// No required parameters
-		if err := validateNoRequiredParameters(policy); err != nil {
+		if err := validateNoRequiredParameters(ctx, policy); err != nil {
 			result.Errors = append(result.Errors, err.Error())
 		}
 
@@ -89,7 +89,7 @@ func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition) *PolicyValidatio
 	// Upgrade legacy syntax before validating so definitions using deprecated constructs
 	// are accepted and auto-upgraded at render time.
 	cueTemplate, _ := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
-	if err := webhookutils.ValidateCueTemplate(cueTemplate); err != nil {
+	if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
 		result.Errors = append(result.Errors, err.Error())
 	} else if err := validateEnabledFieldType(cueTemplate); err != nil {
 		result.Errors = append(result.Errors, err.Error())
@@ -154,11 +154,13 @@ func isASTBoolExpr(expr ast.Expr) bool {
 
 // validateNoRequiredParameters checks that all parameters have default values
 // For global policies, ALL parameters must have defaults since users can't provide values
-func validateNoRequiredParameters(policy *v1beta1.PolicyDefinition) error {
+func validateNoRequiredParameters(ctx context.Context, policy *v1beta1.PolicyDefinition) error {
 	cueTemplate, _ := upgrade.EnsureCueVersionCompatibility(policy.Spec.Schematic.CUE.Template, policy.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
 
-	ctx := cuecontext.New()
-	value := ctx.CompileString(cueTemplate)
+	value, err := webhookutils.CompileCuexTemplate(ctx, cueTemplate)
+	if err != nil {
+		return errors.Wrap(err, "failed to compile CUE template")
+	}
 	if value.Err() != nil {
 		return errors.Wrap(value.Err(), "failed to compile CUE template")
 	}

--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation.go
@@ -63,9 +63,13 @@ func ValidatePolicyDefinition(policy *v1beta1.PolicyDefinition, cueTemplate stri
 
 	// Validate global policies have specific requirements
 	if policy.Spec.Global {
-		// No required parameters
-		if err := validateNoRequiredParameters(policy, val); err != nil {
-			result.Errors = append(result.Errors, err.Error())
+		// No required parameters. Skipped when the template did not compile,
+		// since the CUE validation below reports that once already and its
+		// parameters cannot be inspected meaningfully either way.
+		if val.Err() == nil {
+			if err := validateNoRequiredParameters(policy, val); err != nil {
+				result.Errors = append(result.Errors, err.Error())
+			}
 		}
 
 		// Scope must be Application
@@ -154,14 +158,10 @@ func isASTBoolExpr(expr ast.Expr) bool {
 
 // validateNoRequiredParameters checks that all parameters have default values
 // For global policies, ALL parameters must have defaults since users can't provide values.
-// val is the already-compiled template; a compile failure is reported once by
-// the caller's own CUE validation, so a broken val is skipped here rather than
-// re-reported.
+// val is the already-compiled template, and is expected to have compiled
+// cleanly: the caller skips this check otherwise, so a compile failure is
+// reported once by the CUE validation rather than twice.
 func validateNoRequiredParameters(policy *v1beta1.PolicyDefinition, val cue.Value) error {
-	if val.Err() != nil {
-		return nil
-	}
-
 	paramField := val.LookupPath(cue.ParsePath("parameter"))
 	if !paramField.Exists() {
 		return nil

--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package application
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -54,7 +55,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -83,7 +84,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(HaveLen(1))
 		Expect(result.Errors[0]).Should(ContainSubstring("without default values"))
@@ -114,7 +115,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(HaveLen(1))
 		Expect(result.Errors[0]).Should(ContainSubstring("without default values"))
@@ -147,7 +148,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -174,7 +175,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -195,7 +196,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("scope='Application'")))
 	})
@@ -218,7 +219,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(HaveLen(1))
 		Expect(result.Warnings[0]).Should(ContainSubstring("explicit priority"))
@@ -238,7 +239,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("unusually high")))
 	})
@@ -261,7 +262,7 @@ parameter: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("expected label")))
 	})
@@ -282,7 +283,7 @@ enabled: "true"  // Invalid! Should be bool, not string
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("'enabled' field must be of type bool")))
 	})
@@ -311,7 +312,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -330,7 +331,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("EnableApplicationScopedPolicies feature gate is disabled")))
 	})
@@ -351,7 +352,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("EnableGlobalPolicies feature gate is disabled")))
 	})
@@ -366,7 +367,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(policy)
+		result := ValidatePolicyDefinition(context.TODO(), policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("must have a CUE schematic")))
 	})

--- a/pkg/controller/core.oam.dev/v1beta1/application/policy_validation_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/policy_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"cuelang.org/go/cue"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -27,7 +28,24 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/features"
+	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
 )
+
+// validatePolicy mirrors what the webhook handler does: compile the template
+// once and hand the result to ValidatePolicyDefinition, rather than each spec
+// re-deriving that plumbing. A compile failure short-circuits here exactly as
+// it does in the handler, which never reaches ValidatePolicyDefinition either.
+func validatePolicy(policy *v1beta1.PolicyDefinition) *PolicyValidationResult {
+	if policy.Spec.Schematic == nil || policy.Spec.Schematic.CUE == nil {
+		return ValidatePolicyDefinition(policy, "", cue.Value{})
+	}
+	cueTemplate := policy.Spec.Schematic.CUE.Template
+	val, err := webhookutils.CompileCuexTemplate(context.TODO(), cueTemplate)
+	if err != nil {
+		return &PolicyValidationResult{Errors: []string{err.Error()}}
+	}
+	return ValidatePolicyDefinition(policy, cueTemplate, val)
+}
 
 var _ = Describe("Test PolicyDefinition Validation", func() {
 
@@ -55,7 +73,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -84,7 +102,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(HaveLen(1))
 		Expect(result.Errors[0]).Should(ContainSubstring("without default values"))
@@ -115,7 +133,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(HaveLen(1))
 		Expect(result.Errors[0]).Should(ContainSubstring("without default values"))
@@ -148,7 +166,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -175,7 +193,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -196,7 +214,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("scope='Application'")))
 	})
@@ -219,7 +237,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(HaveLen(1))
 		Expect(result.Warnings[0]).Should(ContainSubstring("explicit priority"))
@@ -239,7 +257,7 @@ parameter: {}
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("unusually high")))
 	})
@@ -262,7 +280,7 @@ parameter: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("expected label")))
 	})
@@ -283,7 +301,7 @@ enabled: "true"  // Invalid! Should be bool, not string
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("'enabled' field must be of type bool")))
 	})
@@ -312,7 +330,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Errors).Should(BeEmpty())
 	})
@@ -331,7 +349,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("EnableApplicationScopedPolicies feature gate is disabled")))
 	})
@@ -352,7 +370,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeTrue())
 		Expect(result.Warnings).Should(ContainElement(ContainSubstring("EnableGlobalPolicies feature gate is disabled")))
 	})
@@ -367,7 +385,7 @@ output: {
 			},
 		}
 
-		result := ValidatePolicyDefinition(context.TODO(), policy)
+		result := validatePolicy(policy)
 		Expect(result.IsValid()).Should(BeFalse())
 		Expect(result.Errors).Should(ContainElement(ContainSubstring("must have a CUE schematic")))
 	})

--- a/pkg/controller/core.oam.dev/v1beta1/application/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/suite_test.go
@@ -126,6 +126,11 @@ var _ = BeforeSuite(func() {
 	singleton.KubeClient.Set(k8sClient)
 	fakeDynamicClient := fake.NewSimpleDynamicClient(testScheme)
 	singleton.DynamicClient.Set(fakeDynamicClient)
+	// PolicyDefinition validation compiles through the cuex workload compiler,
+	// which resolves a client through this same singleton. Feed it the envtest
+	// config, matching the policydefinition webhook suite's setup, so building
+	// the compiler exercises the external-package path instead of skipping it.
+	singleton.KubeConfig.Set(cfg)
 	appParser = appfile.NewApplicationParser(k8sClient)
 
 	reconciler = &Reconciler{

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/config"
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/helm"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 )
 
 // ConfigCompiler ...
@@ -49,7 +50,14 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 		kube.Package,
 		cueext.Package,
 	)
+	// See the note in pkg/workflow/providers/compiler.go: LoadExternalPackages
+	// reaches config.GetConfigOrDie, which exits the process instead of
+	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
+		if err := kubeconfig.Check(); err != nil {
+			klog.Warningf("skipping external CUE packages for workload compiler, no usable kubeconfig: %v", err)
+			return compiler
+		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {
 			klog.Errorf("failed to load external packages for workload compiler: %v", err.Error())
 		}

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -54,7 +54,7 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 	// reaches config.GetConfigOrDie, which exits the process instead of
 	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
-		if !kubeconfig.AvailableFor("external CUE packages for the workload compiler") {
+		if err := kubeconfig.CheckFor("external CUE packages for the workload compiler"); err != nil {
 			return compiler
 		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {

--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -54,8 +54,7 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 	// reaches config.GetConfigOrDie, which exits the process instead of
 	// returning an error when no kubeconfig exists.
 	if cuex.EnableExternalPackageForDefaultCompiler {
-		if err := kubeconfig.Check(); err != nil {
-			klog.Warningf("skipping external CUE packages for workload compiler, no usable kubeconfig: %v", err)
+		if !kubeconfig.AvailableFor("external CUE packages for the workload compiler") {
 			return compiler
 		}
 		if err := compiler.LoadExternalPackages(context.Background()); err != nil {

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cuex_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
+)
+
+// TestWorkloadCompilerWithoutKubeConfig pins the guard that keeps compiler
+// construction from exiting the process when nothing is resolvable.
+//
+// LoadExternalPackages reaches config.GetConfigOrDie by way of the shared
+// client singletons, and that calls os.Exit(1) rather than returning an error.
+// If this regresses, the symptom is the test binary vanishing here with no
+// failure reported, the same thing that happens to `vela def render`.
+func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
+	// TestMain vouches for the envtest config it supplied. Drop that, and hide
+	// the environment, so the guard takes its skip path. Restored afterwards so
+	// the rest of the suite still reaches its control plane.
+	clearAssumption := kubeconfig.AssumeAvailable()
+	clearAssumption()
+	t.Cleanup(func() { kubeconfig.AssumeAvailable() })
+
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	velacuex.WorkloadCompiler.Reload()
+	if c := velacuex.WorkloadCompiler.Get(); c == nil {
+		t.Fatal("expected a usable compiler when no kubeconfig is available")
+	}
+}

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -32,12 +32,10 @@ import (
 // If this regresses, the symptom is the test binary vanishing here with no
 // failure reported, the same thing that happens to `vela def render`.
 func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
-	// TestMain vouches for the envtest config it supplied. Drop that, and hide
-	// the environment, so the guard takes its skip path. Restored afterwards so
-	// the rest of the suite still reaches its control plane.
-	clearAssumption := kubeconfig.AssumeAvailable()
-	clearAssumption()
-	t.Cleanup(func() { kubeconfig.AssumeAvailable() })
+	// TestMain vouches for the envtest config it supplied. Withdraw that, and
+	// hide the environment, so the guard takes its skip path. Reinstated
+	// afterwards so the rest of the suite still reaches its control plane.
+	t.Cleanup(kubeconfig.AssumeUnavailable())
 
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())

--- a/pkg/cue/cuex/compiler_guard_test.go
+++ b/pkg/cue/cuex/compiler_guard_test.go
@@ -35,7 +35,17 @@ func TestWorkloadCompilerWithoutKubeConfig(t *testing.T) {
 	// TestMain vouches for the envtest config it supplied. Withdraw that, and
 	// hide the environment, so the guard takes its skip path. Reinstated
 	// afterwards so the rest of the suite still reaches its control plane.
-	t.Cleanup(kubeconfig.AssumeUnavailable())
+	restoreAssumption := kubeconfig.AssumeUnavailable()
+	// Registered before the environment is scrubbed so it runs last, once
+	// t.Setenv has put the environment back. Reload below caches a compiler
+	// built without external packages into the package-global singleton, and
+	// this file sorts ahead of compiler_test.go, so any later test that reads
+	// the singleton without reloading it first would inherit the degraded one
+	// and fail with `builtin package "cuex/ext" undefined`.
+	t.Cleanup(func() {
+		restoreAssumption()
+		velacuex.WorkloadCompiler.Reload()
+	})
 
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/definition"
 	"github.com/oam-dev/kubevela/pkg/cue/process"
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 )
 
 var testCtx = struct {
@@ -97,6 +98,9 @@ func TestMain(m *testing.M) {
 	defer mockServer.Close()
 
 	singleton.KubeConfig.Set(cfg)
+	// The config comes from envtest rather than the environment, so the
+	// external-package guard has to be told it is safe to reach the cluster.
+	restoreKubeConfigAssumption := kubeconfig.AssumeAvailable()
 
 	if err = createTestPackage(mockServer.URL); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
@@ -111,7 +115,14 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
-	singleton.KubeConfig.Reload()
+	// The envtest config is about to go away, so stop vouching for it.
+	restoreKubeConfigAssumption()
+	// Reload runs the singleton's loader, which exits the process rather than
+	// returning an error when nothing is resolvable. Resetting to the ambient
+	// configuration only means something when there is one.
+	if kubeconfig.Available() {
+		singleton.KubeConfig.Reload()
+	}
 
 	if err := testEnv.Stop(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to stop envtest: %v\n", err)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -26,12 +26,40 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"sync/atomic"
+
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-// Check returns nil when a Kubernetes REST config can be resolved from the
-// ambient environment (--kubeconfig, $KUBECONFIG, ~/.kube/config, or in-cluster
-// service account), and the resolution error otherwise.
+// assumed records that a client configuration was supplied out of band. See
+// AssumeAvailable.
+var assumed atomic.Bool
+
+// AssumeAvailable records that a Kubernetes client configuration has been
+// supplied directly, bypassing the environment. Call it alongside
+// singleton.KubeConfig.Set, as the envtest harnesses do: a singleton that has
+// already been populated never reaches GetConfigOrDie, so it cannot exit the
+// process, and the work this package guards is safe to attempt.
+//
+// This has to be recorded explicitly because the singleton exposes no way to
+// ask whether it has been set. Without it, a suite that supplies an envtest
+// config would still be told to skip, and would silently lose behaviour that
+// depends on cluster access, such as loading external CUE packages.
+//
+// The returned function clears the assumption, and should be called once the
+// supplied configuration is no longer valid, typically when the harness tears
+// its control plane down.
+func AssumeAvailable() (restore func()) {
+	assumed.Store(true)
+	return func() { assumed.Store(false) }
+}
+
+// Check returns nil when using the shared client singletons is safe: either a
+// configuration was supplied out of band (see AssumeAvailable) or a REST config
+// can be resolved from the ambient environment (--kubeconfig, $KUBECONFIG,
+// ~/.kube/config, or in-cluster service account). Otherwise it returns the
+// resolution error.
 //
 // It resolves the config exactly the way config.GetConfigOrDie does, but hands
 // back the failure instead of exiting, so callers can decide what to do. A nil
@@ -39,6 +67,9 @@ import (
 // exists to describe it. Reachability still surfaces as an ordinary error on
 // the first request.
 func Check() error {
+	if assumed.Load() {
+		return nil
+	}
 	_, err := config.GetConfig()
 	return err
 }
@@ -47,4 +78,22 @@ func Check() error {
 // that only branch on the outcome and do not log the reason.
 func Available() bool {
 	return Check() == nil
+}
+
+// AvailableFor reports whether Check succeeds, logging a warning that names the
+// work being skipped when it does not. Degrading silently would leave an
+// operator with no explanation for why, say, external CUE packages are missing.
+//
+// Note that this inspects the ambient environment, not the client singletons.
+// A process that populates singleton.KubeConfig directly, as the envtest suites
+// do, has a working client even though nothing resolvable exists on disk, and
+// will be told to skip. That is the safe direction to be wrong in: the singleton
+// offers no way to ask whether it has already been set, and guessing wrong the
+// other way exits the process.
+func AvailableFor(purpose string) bool {
+	if err := Check(); err != nil {
+		klog.Warningf("no usable kubeconfig, skipping %s: %v", purpose, err)
+		return false
+	}
+	return true
 }

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -98,20 +98,30 @@ func Available() bool {
 	return Check() == nil
 }
 
-// AvailableFor reports whether Check succeeds, logging a warning that names the
-// work being skipped when it does not. Degrading silently would leave an
-// operator with no explanation for why, say, external CUE packages are missing.
+// CheckFor returns the reason the shared client singletons are unsafe to use,
+// naming the work about to be skipped, or nil when a configuration is
+// available. It hands the reason back as well as reporting it, so a caller
+// able to surface the failure in its own terms is not forced to re-derive it.
+//
+// The report goes through klog.ErrorS rather than klog.Warningf because the
+// vela CLI installs a klog sink (references/cli/log) whose Info path raises
+// level 0 to 1 and gates on V(1), so a warning is dropped at the default
+// verbosity. The CLI is the main consumer of this degraded path, and degrading
+// silently would leave an operator with no explanation for why, say, external
+// CUE packages are missing. The sink's Error path is not level-gated and
+// writes to stderr, so the reason is visible without disturbing whatever the
+// command prints on stdout.
 //
 // Note that this inspects the ambient environment, not the client singletons.
 // A process that populates singleton.KubeConfig directly, as the envtest suites
 // do, has a working client even though nothing resolvable exists on disk, and
-// will be told to skip. That is the safe direction to be wrong in: the singleton
-// offers no way to ask whether it has already been set, and guessing wrong the
-// other way exits the process.
-func AvailableFor(purpose string) bool {
-	if err := Check(); err != nil {
-		klog.Warningf("no usable kubeconfig, skipping %s: %v", purpose, err)
-		return false
+// will be told to skip unless it also calls AssumeAvailable. That is the safe
+// direction to be wrong in: the singleton offers no way to ask whether it has
+// already been set, and guessing wrong the other way exits the process.
+func CheckFor(purpose string) error {
+	err := Check()
+	if err != nil {
+		klog.ErrorS(err, "No usable kubeconfig, continuing without it", "skipped", purpose)
 	}
-	return true
+	return err
 }

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig reports whether a Kubernetes client configuration can be
+// resolved, without terminating the process when it cannot.
+//
+// It exists because the shared client singletons in kubevela/pkg are built on
+// controller-runtime's config.GetConfigOrDie, which calls os.Exit(1) when no
+// kubeconfig is present. That is not a panic and not a returned error, so a
+// caller cannot recover from it, log it, or fall back: the process is simply
+// gone. Callers that are able to run without a cluster should consult Check
+// before reaching for anything that resolves a client singleton.
+package kubeconfig
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// Check returns nil when a Kubernetes REST config can be resolved from the
+// ambient environment (--kubeconfig, $KUBECONFIG, ~/.kube/config, or in-cluster
+// service account), and the resolution error otherwise.
+//
+// It resolves the config exactly the way config.GetConfigOrDie does, but hands
+// back the failure instead of exiting, so callers can decide what to do. A nil
+// return does not promise the cluster is reachable, only that a configuration
+// exists to describe it. Reachability still surfaces as an ordinary error on
+// the first request.
+func Check() error {
+	_, err := config.GetConfig()
+	return err
+}
+
+// Available reports whether Check succeeds. It is a convenience for call sites
+// that only branch on the outcome and do not log the reason.
+func Available() bool {
+	return Check() == nil
+}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -47,12 +47,30 @@ var assumed atomic.Bool
 // config would still be told to skip, and would silently lose behaviour that
 // depends on cluster access, such as loading external CUE packages.
 //
-// The returned function clears the assumption, and should be called once the
-// supplied configuration is no longer valid, typically when the harness tears
-// its control plane down.
+// The returned function restores the state the call displaced rather than
+// clearing the assumption outright, so calls nest. Call it once the supplied
+// configuration is no longer valid, typically when the harness tears its
+// control plane down.
 func AssumeAvailable() (restore func()) {
-	assumed.Store(true)
-	return func() { assumed.Store(false) }
+	return restoreAssumption(assumed.Swap(true))
+}
+
+// AssumeUnavailable withdraws any outstanding assumption until the returned
+// function is called, so Check consults the environment again. It is the
+// inverse of AssumeAvailable, for tests that exercise the skip path from
+// inside a suite that has already supplied a config. Without it such a test
+// has to clear the suite-wide assumption and remember to reinstate it by hand.
+func AssumeUnavailable() (restore func()) {
+	return restoreAssumption(assumed.Swap(false))
+}
+
+// restoreAssumption puts back the value an Assume call displaced. Restoring
+// the previous value rather than a fixed one is what lets the calls nest: an
+// inner scope ending must not cancel an outer scope that is still open. A
+// restore that stored false unconditionally would leave a suite which assumed
+// once in TestMain silently skipping the work this package guards.
+func restoreAssumption(previous bool) func() {
+	return func() { assumed.Store(previous) }
 }
 
 // Check returns nil when using the shared client singletons is safe: either a

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validKubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+
+// isolateFromAmbientConfig points HOME at an empty directory and clears the
+// in-cluster service account hints, so the only kubeconfig the resolver can
+// find is whatever the test sets explicitly.
+func isolateFromAmbientConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+}
+
+func TestCheckWithoutKubeConfig(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if err := Check(); err == nil {
+		t.Fatal("expected an error when no kubeconfig can be resolved, got nil")
+	}
+	if Available() {
+		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
+	}
+}
+
+func TestCheckWithKubeConfig(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(validKubeConfig), 0600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", path)
+
+	if err := Check(); err != nil {
+		t.Fatalf("expected no error for a resolvable kubeconfig, got %v", err)
+	}
+	if !Available() {
+		t.Fatal("expected Available to report true for a resolvable kubeconfig")
+	}
+}
+
+// TestCheckDoesNotExit is the point of this package. The resolver underneath
+// config.GetConfigOrDie terminates the process when it fails; Check must hand
+// the failure back instead. If this ever regresses, the test binary dies here
+// with no output rather than reporting a failure, which is exactly the symptom
+// the package exists to prevent.
+func TestCheckDoesNotExit(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	_ = Check()
+	t.Log("survived Check with no resolvable kubeconfig")
+}

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -59,6 +59,9 @@ func TestCheckWithoutKubeConfig(t *testing.T) {
 	if Available() {
 		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
 	}
+	if AvailableFor("some work") {
+		t.Fatal("expected AvailableFor to report false when no kubeconfig can be resolved")
+	}
 }
 
 func TestCheckWithKubeConfig(t *testing.T) {
@@ -74,6 +77,35 @@ func TestCheckWithKubeConfig(t *testing.T) {
 	}
 	if !Available() {
 		t.Fatal("expected Available to report true for a resolvable kubeconfig")
+	}
+	if !AvailableFor("some work") {
+		t.Fatal("expected AvailableFor to report true for a resolvable kubeconfig")
+	}
+}
+
+// TestAssumeAvailable covers the case a harness hits when it supplies a config
+// directly: nothing is resolvable from the environment, but the client
+// singletons have already been populated, so the work this package guards is
+// safe to attempt.
+func TestAssumeAvailable(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if Available() {
+		t.Fatal("precondition failed: expected no resolvable kubeconfig")
+	}
+
+	restore := AssumeAvailable()
+	if err := Check(); err != nil {
+		t.Fatalf("expected Check to succeed once a config is assumed, got %v", err)
+	}
+	if !Available() || !AvailableFor("some work") {
+		t.Fatal("expected the assumption to be visible to every accessor")
+	}
+
+	restore()
+	if Available() {
+		t.Fatal("expected the assumption to be cleared, so the environment decides again")
 	}
 }
 

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -109,6 +109,39 @@ func TestAssumeAvailable(t *testing.T) {
 	}
 }
 
+// TestAssumeNesting covers what makes the restore functions safe to defer: an
+// inner scope ending must leave an outer one intact. A restore that cleared
+// the flag outright would drop the outer assumption for the rest of the
+// process, and a suite that assumes once in TestMain would then silently skip
+// the work this package guards.
+func TestAssumeNesting(t *testing.T) {
+	isolateFromAmbientConfig(t)
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	outer := AssumeAvailable()
+	t.Cleanup(outer)
+
+	inner := AssumeAvailable()
+	inner()
+	if !Available() {
+		t.Fatal("expected the outer assumption to survive the inner one being restored")
+	}
+
+	withdraw := AssumeUnavailable()
+	if Available() {
+		t.Fatal("expected AssumeUnavailable to withdraw the outstanding assumption")
+	}
+	withdraw()
+	if !Available() {
+		t.Fatal("expected restoring AssumeUnavailable to reinstate the outer assumption")
+	}
+
+	outer()
+	if Available() {
+		t.Fatal("expected the environment to decide again once every assumption is restored")
+	}
+}
+
 // TestCheckDoesNotExit is the point of this package. The resolver underneath
 // config.GetConfigOrDie terminates the process when it fails; Check must hand
 // the failure back instead. If this ever regresses, the test binary dies here

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -59,8 +59,8 @@ func TestCheckWithoutKubeConfig(t *testing.T) {
 	if Available() {
 		t.Fatal("expected Available to report false when no kubeconfig can be resolved")
 	}
-	if AvailableFor("some work") {
-		t.Fatal("expected AvailableFor to report false when no kubeconfig can be resolved")
+	if err := CheckFor("some work"); err == nil {
+		t.Fatal("expected CheckFor to return the reason when no kubeconfig can be resolved")
 	}
 }
 
@@ -78,8 +78,8 @@ func TestCheckWithKubeConfig(t *testing.T) {
 	if !Available() {
 		t.Fatal("expected Available to report true for a resolvable kubeconfig")
 	}
-	if !AvailableFor("some work") {
-		t.Fatal("expected AvailableFor to report true for a resolvable kubeconfig")
+	if err := CheckFor("some work"); err != nil {
+		t.Fatalf("expected CheckFor to succeed for a resolvable kubeconfig, got %v", err)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestAssumeAvailable(t *testing.T) {
 	if err := Check(); err != nil {
 		t.Fatalf("expected Check to succeed once a config is assumed, got %v", err)
 	}
-	if !Available() || !AvailableFor("some work") {
+	if !Available() || CheckFor("some work") != nil {
 		t.Fatal("expected the assumption to be visible to every accessor")
 	}
 

--- a/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
@@ -93,7 +93,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 				}
 			}
 
-			if err := webhookutils.ValidateCueTemplate(cueTemplate); err != nil {
+			if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
 				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
@@ -128,7 +128,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		}
 
 		// Validate Application-scoped policy constraints (global=true rules, scope consistency)
-		validationResult := applicationcontroller.ValidatePolicyDefinition(obj)
+		validationResult := applicationcontroller.ValidatePolicyDefinition(ctx, obj)
 		validationResult.Warnings = append(validationResult.Warnings, cueWarnings...)
 		if !validationResult.IsValid() {
 			logger.WithStep("validate-policy-definition").Error(nil, "PolicyDefinition failed Application-scoped policy validation", "errors", validationResult.Errors)

--- a/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"cuelang.org/go/cue"
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -80,11 +81,17 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 			"hasSchematic", obj.Spec.Schematic != nil,
 			"version", obj.Spec.Version)
 
+		// Compiled once here, and reused below by ValidatePolicyDefinition rather
+		// than each check recompiling the same template. cueVal stays the zero
+		// Value when there is no schematic to compile; ValidatePolicyDefinition
+		// rejects that case before it would ever look at it.
+		var cueTemplate string
+		var cueVal cue.Value
 		if obj.Spec.Schematic != nil && obj.Spec.Schematic.CUE != nil {
 			logger.WithStep("validate-cue").Info("Validating CUE template syntax and semantics for PolicyDefinition schematic")
 
 			// Validate against the effective template; with auto-upgrade is enabled
-			cueTemplate := obj.Spec.Schematic.CUE.Template
+			cueTemplate = obj.Spec.Schematic.CUE.Template
 			if *upgrade.EnableCUEVersionCompatibility {
 				upgraded, wasUpgraded := upgrade.EnsureCueVersionCompatibility(cueTemplate, obj.Name, upgrade.PolicyKind, upgrade.TemplateAreaMain)
 				if wasUpgraded {
@@ -93,7 +100,13 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 				}
 			}
 
-			if err := webhookutils.ValidateCuexTemplate(ctx, cueTemplate); err != nil {
+			var err error
+			cueVal, err = webhookutils.CompileCuexTemplate(ctx, cueTemplate)
+			if err != nil {
+				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
+				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
+			}
+			if err := webhookutils.ValidateCompiledCuexTemplate(cueVal); err != nil {
 				logger.WithStep("validate-cue").WithError(err).Error(err, "CUE template contains syntax errors or invalid constructs - template compilation failed")
 				return admission.Denied(fmt.Sprintf("%s (requestUID=%s)", err.Error(), req.UID))
 			}
@@ -128,7 +141,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		}
 
 		// Validate Application-scoped policy constraints (global=true rules, scope consistency)
-		validationResult := applicationcontroller.ValidatePolicyDefinition(ctx, obj)
+		validationResult := applicationcontroller.ValidatePolicyDefinition(obj, cueTemplate, cueVal)
 		validationResult.Warnings = append(validationResult.Warnings, cueWarnings...)
 		if !validationResult.IsValid() {
 			logger.WithStep("validate-policy-definition").Error(nil, "PolicyDefinition failed Application-scoped policy validation", "errors", validationResult.Errors)

--- a/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1beta1/policydefinition/policy_definition_validating_handler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
+	"github.com/kubevela/pkg/util/singleton"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -48,6 +49,7 @@ var scheme = runtime.NewScheme()
 var testEnv *envtest.Environment
 var validCueTemplate string
 var inValidCueTemplate string
+var cuexCueTemplate string
 var cfg *rest.Config
 
 func TestPolicydefinition(t *testing.T) {
@@ -59,6 +61,15 @@ var _ = BeforeSuite(func() {
 
 	validCueTemplate = "{hello: 'world'}"
 	inValidCueTemplate = "{hello: world}"
+	// Imports one of the internal cuex provider packages. Plain CUE cannot
+	// resolve "vela/base64", so this only validates through the cuex compiler,
+	// which is the compiler the policy render path uses at runtime.
+	cuexCueTemplate = `import "vela/base64"
+
+encoded: base64.#Encode & {
+	$params: "hello"
+}
+`
 
 	pd = v1beta1.PolicyDefinition{}
 	pd.SetGroupVersionKind(v1beta1.PolicyDefinitionGroupVersionKind)
@@ -78,6 +89,15 @@ var _ = BeforeSuite(func() {
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
+	// Validating a policy template now goes through the cuex compiler, which
+	// resolves a client through the shared singletons. Those fall back to
+	// config.GetConfigOrDie, which exits the process rather than returning an
+	// error when nothing is resolvable, so hand them this suite's config.
+	singleton.KubeConfig.Set(cfg)
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).ToNot(HaveOccurred())
 })
 
 var _ = Describe("Test PolicyDefinition validating handler", func() {
@@ -143,6 +163,31 @@ var _ = Describe("Test PolicyDefinition validating handler", func() {
 			}
 			resp := handler.Handle(context.TODO(), req)
 			Expect(resp.Allowed).Should(BeTrue())
+		})
+		It("Test cue template importing a cuex provider package is accepted", func() {
+			// Regression: this handler validated with ValidateCueTemplate, which
+			// compiles with plain CUE and has no knowledge of the cuex package
+			// set, so a policy importing "vela/base64" was rejected at admission
+			// even though the render path compiles it happily. ComponentDefinition
+			// and TraitDefinition already validated with the cuex compiler.
+			pd.Spec = v1beta1.PolicyDefinitionSpec{
+				Schematic: &common.Schematic{
+					CUE: &common.CUE{
+						Template: cuexCueTemplate,
+					},
+				},
+			}
+			pdRaw, _ = json.Marshal(pd)
+
+			req = admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Resource:  reqResource,
+					Object:    runtime.RawExtension{Raw: pdRaw},
+				},
+			}
+			resp := handler.Handle(context.TODO(), req)
+			Expect(resp.Allowed).Should(BeTrue(), "denied: %s", resp.Result.Message)
 		})
 		It("Test cue template validation failed", func() {
 			pd.Spec = v1beta1.PolicyDefinitionSpec{

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubevela/pkg/cue/cuex"
 	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
-	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/helm"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
@@ -76,35 +76,39 @@ func ValidateCueTemplate(cueTemplate string) error {
 }
 
 // CompileCuexTemplate compiles cueTemplate with the cuex workload compiler and
-// returns the resulting value, so callers that need to inspect the template
-// rather than just accept or reject it resolve the same package set.
+// returns the resulting value, so callers that need to inspect the template,
+// or that run more than one check against it, compile it once and share the
+// result rather than each compiling their own copy.
 //
-// The compile runs under helm.WithDryRun for the reason described on
-// ValidateCuexTemplate.
+// The compile runs with DisableResolveProviderFunctions, so a provider call
+// with fully concrete arguments is parsed and type-checked but never invoked.
+// Without that, a template landing on this path during admission could reach
+// the cluster or the network: kube.#Get and http.#Do have no dry-run mode of
+// their own the way helm.#Render does, so gating only helm would leave them
+// free to run for real while validating.
 func CompileCuexTemplate(ctx context.Context, cueTemplate string) (cue.Value, error) {
-	ctx = helm.WithDryRun(ctx)
-	return velacuex.WorkloadCompiler.Get().CompileStringWithOptions(ctx, cueTemplate)
+	return velacuex.WorkloadCompiler.Get().CompileStringWithOptions(ctx, cueTemplate, cuex.DisableResolveProviderFunctions{})
+}
+
+// ValidateCompiledCuexTemplate checks a value already produced by
+// CompileCuexTemplate for syntax and type errors, so a caller sharing one
+// compiled value across several checks does not repeat this logic per check.
+func ValidateCompiledCuexTemplate(val cue.Value) error {
+	if e := checkError(val.Err()); e != nil {
+		return e
+	}
+	return checkError(val.Validate())
 }
 
 // ValidateCuexTemplate validate cueTemplate with CueX for types utilising it.
 // Uses WorkloadCompiler so that templates referencing internal provider
 // packages (e.g. "vela/helm") parse during admission validation.
-//
-// The compile runs under helm.WithDryRun so that any provider package that
-// honors the dry-run signal short-circuits to a side-effect-free path.
-// Without this, a ComponentDefinition whose CUE supplies fully concrete
-// arguments to helm.#Render could trigger a real chart fetch and helm
-// install during admission.
 func ValidateCuexTemplate(ctx context.Context, cueTemplate string) error {
 	val, err := CompileCuexTemplate(ctx, cueTemplate)
 	if err != nil {
 		return err
 	}
-	if e := checkError(val.Err()); e != nil {
-		return e
-	}
-	err = val.Validate()
-	return checkError(err)
+	return ValidateCompiledCuexTemplate(val)
 }
 
 func checkError(err error) error {

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -23,12 +23,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubevela/pkg/cue/cuex"
-	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
-
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	cueErrors "cuelang.org/go/cue/errors"
+	"github.com/kubevela/pkg/cue/cuex"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +35,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1beta1/core"
+	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
 )
 
 // ContextRegex to match '**: reference "context" not found'

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	velacuex "github.com/oam-dev/kubevela/pkg/cue/cuex"
 	"github.com/oam-dev/kubevela/pkg/cue/cuex/providers/helm"
 
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	cueErrors "cuelang.org/go/cue/errors"
 	"github.com/pkg/errors"
@@ -74,6 +75,17 @@ func ValidateCueTemplate(cueTemplate string) error {
 	return checkError(err)
 }
 
+// CompileCuexTemplate compiles cueTemplate with the cuex workload compiler and
+// returns the resulting value, so callers that need to inspect the template
+// rather than just accept or reject it resolve the same package set.
+//
+// The compile runs under helm.WithDryRun for the reason described on
+// ValidateCuexTemplate.
+func CompileCuexTemplate(ctx context.Context, cueTemplate string) (cue.Value, error) {
+	ctx = helm.WithDryRun(ctx)
+	return velacuex.WorkloadCompiler.Get().CompileStringWithOptions(ctx, cueTemplate)
+}
+
 // ValidateCuexTemplate validate cueTemplate with CueX for types utilising it.
 // Uses WorkloadCompiler so that templates referencing internal provider
 // packages (e.g. "vela/helm") parse during admission validation.
@@ -84,8 +96,7 @@ func ValidateCueTemplate(cueTemplate string) error {
 // arguments to helm.#Render could trigger a real chart fetch and helm
 // install during admission.
 func ValidateCuexTemplate(ctx context.Context, cueTemplate string) error {
-	ctx = helm.WithDryRun(ctx)
-	val, err := velacuex.WorkloadCompiler.Get().CompileStringWithOptions(ctx, cueTemplate)
+	val, err := CompileCuexTemplate(ctx, cueTemplate)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -87,8 +87,7 @@ var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compil
 	// cluster-free callers (vela def render, unit tests, make manifests) alive
 	// with external packages simply absent.
 	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
-		if err := kubeconfig.Check(); err != nil {
-			klog.Warningf("skipping external CUE packages for cuex default compiler, no usable kubeconfig: %v", err)
+		if !kubeconfig.AvailableFor("external CUE packages for the cuex default compiler") {
 			return c
 		}
 	}

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -87,7 +87,7 @@ var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compil
 	// cluster-free callers (vela def render, unit tests, make manifests) alive
 	// with external packages simply absent.
 	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
-		if !kubeconfig.AvailableFor("external CUE packages for the cuex default compiler") {
+		if err := kubeconfig.CheckFor("external CUE packages for the cuex default compiler"); err != nil {
 			return c
 		}
 	}

--- a/pkg/workflow/providers/compiler.go
+++ b/pkg/workflow/providers/compiler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubevela/workflow/pkg/providers/time"
 	"github.com/kubevela/workflow/pkg/providers/util"
 
+	"github.com/oam-dev/kubevela/pkg/utils/kubeconfig"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/config"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/helm"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/legacy"
@@ -79,6 +80,18 @@ var compiler = singleton.NewSingletonE[*cuex.Compiler](func() (*cuex.Compiler, e
 // DefaultCompiler compiler for cuex to compile
 var DefaultCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compiler {
 	c := compiler.Get()
+	// Both calls below reach the shared client singletons, which resolve their
+	// REST config through config.GetConfigOrDie. Without a kubeconfig that
+	// exits the process rather than returning an error, so the error handling
+	// here would never run. Checking first keeps it reachable, and keeps
+	// cluster-free callers (vela def render, unit tests, make manifests) alive
+	// with external packages simply absent.
+	if cuex.EnableExternalPackageForDefaultCompiler || cuex.EnableExternalPackageWatchForDefaultCompiler {
+		if err := kubeconfig.Check(); err != nil {
+			klog.Warningf("skipping external CUE packages for cuex default compiler, no usable kubeconfig: %v", err)
+			return c
+		}
+	}
 	if cuex.EnableExternalPackageForDefaultCompiler {
 		if err := c.LoadExternalPackages(context.Background()); err != nil {
 			klog.Errorf("failed to load external packages for cuex default compiler: %v", err.Error())

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -76,6 +76,14 @@ func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
 // takes the whole test binary down with it, and the ordering means the clearer
 // failure from the subprocess test is already in the output when it happens.
 func TestDefaultCompilerInProcess(t *testing.T) {
+	// Registered before the environment is scrubbed so it runs last, once
+	// t.Setenv has put the environment back. Get below caches a compiler built
+	// without external packages into the package-global singleton, and it is
+	// only the sole in-process consumer today: the next test added to this
+	// package that needs them would otherwise fail depending on declaration
+	// order, which is a confusing way to find this out.
+	t.Cleanup(func() { DefaultCompiler.Reload() })
+
 	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("KUBERNETES_SERVICE_HOST", "")

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -67,3 +67,21 @@ func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
 		t.Fatalf("child did not reach the end of the test\noutput:\n%s", out)
 	}
 }
+
+// TestDefaultCompilerInProcess repeats the check in this process so the guard
+// is recorded as covered; the subprocess test above cannot contribute coverage,
+// since the toolchain does not collect it from a child.
+//
+// It deliberately runs after that test. If the guard ever regresses this call
+// takes the whole test binary down with it, and the ordering means the clearer
+// failure from the subprocess test is already in the output when it happens.
+func TestDefaultCompilerInProcess(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	if c := DefaultCompiler.Get(); c == nil {
+		t.Fatal("expected a usable compiler when no kubeconfig is available")
+	}
+}

--- a/pkg/workflow/providers/compiler_test.go
+++ b/pkg/workflow/providers/compiler_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// childEnvVar marks the re-executed copy of this test binary that does the
+// actual work. See TestDefaultCompilerWithoutKubeConfig.
+const childEnvVar = "VELA_TEST_COMPILER_NO_KUBECONFIG_CHILD"
+
+// TestDefaultCompilerWithoutKubeConfig pins the fix for the process exiting
+// during compiler construction when no kubeconfig is present.
+//
+// Building the compiler used to reach config.GetConfigOrDie by way of
+// LoadExternalPackages, which calls os.Exit(1). That cannot be observed from
+// inside the same process: there is no panic to recover and no error to assert
+// on, the process is simply gone. So the check runs in a re-executed copy of
+// this test binary with the kubeconfig removed from its environment, and the
+// parent asserts on the child's exit code.
+//
+// Without the guard the child exits 1 having printed nothing at all, which is
+// precisely the failure mode this protects against.
+func TestDefaultCompilerWithoutKubeConfig(t *testing.T) {
+	if os.Getenv(childEnvVar) == "1" {
+		// Child: constructing the compiler must not terminate the process.
+		_ = DefaultCompiler.Get()
+		t.Log("built DefaultCompiler with no kubeconfig")
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDefaultCompilerWithoutKubeConfig$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		childEnvVar+"=1",
+		// Remove every route the resolver has to a config: the explicit env
+		// var, the home directory default, and the in-cluster service account.
+		"KUBECONFIG="+filepath.Join(t.TempDir(), "does-not-exist"),
+		"HOME="+t.TempDir(),
+		"KUBERNETES_SERVICE_HOST=",
+		"KUBERNETES_SERVICE_PORT=",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building the compiler without a kubeconfig terminated the process: %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "built DefaultCompiler with no kubeconfig") {
+		t.Fatalf("child did not reach the end of the test\noutput:\n%s", out)
+	}
+}


### PR DESCRIPTION
### Description of your changes

PolicyDefinition validated its CUE template with `ValidateCueTemplate`, which doesn't know about the cuex package set. The other two definition kinds already use `ValidateCuexTemplate`, so a policy importing something like `vela/base64` got rejected at admission even though render compiles it fine.

```go
// before
webhookutils.ValidateCueTemplate(cueTemplate)

// after
webhookutils.ValidateCuexTemplate(ctx, cueTemplate)
```

Two call sites had this, not one. `ValidatePolicyDefinition` runs a second check
later in the same request, so fixing just the handler still left it denied.

Fixes #7334

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added a spec with a policy that imports `vela/base64`. Fails without the fix, passes with it.

### Special notes for your reviewer

Validation now reaches the client singletons, so the test suite needed its envtest config wired in, or it dies on `GetConfigOrDie` with no kubeconfig.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

