### PR TITLE
Fix: render ForEachMap body operations

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -282,15 +282,7 @@ func (g *CUEGenerator) collectImportsFromOps(ops []ResourceOp) {
 			g.collectImportsFromValue(o.Cond())
 		case *IfBlock:
 			g.collectImportsFromValue(o.Cond())
-			for _, innerOp := range o.Ops() {
-				switch inner := innerOp.(type) {
-				case *SetOp:
-					g.collectImportsFromValue(inner.Value())
-				case *SetIfOp:
-					g.collectImportsFromValue(inner.Value())
-					g.collectImportsFromValue(inner.Cond())
-				}
-			}
+			g.collectImportsFromOps(o.Ops())
 		case *PatchKeyOp:
 			for _, elem := range o.Elements() {
 				g.collectImportsFromValue(elem)

--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -208,6 +208,8 @@ func (g *CUEGenerator) collectImportsFromValue(v interface{}) {
 				g.collectImportsFromItemOps(entry.itemBuilder.Ops())
 			}
 		}
+	case *ForEachMapOp:
+		g.collectImportsFromOps(val.Body())
 	case *PlusExpr:
 		for _, part := range val.Parts() {
 			g.collectImportsFromValue(part)
@@ -2313,7 +2315,8 @@ func (g *CUEGenerator) iterRefToCUE(v Value) string {
 }
 
 // forEachMapOpToCUE converts a ForEachMapOp to CUE map comprehension syntax.
-// Generates: {for k, v in source { (keyExpr): valExpr }}.
+// Without body operations it generates {for k, v in source { (keyExpr): valExpr }}.
+// Body operations replace valExpr with a struct rendered under each output key.
 func (g *CUEGenerator) forEachMapOpToCUE(op *ForEachMapOp) string {
 	keyVar := op.KeyVar()
 	if keyVar == "" {
@@ -2335,7 +2338,16 @@ func (g *CUEGenerator) forEachMapOpToCUE(op *ForEachMapOp) string {
 		valExpr = valVar
 	}
 
-	return fmt.Sprintf("{for %s, %s in %s { (%s): %s }}", keyVar, valVar, op.Source(), keyExpr, valExpr)
+	if len(op.Body()) == 0 {
+		return fmt.Sprintf("{for %s, %s in %s { (%s): %s }}", keyVar, valVar, op.Source(), keyExpr, valExpr)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "{for %s, %s in %s {\n", keyVar, valVar, op.Source())
+	fmt.Fprintf(&sb, "%s(%s): {\n", g.indent, keyExpr)
+	g.writeFieldTree(&sb, g.buildFieldTree(op.Body()), 2)
+	fmt.Fprintf(&sb, "%s}\n}}", g.indent)
+	return sb.String()
 }
 
 // cueFuncToCUE converts a CUE function call to CUE syntax.

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -1858,6 +1858,36 @@ var _ = Describe("CUEGenerator", func() {
 			Expect(generated).To(ContainSubstring("name: strings.ToLower(key)"))
 			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
 		})
+
+		It("should collect imports from nested body operations", func() {
+			labels := defkit.StringKeyMap("labels")
+			metadata := defkit.StringKeyMap("metadata")
+			features := defkit.StringList("features")
+			enabled := defkit.Bool("enabled")
+			body := defkit.NewResource("", "").
+				If(enabled.IsTrue()).
+				Set("metadata.fixed", defkit.Lit("fixed")).
+				SpreadIf(features.Contains("metadata"), "metadata", metadata).
+				EndIf().
+				Ops()
+			comp := defkit.NewComponent("test").
+				Params(labels, metadata, features, enabled).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					content := defkit.ForEachMap().
+						Over("parameter.labels").
+						WithBody(body...)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.content", content))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`"list"`))
+			Expect(generated).To(ContainSubstring(
+				`list.Contains(parameter["features"], "metadata")`,
+			))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("Dedupe from Reference source", func() {

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -19,6 +19,8 @@ package defkit_test
 import (
 	"strings"
 
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -1748,6 +1750,113 @@ var _ = Describe("CUEGenerator", func() {
 			// Inner braces should contain both the field and the conditional
 			Expect(cue).To(ContainSubstring("name: m.name"))
 			Expect(cue).To(ContainSubstring("if m.subPath != _|_"))
+		})
+	})
+
+	Describe("ForEachMap body generation", func() {
+		It("should preserve the default map comprehension", func() {
+			labels := defkit.StringKeyMap("labels")
+			comp := defkit.NewComponent("test").
+				Params(labels).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					tpl.AddLetBinding(
+						"_content",
+						defkit.ForEachMap().Over("parameter.labels"),
+					)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.content", defkit.LetVariable("_content")))
+				})
+
+			Expect(comp.ToCue()).To(ContainSubstring(
+				"let _content = {for k, v in parameter.labels { (k): v }}",
+			))
+		})
+
+		It("should render and evaluate body operations for every map entry", func() {
+			labels := defkit.StringKeyMap("labels")
+			body := defkit.NewResource("", "").
+				Set("name", defkit.Reference("key")).
+				Set("value", defkit.Reference("val")).
+				Set("metadata.owner", defkit.Reference("key")).
+				Ops()
+			comp := defkit.NewComponent("test").
+				Params(labels).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					content := defkit.ForEachMap().
+						Over("parameter.labels").
+						WithVars("key", "val").
+						WithBody(body...)
+					tpl.AddLetBinding("_content", content)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.content", defkit.LetVariable("_content")))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`let _content = {for key, val in parameter.labels {
+	(key): {
+		name: key
+		value: val
+		metadata: {
+			owner: key
+		}
+	}
+}}`))
+
+			base := cuecontext.New().CompileString(generated)
+			Expect(base.Err()).NotTo(HaveOccurred())
+			value := base.FillPath(
+				cue.ParsePath("template.parameter.labels"),
+				map[string]string{
+					"alpha": "one",
+					"beta":  "two",
+				},
+			)
+			Expect(value.Err()).NotTo(HaveOccurred())
+
+			var content map[string]struct {
+				Name     string `json:"name"`
+				Value    string `json:"value"`
+				Metadata struct {
+					Owner string `json:"owner"`
+				} `json:"metadata"`
+			}
+			err := value.LookupPath(
+				cue.ParsePath("template.output.data.content"),
+			).Decode(&content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(HaveLen(2))
+			Expect(content["alpha"].Name).To(Equal("alpha"))
+			Expect(content["alpha"].Value).To(Equal("one"))
+			Expect(content["alpha"].Metadata.Owner).To(Equal("alpha"))
+			Expect(content["beta"].Name).To(Equal("beta"))
+			Expect(content["beta"].Value).To(Equal("two"))
+			Expect(content["beta"].Metadata.Owner).To(Equal("beta"))
+		})
+
+		It("should collect imports required by body values", func() {
+			labels := defkit.StringKeyMap("labels")
+			body := defkit.NewResource("", "").
+				Set("name", defkit.StringsToLower(defkit.Reference("key"))).
+				Set("value", defkit.Reference("val")).
+				Ops()
+			comp := defkit.NewComponent("test").
+				Params(labels).
+				Workload("v1", "ConfigMap").
+				Template(func(tpl *defkit.Template) {
+					content := defkit.ForEachMap().
+						Over("parameter.labels").
+						WithVars("key", "val").
+						WithBody(body...)
+					tpl.Output(defkit.NewResource("v1", "ConfigMap").
+						Set("data.content", content))
+				})
+
+			generated := comp.ToCue()
+			Expect(generated).To(ContainSubstring(`"strings"`))
+			Expect(generated).To(ContainSubstring("name: strings.ToLower(key)"))
+			Expect(cuecontext.New().CompileString(generated).Err()).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
### Description of your changes

`ForEachMap.WithBody` now renders its stored resource operations as a structured value under each generated map key.

The empty-body path is unchanged and continues to generate:

```cue
{for k, v in source { (k): v }}
 ```

When body operations are supplied, the generated value is built under the computed key:

 ```cue
{for key, val in source {
    (key): {
        name: key
        value: val
    }
}}
 ```

The implementation reuses Defkit's existing field-tree renderer, keeping nested field paths and resource-operation rendering consistent with Resource and PatchResource.

Import discovery also traverses ForEachMap body operations so values that require CUE standard-library imports are registered when the expression is inspected by the existing import collector.

Fixes #7283

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added regression coverage for:

 - Preserving the existing no-body map comprehension.
 - Rendering multiple body operations.
 - Rendering nested field paths.
 - Using custom key and value variable names.
 - Discovering imports required by body values.
 - Compiling the complete generated CUE.
 - Evaluating a generated map with two input entries and decoding the result.

The evaluation verifies that each source entry produces an independent structured value under its original key.

### Special notes for your reviewer

Body operations replace the normal valExpr for each generated key. When no body is supplied, the existing keyExpr and valExpr behavior and generated output remain unchanged.

No public API was added or changed. The existing WithBody and Body API is now honored by the CUE generator.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

