### PR TITLE
Fix(chart): propagate multicluster.clusterGateway.port to the controller direct URL

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -280,7 +280,7 @@ spec:
             {{ if .Values.multicluster.enabled }}
             - "--enable-cluster-gateway"
             {{ if .Values.multicluster.clusterGateway.direct }}
-            - "--cluster-gateway-url={{ .Release.Name }}-cluster-gateway-service:9443"
+            - "--cluster-gateway-url={{ .Release.Name }}-cluster-gateway-service:{{ .Values.multicluster.clusterGateway.port }}"
             {{ if .Values.multicluster.clusterGateway.secureTLS.enabled }}
             {{ if .Values.multicluster.clusterGateway.secureTLS.certManager.enabled }}
             - "--cluster-gateway-ca-file=/cluster-gateway-tls-cert/ca.crt"


### PR DESCRIPTION

Fixes #7336


### Description of your changes

The --cluster-gateway-url flag was hardcoded to 9443, but every other place in the chart uses .Values.multicluster.clusterGateway.port, so if you set a different port the controller still dials 9443 and cant reach the gateway.
It only shows up when multicluster.enabled and clusterGateway.direct are both on and the default port is 9443, thats why nobody hit this before.
Fixed by templating the port into the flag, same way cluster-gateway.yaml already does it for --secure-port. Tested with helm template, with port=9999 all three lines agree now and with default values the render is same as before.
Keeping this scoped to the controller URL like we discussed on the issue, the prometheus.io/port annotation have the same problem but I will file that separately.

Fixes #7336


I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

