### PR TITLE
Docs: correct the unknown-flag claim in the IDE debugging guide

### DIFF
--- a/docs/development/ide-debugging.md
+++ b/docs/development/ide-debugging.md
@@ -74,11 +74,23 @@ common case for day-to-day reconciler work. The second additionally starts
 the webhook server on `:9445`; see [`webhook-debugging.md`](./webhook-debugging.md)
 for the certificate and cluster-side setup it needs.
 
-There's no `--webhook-timeout` flag on the controller side, don't add one,
-`pflag` rejects unregistered flags and the process won't start at all. The
-webhook call's timeout is a cluster-side setting: `timeoutSeconds` on each
-rule in the `ValidatingWebhookConfiguration`/`MutatingWebhookConfiguration`
-objects that `hack/debug-webhook-setup.sh` creates.
+There's no `--webhook-timeout` flag on the controller side, and adding one
+fails quietly rather than loudly. `NewCoreCommand` sets
+`FParseErrWhitelist{UnknownFlags: true}` (`cmd/core/app/server.go`) for
+backward compatibility, so an unregistered flag is accepted, ignored, and
+never reported. The controller starts normally and the setting you thought
+you applied does nothing.
+
+That applies to typos too, which is the case worth watching for here: drop a
+letter and `--use-webook=true` leaves the webhook server switched off, with
+no error to point at. Check a flag against `vela-core --help` before relying
+on it. A bad *value* on a real flag is still rejected loudly, so it's only
+the flag name that fails silently.
+
+The webhook call's timeout is a cluster-side setting anyway: `timeoutSeconds`
+on each rule in the
+`ValidatingWebhookConfiguration`/`MutatingWebhookConfiguration` objects that
+`hack/debug-webhook-setup.sh` creates.
 
 ## IntelliJ IDEA / GoLand
 


### PR DESCRIPTION
### Description of your changes

copilot:all

`ide-debugging.md` says pflag rejects unregistered flags and the process won't start. It's the other way round: `NewCoreCommand` sets `FParseErrWhitelist{UnknownFlags: true}`, so an unknown flag is accepted and silently ignored
Corrects the reason and notes the case that actually bites, a typo'd flag name
getting swallowed. The rest of the paragraph was already right and is unchanged

Fixes #7369 

I have:

- [x] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [x] All commits are signed off (DCO).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Docs only. Checked against a build from this branch: `--use-webhook=true` logs `webhookEnabled=true`, `--use-webook=true` logs `webhookEnabled=false` and the webhook server never starts, with nothing in the output naming the flag. A bad value on a real flag (`--webhook-port=notanumber`) still errors, so it's only the name that fails silently.

Skipped `make reviewable`, nothing in it applies to markdown

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

