### PR TITLE
Feat: add negative regex matching conditions in defkit

### DIFF
--- a/pkg/definition/defkit/cuegen.go
+++ b/pkg/definition/defkit/cuegen.go
@@ -3223,6 +3223,9 @@ func (g *CUEGenerator) conditionToCUE(cond Condition) string {
 	case *AllConditionsCondition:
 		return g.allConditionsConditionToCUE(c)
 	case *RegexMatchCondition:
+		if c.IsNegated() {
+			return fmt.Sprintf(`%s !~ %q`, g.valueToCUE(c.Source()), c.Pattern())
+		}
 		// General-purpose regex match: <value> =~ "pattern"
 		return fmt.Sprintf(`%s =~ %q`, g.valueToCUE(c.Source()), c.Pattern())
 	case *RawCUECondition:

--- a/pkg/definition/defkit/cuegen_test.go
+++ b/pkg/definition/defkit/cuegen_test.go
@@ -2080,6 +2080,69 @@ var _ = Describe("CUEGenerator", func() {
 			})
 		})
 
+		Context("RegexNotMatch CUE Generation", func() {
+			It("should generate regex not-match for StringParam.NotMatches", func() {
+				p := defkit.String("name")
+				comp := defkit.NewComponent("test").
+					Params(p).
+					Workload("v1", "ConfigMap").
+					Template(func(tpl *defkit.Template) {
+						tpl.Output(defkit.NewResource("v1", "ConfigMap").
+							SetIf(p.NotMatches("^prod-"), "data.env", defkit.Lit("non-production")))
+					})
+
+				cue := gen.GenerateTemplate(comp)
+				Expect(cue).To(ContainSubstring(`parameter.name !~ "^prod-"`))
+				Expect(cue).NotTo(ContainSubstring(`parameter.name =~ "^prod-"`))
+			})
+
+			It("should generate regex not-match for LocalFieldRef.NotMatches in validator", func() {
+				v := defkit.Validate("bad").
+					WithName("_v").
+					FailWhen(defkit.LocalField("host").NotMatches(`\.internal$`))
+
+				comp := defkit.NewComponent("test").Validators(v)
+				cue := gen.GenerateParameterSchema(comp)
+				Expect(cue).To(ContainSubstring(`host !~ "\\.internal$"`))
+			})
+
+			It("should keep Matches and NotMatches distinct on the same param", func() {
+				p := defkit.String("name")
+				comp := defkit.NewComponent("test").
+					Params(p).
+					Workload("v1", "ConfigMap").
+					Template(func(tpl *defkit.Template) {
+						tpl.Output(defkit.NewResource("v1", "ConfigMap").
+							SetIf(p.Matches("^prod-"), "data.env", defkit.Lit("production")).
+							SetIf(p.NotMatches("^prod-"), "data.env", defkit.Lit("non-production")))
+					})
+
+				cue := gen.GenerateTemplate(comp)
+				Expect(cue).To(ContainSubstring(`parameter.name =~ "^prod-"`))
+				Expect(cue).To(ContainSubstring(`parameter.name !~ "^prod-"`))
+			})
+
+			It("should render NotMatches inside a compound And condition", func() {
+				name := defkit.String("name")
+				env := defkit.String("env")
+				comp := defkit.NewComponent("test").
+					Params(name, env).
+					Workload("v1", "ConfigMap").
+					Template(func(tpl *defkit.Template) {
+						tpl.Output(defkit.NewResource("v1", "ConfigMap").
+							SetIf(
+								defkit.And(
+									name.NotMatches("^prod-"),
+									defkit.Eq(env, defkit.Lit("dev")),
+								),
+								"data.debug", defkit.Lit("true")))
+					})
+
+				cue := gen.GenerateTemplate(comp)
+				Expect(cue).To(ContainSubstring(`parameter.name !~ "^prod-" && parameter.env == "dev"`))
+			})
+		})
+
 		Context("LocalFieldRef NotSet CUE Generation", func() {
 			It("should generate == _|_ for LocalFieldRef.NotSet", func() {
 				v := defkit.Validate("role required").

--- a/pkg/definition/defkit/expr.go
+++ b/pkg/definition/defkit/expr.go
@@ -218,9 +218,9 @@ func (c *StringContainsCondition) ParamName() string { return c.paramName }
 // Substr returns the substring to check for.
 func (c *StringContainsCondition) Substr() string { return c.substr }
 
-// RegexMatchCondition checks if any Value matches a regex pattern.
-// Generates: <value> =~ "pattern"
-// Used by both LocalFieldRef.Matches() and StringParam.Matches().
+// RegexMatchCondition checks if any Value matches or does not match a regex pattern.
+// Generates: <value> =~ "pattern" or <value> !~ "pattern"
+// Used by LocalFieldRef.Matches(), StringParam.Matches(), LocalFieldRef.NotMatches() and StringParam.NotMatches().
 type RegexMatchCondition struct {
 	baseCondition
 	source  Value
@@ -238,8 +238,13 @@ func (c *RegexMatchCondition) Pattern() string { return c.pattern }
 func (c *RegexMatchCondition) IsNegated() bool { return c.negate }
 
 // RegexMatch creates a condition that checks if a value matches a regex pattern.
-func RegexMatch(source Value, pattern string, negate bool) *RegexMatchCondition {
-	return &RegexMatchCondition{source: source, pattern: pattern, negate: negate}
+func RegexMatch(source Value, pattern string) *RegexMatchCondition {
+	return &RegexMatchCondition{source: source, pattern: pattern, negate: false}
+}
+
+// RegexNotMatch creates a condition that checks if a value does not match a regex pattern.
+func RegexNotMatch(source Value, pattern string) *RegexMatchCondition {
+	return &RegexMatchCondition{source: source, pattern: pattern, negate: true}
 }
 
 // StringStartsWithCondition checks if a string parameter starts with a prefix.

--- a/pkg/definition/defkit/expr.go
+++ b/pkg/definition/defkit/expr.go
@@ -225,6 +225,7 @@ type RegexMatchCondition struct {
 	baseCondition
 	source  Value
 	pattern string
+	negate  bool
 }
 
 // Source returns the value being matched.
@@ -233,9 +234,12 @@ func (c *RegexMatchCondition) Source() Value { return c.source }
 // Pattern returns the regex pattern.
 func (c *RegexMatchCondition) Pattern() string { return c.pattern }
 
+// IsNegated returns whether it is a positive or negative match.
+func (c *RegexMatchCondition) IsNegated() bool { return c.negate }
+
 // RegexMatch creates a condition that checks if a value matches a regex pattern.
-func RegexMatch(source Value, pattern string) *RegexMatchCondition {
-	return &RegexMatchCondition{source: source, pattern: pattern}
+func RegexMatch(source Value, pattern string, negate bool) *RegexMatchCondition {
+	return &RegexMatchCondition{source: source, pattern: pattern, negate: negate}
 }
 
 // StringStartsWithCondition checks if a string parameter starts with a prefix.

--- a/pkg/definition/defkit/expr_test.go
+++ b/pkg/definition/defkit/expr_test.go
@@ -355,18 +355,20 @@ var _ = Describe("Expressions", func() {
 	})
 
 	Context("RegexMatch", func() {
-		It("should create a RegexMatchCondition with source and pattern", func() {
+		It("should create a RegexMatchCondition with negate=false, source and pattern", func() {
 			ref := defkit.LocalField("name")
-			rm := defkit.RegexMatch(ref, "^test-")
+			rm := defkit.RegexMatch(ref, "^test-", false)
 			Expect(rm.Pattern()).To(Equal("^test-"))
 			Expect(rm.Source()).To(Equal(ref))
+			Expect(rm.IsNegated()).To(BeFalse())
 		})
 
 		It("should work with StringParam as source", func() {
 			p := defkit.String("host")
-			rm := defkit.RegexMatch(p, `^prod-.*$`)
+			rm := defkit.RegexMatch(p, `^prod-.*$`, false)
 			Expect(rm.Pattern()).To(Equal(`^prod-.*$`))
 			Expect(rm.Source()).To(Equal(p))
+			Expect(rm.IsNegated()).To(BeFalse())
 		})
 
 		It("should be produced by StringParam.Matches", func() {
@@ -376,6 +378,7 @@ var _ = Describe("Expressions", func() {
 			Expect(ok).To(BeTrue())
 			Expect(rm.Pattern()).To(Equal("^prod-"))
 			Expect(rm.Source()).To(Equal(p))
+			Expect(rm.IsNegated()).To(BeFalse())
 		})
 
 		It("should be produced by LocalFieldRef.Matches", func() {
@@ -385,6 +388,43 @@ var _ = Describe("Expressions", func() {
 			Expect(ok).To(BeTrue())
 			Expect(rm.Pattern()).To(Equal(".*-$"))
 			Expect(rm.Source()).To(Equal(ref))
+			Expect(rm.IsNegated()).To(BeFalse())
+		})
+
+		It("should create a RegexMatchCondition with negative match, source and pattern", func() {
+			ref := defkit.LocalField("name")
+			rm := defkit.RegexMatch(ref, "^test", true)
+			Expect(rm.Pattern()).To(Equal("^test-"))
+			Expect(rm.Source()).To(Equal(ref))
+			Expect(rm.IsNegated()).To(BeTrue())
+		})
+
+		It("should work with StringParam as source for negative match", func() {
+			p := defkit.String("host")
+			rm := defkit.RegexMatch(p, `^prod-.*$`, true)
+			Expect(rm.Pattern()).To(Equal(`^prod-.*$`))
+			Expect(rm.Source()).To(Equal(p))
+			Expect(rm.IsNegated()).To(BeTrue())
+		})
+
+		It("should be produced by StringParam.NotMatches", func() {
+			p := defkit.String("name")
+			cond := p.NotMatches("^prod-")
+			rm, ok := cond.(*defkit.RegexMatchCondition)
+			Expect(ok).To(BeTrue())
+			Expect(rm.Pattern()).To(Equal("^prod-"))
+			Expect(rm.Source()).To(Equal(p))
+			Expect(rm.IsNegated()).To(BeTrue())
+		})
+
+		It("should be produced by LocalFieldRef.NotMatches", func() {
+			ref := defkit.LocalField("tenantName")
+			cond := ref.NotMatches(".*-$")
+			rm, ok := cond.(*defkit.RegexMatchCondition)
+			Expect(ok).To(BeTrue())
+			Expect(rm.Pattern()).To(Equal(".*-$"))
+			Expect(rm.Source()).To(Equal(ref))
+			Expect(rm.IsNegated()).To(BeTrue())
 		})
 	})
 

--- a/pkg/definition/defkit/expr_test.go
+++ b/pkg/definition/defkit/expr_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 var _ = Describe("Expressions", func() {
-
 	Context("Literal", func() {
 		It("should create string literal", func() {
 			lit := defkit.Lit("hello")
@@ -355,9 +354,9 @@ var _ = Describe("Expressions", func() {
 	})
 
 	Context("RegexMatch", func() {
-		It("should create a RegexMatchCondition with negate=false, source and pattern", func() {
+		It("should create a RegexMatchCondition source and pattern", func() {
 			ref := defkit.LocalField("name")
-			rm := defkit.RegexMatch(ref, "^test-", false)
+			rm := defkit.RegexMatch(ref, "^test-")
 			Expect(rm.Pattern()).To(Equal("^test-"))
 			Expect(rm.Source()).To(Equal(ref))
 			Expect(rm.IsNegated()).To(BeFalse())
@@ -365,7 +364,7 @@ var _ = Describe("Expressions", func() {
 
 		It("should work with StringParam as source", func() {
 			p := defkit.String("host")
-			rm := defkit.RegexMatch(p, `^prod-.*$`, false)
+			rm := defkit.RegexMatch(p, `^prod-.*$`)
 			Expect(rm.Pattern()).To(Equal(`^prod-.*$`))
 			Expect(rm.Source()).To(Equal(p))
 			Expect(rm.IsNegated()).To(BeFalse())
@@ -390,18 +389,20 @@ var _ = Describe("Expressions", func() {
 			Expect(rm.Source()).To(Equal(ref))
 			Expect(rm.IsNegated()).To(BeFalse())
 		})
+	})
 
+	Context("RegexNotMatch", func() {
 		It("should create a RegexMatchCondition with negative match, source and pattern", func() {
 			ref := defkit.LocalField("name")
-			rm := defkit.RegexMatch(ref, "^test", true)
-			Expect(rm.Pattern()).To(Equal("^test-"))
+			rm := defkit.RegexNotMatch(ref, "^test")
+			Expect(rm.Pattern()).To(Equal("^test"))
 			Expect(rm.Source()).To(Equal(ref))
 			Expect(rm.IsNegated()).To(BeTrue())
 		})
 
 		It("should work with StringParam as source for negative match", func() {
 			p := defkit.String("host")
-			rm := defkit.RegexMatch(p, `^prod-.*$`, true)
+			rm := defkit.RegexNotMatch(p, `^prod-.*$`)
 			Expect(rm.Pattern()).To(Equal(`^prod-.*$`))
 			Expect(rm.Source()).To(Equal(p))
 			Expect(rm.IsNegated()).To(BeTrue())

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -277,7 +277,13 @@ func (p *StringParam) Contains(substr string) Condition {
 // Matches creates a condition that checks if this string parameter matches a regex pattern.
 // Example: name.Matches("^prod-") generates: parameter.name =~ "^prod-"
 func (p *StringParam) Matches(pattern string) Condition {
-	return RegexMatch(p, pattern)
+	return RegexMatch(p, pattern, false)
+}
+
+// NotMatches creates a condition that checks if this string parameter does not match a regex pattern.
+// Example: name.NotMatches("^prod-") generates: parameter.name !~ "^prod-"
+func (p *StringParam) NotMatches(pattern string) Condition {
+	return RegexMatch(p, pattern, true)
 }
 
 // StartsWith creates a condition that checks if this string parameter starts with a prefix.

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -277,13 +277,13 @@ func (p *StringParam) Contains(substr string) Condition {
 // Matches creates a condition that checks if this string parameter matches a regex pattern.
 // Example: name.Matches("^prod-") generates: parameter.name =~ "^prod-"
 func (p *StringParam) Matches(pattern string) Condition {
-	return RegexMatch(p, pattern, false)
+	return RegexMatch(p, pattern)
 }
 
 // NotMatches creates a condition that checks if this string parameter does not match a regex pattern.
 // Example: name.NotMatches("^prod-") generates: parameter.name !~ "^prod-"
 func (p *StringParam) NotMatches(pattern string) Condition {
-	return RegexMatch(p, pattern, true)
+	return RegexNotMatch(p, pattern)
 }
 
 // StartsWith creates a condition that checks if this string parameter starts with a prefix.

--- a/pkg/definition/defkit/render.go
+++ b/pkg/definition/defkit/render.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package defkit
 
+import "regexp"
+
 // Render executes the component template with the given test context
 // and returns the rendered primary output resource.
 func (c *ComponentDefinition) Render(ctx *TestContextBuilder) *RenderedResource {
@@ -266,6 +268,8 @@ func evaluateCondition(cond Condition, ctx *TestRuntimeContext) bool {
 		// Resolve the ports value and check if any have expose=true
 		portsValue := resolveValue(c.ports, ctx)
 		return hasExposedPorts(portsValue)
+	case *RegexMatchCondition:
+		return evaluateRegexMatch(c, ctx)
 	default:
 		// For parameter-based conditions (param used as condition)
 		if v, ok := cond.(Value); ok {
@@ -274,6 +278,30 @@ func evaluateCondition(cond Condition, ctx *TestRuntimeContext) bool {
 		}
 		return true
 	}
+}
+
+// evaluateRegexMatch evaluates a RegexMatchCondition against the resolved
+// source value, honouring the condition's negation flag.
+//
+// Anything that cannot be evaluated as a regex match -- an absent or nil
+// source, a non-string source, or an invalid pattern -- yields false for both
+// the positive and the negated form. That mirrors the generated CUE, where
+// `parameter.x =~ "p"` and `parameter.x !~ "p"` both fail to select the
+// guarded field when `parameter.x` is absent, and follows hasExposedPorts,
+// which likewise returns false for a value of the wrong shape.
+func evaluateRegexMatch(c *RegexMatchCondition, ctx *TestRuntimeContext) bool {
+	str, ok := resolveValue(c.Source(), ctx).(string)
+	if !ok {
+		return false
+	}
+	matched, err := regexp.MatchString(c.Pattern(), str)
+	if err != nil {
+		return false
+	}
+	if c.IsNegated() {
+		return !matched
+	}
+	return matched
 }
 
 // hasExposedPorts checks if a ports array has any port with expose=true.

--- a/pkg/definition/defkit/render_test.go
+++ b/pkg/definition/defkit/render_test.go
@@ -716,6 +716,98 @@ var _ = Describe("Render", func() {
 		})
 	})
 
+	Context("RegexMatch condition", func() {
+		// regexComp builds a ConfigMap whose data.marked field is set only when
+		// cond holds, so a nil Get means the condition evaluated to false.
+		regexComp := func(param defkit.Param, cond defkit.Condition) *defkit.ComponentDefinition {
+			return defkit.NewComponent("test").
+				Workload("v1", "ConfigMap").
+				Params(param).
+				Template(func(tpl *defkit.Template) {
+					tpl.Output(
+						defkit.NewResource("v1", "ConfigMap").
+							SetIf(cond, "data.marked", defkit.Lit("yes")),
+					)
+				})
+		}
+
+		It("should apply Matches when the value matches the pattern", func() {
+			name := defkit.String("name")
+			rendered := regexComp(name, name.Matches("^prod-")).Render(
+				defkit.TestContext().WithParam("name", "prod-web"),
+			)
+			Expect(rendered.Get("data.marked")).To(Equal("yes"))
+		})
+
+		It("should skip Matches when the value does not match the pattern", func() {
+			name := defkit.String("name")
+			rendered := regexComp(name, name.Matches("^prod-")).Render(
+				defkit.TestContext().WithParam("name", "dev-web"),
+			)
+			Expect(rendered.Get("data.marked")).To(BeNil())
+		})
+
+		It("should apply NotMatches when the value does not match the pattern", func() {
+			name := defkit.String("name")
+			rendered := regexComp(name, name.NotMatches("^prod-")).Render(
+				defkit.TestContext().WithParam("name", "dev-web"),
+			)
+			Expect(rendered.Get("data.marked")).To(Equal("yes"))
+		})
+
+		It("should skip NotMatches when the value matches the pattern", func() {
+			name := defkit.String("name")
+			rendered := regexComp(name, name.NotMatches("^prod-")).Render(
+				defkit.TestContext().WithParam("name", "prod-web"),
+			)
+			Expect(rendered.Get("data.marked")).To(BeNil())
+		})
+
+		It("should anchor NotMatches on a suffix pattern", func() {
+			tenant := defkit.String("tenant")
+			comp := regexComp(tenant, tenant.NotMatches(".*-$"))
+
+			Expect(comp.Render(defkit.TestContext().WithParam("tenant", "acme")).
+				Get("data.marked")).To(Equal("yes"))
+			Expect(comp.Render(defkit.TestContext().WithParam("tenant", "acme-")).
+				Get("data.marked")).To(BeNil())
+		})
+
+		It("should skip both forms when the optional source is absent", func() {
+			positive := defkit.String("name").Optional()
+			negative := defkit.String("name").Optional()
+
+			Expect(regexComp(positive, positive.Matches("^prod-")).
+				Render(defkit.TestContext()).Get("data.marked")).To(BeNil())
+			Expect(regexComp(negative, negative.NotMatches("^prod-")).
+				Render(defkit.TestContext()).Get("data.marked")).To(BeNil())
+		})
+
+		It("should skip both forms for a non-string source", func() {
+			positive := defkit.Int("port")
+			negative := defkit.Int("port")
+
+			Expect(regexComp(positive, defkit.RegexMatch(positive, "^80")).
+				Render(defkit.TestContext().WithParam("port", 8080)).
+				Get("data.marked")).To(BeNil())
+			Expect(regexComp(negative, defkit.RegexNotMatch(negative, "^80")).
+				Render(defkit.TestContext().WithParam("port", 8080)).
+				Get("data.marked")).To(BeNil())
+		})
+
+		It("should skip both forms for an invalid pattern", func() {
+			positive := defkit.String("name")
+			negative := defkit.String("name")
+
+			Expect(regexComp(positive, positive.Matches("[")).
+				Render(defkit.TestContext().WithParam("name", "prod-web")).
+				Get("data.marked")).To(BeNil())
+			Expect(regexComp(negative, negative.NotMatches("[")).
+				Render(defkit.TestContext().WithParam("name", "prod-web")).
+				Get("data.marked")).To(BeNil())
+		})
+	})
+
 	Context("evaluateCondition with NotExpr", func() {
 		It("should negate IsSet via NotExpr (ParamNotSet)", func() {
 			comp := defkit.NewComponent("test").

--- a/pkg/definition/defkit/validator.go
+++ b/pkg/definition/defkit/validator.go
@@ -106,7 +106,14 @@ func (s *LocalFieldRef) Name() string { return s.fieldName }
 // Example: LocalField("tenantName").Matches(".*-$") generates: tenantName =~ ".*-$"
 // Reuses upstream RegexMatchCondition.
 func (s *LocalFieldRef) Matches(pattern string) Condition {
-	return RegexMatch(s, pattern)
+	return RegexMatch(s, pattern, false)
+}
+
+// NotMatches creates a condition that checks if this field does not match a regex pattern.
+// Example: LocalField("tenantName").NotMatches(".*-$") generates: tenantName !~ ".*-$"
+// Reuses upstream RegexMatchCondition.
+func (s *LocalFieldRef) NotMatches(pattern string) Condition {
+	return RegexMatch(s, pattern, true)
 }
 
 // Eq creates a condition comparing this field to a value.

--- a/pkg/definition/defkit/validator.go
+++ b/pkg/definition/defkit/validator.go
@@ -106,14 +106,14 @@ func (s *LocalFieldRef) Name() string { return s.fieldName }
 // Example: LocalField("tenantName").Matches(".*-$") generates: tenantName =~ ".*-$"
 // Reuses upstream RegexMatchCondition.
 func (s *LocalFieldRef) Matches(pattern string) Condition {
-	return RegexMatch(s, pattern, false)
+	return RegexMatch(s, pattern)
 }
 
 // NotMatches creates a condition that checks if this field does not match a regex pattern.
 // Example: LocalField("tenantName").NotMatches(".*-$") generates: tenantName !~ ".*-$"
 // Reuses upstream RegexMatchCondition.
 func (s *LocalFieldRef) NotMatches(pattern string) Condition {
-	return RegexMatch(s, pattern, true)
+	return RegexNotMatch(s, pattern)
 }
 
 // Eq creates a condition comparing this field to a value.


### PR DESCRIPTION
Signed-off-by: Naveen Kumar Sangi <nkprince007@icloud.com>


### Description of your changes

Fixes #7353 

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

