### PR TITLE
Fix: watch external Package CRs in WorkloadCompiler

### DIFF
--- a/pkg/cue/cuex/compiler.go
+++ b/pkg/cue/cuex/compiler.go
@@ -54,5 +54,8 @@ var WorkloadCompiler = singleton.NewSingleton[*cuex.Compiler](func() *cuex.Compi
 			klog.Errorf("failed to load external packages for workload compiler: %v", err.Error())
 		}
 	}
+	if cuex.EnableExternalPackageWatchForDefaultCompiler {
+		go compiler.ListenExternalPackages(nil)
+	}
 	return compiler
 })

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -124,7 +124,6 @@ func TestMain(m *testing.M) {
 func TestWorkloadCompiler(t *testing.T) {
 	testCases := map[string]struct {
 		cuexEnabled            bool
-		watchEnabled           bool
 		workloadTemplate       string
 		params                 map[string]interface{}
 		expectedObj            runtime.Object
@@ -167,20 +166,10 @@ func TestWorkloadCompiler(t *testing.T) {
 			expectedAdditionalObjs: make(map[string]runtime.Object),
 			hasCompileErr:          false,
 		},
-		"cuex enabled with external packages and watch enabled": {
-			cuexEnabled:            true,
-			watchEnabled:           true,
-			workloadTemplate:       getWorkloadTemplate(true),
-			params:                 make(map[string]interface{}),
-			expectedObj:            getExpectedObj(true),
-			expectedAdditionalObjs: make(map[string]runtime.Object),
-			hasCompileErr:          false,
-		},
 	}
 
 	for _, tc := range testCases {
 		cuex.EnableExternalPackageForDefaultCompiler = tc.cuexEnabled
-		cuex.EnableExternalPackageWatchForDefaultCompiler = tc.watchEnabled
 		velacuex.WorkloadCompiler.Reload()
 
 		ctx := process.NewContext(process.ContextData{
@@ -208,6 +197,74 @@ func TestWorkloadCompiler(t *testing.T) {
 	}
 }
 
+// TestWorkloadCompilerExternalPackageWatch verifies that, once the watch is
+// enabled, a Package CR created after the compiler has already started is
+// picked up by the background informer, without another explicit Reload.
+func TestWorkloadCompilerExternalPackageWatch(t *testing.T) {
+	const (
+		watchTestPackage = "cuex-test-package-watch"
+		watchTestPath    = "cuex/ext-watch"
+	)
+
+	mockServer := createMockServer()
+	defer mockServer.Close()
+
+	cuex.EnableExternalPackageForDefaultCompiler = true
+	cuex.EnableExternalPackageWatchForDefaultCompiler = true
+	velacuex.WorkloadCompiler.Reload()
+	defer func() {
+		close(velacuex.WorkloadCompiler.Get().StopCh)
+		cuex.EnableExternalPackageWatchForDefaultCompiler = false
+		cuex.EnableExternalPackageForDefaultCompiler = false
+		velacuex.WorkloadCompiler.Reload()
+	}()
+
+	if err := createExternalPackage(watchTestPackage, watchTestPath, mockServer.URL); err != nil {
+		t.Fatalf("failed to create package after compiler startup: %v", err)
+	}
+	defer func() {
+		if err := deleteExternalPackage(watchTestPackage); err != nil {
+			t.Errorf("failed to delete watch test package: %v", err)
+		}
+	}()
+
+	workloadTemplate := strings.TrimSpace(fmt.Sprintf(`
+		import (
+			extwatch "%s"
+		)
+
+		external: extwatch.#ExternalFunction & {
+			$params: {
+				%s: "external"
+			}
+		}
+
+		output: {
+			apiVersion: "apps/v1"
+			kind: "Deployment"
+			metadata: name: "test-deployment-\(external.$returns.output)"
+			spec: replicas: 1
+		}
+	`, watchTestPath, testCtx.InputParamName))
+
+	var lastErr error
+	err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		ctx := process.NewContext(process.ContextData{
+			AppName:         "test-app",
+			CompName:        "test-component",
+			Namespace:       testCtx.Namespace,
+			AppRevisionName: "test-app-v1",
+			ClusterVersion:  types.ClusterVersion{Minor: "19+"},
+		})
+		wt := definition.NewWorkloadAbstractEngine("test-workload")
+		lastErr = wt.Complete(ctx, workloadTemplate, make(map[string]interface{}))
+		return lastErr == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("watch did not pick up package created after startup without a Reload: %v", lastErr)
+	}
+}
+
 func createMockServer() *httptest.Server {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/"+testCtx.ExternalFnName {
@@ -224,6 +281,14 @@ func createMockServer() *httptest.Server {
 }
 
 func createTestPackage(url string) error {
+	return createExternalPackage(testCtx.CueXTestPackage, testCtx.CueXPath, url)
+}
+
+func deleteTestPackage() error {
+	return deleteExternalPackage(testCtx.CueXTestPackage)
+}
+
+func createExternalPackage(name, path, url string) error {
 	ctx := context.Background()
 
 	packageObj := &unstructured.Unstructured{
@@ -231,11 +296,11 @@ func createTestPackage(url string) error {
 			"apiVersion": "cue.oam.dev/v1alpha1",
 			"kind":       "Package",
 			"metadata": map[string]interface{}{
-				"name":      testCtx.CueXTestPackage,
+				"name":      name,
 				"namespace": testCtx.Namespace,
 			},
 			"spec": map[string]interface{}{
-				"path": testCtx.CueXPath,
+				"path": path,
 				"provider": map[string]interface{}{
 					"endpoint": url,
 					"protocol": "http",
@@ -254,7 +319,7 @@ func createTestPackage(url string) error {
                                 %s: string
                             }
                         }
-                    `, testCtx.ExternalFnName, testCtx.CueXTestPackage, testCtx.InputParamName, testCtx.OutputParamName)),
+                    `, testCtx.ExternalFnName, name, testCtx.InputParamName, testCtx.OutputParamName)),
 				},
 			},
 		},
@@ -264,7 +329,7 @@ func createTestPackage(url string) error {
 
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
 		err = testCtx.K8sClient.Get(ctx, client.ObjectKey{
-			Name:      testCtx.CueXTestPackage,
+			Name:      name,
 			Namespace: testCtx.Namespace,
 		}, packageObj)
 		if err != nil {
@@ -273,12 +338,12 @@ func createTestPackage(url string) error {
 		return true, nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create test package: %w", err)
+		return fmt.Errorf("failed to create package %s: %w", name, err)
 	}
 	return nil
 }
 
-func deleteTestPackage() error {
+func deleteExternalPackage(name string) error {
 	ctx := context.Background()
 
 	testPkg := &unstructured.Unstructured{}
@@ -287,16 +352,16 @@ func deleteTestPackage() error {
 		Version: "v1alpha1",
 		Kind:    "Package",
 	})
-	testPkg.SetName(testCtx.CueXTestPackage)
+	testPkg.SetName(name)
 	testPkg.SetNamespace(testCtx.Namespace)
 
 	err := testCtx.K8sClient.Delete(ctx, testPkg)
 	if err != nil {
-		return fmt.Errorf("failed to delete test package: %w", err)
+		return fmt.Errorf("failed to delete package %s: %w", name, err)
 	}
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
 		err := testCtx.K8sClient.Get(ctx, client.ObjectKey{
-			Name:      testCtx.CueXTestPackage,
+			Name:      name,
 			Namespace: testCtx.Namespace,
 		}, testPkg)
 		if err != nil {
@@ -308,7 +373,7 @@ func deleteTestPackage() error {
 		return false, nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to delete test package: %w", err)
+		return fmt.Errorf("failed to delete package %s: %w", name, err)
 	}
 	return nil
 }

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -209,13 +209,17 @@ func TestWorkloadCompilerExternalPackageWatch(t *testing.T) {
 	mockServer := createMockServer()
 	defer mockServer.Close()
 
+	origExternal := cuex.EnableExternalPackageForDefaultCompiler
+	origWatch := cuex.EnableExternalPackageWatchForDefaultCompiler
 	cuex.EnableExternalPackageForDefaultCompiler = true
 	cuex.EnableExternalPackageWatchForDefaultCompiler = true
 	velacuex.WorkloadCompiler.Reload()
 	defer func() {
-		close(velacuex.WorkloadCompiler.Get().StopCh)
-		cuex.EnableExternalPackageWatchForDefaultCompiler = false
-		cuex.EnableExternalPackageForDefaultCompiler = false
+		if stopCh := velacuex.WorkloadCompiler.Get().StopCh; stopCh != nil {
+			close(stopCh)
+		}
+		cuex.EnableExternalPackageForDefaultCompiler = origExternal
+		cuex.EnableExternalPackageWatchForDefaultCompiler = origWatch
 		velacuex.WorkloadCompiler.Reload()
 	}()
 

--- a/pkg/cue/cuex/compiler_test.go
+++ b/pkg/cue/cuex/compiler_test.go
@@ -124,6 +124,7 @@ func TestMain(m *testing.M) {
 func TestWorkloadCompiler(t *testing.T) {
 	testCases := map[string]struct {
 		cuexEnabled            bool
+		watchEnabled           bool
 		workloadTemplate       string
 		params                 map[string]interface{}
 		expectedObj            runtime.Object
@@ -166,10 +167,20 @@ func TestWorkloadCompiler(t *testing.T) {
 			expectedAdditionalObjs: make(map[string]runtime.Object),
 			hasCompileErr:          false,
 		},
+		"cuex enabled with external packages and watch enabled": {
+			cuexEnabled:            true,
+			watchEnabled:           true,
+			workloadTemplate:       getWorkloadTemplate(true),
+			params:                 make(map[string]interface{}),
+			expectedObj:            getExpectedObj(true),
+			expectedAdditionalObjs: make(map[string]runtime.Object),
+			hasCompileErr:          false,
+		},
 	}
 
 	for _, tc := range testCases {
 		cuex.EnableExternalPackageForDefaultCompiler = tc.cuexEnabled
+		cuex.EnableExternalPackageWatchForDefaultCompiler = tc.watchEnabled
 		velacuex.WorkloadCompiler.Reload()
 
 		ctx := process.NewContext(process.ContextData{


### PR DESCRIPTION
### Description of your changes

copilot:all

`WorkloadCompiler` (used for component/trait definition rendering and webhook
validation) only loaded external `Package` CRs once at startup via
`LoadExternalPackages`. Unlike `providers.DefaultCompiler` and `cuex.DefaultCompiler`,
it never started a watch, so `Package` CRs created after startup were ignored
until `vela-core` was restarted, even with
`--enable-external-package-watch-for-default-compiler=true`.

This adds the same `go compiler.ListenExternalPackages(nil)` call (gated behind
`cuex.EnableExternalPackageWatchForDefaultCompiler`) that `providers.DefaultCompiler`
already uses in `pkg/workflow/providers/compiler.go`, so all three compilers now
watch for `Package` changes consistently.

Fixes #

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go build ./pkg/cue/cuex/...` — succeeds.
- `go vet ./pkg/cue/cuex/...` and `gofmt -l pkg/cue/cuex/compiler.go` — clean.
- `golangci-lint` (repo-pinned v1.60.1, via `./hack/utils/golangci-lint-wrapper.sh`) — exit 0, no findings.
- `go test ./pkg/cue/cuex/ -run TestWorkloadCompiler -v` (with `KUBEBUILDER_ASSETS` pointed
  at a local envtest toolchain) — `TestWorkloadCompiler` passes, including the
  "cuex enabled with external packages" subcase which loads a real `Package` CR via
  envtest and confirms `WorkloadCompiler` still resolves external packages correctly
  after this change.

Note: in this local sandbox (no real/default kubeconfig available), the `cue/cuex`
test *package* reports an overall `FAIL` after `TestWorkloadCompiler` passes. This is
pre-existing and unrelated to this change — verified it reproduces identically via
`git stash` on the unmodified baseline. Root cause: `TestMain` in
`pkg/cue/cuex/compiler_test.go` calls `singleton.KubeConfig.Reload()` after
`m.Run()`, which invokes controller-runtime's `config.GetConfigOrDie()` and requires
a real, reachable kubeconfig (`KUBECONFIG` / `~/.kube/config` / in-cluster) rather
than the in-process envtest config — none of which exist in this sandbox.
`.github/workflows/unit-test.yml` sets up a real KinD cluster via
`./.github/actions/setup-kind-cluster` before running unit tests, which is why this
passes in CI. I could not run against a live KinD cluster here, but the change
itself (a 3-line addition mirroring an already-working, identical pattern) is
covered by the assertions above.

The added code path (`ListenExternalPackages`) is not exercised by the existing
test suite, since `EnableExternalPackageWatchForDefaultCompiler` defaults to `false`
and no test sets it to `true`; it uses the exact same `*cuex.Compiler` method,
called the same way, as the already-merged and working `providers.DefaultCompiler`.

### Special notes for your reviewer

This mirrors the identical, already-working pattern in
`pkg/workflow/providers/compiler.go`'s `DefaultCompiler` initializer
(`go c.ListenExternalPackages(nil)` gated on the same flag). No other compiler
in this codebase needed a change — `cuex.DefaultCompiler` (from the
`github.com/kubevela/pkg` module) already does this internally.

Fixes #7358

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

