### PR TITLE
Fix: vela addon upgrade accepts the <registry>/<addon> form

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -323,15 +323,24 @@ non-empty new arg
 				if filepath.IsAbs(addonOrDir) || strings.HasPrefix(addonOrDir, ".") || strings.HasSuffix(addonOrDir, "/") {
 					return fmt.Errorf("addon directory %s not found in local", addonOrDir)
 				}
-				name = addonOrDir
-				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, addonOrDir)
+				// `enable` accepts <registry>/<addon> and splits it before resolving the
+				// Application; do the same here. Without this the registry prefix reaches
+				// FetchAddonRelatedApp and lands in the Application name, which then fails
+				// Kubernetes name validation with `may not contain '/'`.
+				_, addonName, err := splitSpecifyRegistry(addonOrDir)
 				if err != nil {
-					return errors.Wrapf(err, "cannot fetch addon related addon %s", addonOrDir)
+					return fmt.Errorf("failed to split addonName and addonRegistry: %w", err)
+				}
+				name = addonName
+				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)
+				if err != nil {
+					return errors.Wrapf(err, "cannot fetch addon related addon %s", name)
 				}
 				addonArgs, err := pkgaddon.MergeAddonInstallArgs(ctx, k8sClient, name, addonInputArgs)
 				if err != nil {
 					return err
 				}
+				// enableAddon splits the registry off itself, so it keeps the qualified form.
 				additionalInfo, err = enableAddon(ctx, k8sClient, dc, config, addonOrDir, addonVersion, addonArgs)
 				if err != nil {
 					return err


### PR DESCRIPTION
Fixes #7363.

## Description of your changes

`vela addon enable` splits a registry-qualified addon name before using it; `vela addon upgrade` passed `args[0]` through unchanged. The prefix then reached `pkgaddon.FetchAddonRelatedApp` and ended up in the Application name:

```console
$ vela addon upgrade KubeVela/velaux
Error: cannot fetch addon related addon KubeVela/velaux: invalid resource name "addon-KubeVela/velaux": [may not contain '/']

$ vela addon enable KubeVela/velaux
Addon velaux enabled successfully.
```

The upgrade path now calls `splitSpecifyRegistry` — the same helper `enableAddon` uses — and resolves the Application and the merged install args from the **bare** addon name.

`enableAddon` still receives the **qualified** form, because it splits the registry itself (`addon.go:576`) and needs the prefix to scope the lookup to that registry. That keeps `upgrade KubeVela/velaux` scoped to the `KubeVela` registry, matching `enable`.

A side effect worth noting: an invalid multi-slash name such as `a/b/c` now reports `failed to split addonName and addonRegistry: invalid addon name, ...` instead of surfacing a Kubernetes name-validation error, which the issue also asked for as a minimum.

Behaviour for a bare addon name is unchanged — `splitSpecifyRegistry` returns `("", name)` for it.

## Verification

- `go build ./references/cli/` — passes
- `go vet ./references/cli/` — clean
- `go test ./references/cli/ -run 'TestAddonUpgradeCmdWithErrLocalPath|TestCheckSpecifyRegistry' -v` — both PASS

I did not add a unit test for the registry-qualified path: the branch runs after `c.GetClient()`, so reaching it needs a live cluster, and the existing `TestAddonUpgradeCmdWithErrLocalPath` cases stop at the local-directory guard before that point. Happy to add an envtest-based case if you would like one.

Not run here: an end-to-end `vela addon upgrade` against a cluster.

## I have:

- [x] Read and followed the [CONTRIBUTING](https://github.com/kubevela/kubevela/blob/master/CONTRIBUTING.md) guide.
- [x] Signed off my commits (DCO).
- [x] Run `go build` and `go vet`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

