### PR TITLE
Feat(defkit): support expression-based validator messages

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -19,6 +19,7 @@ package defkit
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -149,6 +150,12 @@ func (g *CUEGenerator) detectRequiredImports(c *ComponentDefinition) {
 		}
 	}
 
+	// Check validator message expressions, at the top level and inside params.
+	g.collectImportsFromValidators(c.GetValidators())
+	for _, param := range c.GetParams() {
+		g.collectImportsFromParamValidators(param)
+	}
+
 	// Check resource operations in output
 	if output := tpl.GetOutput(); output != nil {
 		g.collectImportsFromResource(output)
@@ -157,6 +164,42 @@ func (g *CUEGenerator) detectRequiredImports(c *ComponentDefinition) {
 	// Check resource operations in outputs
 	for _, res := range tpl.GetOutputs() {
 		g.collectImportsFromResource(res)
+	}
+}
+
+// collectImportsFromValidators adds the imports needed by validator message
+// expressions.
+//
+// A message can hold any Value, including a CUE standard library call such as
+// strings.ToLower, and the reference is emitted whether or not the import is
+// there. Only the message is walked: a validator built with Validate carries no
+// expression and contributes nothing, so this cannot change what any existing
+// definition generates.
+func (g *CUEGenerator) collectImportsFromValidators(validators []*Validator) {
+	for _, v := range validators {
+		if v == nil {
+			continue
+		}
+		if msg := v.MessageValue(); msg != nil {
+			g.collectImportsFromValue(msg)
+		}
+	}
+}
+
+// collectImportsFromParamValidators walks a parameter for validators, including
+// the ones attached to nested fields of maps and array elements.
+func (g *CUEGenerator) collectImportsFromParamValidators(param Param) {
+	switch p := param.(type) {
+	case *MapParam:
+		g.collectImportsFromValidators(p.GetValidators())
+		for _, field := range p.GetFields() {
+			g.collectImportsFromParamValidators(field)
+		}
+	case *ArrayParam:
+		g.collectImportsFromValidators(p.GetValidators())
+		for _, field := range p.GetFields() {
+			g.collectImportsFromParamValidators(field)
+		}
 	}
 }
 
@@ -211,6 +254,14 @@ func (g *CUEGenerator) collectImportsFromValue(v interface{}) {
 	case *PlusExpr:
 		for _, part := range val.Parts() {
 			g.collectImportsFromValue(part)
+		}
+	case *InterpolatedString:
+		for _, part := range val.Parts() {
+			g.collectImportsFromValue(part)
+		}
+	case *CUEFunc:
+		for _, arg := range val.Args() {
+			g.collectImportsFromValue(arg)
 		}
 	}
 }
@@ -612,14 +663,48 @@ func (g *CUEGenerator) validatorMessageKey(v *Validator) (letDecl, key string) {
 		}
 	}
 	rendered := g.valueToCUE(expr)
-	if rendered == "" || rendered == "_" {
-		// valueToCUE has no rendering for this Value, so it fell through to its
-		// placeholder. Binding that would produce a label CUE never resolves and
-		// a validator that silently never fires, which is the one outcome worth
-		// avoiding here, so fail in the generated CUE instead.
+	if !g.messageRenderable(expr) {
+		// Some part of the message has no rendering and fell through to
+		// valueToCUE's placeholder. Binding that would produce a label CUE
+		// never resolves and a validator that silently never fires, which is
+		// the one outcome worth avoiding here, so fail in the generated CUE
+		// instead.
 		rendered = "_|_ // defkit: validator message expression cannot be rendered"
 	}
 	return fmt.Sprintf("let %s = %s", validatorMessageVar, rendered), fmt.Sprintf("(%s)", validatorMessageVar)
+}
+
+// messageRenderable reports whether every leaf of a validator message
+// expression has a rendering.
+//
+// Checking the rendered string as a whole is not enough. valueToCUE falls back
+// to "_" for values it does not know, and nested inside an interpolation that
+// placeholder does not stand out: "region '\(_)' bad" is a perfectly ordinary
+// non-concrete string, so CUE leaves it alone and the validator never fires.
+// Walking the parts is what lets the whole message fail loudly instead.
+func (g *CUEGenerator) messageRenderable(v Value) bool {
+	switch val := v.(type) {
+	case *InterpolatedString:
+		return g.partsRenderable(val.Parts())
+	case *PlusExpr:
+		return g.partsRenderable(val.Parts())
+	case *CUEFunc:
+		return g.partsRenderable(val.Args())
+	default:
+		rendered := g.valueToCUE(v)
+		return rendered != "" && rendered != "_"
+	}
+}
+
+// partsRenderable reports whether every part of a compound message value has a
+// rendering.
+func (g *CUEGenerator) partsRenderable(parts []Value) bool {
+	for _, part := range parts {
+		if !g.messageRenderable(part) {
+			return false
+		}
+	}
+	return true
 }
 
 // writeIfBlocksForCond writes one or more `if cond { body }` blocks. For
@@ -2393,6 +2478,19 @@ func (g *CUEGenerator) cueFuncToCUE(fn *CUEFunc) string {
 	return fmt.Sprintf("%s.%s(%s)", fn.Package(), fn.Function(), strings.Join(args, ", "))
 }
 
+// cueStringContent escapes s for use inside a CUE double-quoted string and
+// returns the content only, without the surrounding quotes.
+//
+// Interpolated strings are assembled by hand rather than through %q, because
+// the \(...) segments have to stay live. That means the literal segments
+// between them still need escaping: an unescaped quote ends the string early
+// and breaks the definition, and an unescaped backslash silently turns
+// something like a Windows path into an escape sequence.
+func cueStringContent(s string) string {
+	quoted := strconv.Quote(s)
+	return quoted[1 : len(quoted)-1]
+}
+
 // interpolatedStringToCUE converts an InterpolatedString to CUE string interpolation.
 // Literal string values are inlined directly. All other values are wrapped in \(...).
 // Example: Interpolation(vela.Namespace(), Lit(":"), name) → "\(context.namespace):\(parameter.name)"
@@ -2402,7 +2500,7 @@ func (g *CUEGenerator) interpolatedStringToCUE(is *InterpolatedString) string {
 	for _, part := range is.Parts() {
 		if lit, ok := part.(*Literal); ok {
 			if s, ok := lit.Val().(string); ok {
-				sb.WriteString(s)
+				sb.WriteString(cueStringContent(s))
 				continue
 			}
 		}

--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -534,6 +534,12 @@ func (g *CUEGenerator) generateParameterBlock(c *ComponentDefinition, depth int)
 	return sb.String()
 }
 
+// validatorMessageVar is the CUE let binding holding a computed validator
+// message. It is declared inside the validator block rather than beside it, so
+// each validator gets its own binding and several validators can share a
+// struct without their message bindings colliding.
+const validatorMessageVar = "_message"
+
 // writeValidator writes a CUE _validate* block.
 // Example output:
 //
@@ -543,6 +549,9 @@ func (g *CUEGenerator) generateParameterBlock(c *ComponentDefinition, depth int)
 //	        "tenantName must not end with a hyphen": false
 //	    }
 //	}
+//
+// Validators built with ValidateValue carry an expression message instead, and
+// the two branches share a computed key. See validatorMessageKey.
 func (g *CUEGenerator) writeValidator(sb *strings.Builder, v *Validator, depth int) {
 	indent := strings.Repeat(g.indent, depth)
 	inner := strings.Repeat(g.indent, depth+1)
@@ -555,12 +564,17 @@ func (g *CUEGenerator) writeValidator(sb *strings.Builder, v *Validator, depth i
 		name = "_validate"
 	}
 
+	letDecl, key := g.validatorMessageKey(v)
+
 	writeBody := func(bodyIndent, innerBodyIndent string) {
 		sb.WriteString(fmt.Sprintf("%s%s: {\n", bodyIndent, name))
-		sb.WriteString(fmt.Sprintf("%s%q: true\n", innerBodyIndent, v.Message()))
+		if letDecl != "" {
+			sb.WriteString(fmt.Sprintf("%s%s\n", innerBodyIndent, letDecl))
+		}
+		sb.WriteString(fmt.Sprintf("%s%s: true\n", innerBodyIndent, key))
 		if v.FailCondition() != nil {
 			g.writeIfBlocksForCond(sb, v.FailCondition(), innerBodyIndent, func() {
-				sb.WriteString(fmt.Sprintf("%s\t%q: false\n", innerBodyIndent, v.Message()))
+				sb.WriteString(fmt.Sprintf("%s\t%s: false\n", innerBodyIndent, key))
 			})
 		}
 		sb.WriteString(fmt.Sprintf("%s}\n", bodyIndent))
@@ -574,6 +588,38 @@ func (g *CUEGenerator) writeValidator(sb *strings.Builder, v *Validator, depth i
 	} else {
 		writeBody(indent, inner)
 	}
+}
+
+// validatorMessageKey returns the optional `let` declaration a validator needs
+// and the CUE field label its two branches share.
+//
+// A fixed string message is emitted as a quoted label directly. An expression
+// message is bound to a let and both branches use the computed label
+// (_message). Going through the let is what keeps the two labels identical:
+// they have to unify into one field for the validator to conflict, and reaching
+// for the same binding twice guarantees that in a way repeating the expression
+// does not. It also keeps a long message out of the generated CUE twice over.
+func (g *CUEGenerator) validatorMessageKey(v *Validator) (letDecl, key string) {
+	expr := v.MessageValue()
+	if expr == nil {
+		return "", fmt.Sprintf("%q", v.Message())
+	}
+	// A literal string needs no indirection: emit the label the fixed-string
+	// form would have produced.
+	if lit, ok := expr.(*Literal); ok {
+		if s, ok := lit.Val().(string); ok {
+			return "", fmt.Sprintf("%q", s)
+		}
+	}
+	rendered := g.valueToCUE(expr)
+	if rendered == "" || rendered == "_" {
+		// valueToCUE has no rendering for this Value, so it fell through to its
+		// placeholder. Binding that would produce a label CUE never resolves and
+		// a validator that silently never fires, which is the one outcome worth
+		// avoiding here, so fail in the generated CUE instead.
+		rendered = "_|_ // defkit: validator message expression cannot be rendered"
+	}
+	return fmt.Sprintf("let %s = %s", validatorMessageVar, rendered), fmt.Sprintf("(%s)", validatorMessageVar)
 }
 
 // writeIfBlocksForCond writes one or more `if cond { body }` blocks. For

--- a/pkg/definition/defkit/trait.go
+++ b/pkg/definition/defkit/trait.go
@@ -499,6 +499,19 @@ func (g *TraitCUEGenerator) detectRequiredImports(t *TraitDefinition) {
 		}
 	}
 
+	// Validator message expressions on nested params. Traits do not emit
+	// top-level validators, but writeParam emits the ones attached to map and
+	// array params, so those messages can still reference a CUE stdlib call.
+	// Scanned before the template check so traits without a Template body are
+	// covered too.
+	validatorScan := NewCUEGenerator()
+	for _, param := range t.GetParams() {
+		validatorScan.collectImportsFromParamValidators(param)
+	}
+	for _, imp := range validatorScan.imports {
+		g.addImportIfMissing(imp)
+	}
+
 	if !t.HasTemplate() {
 		return
 	}

--- a/pkg/definition/defkit/validator.go
+++ b/pkg/definition/defkit/validator.go
@@ -29,16 +29,58 @@ package defkit
 // Validators can be guarded (only active when a condition is true) and can be attached
 // at different levels: top-level parameter, inside map/struct params, or inside array elements.
 type Validator struct {
-	message   string    // the validation message (used as CUE field key)
-	failCond  Condition // when this condition is true, validation fails
-	guardCond Condition // optional: validator only active when guard is true
-	name      string    // optional: override the CUE variable name (default: derived from message)
+	message     string    // the validation message (used as CUE field key)
+	messageExpr Value     // optional: message built from an expression instead of a fixed string
+	failCond    Condition // when this condition is true, validation fails
+	guardCond   Condition // optional: validator only active when guard is true
+	name        string    // optional: override the CUE variable name (default: derived from message)
 }
 
 // Validate creates a new Validator with the given error message.
 // The message is used both as the CUE field key and as the error shown on failure.
 func Validate(message string) *Validator {
 	return &Validator{message: message}
+}
+
+// ValidateValue creates a Validator whose message is a CUE expression rather
+// than a fixed Go string, so the message can name the value that broke the rule.
+//
+// The expression is bound to a let inside the validator block and used as a
+// computed field key in both branches:
+//
+//	ValidateValue(
+//	    Interpolation(
+//	        Lit("region '"),
+//	        LocalField("region"),
+//	        Lit("' must not match the primary region"),
+//	    ),
+//	).
+//	    FailWhen(Eq(LocalField("region"), Reference("parameter.primaryRegion"))).
+//	    WithName("_validateReplicaRegion")
+//
+// generates:
+//
+//	_validateReplicaRegion: {
+//	    let _message = "region '\(region)' must not match the primary region"
+//	    (_message): true
+//	    if region == parameter.primaryRegion {
+//	        (_message): false
+//	    }
+//	}
+//
+// and fails with `region 'us-west-2' must not match the primary region`.
+//
+// Fixed messages are the better default for simple rules; use this when a list
+// or map has several similar entries and the message has to say which one
+// failed. Note that CUE leaves a validator whose message is not yet concrete
+// unevaluated rather than reporting it, the same way it already does for a
+// fail condition that is not yet concrete, so an expression referring to an
+// optional field only reports once that field is set.
+//
+// Passing a literal string Value is equivalent to Validate: the let is skipped
+// and the quoted message is emitted directly.
+func ValidateValue(message Value) *Validator {
+	return &Validator{messageExpr: message}
 }
 
 // FailWhen sets the condition that causes validation to fail.
@@ -62,8 +104,13 @@ func (v *Validator) WithName(name string) *Validator {
 	return v
 }
 
-// Message returns the validation message.
+// Message returns the fixed validation message.
+// It is empty for validators built with ValidateValue; use MessageValue for those.
 func (v *Validator) Message() string { return v.message }
+
+// MessageValue returns the message expression, or nil when the validator was
+// built with Validate and carries a fixed string message.
+func (v *Validator) MessageValue() Value { return v.messageExpr }
 
 // FailCondition returns the fail condition.
 func (v *Validator) FailCondition() Condition { return v.failCond }

--- a/pkg/definition/defkit/validator_internal_test.go
+++ b/pkg/definition/defkit/validator_internal_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defkit
+
+import (
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// unrenderableValue is a Value the generator has no case for, standing in for a
+// future defkit Value someone adds without teaching valueToCUE about it. Value
+// cannot be implemented outside this package, which is why this lives here.
+type unrenderableValue struct{}
+
+func (unrenderableValue) expr()  {}
+func (unrenderableValue) value() {}
+
+var _ = ginkgo.Describe("Validator message rendering", func() {
+	ginkgo.It("should fail in the generated CUE when the message cannot be rendered", func() {
+		gen := NewCUEGenerator()
+		comp := NewComponent("test").
+			Params(String("name")).
+			Validators(
+				ValidateValue(unrenderableValue{}).
+					FailWhen(LocalField("name").Eq("")).
+					WithName("_validateName"),
+			)
+
+		cue := gen.GenerateParameterSchema(comp)
+
+		gomega.Expect(cue).To(gomega.ContainSubstring("let _message = _|_"))
+		gomega.Expect(cue).To(gomega.ContainSubstring("defkit: validator message expression cannot be rendered"))
+
+		// A validator with an unusable message must not quietly render to CUE
+		// that compiles and never fires. Making it bottom is what turns that
+		// into something the author sees.
+		v := cuecontext.New().CompileString(cue)
+		gomega.Expect(v.Err()).To(gomega.HaveOccurred())
+	})
+})

--- a/pkg/definition/defkit/validator_internal_test.go
+++ b/pkg/definition/defkit/validator_internal_test.go
@@ -52,4 +52,49 @@ var _ = ginkgo.Describe("Validator message rendering", func() {
 		v := cuecontext.New().CompileString(cue)
 		gomega.Expect(v.Err()).To(gomega.HaveOccurred())
 	})
+
+	// Checking the rendered message as a whole is not enough. Nested inside an
+	// interpolation the "_" placeholder does not stand out: "region '\(_)' bad"
+	// is an ordinary non-concrete string, so CUE leaves it alone and the
+	// validator never fires. These are the cases that have to fail loudly.
+	ginkgo.DescribeTable("should fail when an unrenderable value is nested in the message",
+		func(message Value) {
+			comp := NewComponent("test").
+				Params(String("region")).
+				Validators(
+					ValidateValue(message).
+						FailWhen(LocalField("region").Eq("x")).
+						WithName("_v"),
+				)
+
+			cue := NewCUEGenerator().GenerateParameterSchema(comp)
+			gomega.Expect(cue).To(gomega.ContainSubstring("let _message = _|_"))
+
+			v := cuecontext.New().CompileString(cue + "\nparameter: region: \"x\"")
+			gomega.Expect(v.Err()).To(gomega.HaveOccurred())
+		},
+		ginkgo.Entry("in an interpolation",
+			Interpolation(Lit("region '"), unrenderableValue{}, Lit("' bad"))),
+		ginkgo.Entry("in a plus expression",
+			Plus(Lit("region "), unrenderableValue{})),
+		ginkgo.Entry("nested two deep",
+			Interpolation(Lit("a "), Plus(Lit("b"), unrenderableValue{}), Lit(" c"))),
+	)
+
+	ginkgo.It("should still render a message whose parts are all known", func() {
+		comp := NewComponent("test").
+			Params(String("region")).
+			Validators(
+				ValidateValue(Interpolation(Lit("region '"), LocalField("region"), Lit("' bad"))).
+					FailWhen(LocalField("region").Eq("x")).
+					WithName("_v"),
+			)
+
+		cue := NewCUEGenerator().GenerateParameterSchema(comp)
+		gomega.Expect(cue).NotTo(gomega.ContainSubstring("_|_"))
+
+		v := cuecontext.New().CompileString(cue + "\nparameter: region: \"x\"")
+		gomega.Expect(v.Err()).To(gomega.HaveOccurred())
+		gomega.Expect(v.Err().Error()).To(gomega.ContainSubstring("region 'x' bad"))
+	})
 })

--- a/pkg/definition/defkit/validator_test.go
+++ b/pkg/definition/defkit/validator_test.go
@@ -414,6 +414,85 @@ var _ = Describe("Validator", func() {
 			Expect(err.Error()).To(ContainSubstring("region 'us-west-2' must not match the primary region"))
 			Expect(err.Error()).To(ContainSubstring("replicas.1"))
 		})
+
+		// A message is assembled by hand rather than through %q, so the literal
+		// segments between the \(...) parts have to be escaped here. Left
+		// unescaped, a quote ends the CUE string early and the definition does
+		// not compile at all, and a backslash silently becomes an escape
+		// sequence (C:\temp turning into a tab).
+		DescribeTable("should escape characters in literal message parts",
+			func(literal, wantInCUE, wantInErr string) {
+				comp := defkit.NewComponent("test").
+					Params(defkit.String("name")).
+					Validators(
+						defkit.ValidateValue(defkit.Interpolation(
+							defkit.Lit(literal), defkit.LocalField("name"),
+						)).FailWhen(defkit.LocalField("name").Eq("x")).WithName("_v"),
+					)
+
+				schema := gen.GenerateParameterSchema(comp)
+				Expect(schema).To(ContainSubstring(wantInCUE))
+
+				v := cuecontext.New().CompileString(schema + "\nparameter: name: \"x\"")
+				err := v.Err()
+				Expect(err).To(HaveOccurred(), "validator should still fire")
+				Expect(err.Error()).To(ContainSubstring(wantInErr))
+			},
+			Entry("double quote", `say "hi" `, `let _message = "say \"hi\" \(name)"`, `say \"hi\" x`),
+			Entry("backslash", `C:\temp `, `let _message = "C:\\temp \(name)"`, `C:\\temp x`),
+			Entry("newline", "line one\nline two ", `let _message = "line one\nline two \(name)"`, `line one\nline two x`),
+		)
+
+		It("should add the CUE import a message expression needs", func() {
+			comp := defkit.NewComponent("test").
+				Params(defkit.String("region")).
+				Validators(
+					defkit.ValidateValue(defkit.Interpolation(
+						defkit.Lit("region '"),
+						defkit.StringsToLower(defkit.LocalField("region")),
+						defkit.Lit("' is not allowed"),
+					)).FailWhen(defkit.LocalField("region").Eq("X")).WithName("_v"),
+				)
+
+			full := defkit.NewCUEGenerator().GenerateFullDefinition(comp)
+
+			// Without the import the reference is emitted anyway and the
+			// definition does not compile.
+			Expect(full).To(ContainSubstring("strings.ToLower(region)"))
+			Expect(full).To(ContainSubstring(`"strings"`))
+		})
+
+		It("should add imports for a message on a validator nested in a param", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.Array("replicas").WithFields(defkit.String("region")).Validators(
+						defkit.ValidateValue(defkit.Interpolation(
+							defkit.Lit("region '"),
+							defkit.StringsToUpper(defkit.LocalField("region")),
+							defkit.Lit("' is not allowed"),
+						)).FailWhen(defkit.LocalField("region").Eq("x")).WithName("_v"),
+					),
+				)
+
+			full := defkit.NewCUEGenerator().GenerateFullDefinition(comp)
+
+			Expect(full).To(ContainSubstring("strings.ToUpper(region)"))
+			Expect(full).To(ContainSubstring(`"strings"`))
+		})
+
+		It("should not add imports for a fixed string validator", func() {
+			comp := defkit.NewComponent("test").
+				Params(defkit.String("name")).
+				Validators(
+					defkit.Validate("name is required").
+						FailWhen(defkit.LocalField("name").Eq("")).WithName("_v"),
+				)
+
+			// Validate carries no message expression, so scanning validators
+			// must not change what an existing definition generates.
+			Expect(defkit.NewCUEGenerator().GenerateFullDefinition(comp)).
+				NotTo(ContainSubstring("import"))
+		})
 	})
 
 	// --- LocalFieldRef ---

--- a/pkg/definition/defkit/validator_test.go
+++ b/pkg/definition/defkit/validator_test.go
@@ -19,6 +19,7 @@ package defkit_test
 import (
 	"strings"
 
+	"cuelang.org/go/cue/cuecontext"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -252,6 +253,166 @@ var _ = Describe("Validator", func() {
 			cue := gen.GenerateParameterSchema(comp)
 
 			Expect(cue).To(ContainSubstring("len(allowedMethods) == 0"))
+		})
+	})
+
+	// --- Expression-based validator messages ---
+
+	Context("Expression Message Validators", func() {
+		// The message expression used throughout: "region '<region>' must not
+		// match the primary region".
+		regionMessage := func() defkit.Value {
+			return defkit.Interpolation(
+				defkit.Lit("region '"),
+				defkit.LocalField("region"),
+				defkit.Lit("' must not match the primary region"),
+			)
+		}
+
+		It("should keep the expression on the validator and leave Message empty", func() {
+			msg := regionMessage()
+			v := defkit.ValidateValue(msg)
+
+			Expect(v.MessageValue()).To(Equal(msg))
+			Expect(v.Message()).To(BeEmpty())
+		})
+
+		It("should report no expression for a fixed string validator", func() {
+			Expect(defkit.Validate("msg").MessageValue()).To(BeNil())
+		})
+
+		It("should bind the message to a let and use it as the key in both branches", func() {
+			comp := defkit.NewComponent("test").
+				Params(defkit.String("primaryRegion"), defkit.String("region")).
+				Validators(
+					defkit.ValidateValue(regionMessage()).
+						FailWhen(defkit.Eq(defkit.LocalField("region"), defkit.Reference("parameter.primaryRegion"))).
+						WithName("_validateRegion"),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring(`_validateRegion: {
+		let _message = "region '\(region)' must not match the primary region"
+		(_message): true
+		if region == parameter.primaryRegion {
+			(_message): false
+		}
+	}`))
+			// Both branches have to reach for the binding rather than repeat the
+			// expression, otherwise they are not guaranteed to be one field.
+			Expect(strings.Count(cue, "(_message)")).To(Equal(2))
+			Expect(strings.Count(cue, "let _message")).To(Equal(1))
+		})
+
+		It("should emit the expression message inside an array element struct", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.String("primaryRegion"),
+					defkit.Array("replicas").WithFields(defkit.String("region")).Validators(
+						defkit.ValidateValue(regionMessage()).
+							FailWhen(defkit.Eq(defkit.LocalField("region"), defkit.Reference("parameter.primaryRegion"))).
+							WithName("_validateReplicaRegion"),
+					),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring("replicas: [...{"))
+			Expect(cue).To(ContainSubstring(`let _message = "region '\(region)' must not match the primary region"`))
+			Expect(strings.Count(cue, "(_message)")).To(Equal(2))
+		})
+
+		It("should scope the let per validator so two can share a struct", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.Object("gov").WithFields(
+						defkit.String("tenant"),
+						defkit.String("dept"),
+					).Validators(
+						defkit.ValidateValue(defkit.Interpolation(
+							defkit.Lit("tenant '"), defkit.LocalField("tenant"), defkit.Lit("' is reserved"),
+						)).FailWhen(defkit.LocalField("tenant").Eq("system")).WithName("_validateTenant"),
+						defkit.ValidateValue(defkit.Interpolation(
+							defkit.Lit("dept '"), defkit.LocalField("dept"), defkit.Lit("' is reserved"),
+						)).FailWhen(defkit.LocalField("dept").Eq("root")).WithName("_validateDept"),
+					),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring(`let _message = "tenant '\(tenant)' is reserved"`))
+			Expect(cue).To(ContainSubstring(`let _message = "dept '\(dept)' is reserved"`))
+			Expect(strings.Count(cue, "let _message")).To(Equal(2))
+			Expect(strings.Count(cue, "(_message)")).To(Equal(4))
+		})
+
+		It("should put the let inside the validator block when the validator is guarded", func() {
+			comp := defkit.NewComponent("test").
+				Params(defkit.Bool("strict"), defkit.String("name")).
+				Validators(
+					defkit.ValidateValue(defkit.Interpolation(
+						defkit.Lit("name '"), defkit.LocalField("name"), defkit.Lit("' must not end with a hyphen"),
+					)).
+						OnlyWhen(defkit.LocalField("strict").Eq(true)).
+						FailWhen(defkit.LocalField("name").Matches(".*-$")).
+						WithName("_validateName"),
+				)
+
+			cue := gen.GenerateParameterSchema(comp)
+
+			Expect(cue).To(ContainSubstring(`if strict == true {
+		_validateName: {
+			let _message = "name '\(name)' must not end with a hyphen"
+			(_message): true`))
+		})
+
+		It("should emit a literal string message as a plain key, same as Validate", func() {
+			build := func(v *defkit.Validator) string {
+				return defkit.NewCUEGenerator().GenerateParameterSchema(
+					defkit.NewComponent("test").Params(defkit.String("name")).Validators(v),
+				)
+			}
+
+			expr := build(defkit.ValidateValue(defkit.Lit("name must not be empty")).
+				FailWhen(defkit.LocalField("name").Eq("")).WithName("_validateName"))
+			fixed := build(defkit.Validate("name must not be empty").
+				FailWhen(defkit.LocalField("name").Eq("")).WithName("_validateName"))
+
+			Expect(expr).To(Equal(fixed))
+			Expect(expr).NotTo(ContainSubstring("let _message"))
+			Expect(expr).To(ContainSubstring(`"name must not be empty": true`))
+		})
+
+		It("should compile, and name the offending value when the rule is broken", func() {
+			comp := defkit.NewComponent("test").
+				Params(
+					defkit.String("primaryRegion"),
+					defkit.Array("replicas").WithFields(defkit.String("region")).Validators(
+						defkit.ValidateValue(regionMessage()).
+							FailWhen(defkit.Eq(defkit.LocalField("region"), defkit.Reference("parameter.primaryRegion"))).
+							WithName("_validateReplicaRegion"),
+					),
+				)
+
+			schema := gen.GenerateParameterSchema(comp)
+			compile := func(input string) error {
+				v := cuecontext.New().CompileString(schema + "\n" + input)
+				if err := v.Err(); err != nil {
+					return err
+				}
+				return v.Validate()
+			}
+
+			Expect(compile(`parameter: {primaryRegion: "us-west-2", replicas: [{region: "us-east-1"}]}`)).
+				To(Succeed())
+
+			err := compile(`parameter: {primaryRegion: "us-west-2", replicas: [{region: "us-east-1"}, {region: "us-west-2"}]}`)
+			Expect(err).To(HaveOccurred())
+			// The whole point of the feature: the message names the value that
+			// broke the rule, and CUE's path names the element it came from.
+			Expect(err.Error()).To(ContainSubstring("region 'us-west-2' must not match the primary region"))
+			Expect(err.Error()).To(ContainSubstring("replicas.1"))
 		})
 	})
 


### PR DESCRIPTION
### Description of your changes

Validate takes a Go string, and writeValidator writes that same quoted string as the field label in both branches. That means a message can describe the rule but not the value that broke it, so on a list of similar entries you can say "replica regions must not match the primary region" but not which replica.

This adds ValidateValue, which takes a Value instead of a string:

```defkit.ValidateValue(
    defkit.Interpolation(
        defkit.Lit("region '"),
        defkit.LocalField("region"),
        defkit.Lit("' must not match the primary region"),
    ),
).
    FailWhen(defkit.Eq(defkit.LocalField("region"), defkit.Reference("parameter.primaryRegion"))).
    WithName("_validateReplicaRegion")
```

which generates:

```cue
_validateReplicaRegion: {
      let _message = "region '\(region)' must not match the primary region"
      (_message): true
      if region == parameter.primaryRegion {
              (_message): false
      }
}
```
The message goes through a let rather than being repeated in both branches. The two labels have to unify into one field for the validator to conflict at all, and reaching for the same binding twice guarantees that in a way repeating an expression does not. It also keeps a long message out of the output twice over.

Two smaller decisions worth flagging:

- Passing a literal string Value skips the let and emits the same quoted label Validate would, so the two forms stay interchangeable and simple rules do not pay for the indirection.
- A message the generator has no rendering for becomes _|_ with a comment, instead of a label CUE never resolves. A validator that silently never fires seemed like the one outcome worth ruling out.

Validate is untouched and generates byte-identical CUE. Fixed messages aris is for when a list has several similar entries and the message has tosay which one failed.

Fixes #7289

I have:

- [x] Read and followed KubeVela's pull request process (https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] Related Docs (https://github.com/kubevela/kubevela.io) updated properly.
- [x] Run make reviewable to ensure this PR is ready for review.
- [ ] Added backport release-x.y labels to auto-backport this PR if necessary.

How has this code been tested

Nine specs in validator_test.go and validator_internal_test.go covering the let binding and shared key, array elements, two validators in one struct, guarded validators, the
literal-string equivalence, and the unrenderable case.

One of them compiles the generated CUE and asserts on the error, since thlure says:

parameter.replicas.1._validateReplicaRegion."region 'us-west-2' must not nflicting values true and false

I also checked these actually bite: disabling only the new rendering path stay green are pure accessor tests that never reach the generator). Fullsuite is 1262 specs green, and make reviewable is clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

