### PR TITLE
Fix: fold repoURL into the helm chart cache key to isolate repositories

### DIFF
--- a/pkg/cue/cuex/providers/helm/chart_fetch.go
+++ b/pkg/cue/cuex/providers/helm/chart_fetch.go
@@ -128,15 +128,21 @@ func (p *Provider) fetchChart(ctx context.Context, params *ChartSourceParams, op
 	}
 
 	// Build cache key:
-	// <cache_key_prefix>/<source_type>/<source>/repo-<tag>/<version>[/auth-<tag>]
-	// The repo-<tag> segment keeps charts with the same name and version but
-	// different repository URLs (or no URL at all) isolated from each other.
-	repoTag := "repo-" + repoCacheTag(params.RepoURL)
-	cacheKey := fmt.Sprintf("%s/%s/%s/%s",
-		sourceType,
-		strings.ReplaceAll(strings.ReplaceAll(params.Source, "://", "-"), "/", "-"),
-		repoTag,
-		params.Version)
+	// <cache_key_prefix>/<source_type>/<source>[/repo-<tag>]/<version>[/auth-<tag>]
+	// The repo-<tag> segment isolates repository-based charts with the same
+	// name and version that are served by different repositories. Only
+	// repository sources need it: for OCI and direct-URL sources the source
+	// string already pins the registry or file location, and any
+	// credential-dependent variation is covered by the auth-<tag> suffix.
+	sanitizedSource := strings.ReplaceAll(strings.ReplaceAll(params.Source, "://", "-"), "/", "-")
+	cacheKey := fmt.Sprintf("%s/%s/%s", sourceType, sanitizedSource, params.Version)
+	if sourceType == sourceTypeRepo {
+		cacheKey = fmt.Sprintf("%s/%s/repo-%s/%s",
+			sourceType,
+			sanitizedSource,
+			repoCacheTag(params.RepoURL),
+			params.Version)
+	}
 	if options != nil && options.Cache != nil && options.Cache.Key != "" {
 		// User provided cache key prefix
 		cacheKey = options.Cache.Key + "/" + cacheKey

--- a/pkg/cue/cuex/providers/helm/chart_fetch.go
+++ b/pkg/cue/cuex/providers/helm/chart_fetch.go
@@ -21,6 +21,8 @@ package helm
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -94,6 +96,20 @@ func isMutableVersion(version string) bool {
 	return true
 }
 
+// repoCacheTag folds the repository URL into the chart cache key. The public
+// path mirrors computeAuthCacheTag's hashed suffix so that charts fetched
+// from different repositories never collide on the same chart name and
+// version, and the tag itself stays free of '/' so it cannot shift the
+// slash-separated namespace of the key. An empty URL (a chart supplied as a
+// bare source) maps to a fixed tag rather than an empty segment.
+func repoCacheTag(repoURL string) string {
+	if repoURL == "" {
+		return "none"
+	}
+	sum := sha256.Sum256([]byte(repoURL))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
 // fetchChart fetches a Helm chart from the specified source
 func (p *Provider) fetchChart(ctx context.Context, params *ChartSourceParams, options *RenderOptionsParams, appNamespace, releaseNamespace string) (*chart.Chart, error) {
 	sourceType := detectChartSourceType(params.Source)
@@ -111,21 +127,19 @@ func (p *Provider) fetchChart(ctx context.Context, params *ChartSourceParams, op
 		return nil, err
 	}
 
-	// Build cache key: <cache_key_prefix>/<source_type>/<source>/<version>[/auth-<tag>]
-	var cacheKey string
+	// Build cache key:
+	// <cache_key_prefix>/<source_type>/<source>/repo-<tag>/<version>[/auth-<tag>]
+	// The repo-<tag> segment keeps charts with the same name and version but
+	// different repository URLs (or no URL at all) isolated from each other.
+	repoTag := "repo-" + repoCacheTag(params.RepoURL)
+	cacheKey := fmt.Sprintf("%s/%s/%s/%s",
+		sourceType,
+		strings.ReplaceAll(strings.ReplaceAll(params.Source, "://", "-"), "/", "-"),
+		repoTag,
+		params.Version)
 	if options != nil && options.Cache != nil && options.Cache.Key != "" {
-		// User provided cache key
-		cacheKey = fmt.Sprintf("%s/%s/%s/%s",
-			options.Cache.Key,
-			sourceType,
-			strings.ReplaceAll(strings.ReplaceAll(params.Source, "://", "-"), "/", "-"),
-			params.Version)
-	} else {
-		// No cache key provided - use source-based key
-		cacheKey = fmt.Sprintf("%s/%s/%s",
-			sourceType,
-			strings.ReplaceAll(strings.ReplaceAll(params.Source, "://", "-"), "/", "-"),
-			params.Version)
+		// User provided cache key prefix
+		cacheKey = options.Cache.Key + "/" + cacheKey
 	}
 	if authTag != "" {
 		cacheKey = cacheKey + "/auth-" + authTag

--- a/pkg/cue/cuex/providers/helm/chart_fetch_test.go
+++ b/pkg/cue/cuex/providers/helm/chart_fetch_test.go
@@ -226,7 +226,9 @@ var _ = Describe("chart_fetch", func() {
 			}
 			// OCI source: oci://ghcr.io/example/chart
 			// After replacing "://" with "-" and "/" with "-": oci-ghcr.io-example-chart
-			cacheKey := "oci/oci-ghcr.io-example-chart/repo-none/3.0.0"
+			// OCI sources are keyed without a repo tag: the source already
+			// pins the registry location.
+			cacheKey := "oci/oci-ghcr.io-example-chart/3.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -242,7 +244,9 @@ var _ = Describe("chart_fetch", func() {
 			}
 			// URL source: https://example.com/chart.tgz
 			// After replacing "://" with "-" and "/" with "-": https-example.com-chart.tgz
-			cacheKey := "url/https-example.com-chart.tgz/repo-none/1.0.0"
+			// URL sources are keyed without a repo tag: the source already
+			// pins the file location.
+			cacheKey := "url/https-example.com-chart.tgz/1.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -250,6 +254,26 @@ var _ = Describe("chart_fetch", func() {
 				nil, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.Metadata.Name).To(Equal("url-chart"))
+		})
+
+		It("does not fragment cache entries of OCI sources by repoURL", func() {
+			// For OCI and direct-URL sources the source string already pins
+			// the chart location, so the cache key must not change when a
+			// repoURL is also supplied.
+			testChart := &chart.Chart{
+				Metadata: &chart.Metadata{Name: "oci-chart", Version: "3.0.0"},
+			}
+			p.cache.Put("oci/oci-ghcr.io-example-chart/3.0.0", testChart, 1*time.Hour)
+
+			result, err := p.fetchChart(context.Background(),
+				&ChartSourceParams{
+					Source:  "oci://ghcr.io/example/chart",
+					RepoURL: "https://ghcr.io",
+					Version: "3.0.0",
+				},
+				nil, "", "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result.Metadata.Name).To(Equal("oci-chart"))
 		})
 	})
 

--- a/pkg/cue/cuex/providers/helm/chart_fetch_test.go
+++ b/pkg/cue/cuex/providers/helm/chart_fetch_test.go
@@ -183,8 +183,8 @@ var _ = Describe("chart_fetch", func() {
 			testChart := &chart.Chart{
 				Metadata: &chart.Metadata{Name: "cached-chart", Version: "1.0.0"},
 			}
-			// Pre-seed the cache with the expected key format: <sourceType>/<source>/<version>
-			cacheKey := "repo/nginx/1.0.0"
+			// Pre-seed the cache with the expected key format: <sourceType>/<source>/repo-<tag>/<version>
+			cacheKey := "repo/nginx/repo-none/1.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -198,8 +198,8 @@ var _ = Describe("chart_fetch", func() {
 			testChart := &chart.Chart{
 				Metadata: &chart.Metadata{Name: "custom-cached", Version: "2.0.0"},
 			}
-			// With custom cache key: <cache_key_prefix>/<sourceType>/<source>/<version>
-			cacheKey := "my-prefix/repo/myapp/2.0.0"
+			// With custom cache key: <cache_key_prefix>/<sourceType>/<source>/repo-<tag>/<version>
+			cacheKey := "my-prefix/repo/myapp/repo-none/2.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -226,7 +226,7 @@ var _ = Describe("chart_fetch", func() {
 			}
 			// OCI source: oci://ghcr.io/example/chart
 			// After replacing "://" with "-" and "/" with "-": oci-ghcr.io-example-chart
-			cacheKey := "oci/oci-ghcr.io-example-chart/3.0.0"
+			cacheKey := "oci/oci-ghcr.io-example-chart/repo-none/3.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -242,7 +242,7 @@ var _ = Describe("chart_fetch", func() {
 			}
 			// URL source: https://example.com/chart.tgz
 			// After replacing "://" with "-" and "/" with "-": https-example.com-chart.tgz
-			cacheKey := "url/https-example.com-chart.tgz/1.0.0"
+			cacheKey := "url/https-example.com-chart.tgz/repo-none/1.0.0"
 			p.cache.Put(cacheKey, testChart, 1*time.Hour)
 
 			result, err := p.fetchChart(context.Background(),
@@ -466,8 +466,8 @@ entries:
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ch.Metadata.Name).To(Equal("cache-miss"))
 
-			// Verify it's now cached
-			cached, found := p.cache.Get("repo/cache-miss/1.0.0")
+			// Verify it's now cached under the repo-tagged key
+			cached, found := p.cache.Get("repo/cache-miss/repo-" + repoCacheTag(server.URL) + "/1.0.0")
 			Expect(found).To(BeTrue())
 			Expect(cached).ToNot(BeNil())
 		})
@@ -487,6 +487,75 @@ entries:
 			}, nil, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ch.Metadata.Name).To(Equal("url-cache"))
+		})
+
+		It("isolates cached charts by repoURL for public charts", func() {
+			// Regression for https://github.com/kubevela/kubevela/issues/7338.
+			// Two repositories publish a chart with the same name and version
+			// but different contents. With no auth.secretRef, the cache key
+			// used to ignore repoURL entirely, so the second fetch hit the
+			// first repository's cached bytes without ever contacting repo B.
+			type repoServer struct {
+				url       string
+				chartName string
+				requests  int
+			}
+			var servers []*httptest.Server
+			defer func() {
+				for _, s := range servers {
+					s.Close()
+				}
+			}()
+			newRepo := func(chartName string) *repoServer {
+				srv := &repoServer{chartName: chartName}
+				archive := createMinimalChartArchive(chartName, "1.0.0")
+				httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					srv.requests++
+					switch r.URL.Path {
+					case "/index.yaml":
+						_, _ = w.Write([]byte(`apiVersion: v1
+entries:
+  demo:
+    - name: demo
+      version: 1.0.0
+      urls:
+        - demo-1.0.0.tgz
+`))
+					case "/demo-1.0.0.tgz":
+						_, _ = w.Write(archive)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				srv.url = httpSrv.URL
+				servers = append(servers, httpSrv)
+				return srv
+			}
+
+			repoA := newRepo("first-chart")
+			repoB := newRepo("second-chart")
+			p := NewProviderWithConfig(nil)
+
+			first, err := p.fetchChart(context.Background(), &ChartSourceParams{
+				Source:  "demo",
+				RepoURL: repoA.url,
+				Version: "1.0.0",
+			}, nil, "", "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(first.Metadata.Name).To(Equal("first-chart"))
+
+			second, err := p.fetchChart(context.Background(), &ChartSourceParams{
+				Source:  "demo",
+				RepoURL: repoB.url,
+				Version: "1.0.0",
+			}, nil, "", "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(second.Metadata.Name).To(Equal("second-chart"))
+
+			// repo B must have been contacted: the second request is a
+			// different cache entry, not a hit on repo A's cached chart.
+			Expect(repoA.requests).To(BeNumerically(">=", 1))
+			Expect(repoB.requests).To(BeNumerically(">=", 1))
 		})
 
 		It("re-runs the auth resolver on a cache hit when the source declares auth.secretRef", func() {

--- a/pkg/cue/cuex/providers/helm/helm_test.go
+++ b/pkg/cue/cuex/providers/helm/helm_test.go
@@ -61,7 +61,7 @@ spec:
 					},
 				},
 			}
-			p.cache.Put("repo/my-chart/1.0.0", testChart, 1*time.Hour)
+			p.cache.Put("repo/my-chart/repo-none/1.0.0", testChart, 1*time.Hour)
 
 			// Call the provider's internal render logic in dry-run mode
 			ctx := WithDryRun(context.Background())
@@ -113,7 +113,7 @@ spec:
 					},
 				},
 			}
-			p.cache.Put("repo/render-dryrun/1.0.0", testChart, 1*time.Hour)
+			p.cache.Put("repo/render-dryrun/repo-none/1.0.0", testChart, 1*time.Hour)
 
 			ctx := WithDryRun(context.Background())
 			result, err := Render(ctx, &providers.Params[RenderParams]{
@@ -162,7 +162,7 @@ data:
 					},
 				},
 			}
-			p.cache.Put("repo/render-defaults/2.0.0", testChart, 1*time.Hour)
+			p.cache.Put("repo/render-defaults/repo-none/2.0.0", testChart, 1*time.Hour)
 
 			ctx := WithDryRun(context.Background())
 			result, err := Render(ctx, &providers.Params[RenderParams]{
@@ -312,7 +312,7 @@ data:
 			singleton.KubeClient.Set(c)
 
 			p := NewProvider()
-			p.cache.Put("repo/render-defense-dryrun/1.0.0", &chart.Chart{
+			p.cache.Put("repo/render-defense-dryrun/repo-none/1.0.0", &chart.Chart{
 				Metadata: &chart.Metadata{Name: "render-defense-dryrun", Version: "1.0.0"},
 				Templates: []*chart.File{{
 					Name: "templates/cm.yaml",


### PR DESCRIPTION
Fixes #7338

### What

`pkg/cue/cuex/providers/helm` builds the in-memory chart cache key from `<cache prefix>/<source type>/<sanitized source>/<version>[/auth-<tag>]`. For repository-based charts, `source` is just the chart name, so two Helm repositories serving a chart with the same name and version produce the same key. The process-wide singleton provider then serves the first repository's cached chart to the second one without contacting it (24h immutable TTL by default).

### How

The cache key for repository-based charts now carries a `repo-<tag>` segment derived from the repository URL — `sha256(repoURL)` truncated to 16 hex chars, mirroring the `computeAuthCacheTag` suffix already used on the auth path (which already folds repoURL in). An empty repoURL maps to the fixed tag `repo-none`. The tag is hash-only, so it cannot shift the slash-separated key namespace.

New key format: `[<cache prefix>/]<source type>/<source>[/repo-<tag>]/<version>[/auth-<tag>]`

The `repo-<tag>` segment applies only to repository-based sources: for OCI and direct-URL sources the source string already pins the chart location, and credential-dependent variation is covered by the `auth-<tag>` suffix, so their keys are unchanged from the previous behavior.

### Tests

- New regression spec `isolates cached charts by repoURL for public charts`: two httptest repositories serve a chart with the same name and version but different contents; the second fetch must return repo B's chart and must actually contact repo B (it used to hit repo A's cached bytes with `repo-b requests = 0`).
- New spec `does not fragment cache entries of OCI sources by repoURL`: an OCI chart fetched with a stray repoURL still hits the plain key.
- Repository-based hard-coded cache-key specs updated to the new format (empty repoURL → `repo-none`); OCI/URL key specs unchanged.

### Notes for reviewers

- This changes in-memory cache keys only — no persisted state; a restart starts with a cold cache.
- Happy to switch to a plain sanitized-URL segment if maintainers prefer readability over hashing — the isolation property is the same.
