### PR TITLE
Fix(cli): strip registry prefix before building addon resource name in upgrade

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -375,7 +375,10 @@ func NewAddonDisableCommand(c common.Args, _ cmdutil.IOStreams) *cobra.Command {
 			if len(args) < 1 {
 				return fmt.Errorf("must specify addon name")
 			}
-			name := args[0]
+			_, name, err := splitSpecifyRegistry(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to split addonName and addonRegistry: %w", err)
+			}
 			k8sClient, err := c.GetClient()
 			if err != nil {
 				return err
@@ -407,8 +410,11 @@ func NewAddonStatusCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 			if len(args) < 1 {
 				return fmt.Errorf("must specify addon name")
 			}
-			name := args[0]
-			err := statusAddon(name, ioStream, cmd, c)
+			_, name, err := splitSpecifyRegistry(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to split addonName and addonRegistry: %w", err)
+			}
+			err = statusAddon(name, ioStream, cmd, c)
 			if err != nil {
 				return err
 			}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -323,10 +323,13 @@ non-empty new arg
 				if filepath.IsAbs(addonOrDir) || strings.HasPrefix(addonOrDir, ".") || strings.HasSuffix(addonOrDir, "/") {
 					return fmt.Errorf("addon directory %s not found in local", addonOrDir)
 				}
-				name = addonOrDir
-				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, addonOrDir)
+				_, name, err = splitSpecifyRegistry(addonOrDir)
 				if err != nil {
-					return errors.Wrapf(err, "cannot fetch addon related addon %s", addonOrDir)
+					return fmt.Errorf("failed to split addonName and addonRegistry: %w", err)
+				}
+				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)
+				if err != nil {
+					return errors.Wrapf(err, "cannot fetch addon related addon %s", name)
 				}
 				addonArgs, err := pkgaddon.MergeAddonInstallArgs(ctx, k8sClient, name, addonInputArgs)
 				if err != nil {

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -579,3 +579,63 @@ var _ = Describe("Addon upgrade command with a registry-prefixed addon name", fu
 		Expect(err.Error()).To(ContainSubstring("specified registry myregistry not exist"))
 	})
 })
+
+var _ = Describe("Addon status command with a registry-prefixed addon name", func() {
+	var c common.Args
+	var fluxcd v1beta1.Application
+
+	BeforeEach(func() {
+		c.SetClient(k8sClient)
+		c.SetConfig(cfg)
+
+		fluxcd = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)).To(Succeed())
+		Expect(k8sClient.Create(context.Background(), &fluxcd)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(context.Background(), &fluxcd)).To(Succeed())
+	})
+
+	It("should strip the registry prefix instead of using it to build the addon's k8s resource name", func() {
+		args := []string{"myregistry/fluxcd"}
+		cmd := NewAddonStatusCommand(c, cmdutil.IOStreams{})
+		cmd.SetArgs(args)
+		err := cmd.RunE(cmd, args)
+		// Before the fix, the un-split "myregistry/fluxcd" was used to build the
+		// addon's k8s resource name, which fails fast with an invalid name error.
+		if err != nil {
+			Expect(err.Error()).ToNot(ContainSubstring("may not contain '/'"))
+		}
+	})
+})
+
+var _ = Describe("Addon disable command with a registry-prefixed addon name", func() {
+	var c common.Args
+	var fluxcd v1beta1.Application
+
+	BeforeEach(func() {
+		c.SetClient(k8sClient)
+		c.SetConfig(cfg)
+
+		fluxcd = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)).To(Succeed())
+		Expect(k8sClient.Create(context.Background(), &fluxcd)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(context.Background(), &fluxcd)).Should(SatisfyAny(Succeed(), util.NotFoundMatcher{}))
+	})
+
+	It("should strip the registry prefix instead of using it to build the addon's k8s resource name", func() {
+		args := []string{"myregistry/fluxcd"}
+		cmd := NewAddonDisableCommand(c, cmdutil.IOStreams{})
+		cmd.SetArgs(args)
+		err := cmd.RunE(cmd, args)
+		// Before the fix, the un-split "myregistry/fluxcd" was used to build the
+		// addon's k8s resource name, which fails fast with an invalid name error.
+		if err != nil {
+			Expect(err.Error()).ToNot(ContainSubstring("may not contain '/'"))
+		}
+	})
+})

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -38,6 +38,7 @@ import (
 	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
 )
 
 const (
@@ -543,5 +544,37 @@ var _ = Describe("Addon push command", func() {
 			err := cmd.RunE(cmd, args)
 			Expect(err).Should(Succeed())
 		})
+	})
+})
+
+var _ = Describe("Addon upgrade command with a registry-prefixed addon name", func() {
+	var c common.Args
+	fluxcd := v1beta1.Application{}
+	Expect(yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)).To(Succeed())
+
+	BeforeEach(func() {
+		c.SetClient(k8sClient)
+		c.SetConfig(cfg)
+
+		Expect(k8sClient.Create(context.Background(), &fluxcd)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(context.Background(), &fluxcd)).To(Succeed())
+	})
+
+	It("should strip the registry prefix instead of using it to build the addon's k8s resource name", func() {
+		args := []string{"myregistry/fluxcd"}
+		cmd := NewAddonUpgradeCommand(c, cmdutil.IOStreams{})
+		cmd.SetArgs(args)
+		err := cmd.RunE(cmd, args)
+		Expect(err).ShouldNot(Succeed())
+		// Before the fix, the un-split "myregistry/fluxcd" was used to build the
+		// addon's k8s resource name, which fails fast with an invalid name error.
+		Expect(err.Error()).ToNot(ContainSubstring("may not contain '/'"))
+		Expect(err.Error()).ToNot(ContainSubstring("cannot fetch addon related addon"))
+		// After the fix, lookups use the plain addon name, so the command proceeds
+		// to resolving the registry, which legitimately fails since "myregistry" is unregistered.
+		Expect(err.Error()).To(ContainSubstring("specified registry myregistry not exist"))
 	})
 })

--- a/references/cli/addon_suite_test.go
+++ b/references/cli/addon_suite_test.go
@@ -549,13 +549,14 @@ var _ = Describe("Addon push command", func() {
 
 var _ = Describe("Addon upgrade command with a registry-prefixed addon name", func() {
 	var c common.Args
-	fluxcd := v1beta1.Application{}
-	Expect(yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)).To(Succeed())
+	var fluxcd v1beta1.Application
 
 	BeforeEach(func() {
 		c.SetClient(k8sClient)
 		c.SetConfig(cfg)
 
+		fluxcd = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(fluxcdYaml), &fluxcd)).To(Succeed())
 		Expect(k8sClient.Create(context.Background(), &fluxcd)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
 	})
 


### PR DESCRIPTION
### Description of your changes

copilot:all

`vela addon upgrade <registry>/<addon>` (upgrading an addon that was enabled from a
named registry via `<registry>/<addon>` syntax) fails with:

```
Error: cannot fetch addon related addon vortexa/fluxcd: invalid resource name "addon-myregistry/fluxcd": [may not contain '/']
```

The upgrade command's non-local-dir path was passing the raw `<registry>/<addon>`
string directly into `FetchAddonRelatedApp` and `MergeAddonInstallArgs`, both of which
build a Kubernetes resource name by prefixing it with `addon-`. Since K8s resource
names can't contain `/`, any addon enabled from a named registry could never be
upgraded again.

The sibling `enable` command already handles this correctly: it calls
`splitSpecifyRegistry()` to strip the registry prefix before using the plain addon
name for k8s lookups, while still passing the full `<registry>/<addon>` string to
`enableAddon()` (which resolves the registry internally). This change applies the
same pattern to `upgrade`.

Fixes #7356

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go build ./references/...`
- `go test ./references/cli/...` (plain unit tests): pass.
- Added a Ginkgo envtest regression test exercising
  `vela addon upgrade myregistry/fluxcd` against a pre-existing `addon-fluxcd`
  Application. Ran the full suite with `KUBEBUILDER_ASSETS` pointed at the envtest
  1.31.0 binaries: `go test ./references/cli -run TestCli -count=1`, 8 consecutive
  clean runs (79/79 specs).
- Confirmed the new test fails with the original "may not contain '/'" error when the
  `addon.go` change is reverted, and passes once it's restored — a genuine
  failing-then-passing regression test, not just a compiled-but-unrun test.
- `./hack/utils/golangci-lint-wrapper.sh` with the repo-pinned golangci-lint v1.60.1:
  exit 0, no findings in the changed files.
- `go vet ./references/cli/...` and `gofmt -l` on both changed files: clean.

### Special notes for your reviewer

- Minimal, surgical fix mirroring the existing `enable` command's registry-prefix
  handling — no behavior change for the (much more common) no-registry-prefix case.
- The regression test originally leaked its test `Application` across specs (no
  `AfterEach` cleanup), which caused an unrelated spec to fail intermittently under
  Ginkgo's randomized ordering; that's fixed by adding proper cleanup, verified with
  8 repeated full-suite runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

