### PR TITLE
Fix: ResourceTracker GC deletes live resources after rapid A -> B -> A spec update

### DIFF
--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -250,9 +250,19 @@ func (h *gcHandler) scan(ctx context.Context) (inactiveRTs []*v1beta1.ResourceTr
 			// and the newest historyRT of the current revision still tracks the live
 			// resources. Keep it instead of recycling live resources.
 			if h._currentRT == nil && h.app.Status.LatestRevision != nil {
+				// Multiple history RTs can carry the current revision label after
+				// repeated spec flips. Protect the one with the highest application
+				// generation (the same ordering used for currentRT selection) and
+				// never pick an RT that is already being deleted.
 				keep := -1
 				for i, rt := range inactiveRTs {
-					if rt != nil && rt.GetLabels()[oam.LabelAppRevision] == h.app.Status.LatestRevision.Name {
+					if rt == nil || rt.GetDeletionTimestamp() != nil {
+						continue
+					}
+					if rt.GetLabels()[oam.LabelAppRevision] != h.app.Status.LatestRevision.Name {
+						continue
+					}
+					if keep < 0 || rt.Spec.ApplicationGeneration > inactiveRTs[keep].Spec.ApplicationGeneration {
 						keep = i
 					}
 				}

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -96,6 +96,9 @@ func newGCConfig(options ...GCOption) *gcConfig {
 //	   i.  GarbageCollectionMode is not set to `passive`
 //	   ii. All managed resources are RECYCLED. (RECYCLED means resource does not exist or managed by latest
 //	       resourcetrackers)
+//	c. when no currentRT exists for the application's generation (the generation advanced without a
+//	   workflow restart, e.g. a rapid A -> B -> A spec flip back to an already-reconciled revision), the
+//	   newest historyRT of the current revision is not marked, as it still tracks the live resources.
 //
 // NOTE: Mark Stage will always work for each application reconcile, not matter whether workflow is ended
 //
@@ -241,6 +244,24 @@ func (h *gcHandler) scan(ctx context.Context) (inactiveRTs []*v1beta1.ResourceTr
 			}
 		} else {
 			inactiveRTs = h._historyRTs
+			// A finished workflow normally implies a currentRT exists. When the generation
+			// advanced without a workflow restart (e.g. a rapid A -> B -> A spec flip back
+			// to an already-reconciled revision), no RT is created for the new generation
+			// and the newest historyRT of the current revision still tracks the live
+			// resources. Keep it instead of recycling live resources.
+			if h._currentRT == nil && h.app.Status.LatestRevision != nil {
+				keep := -1
+				for i, rt := range inactiveRTs {
+					if rt != nil && rt.GetLabels()[oam.LabelAppRevision] == h.app.Status.LatestRevision.Name {
+						keep = i
+					}
+				}
+				if keep >= 0 {
+					filtered := make([]*v1beta1.ResourceTracker, 0, len(inactiveRTs)-1)
+					filtered = append(filtered, inactiveRTs[:keep]...)
+					inactiveRTs = append(filtered, inactiveRTs[keep+1:]...)
+				}
+			}
 		}
 	}
 	return inactiveRTs

--- a/pkg/resourcekeeper/gc_test.go
+++ b/pkg/resourcekeeper/gc_test.go
@@ -451,18 +451,25 @@ func TestResourceKeeperGarbageCollectKeepsNewestMatchingHistoryRT(t *testing.T) 
 	r := require.New(t)
 	ctx := context.Background()
 
-	// two history RTs carry the same revision label after repeated spec flips;
-	// only the one with the highest application generation tracks the live
-	// resources and must be protected
+	// history RTs carry the same revision label after repeated spec flips.
+	// The newest live one tracks the live resources and must be protected,
+	// while an older RT and an RT that is already being deleted must be
+	// recycled. historyRTs come back sorted by application generation
+	// ascending (SortResourceTrackersByVersion), so slice order always agrees
+	// with generation order here: the deleting RT is what discriminates the
+	// fix from the old keep-the-last-matching logic, which would protect
+	// app-v1-gen3 and recycle the live cm-new instead.
 	setup := func() client.Client {
 		cli := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		for _, tt := range []struct {
-			name string
-			gen  int64
-			cm   string
+			name     string
+			gen      int64
+			cm       string
+			deleting bool
 		}{
-			{"app-v1-gen1", 1, "cm-old"},
-			{"app-v1-gen2", 2, "cm-new"},
+			{"app-v1-gen1", 1, "cm-old", false},
+			{"app-v1-gen2", 2, "cm-new", false},
+			{"app-v1-gen3", 3, "cm-dying", true},
 		} {
 			rt := &v1beta1.ResourceTracker{
 				ObjectMeta: metav1.ObjectMeta{Name: tt.name, Labels: map[string]string{
@@ -487,13 +494,18 @@ func TestResourceKeeperGarbageCollectKeepsNewestMatchingHistoryRT(t *testing.T) 
 			})
 			r.NoError(cli.Create(ctx, cm))
 			r.NoError(resourcetracker.RecordManifestsInResourceTracker(ctx, cli, rt, []*unstructured.Unstructured{cm}, true, false, ""))
+			if tt.deleting {
+				// the finalizer keeps the RT around with a deletion timestamp,
+				// as after a previous GC round already marked it
+				r.NoError(cli.Delete(ctx, rt))
+			}
 		}
 		return cli
 	}
 
 	gc := func(cli client.Client) (bool, error) {
 		app := &v1beta1.Application{
-			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid", Generation: 3},
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid", Generation: 4},
 		}
 		app.Status.LatestRevision = &apicommon.Revision{Name: "app-v1"}
 		_rk, err := NewResourceKeeper(ctx, cli, app)
@@ -515,15 +527,18 @@ func TestResourceKeeperGarbageCollectKeepsNewestMatchingHistoryRT(t *testing.T) 
 	finished, err := gc(cli)
 	r.NoError(err)
 	r.False(finished)
-	// the newer matching RT and its resources are protected
+	// the newest live matching RT and its resources are protected
 	r.True(exists(cli, "app-v1-gen2"))
 	r.True(cmExists(cli, "cm-new"))
 	// the older RT sharing the same revision label is recycled
 	r.False(cmExists(cli, "cm-old"))
+	// the RT already being deleted is not protected either
+	r.False(cmExists(cli, "cm-dying"))
 	finished, err = gc(cli)
 	r.NoError(err)
 	r.True(finished)
 	r.False(exists(cli, "app-v1-gen1"))
+	r.False(exists(cli, "app-v1-gen3"))
 	r.True(exists(cli, "app-v1-gen2"))
 	r.True(cmExists(cli, "cm-new"))
 }

--- a/pkg/resourcekeeper/gc_test.go
+++ b/pkg/resourcekeeper/gc_test.go
@@ -446,6 +446,88 @@ func TestResourceKeeperGarbageCollectWithoutCurrentRT(t *testing.T) {
 	r.False(cmExists(cli))
 }
 
+func TestResourceKeeperGarbageCollectKeepsNewestMatchingHistoryRT(t *testing.T) {
+	MarkWithProbability = 1.0
+	r := require.New(t)
+	ctx := context.Background()
+
+	// two history RTs carry the same revision label after repeated spec flips;
+	// only the one with the highest application generation tracks the live
+	// resources and must be protected
+	setup := func() client.Client {
+		cli := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
+		for _, tt := range []struct {
+			name string
+			gen  int64
+			cm   string
+		}{
+			{"app-v1-gen1", 1, "cm-old"},
+			{"app-v1-gen2", 2, "cm-new"},
+		} {
+			rt := &v1beta1.ResourceTracker{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.name, Labels: map[string]string{
+					oam.LabelAppName:      "app",
+					oam.LabelAppNamespace: "default",
+					oam.LabelAppUID:       "uid",
+					oam.LabelAppRevision:  "app-v1",
+				}, Finalizers: []string{resourcetracker.Finalizer}},
+				Spec: v1beta1.ResourceTrackerSpec{
+					Type:                  v1beta1.ResourceTrackerTypeVersioned,
+					ApplicationGeneration: tt.gen,
+				},
+			}
+			r.NoError(cli.Create(ctx, rt))
+			cm := &unstructured.Unstructured{}
+			cm.SetName(tt.cm)
+			cm.SetNamespace("default")
+			cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+			cm.SetLabels(map[string]string{
+				oam.LabelAppName:      "app",
+				oam.LabelAppNamespace: "default",
+			})
+			r.NoError(cli.Create(ctx, cm))
+			r.NoError(resourcetracker.RecordManifestsInResourceTracker(ctx, cli, rt, []*unstructured.Unstructured{cm}, true, false, ""))
+		}
+		return cli
+	}
+
+	gc := func(cli client.Client) (bool, error) {
+		app := &v1beta1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid", Generation: 3},
+		}
+		app.Status.LatestRevision = &apicommon.Revision{Name: "app-v1"}
+		_rk, err := NewResourceKeeper(ctx, cli, app)
+		r.NoError(err)
+		finished, _, err := _rk.(*resourceKeeper).GarbageCollect(ctx)
+		return finished, err
+	}
+	exists := func(cli client.Client, name string) bool {
+		rt := &v1beta1.ResourceTracker{}
+		return cli.Get(ctx, client.ObjectKey{Name: name}, rt) == nil
+	}
+	cmExists := func(cli client.Client, name string) bool {
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		return cli.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, cm) == nil
+	}
+
+	cli := setup()
+	finished, err := gc(cli)
+	r.NoError(err)
+	r.False(finished)
+	// the newer matching RT and its resources are protected
+	r.True(exists(cli, "app-v1-gen2"))
+	r.True(cmExists(cli, "cm-new"))
+	// the older RT sharing the same revision label is recycled
+	r.False(cmExists(cli, "cm-old"))
+	finished, err = gc(cli)
+	r.NoError(err)
+	r.True(finished)
+	r.False(exists(cli, "app-v1-gen1"))
+	r.True(exists(cli, "app-v1-gen2"))
+	r.True(cmExists(cli, "cm-new"))
+}
+
 func TestUpdateSharedManagedResourceOwner(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/resourcekeeper/gc_test.go
+++ b/pkg/resourcekeeper/gc_test.go
@@ -349,6 +349,103 @@ func TestEnableMarkStageGCOnWorkflowFailure(t *testing.T) {
 	require.False(t, cfg.disableMark)
 }
 
+func TestResourceKeeperGarbageCollectWithoutCurrentRT(t *testing.T) {
+	MarkWithProbability = 1.0
+	r := require.New(t)
+	ctx := context.Background()
+
+	// app reconciled spec at generation 1, then a rapid A -> B -> A spec flip
+	// advanced the generation to 3 without a workflow restart, so no RT was
+	// created for generation 3 and the generation-1 RT became history while
+	// still tracking the live resources of the current revision.
+	setup := func() client.Client {
+		cli := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
+		rt := &v1beta1.ResourceTracker{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-v1", Labels: map[string]string{
+				oam.LabelAppName:      "app",
+				oam.LabelAppNamespace: "default",
+				oam.LabelAppUID:       "uid",
+				oam.LabelAppRevision:  "app-v1",
+			}, Finalizers: []string{resourcetracker.Finalizer}},
+			Spec: v1beta1.ResourceTrackerSpec{
+				Type:                  v1beta1.ResourceTrackerTypeVersioned,
+				ApplicationGeneration: 1,
+			},
+		}
+		r.NoError(cli.Create(ctx, rt))
+		cm := &unstructured.Unstructured{}
+		cm.SetName("cm-1")
+		cm.SetNamespace("default")
+		cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		cm.SetLabels(map[string]string{
+			oam.LabelAppName:      "app",
+			oam.LabelAppNamespace: "default",
+		})
+		r.NoError(cli.Create(ctx, cm))
+		r.NoError(resourcetracker.RecordManifestsInResourceTracker(ctx, cli, rt, []*unstructured.Unstructured{cm}, true, false, ""))
+		return cli
+	}
+
+	gc := func(cli client.Client, latestRevision string) (bool, error) {
+		app := &v1beta1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid", Generation: 3},
+		}
+		if latestRevision != "" {
+			app.Status.LatestRevision = &apicommon.Revision{Name: latestRevision}
+		}
+		_rk, err := NewResourceKeeper(ctx, cli, app)
+		r.NoError(err)
+		finished, _, err := _rk.(*resourceKeeper).GarbageCollect(ctx)
+		return finished, err
+	}
+	rtExists := func(cli client.Client) (*v1beta1.ResourceTracker, bool) {
+		rt := &v1beta1.ResourceTracker{}
+		err := cli.Get(ctx, client.ObjectKey{Namespace: "", Name: "app-v1"}, rt)
+		return rt, err == nil
+	}
+	cmExists := func(cli client.Client) bool {
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		return cli.Get(ctx, client.ObjectKey{Namespace: "default", Name: "cm-1"}, cm) == nil
+	}
+
+	// the history RT of the current revision is kept along with its resources
+	cli := setup()
+	finished, err := gc(cli, "app-v1")
+	r.NoError(err)
+	r.True(finished)
+	rt, ok := rtExists(cli)
+	r.True(ok)
+	r.Nil(rt.GetDeletionTimestamp())
+	r.True(cmExists(cli))
+	finished, err = gc(cli, "app-v1")
+	r.NoError(err)
+	r.True(finished)
+	_, ok = rtExists(cli)
+	r.True(ok)
+	r.True(cmExists(cli))
+
+	// a history RT of an outdated revision is still collected when no
+	// current RT exists (e.g. all components removed from the spec)
+	cli = setup()
+	finished, err = gc(cli, "app-v2")
+	r.NoError(err)
+	r.False(finished)
+	r.False(cmExists(cli))
+	finished, err = gc(cli, "app-v2")
+	r.NoError(err)
+	r.True(finished)
+	_, ok = rtExists(cli)
+	r.False(ok)
+
+	// no revision recorded at all: keep the previous behavior
+	cli = setup()
+	finished, err = gc(cli, "")
+	r.NoError(err)
+	r.False(finished)
+	r.False(cmExists(cli))
+}
+
 func TestUpdateSharedManagedResourceOwner(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
### Description of your changes

copilot:all

Ran into #7278 while looking through the ResourceTracker GC code. If the spec gets flipped A -> B -> A before the controller reconciles the intermediate state, the generation advances twice but the final spec still matches the revision that was already reconciled. The workflow isn't restarted, no RT gets created for the new generation, and the mark stage then happily deletes the old RT along with everything it tracks. The app keeps saying `running` / `healthy: true` while its Deployment, Service etc. are gone.

The trigger is that workflow restart detection is keyed on revision + spec hash while current-RT detection uses the generation, so the two can diverge.

What I changed: in the mark stage, when there is no current-generation RT and the app isn't being deleted, keep the newest history RT whose `app.oam.dev/appRevision` label matches the app's current revision, since that's the RT still tracking the live resources. History RTs from other revisions are still collected like before, so removing all components from a spec (workflow restarts, dispatches nothing, old RT must go) behaves exactly as it does today. The legacy RT GC in the same file already skips the no-current-RT state, this just extends the same idea to the mark stage.

Fixes #7278

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added `TestResourceKeeperGarbageCollectWithoutCurrentRT` which reproduces the issue against a fake client: a generation-1 RT tracking a ConfigMap, app bumped to generation 3 with the revision unchanged (the A -> B -> A case). On master the RT gets marked and the ConfigMap is deleted; with this change both survive, across repeated reconciles.

Also covers the two paths that must not change:

- history RT of an outdated revision with no current RT (e.g. all components removed) is still collected, resources and all
- no `LatestRevision` recorded at all falls back to the old behavior

`go test ./pkg/resourcekeeper/...` passes, including the envtest suite (1.31.0 binaries), plus `gofmt` and `go vet`. I didn't manage a full `make reviewable` run locally, sorry about that.

### Special notes for your reviewer

One thing I wasn't 100% sure about: matching the RT to the revision via the `app.oam.dev/appRevision` label. It works because the RT is labeled with `Status.LatestRevision` at creation and the flip scenario reuses the existing revision. Older RTs without the label just fall through to the old behavior, which seemed safer than guessing. Happy to switch to comparing generations or a spec hash if you'd rather not depend on the label.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

