### PR TITLE
Docs(kep): bound hub authority by the spoke rather than by the grant

### DIFF
--- a/design/vela-core/keps/2.2-spoke-controller/README.md
+++ b/design/vela-core/keps/2.2-spoke-controller/README.md
@@ -42,6 +42,36 @@ Hub application-controller
 
 ---
 
+## Open Decision: Where Rendering Happens
+
+This KEP has the spoke render: it loads `ComponentDefinition`s locally or from hub-dispatched snapshots and does the CUE work itself. The alternative is for the hub to render and ship concrete resources, with the spoke applying, tracking and reporting but never evaluating a template. **Not yet decided**, and the choice has consequences beyond where the CPU cycles land.
+
+| | Spoke renders (this KEP) | Hub renders |
+|---|---|---|
+| Definition governance | spoke needs the definition set; versions drift across the fleet | central, no skew |
+| Hub compute | distributed | the fleet bottleneck |
+| Payload | parameters and a signed snapshot | full rendered manifests, including rendered Secret material |
+| Authority bound | spoke RBAC **and** the local definition set | spoke RBAC alone |
+| Partition behaviour | spoke keeps rendering and reconciling | spoke keeps reconciling what it last received |
+
+Neither is wrong. Spoke-renders distributes compute and keeps rendered Secret material out of an object that travels between clusters. Hub-renders is simpler and keeps definitions centrally governed, at the cost of hub scaling. The fourth row usually decides it: under spoke-renders the local definition set is part of the trust boundary, which argues for or against depending on who administers the spoke.
+
+---
+
+## Keep the Spoke Controller Source-Agnostic
+
+**The spoke controller is a local controller over `Component` CRs in its own cluster, and nothing else.** It watches a namespace, renders, applies, tracks, evaluates health, and writes status back onto the object. It has no opinion about how those objects arrived.
+
+This is what makes push versus pull a later delivery-layer swap rather than a rewrite. Three things would break it:
+
+- an inbound endpoint the hub calls, rather than the spoke watching its own API
+- status reported anywhere other than the local object's status field
+- cluster context injected by the hub that only makes sense because the hub wrote it
+
+The third is the one most easily done by accident.
+
+---
+
 ## Spoke Reconcile Pipeline
 
 ```

--- a/design/vela-core/keps/2.3-hub-controller/README.md
+++ b/design/vela-core/keps/2.3-hub-controller/README.md
@@ -44,6 +44,29 @@ The application-controller's job shrinks dramatically: resolve Definitions, inje
 
 ---
 
+## Effective Authority Is Bounded by the Spoke, Not by the Grant
+
+The hub's RBAC on each spoke narrows to a single GVK: create and watch `Component` CRs. That improves accidental scope and audit legibility: a reviewer can see at a glance what the hub is permitted to do, and a bug in hub code cannot write a ClusterRoleBinding.
+
+**It is not a reduction in what an attacker can do.** A credential that can create `Component` CRs is exactly as powerful as whatever the spoke component-controller will apply on its behalf, and the spoke applies whatever the rendered definition emits. Narrow grant, unchanged blast radius.
+
+What actually bounds authority is the spoke refusing things: a GVK allowlist, namespace scoping, and a policy over what a rendered Component may apply. Until that exists, "minimal RBAC, only needs permission to create/watch Component CRs" describes the shape of the grant rather than its power, and the phrase will be quoted in a security review as though the narrow grant were the protection.
+
+This matters for sequencing, because the steps are independently deliverable and only one of them is security:
+
+| Step | Buys | Security? |
+|---|---|---|
+| 1. Ship the spoke controller and `Component` CR | status fidelity, partition tolerance | no |
+| 2. Narrow the hub's RBAC to one GVK | audit legibility, accidental scope | no |
+| 3. Add the spoke's apply policy | **bounded authority** | **yes** |
+| 4. Optionally revisit pull-based delivery | removes the hub credential entirely | marginal, given 3 |
+
+Steps 1 and 2 are worth doing on their own merits, and each is useful without the next. Nobody should declare the credential problem solved after step 2.
+
+Step 4 is not free with today's transport. cluster-gateway proxies with an upgrade-aware handler, so watches and streaming already pass through. But konnectivity's agent only ever *receives* `DIAL_REQ` and never sends one, so the tunnel cannot be reversed to let a spoke initiate connections to the hub. Pull needs its own channel and its own registration flow, not a reuse of the existing one.
+
+---
+
 ## Hub Reconcile Pipeline
 
 ```
@@ -111,6 +134,9 @@ The three trait phases:
 ## Dispatching Component CRs
 
 The hub creates one `Component` CR per component in the Application. Each Component CR carries:
+
+> **On the name.** `Component` is free at the API level — no `Component` kind is registered under `core.oam.dev` and no such CRD ships today; `component_types.go` holds only constants, and the inline type in `spec.components[]` is `ApplicationComponent`. The ambiguity is in prose rather than in the API: "component" will mean both an entry in `spec.components[]` and a dispatched CR, and the two are one-to-one but not the same object. `ComponentWork` was considered and rejected as needless once the collision turned out not to exist.
+
 
 - `spec.type` — the ComponentDefinition name
 - `spec.properties` — the resolved properties (after `fromParameter` substitution)

--- a/design/vela-core/keps/2.5-credential-model/README.md
+++ b/design/vela-core/keps/2.5-credential-model/README.md
@@ -51,6 +51,16 @@ The hub drives all token rotation. A request/response Secret on the spoke serves
 
 The fresh RSA keypair per rotation cycle provides **forward secrecy on token delivery** — compromise of one cycle's private key cannot expose tokens from any other cycle.
 
+## Rotation Has a Circular Dependency
+
+The rotation request travels to the spoke **through cluster-gateway**, which needs a currently valid credential to reach it. So the channel that repairs an expired credential is the same channel the expired credential gates.
+
+A single failed rotation is harmless, since the old token is still valid and the next attempt succeeds. Sustained failure is not: once the credential expires, there is no in-band way to deliver a new one, and recovery means manual re-registration against every affected spoke. That turns a transient outage on the rotation path into an operational incident proportional to fleet size.
+
+This needs designing for rather than discovering. Rotation must begin far enough before expiry that the retry budget exceeds any plausible outage, and the alert has to fire on *rotation failing*, not on the credential having expired. By then the channel is gone.
+
+---
+
 ## Secret Lifecycle & Audit
 
 Request Secrets are deleted from the spoke immediately after the hub reads and stores the response. The hub-side audit trail is maintained via structured controller logs:


### PR DESCRIPTION
### Description of your changes

copilot:all

WORKS IN PROGRESS

Updates 2.2 and 2.5 in respect of the proposed Component CR. 

Fixes #

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

