### PR TITLE
Fix: restore GitHub issue forms by filling empty title fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: "🐛 Bug report"
 description: Create a report to help us improve
-title: ""
+title: "[Bug]"
 labels: ["type/bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,6 +1,6 @@
 name: "✨ Enhancement request"
 description: Suggest an improvement to an existing feature or component
-title: ""
+title: "[Enhancement]"
 labels: ["type/enhancement"]
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "🚀 Feature request"
 description: Suggest a brand new capability that doesn't exist yet
-title: ""
+title: "[Feature]"
 labels: ["type/feature"]
 body:
   - type: checkboxes


### PR DESCRIPTION
### Description of your changes

Restores the Bug / Feature / Enhancement issue forms in the create-issue chooser.

After #7337, every YAML issue form set `title: ""`. GitHub rejects empty strings for optional string fields, so all three forms failed validation. With `blank_issues_enabled: false`, the chooser only showed contact links (Questions & Help / Security) and users could not open normal issues.

This sets non-empty default titles (`[Bug]`, `[Feature]`, `[Enhancement]`), matching the prior markdown feature/enhancement prefixes.

Note: create the `type/feature` label on this repo if it is missing; the feature form references it.

Fixes #

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Confirmed via GraphQL that `repository.issueTemplates` returned `[]` on `kubevela/kubevela` while the fork (still on markdown templates) still listed the three templates.
- YAML forms parse cleanly; the only schema violation was the empty `title` values.
- After merge: open https://github.com/kubevela/kubevela/issues/new/choose and confirm the three forms appear; spot-check prefills, required fields, and labels.

### Special notes for your reviewer

This is a hotfix for broken issue intake. No runtime code paths change. If `type/feature` does not exist yet, please create it (or say if you prefer the feature form to use `type/enhancement` instead).