### PR TITLE
Fix: degrade OpenAPI schema instead of failing generation on unencodable CUE

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -342,12 +342,8 @@ func GenOpenAPI(val cue.Value) (b []byte, err error) {
 	if val.Err() != nil {
 		return nil, val.Err()
 	}
-	paramOnlyVal, err := RefineParameterValue(val)
-	if err != nil {
-		return nil, err
-	}
 	defaultConfig := &openapi.Config{ExpandReferences: true}
-	b, err = openapi.Gen(paramOnlyVal, defaultConfig)
+	b, err = genOpenAPIWithFallback(val, RefineParameterValue, defaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -368,9 +364,10 @@ func GenOpenAPIWithCueX(val cue.Value) (b []byte, err error) {
 	if val.Err() != nil {
 		return nil, val.Err()
 	}
-	paramOnlyVal := FillParameterDefinitionFieldIfNotExist(val)
 	defaultConfig := &openapi.Config{ExpandReferences: true}
-	b, err = openapi.Gen(paramOnlyVal, defaultConfig)
+	b, err = genOpenAPIWithFallback(val, func(v cue.Value) (cue.Value, error) {
+		return FillParameterDefinitionFieldIfNotExist(v), nil
+	}, defaultConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/common/openapi_sanitize.go
+++ b/pkg/utils/common/openapi_sanitize.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/ast/astutil"
+	"cuelang.org/go/cue/token"
+	"cuelang.org/go/encoding/openapi"
+	"k8s.io/klog/v2"
+)
+
+var openAPIUnencodableOps = map[token.Token]bool{
+	token.NEQ: true,
+	token.GTR: true,
+	token.LSS: true,
+	token.GEQ: true,
+	token.LEQ: true,
+}
+
+// refineFunc narrows a compiled template down to the value the OpenAPI encoder
+// should see. Callers supply their own because the two entry points differ.
+type refineFunc func(cue.Value) (cue.Value, error)
+
+func genOpenAPIWithFallback(val cue.Value, refine refineFunc, cfg *openapi.Config) ([]byte, error) {
+	refined, err := refine(val)
+	if err != nil {
+		return nil, err
+	}
+	b, genErr := openapi.Gen(refined, cfg)
+	if genErr == nil {
+		return b, nil
+	}
+	if out, ok := genSanitized(val, refined, refine, cfg, genErr); ok {
+		return out, nil
+	}
+	return nil, genErr
+}
+
+// genSanitized never returns the sanitizer's own failure. The caller keeps the
+// original encoder error so a rewrite that cannot help leaves diagnostics intact,
+// including when cuelang panics part way through the rebuild.
+func genSanitized(val, refined cue.Value, refine refineFunc, cfg *openapi.Config, genErr error) (out []byte, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.V(4).Infof("OpenAPI fallback panicked, keeping original error: %v", r)
+			out, ok = nil, false
+		}
+	}()
+	if val.Context() == nil {
+		return nil, false
+	}
+
+	// Rewriting the whole template keeps definitions the parameter block refers to
+	// in scope, so references resolve without cue.ResolveReferences, which would
+	// discard pattern constraints and struct ellipsis on unrelated fields.
+	if b, dropped, err := rewriteAndGen(val, refine, cfg, false); err == nil {
+		logDropped(dropped, genErr)
+		return b, true
+	} else if err != errNothingDropped {
+		klog.V(4).Infof("OpenAPI fallback on full template failed: %v", err)
+	}
+
+	// Last resort: rewrite the already-narrowed value with references resolved.
+	if b, dropped, err := rewriteAndGen(refined, nil, cfg, true); err == nil {
+		logDropped(dropped, genErr)
+		return b, true
+	} else if err != errNothingDropped {
+		klog.V(4).Infof("OpenAPI fallback on resolved value failed: %v", err)
+	}
+
+	return nil, false
+}
+
+var errNothingDropped = fmt.Errorf("no unencodable constraint found")
+
+func rewriteAndGen(val cue.Value, refine refineFunc, cfg *openapi.Config, resolveRefs bool) ([]byte, []string, error) {
+	sanitized, dropped, err := rewriteUnencodable(val, resolveRefs)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(dropped) == 0 {
+		return nil, nil, errNothingDropped
+	}
+	if refine != nil {
+		if sanitized, err = refine(sanitized); err != nil {
+			return nil, nil, err
+		}
+	}
+	b, err := openapi.Gen(sanitized, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, dropped, nil
+}
+
+func logDropped(dropped []string, genErr error) {
+	klog.Warningf("OpenAPI schema generated without constraints the encoder cannot represent: %s (original error: %v)",
+		strings.Join(dropped, ", "), genErr)
+}
+
+// rewriteUnencodable replaces constraints that cuelang's OpenAPI encoder rejects
+// with their plain base type. CUE absorbs the base type into the constraint
+// (`string & !=""` reduces to `!=""`), so the node is substituted rather than
+// deleted, otherwise the field would be left with no type at all.
+func rewriteUnencodable(val cue.Value, resolveRefs bool) (cue.Value, []string, error) {
+	opts := []cue.Option{cue.All(), cue.Docs(true)}
+	if resolveRefs {
+		opts = append(opts, cue.ResolveReferences(true))
+	}
+	f, err := asOpenAPIFile(val.Syntax(opts...))
+	if err != nil {
+		return cue.Value{}, nil, err
+	}
+
+	var dropped []string
+	rewritten := astutil.Apply(f, nil, func(c astutil.Cursor) bool {
+		u, ok := c.Node().(*ast.UnaryExpr)
+		if !ok || !openAPIUnencodableOps[u.Op] {
+			return true
+		}
+		lit, ok := u.X.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		dropped = append(dropped, fmt.Sprintf("%s (%s%s)", fieldPath(c), u.Op, lit.Value))
+		c.Replace(ast.NewIdent(baseTypeOfLiteral(lit)))
+		return true
+	})
+	if len(dropped) == 0 {
+		return cue.Value{}, nil, nil
+	}
+
+	out, ok := rewritten.(*ast.File)
+	if !ok {
+		return cue.Value{}, nil, fmt.Errorf("unexpected node %T after rewrite", rewritten)
+	}
+	sanitized := val.Context().BuildFile(out)
+	if sanitized.Err() != nil {
+		return cue.Value{}, nil, sanitized.Err()
+	}
+	return sanitized, dropped, nil
+}
+
+// baseTypeOfLiteral reports the CUE base type a quoted literal belongs to. CUE
+// tokenizes both string and bytes literals as token.STRING and distinguishes
+// them by quote style, so a bytes constraint must not be replaced with `string`.
+func baseTypeOfLiteral(lit *ast.BasicLit) string {
+	if strings.HasPrefix(lit.Value, "'") {
+		return "__bytes"
+	}
+	return "__string"
+}
+
+func fieldPath(c astutil.Cursor) string {
+	var parts []string
+	for cur := c; cur != nil; cur = cur.Parent() {
+		f, ok := cur.Node().(*ast.Field)
+		if !ok {
+			continue
+		}
+		name, _, err := ast.LabelName(f.Label)
+		if err != nil || name == "" {
+			continue
+		}
+		parts = append(parts, name)
+	}
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	path := strings.Join(parts, ".")
+	for _, prefix := range []string{"#parameter.", "parameter."} {
+		path = strings.TrimPrefix(path, prefix)
+	}
+	if path == "" {
+		return "<parameter>"
+	}
+	return path
+}
+
+func asOpenAPIFile(n ast.Node) (*ast.File, error) {
+	switch x := n.(type) {
+	case *ast.File:
+		return x, nil
+	case *ast.StructLit:
+		return &ast.File{Decls: x.Elts}, nil
+	case ast.Expr:
+		return &ast.File{Decls: []ast.Decl{&ast.EmbedDecl{Expr: x}}}, nil
+	}
+	return nil, fmt.Errorf("unexpected node %T", n)
+}

--- a/pkg/utils/common/openapi_sanitize.go
+++ b/pkg/utils/common/openapi_sanitize.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -49,7 +50,7 @@ func genOpenAPIWithFallback(val cue.Value, refine refineFunc, cfg *openapi.Confi
 	if genErr == nil {
 		return b, nil
 	}
-	if out, ok := genSanitized(val, refined, refine, cfg, genErr); ok {
+	if out, ok := genSanitized(val, refine, cfg, genErr); ok {
 		return out, nil
 	}
 	return nil, genErr
@@ -58,7 +59,7 @@ func genOpenAPIWithFallback(val cue.Value, refine refineFunc, cfg *openapi.Confi
 // genSanitized never returns the sanitizer's own failure. The caller keeps the
 // original encoder error so a rewrite that cannot help leaves diagnostics intact,
 // including when cuelang panics part way through the rebuild.
-func genSanitized(val, refined cue.Value, refine refineFunc, cfg *openapi.Config, genErr error) (out []byte, ok bool) {
+func genSanitized(val cue.Value, refine refineFunc, cfg *openapi.Config, genErr error) (out []byte, ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(4).Infof("OpenAPI fallback panicked, keeping original error: %v", r)
@@ -69,31 +70,21 @@ func genSanitized(val, refined cue.Value, refine refineFunc, cfg *openapi.Config
 		return nil, false
 	}
 
-	// Rewriting the whole template keeps definitions the parameter block refers to
-	// in scope, so references resolve without cue.ResolveReferences, which would
-	// discard pattern constraints and struct ellipsis on unrelated fields.
-	if b, dropped, err := rewriteAndGen(val, refine, cfg, false); err == nil {
-		logDropped(dropped, genErr)
-		return b, true
-	} else if err != errNothingDropped {
-		klog.V(4).Infof("OpenAPI fallback on full template failed: %v", err)
+	b, dropped, err := rewriteAndGen(val, refine, cfg)
+	if err != nil {
+		if !errors.Is(err, errNothingDropped) {
+			klog.V(4).Infof("OpenAPI fallback failed, keeping original error: %v", err)
+		}
+		return nil, false
 	}
-
-	// Last resort: rewrite the already-narrowed value with references resolved.
-	if b, dropped, err := rewriteAndGen(refined, nil, cfg, true); err == nil {
-		logDropped(dropped, genErr)
-		return b, true
-	} else if err != errNothingDropped {
-		klog.V(4).Infof("OpenAPI fallback on resolved value failed: %v", err)
-	}
-
-	return nil, false
+	logDropped(dropped, genErr)
+	return b, true
 }
 
-var errNothingDropped = fmt.Errorf("no unencodable constraint found")
+var errNothingDropped = errors.New("no unencodable constraint found")
 
-func rewriteAndGen(val cue.Value, refine refineFunc, cfg *openapi.Config, resolveRefs bool) ([]byte, []string, error) {
-	sanitized, dropped, err := rewriteUnencodable(val, resolveRefs)
+func rewriteAndGen(val cue.Value, refine refineFunc, cfg *openapi.Config) ([]byte, []string, error) {
+	sanitized, dropped, err := rewriteUnencodable(val)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,15 +109,13 @@ func logDropped(dropped []string, genErr error) {
 }
 
 // rewriteUnencodable replaces constraints that cuelang's OpenAPI encoder rejects
-// with their plain base type. CUE absorbs the base type into the constraint
+// with their plain base type. It rewrites the whole template so definitions the
+// parameter block refers to stay in scope and resolve without inlining, which
+// would discard pattern constraints and struct ellipsis on unrelated fields. CUE absorbs the base type into the constraint
 // (`string & !=""` reduces to `!=""`), so the node is substituted rather than
 // deleted, otherwise the field would be left with no type at all.
-func rewriteUnencodable(val cue.Value, resolveRefs bool) (cue.Value, []string, error) {
-	opts := []cue.Option{cue.All(), cue.Docs(true)}
-	if resolveRefs {
-		opts = append(opts, cue.ResolveReferences(true))
-	}
-	f, err := asOpenAPIFile(val.Syntax(opts...))
+func rewriteUnencodable(val cue.Value) (cue.Value, []string, error) {
+	f, err := asOpenAPIFile(val.Syntax(cue.All(), cue.Docs(true)))
 	if err != nil {
 		return cue.Value{}, nil, err
 	}

--- a/pkg/utils/common/openapi_sanitize_test.go
+++ b/pkg/utils/common/openapi_sanitize_test.go
@@ -1,0 +1,468 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/token"
+	"cuelang.org/go/encoding/openapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genProps runs the real GenOpenAPI entry point over a CUE template and returns
+// the `properties` block of the generated parameter schema.
+func genProps(t *testing.T, src string) map[string]any {
+	t.Helper()
+	val := cuecontext.New().CompileString(src)
+	require.NoError(t, val.Err())
+
+	b, err := GenOpenAPI(val)
+	require.NoError(t, err)
+
+	var doc struct {
+		Components struct {
+			Schemas struct {
+				Parameter struct {
+					Properties map[string]any `json:"properties"`
+				} `json:"parameter"`
+			} `json:"schemas"`
+		} `json:"components"`
+	}
+	require.NoError(t, json.Unmarshal(b, &doc))
+	return doc.Components.Schemas.Parameter.Properties
+}
+
+func prop(t *testing.T, props map[string]any, name string) map[string]any {
+	t.Helper()
+	v, ok := props[name]
+	require.Truef(t, ok, "property %q missing from schema", name)
+	m, ok := v.(map[string]any)
+	require.Truef(t, ok, "property %q is not an object", name)
+	return m
+}
+
+// TestGenOpenAPIConstraintFallback covers the constraints cuelang's OpenAPI
+// encoder rejects. Every case here fails outright without the fallback.
+func TestGenOpenAPIConstraintFallback(t *testing.T) {
+	testCases := map[string]struct {
+		src    string
+		verify func(t *testing.T, props map[string]any)
+	}{
+		"string inequality is dropped but the type survives": {
+			src: `parameter: { bucketName: string & !="" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				p := prop(t, props, "bucketName")
+				assert.Equal(t, "string", p["type"])
+				assert.NotContains(t, p, "minLength")
+			},
+		},
+		"all five relational operators on strings": {
+			src: `parameter: {
+	a: string & >"a" & <"z"
+	b: string & >="m"
+	c: string & <="q"
+	d: string & !=""
+}`,
+			verify: func(t *testing.T, props map[string]any) {
+				for _, k := range []string{"a", "b", "c", "d"} {
+					assert.Equal(t, "string", prop(t, props, k)["type"], "field %s", k)
+				}
+			},
+		},
+		"bytes keeps its binary format instead of becoming a plain string": {
+			src: `parameter: { blob: bytes & !='', plain: bytes }`,
+			verify: func(t *testing.T, props map[string]any) {
+				blob := prop(t, props, "blob")
+				assert.Equal(t, "binary", blob["format"])
+				assert.Equal(t, prop(t, props, "plain")["format"], blob["format"])
+			},
+		},
+		"a parameter named string does not capture the substituted type": {
+			src: `parameter: { string: "hello", name: !="" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				name := prop(t, props, "name")
+				assert.Equal(t, "string", name["type"])
+				assert.NotContains(t, name, "enum")
+				assert.Equal(t, []any{"hello"}, prop(t, props, "string")["enum"])
+			},
+		},
+		"a nested parameter named string does not capture either": {
+			src: `parameter: { inner: { string: "shadowed", name: !="" } }`,
+			verify: func(t *testing.T, props map[string]any) {
+				inner := prop(t, props, "inner")["properties"].(map[string]any)
+				assert.NotContains(t, inner["name"].(map[string]any), "enum")
+			},
+		},
+		"a parameter named bytes does not capture the substituted type": {
+			src: `parameter: { bytes: "hi", blob: !='' }`,
+			verify: func(t *testing.T, props map[string]any) {
+				blob := prop(t, props, "blob")
+				assert.Equal(t, "binary", blob["format"])
+				assert.NotContains(t, blob, "enum")
+			},
+		},
+		"encodable siblings are left alone": {
+			src: `parameter: {
+	bad:    string & !=""
+	region: *"us-west-2" | string
+	class?: "STANDARD" | "GLACIER"
+	count:  int & >0 & <10
+	rx:     =~"^a.*"
+}`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, "us-west-2", prop(t, props, "region")["default"])
+				assert.Equal(t, []any{"STANDARD", "GLACIER"}, prop(t, props, "class")["enum"])
+				assert.Equal(t, "^a.*", prop(t, props, "rx")["pattern"])
+				count := prop(t, props, "count")
+				assert.EqualValues(t, 0, count["minimum"])
+				assert.EqualValues(t, 10, count["maximum"])
+			},
+		},
+		"doc comments survive the rewrite": {
+			src: `parameter: {
+	// +usage=Name of the bucket
+	bucketName: string & !=""
+}`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, "+usage=Name of the bucket", prop(t, props, "bucketName")["description"])
+			},
+		},
+		"maps keep their value type": {
+			src: `parameter: { bad: string & !="", labels: [string]: string }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, map[string]any{"type": "string"}, prop(t, props, "labels")["additionalProperties"])
+			},
+		},
+		"open structs keep their ellipsis": {
+			src: `parameter: { bad: string & !="", extra: {known: string, ...} }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Contains(t, prop(t, props, "extra"), "additionalProperties")
+			},
+		},
+		"a map whose value carries the bad constraint": {
+			src: `parameter: { labels: [string]: string & !="" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, map[string]any{"type": "string"}, prop(t, props, "labels")["additionalProperties"])
+			},
+		},
+		"referenced definitions still expand": {
+			src: `#Port: { port: int, name?: string }
+parameter: { p: #Port, bad: string & !="" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				inner := prop(t, props, "p")["properties"].(map[string]any)
+				assert.Contains(t, inner, "port")
+				assert.Contains(t, inner, "name")
+			},
+		},
+		"maps, open structs and references together": {
+			src: `#Port: { port: int, name?: string }
+parameter: {
+	bad:    string & !=""
+	labels: [string]: string
+	extra:  {known: string, ...}
+	p:      #Port
+}`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, map[string]any{"type": "string"}, prop(t, props, "labels")["additionalProperties"])
+				assert.Contains(t, prop(t, props, "extra"), "additionalProperties")
+				assert.Contains(t, prop(t, props, "p")["properties"].(map[string]any), "port")
+				assert.Equal(t, "string", prop(t, props, "bad")["type"])
+			},
+		},
+		"deeply nested fields are reached": {
+			src: `parameter: { a: b: c: d: string & !="" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				a := prop(t, props, "a")["properties"].(map[string]any)
+				b := a["b"].(map[string]any)["properties"].(map[string]any)
+				c := b["c"].(map[string]any)["properties"].(map[string]any)
+				assert.Equal(t, "string", c["d"].(map[string]any)["type"])
+			},
+		},
+		"defaults on a disjunction with a bad branch": {
+			src: `parameter: { a?: *"d" | (string & !="") }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, "d", prop(t, props, "a")["default"])
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.verify(t, genProps(t, tc.src))
+		})
+	}
+}
+
+// TestGenOpenAPIUnaffected pins the behaviour of templates the encoder already
+// handles. These must never enter the fallback, so their schemas must not change.
+func TestGenOpenAPIUnaffected(t *testing.T) {
+	testCases := map[string]struct {
+		src    string
+		verify func(t *testing.T, props map[string]any)
+	}{
+		"plain types": {
+			src: `parameter: { image: string, replicas: *1 | int, port?: int }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, "string", prop(t, props, "image")["type"])
+				assert.EqualValues(t, 1, prop(t, props, "replicas")["default"])
+				assert.Equal(t, "integer", prop(t, props, "port")["type"])
+			},
+		},
+		"regex, negated regex, bounds and enum": {
+			src: `parameter: { rx: =~"^a.*", nrx: string & !~"^x", n: int & >0 & <10, e: "A" | "B" }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.Equal(t, "^a.*", prop(t, props, "rx")["pattern"])
+				assert.Contains(t, prop(t, props, "nrx"), "not")
+				assert.EqualValues(t, 10, prop(t, props, "n")["maximum"])
+				assert.Equal(t, []any{"A", "B"}, prop(t, props, "e")["enum"])
+			},
+		},
+		"builtin string validators encode natively": {
+			src: `import "strings"
+parameter: { s: strings.MinRunes(3) }`,
+			verify: func(t *testing.T, props map[string]any) {
+				assert.EqualValues(t, 3, prop(t, props, "s")["minLength"])
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.verify(t, genProps(t, tc.src))
+		})
+	}
+}
+
+// TestGenOpenAPIStillFails covers templates the fallback must not rescue. A
+// template that does not compile is broken for rendering too, and the caller
+// must see the original diagnostic rather than a masked one.
+func TestGenOpenAPIStillFails(t *testing.T) {
+	testCases := map[string]struct {
+		src     string
+		wantErr string
+	}{
+		"unused import":         {src: "import \"strings\"\nparameter: { a: string }", wantErr: "imported and not used"},
+		"undefined reference":   {src: `parameter: { a: nope }`, wantErr: `reference "nope" not found`},
+		"no parameter at all":   {src: `output: { kind: "Deployment" }`, wantErr: ""},
+		"unencodable but unfix": {src: `parameter: { a: string, _hidden: !="" }`, wantErr: ""},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			val := cuecontext.New().CompileString(tc.src)
+			if val.Err() != nil {
+				assert.Contains(t, val.Err().Error(), tc.wantErr)
+				return
+			}
+			_, err := GenOpenAPI(val)
+			if tc.wantErr == "" {
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestGenOpenAPIPreservesOriginalError asserts the invariant that a failing
+// fallback never replaces the encoder's own diagnostic.
+func TestGenOpenAPIPreservesOriginalError(t *testing.T) {
+	// list.MinItems is not imported, so the template cannot compile and the
+	// fallback has nothing to rebuild.
+	val := cuecontext.New().CompileString(`parameter: { a: [...string] & list.MinItems(1) }`)
+	_, err := GenOpenAPI(val)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list")
+}
+
+func TestBaseTypeOfLiteral(t *testing.T) {
+	testCases := map[string]struct {
+		value string
+		want  string
+	}{
+		"double quoted is a string": {value: `""`, want: "__string"},
+		"non empty string":          {value: `"abc"`, want: "__string"},
+		"multiline string":          {value: `"""x"""`, want: "__string"},
+		"single quoted is bytes":    {value: `''`, want: "__bytes"},
+		"non empty bytes":           {value: `'\x00'`, want: "__bytes"},
+		"multiline bytes":           {value: `'''x'''`, want: "__bytes"},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := baseTypeOfLiteral(&ast.BasicLit{Kind: token.STRING, Value: tc.value})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRewriteUnencodableReportsFieldPaths(t *testing.T) {
+	testCases := map[string]struct {
+		src         string
+		wantDropped []string
+	}{
+		"single field": {
+			src:         `parameter: { bucketName: string & !="" }`,
+			wantDropped: []string{`bucketName (!="")`},
+		},
+		"two fields": {
+			src:         `parameter: { a: string & !="", b: string & >"m" }`,
+			wantDropped: []string{`a (!="")`, `b (>"m")`},
+		},
+		"nested field reports its full path": {
+			src:         `parameter: { cfg: inner: name: string & !="" }`,
+			wantDropped: []string{`cfg.inner.name (!="")`},
+		},
+		"nothing to drop": {
+			src:         `parameter: { a: string }`,
+			wantDropped: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			val := cuecontext.New().CompileString(tc.src)
+			require.NoError(t, val.Err())
+
+			_, dropped, err := rewriteUnencodable(val, false)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantDropped, dropped)
+		})
+	}
+}
+
+func TestGenSanitizedRejectsZeroValue(t *testing.T) {
+	_, ok := genSanitized(cue.Value{}, cue.Value{}, RefineParameterValue,
+		&openapi.Config{ExpandReferences: true}, assert.AnError)
+	assert.False(t, ok, "a zero cue.Value must not be rewritten")
+}
+
+func TestAsOpenAPIFile(t *testing.T) {
+	t.Run("file passes through", func(t *testing.T) {
+		in := &ast.File{}
+		got, err := asOpenAPIFile(in)
+		require.NoError(t, err)
+		assert.Same(t, in, got)
+	})
+
+	t.Run("struct literal becomes a file", func(t *testing.T) {
+		got, err := asOpenAPIFile(&ast.StructLit{Elts: []ast.Decl{&ast.EmbedDecl{Expr: ast.NewIdent("string")}}})
+		require.NoError(t, err)
+		assert.Len(t, got.Decls, 1)
+	})
+
+	t.Run("bare expression is embedded", func(t *testing.T) {
+		got, err := asOpenAPIFile(ast.NewIdent("string"))
+		require.NoError(t, err)
+		assert.Len(t, got.Decls, 1)
+	})
+
+	t.Run("unsupported node is an error", func(t *testing.T) {
+		_, err := asOpenAPIFile(&ast.CommentGroup{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected node")
+	})
+}
+
+// badValue is a template whose parameter block carries an unencodable constraint,
+// used to drive the fallback into its error branches.
+const badValue = `parameter: { a: string & !="" }`
+
+func TestGenSanitizedRecoversFromPanic(t *testing.T) {
+	val := cuecontext.New().CompileString(badValue)
+	require.NoError(t, val.Err())
+
+	panicking := func(cue.Value) (cue.Value, error) { panic("boom") }
+
+	out, ok := genSanitized(val, val, panicking, &openapi.Config{ExpandReferences: true}, assert.AnError)
+	assert.False(t, ok, "a panic in the fallback must not be reported as success")
+	assert.Nil(t, out)
+}
+
+func TestGenSanitizedKeepsOriginalErrorWhenRefineFails(t *testing.T) {
+	val := cuecontext.New().CompileString(badValue)
+	require.NoError(t, val.Err())
+
+	failing := func(cue.Value) (cue.Value, error) { return cue.Value{}, assert.AnError }
+
+	out, ok := genSanitized(val, val, failing, &openapi.Config{ExpandReferences: true}, assert.AnError)
+	assert.False(t, ok)
+	assert.Nil(t, out)
+}
+
+func TestRewriteAndGenReportsNothingDropped(t *testing.T) {
+	val := cuecontext.New().CompileString(`parameter: { a: string }`)
+	require.NoError(t, val.Err())
+
+	_, _, err := rewriteAndGen(val, RefineParameterValue, &openapi.Config{ExpandReferences: true}, false)
+	assert.ErrorIs(t, err, errNothingDropped)
+}
+
+// TestGenOpenAPIFallbackSecondTier drives templates whose full-template rewrite
+// cannot be rebuilt, so the fallback has to retry against the narrowed value with
+// references resolved.
+func TestGenOpenAPIFallbackSecondTier(t *testing.T) {
+	testCases := map[string]string{
+		"imported builtin alongside a bad constraint": `import "strings"
+parameter: { a: string & !="", b: strings.MinRunes(2) }`,
+		"hidden field alongside a bad constraint": `_hidden: "x"
+parameter: { a: string & !="" }`,
+	}
+
+	for name, src := range testCases {
+		t.Run(name, func(t *testing.T) {
+			props := genProps(t, src)
+			assert.Equal(t, "string", prop(t, props, "a")["type"])
+		})
+	}
+}
+
+func TestGenOpenAPIWithCueXConstraintFallback(t *testing.T) {
+	val := cuecontext.New().CompileString(`parameter: { bucketName: string & !="" }`)
+	require.NoError(t, val.Err())
+
+	b, err := GenOpenAPIWithCueX(val)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"bucketName"`)
+	assert.NotContains(t, string(b), "minLength")
+}
+
+// TestGenOpenAPIUnfixableFailureKeepsOriginalError covers a template the encoder
+// rejects for a reason the rewrite cannot address. Both tiers must decline and
+// the caller must receive the encoder's own diagnostic.
+func TestGenOpenAPIUnfixableFailureKeepsOriginalError(t *testing.T) {
+	val := cuecontext.New().CompileString(`parameter: { a: [string, int] }`)
+	require.NoError(t, val.Err())
+
+	_, err := GenOpenAPI(val)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot convert incomplete value")
+}
+
+// TestGenOpenAPINumericOperatorsUntouched pins that relational operators on
+// numbers are encodable and must never be rewritten.
+func TestGenOpenAPINumericOperatorsUntouched(t *testing.T) {
+	props := genProps(t, `parameter: { a: number & !=1.5, b: int & >=2 }`)
+	assert.Contains(t, prop(t, props, "a"), "not")
+	assert.EqualValues(t, 2, prop(t, props, "b")["minimum"])
+}

--- a/pkg/utils/common/openapi_sanitize_test.go
+++ b/pkg/utils/common/openapi_sanitize_test.go
@@ -344,7 +344,7 @@ func TestRewriteUnencodableReportsFieldPaths(t *testing.T) {
 			val := cuecontext.New().CompileString(tc.src)
 			require.NoError(t, val.Err())
 
-			_, dropped, err := rewriteUnencodable(val, false)
+			_, dropped, err := rewriteUnencodable(val)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantDropped, dropped)
 		})
@@ -352,7 +352,7 @@ func TestRewriteUnencodableReportsFieldPaths(t *testing.T) {
 }
 
 func TestGenSanitizedRejectsZeroValue(t *testing.T) {
-	_, ok := genSanitized(cue.Value{}, cue.Value{}, RefineParameterValue,
+	_, ok := genSanitized(cue.Value{}, RefineParameterValue,
 		&openapi.Config{ExpandReferences: true}, assert.AnError)
 	assert.False(t, ok, "a zero cue.Value must not be rewritten")
 }
@@ -394,7 +394,7 @@ func TestGenSanitizedRecoversFromPanic(t *testing.T) {
 
 	panicking := func(cue.Value) (cue.Value, error) { panic("boom") }
 
-	out, ok := genSanitized(val, val, panicking, &openapi.Config{ExpandReferences: true}, assert.AnError)
+	out, ok := genSanitized(val, panicking, &openapi.Config{ExpandReferences: true}, assert.AnError)
 	assert.False(t, ok, "a panic in the fallback must not be reported as success")
 	assert.Nil(t, out)
 }
@@ -405,7 +405,7 @@ func TestGenSanitizedKeepsOriginalErrorWhenRefineFails(t *testing.T) {
 
 	failing := func(cue.Value) (cue.Value, error) { return cue.Value{}, assert.AnError }
 
-	out, ok := genSanitized(val, val, failing, &openapi.Config{ExpandReferences: true}, assert.AnError)
+	out, ok := genSanitized(val, failing, &openapi.Config{ExpandReferences: true}, assert.AnError)
 	assert.False(t, ok)
 	assert.Nil(t, out)
 }
@@ -414,14 +414,13 @@ func TestRewriteAndGenReportsNothingDropped(t *testing.T) {
 	val := cuecontext.New().CompileString(`parameter: { a: string }`)
 	require.NoError(t, val.Err())
 
-	_, _, err := rewriteAndGen(val, RefineParameterValue, &openapi.Config{ExpandReferences: true}, false)
+	_, _, err := rewriteAndGen(val, RefineParameterValue, &openapi.Config{ExpandReferences: true})
 	assert.ErrorIs(t, err, errNothingDropped)
 }
 
-// TestGenOpenAPIFallbackSecondTier drives templates whose full-template rewrite
-// cannot be rebuilt, so the fallback has to retry against the narrowed value with
-// references resolved.
-func TestGenOpenAPIFallbackSecondTier(t *testing.T) {
+// TestGenOpenAPIFallbackWithSurroundingDecls drives templates that carry imports
+// or hidden fields alongside the offending constraint.
+func TestGenOpenAPIFallbackWithSurroundingDecls(t *testing.T) {
 	testCases := map[string]string{
 		"imported builtin alongside a bad constraint": `import "strings"
 parameter: { a: string & !="", b: strings.MinRunes(2) }`,

--- a/test/e2e-test/definition_schema_test.go
+++ b/test/e2e-test/definition_schema_test.go
@@ -1,0 +1,236 @@
+/*
+ Copyright 2026. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/condition"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+// The OpenAPI encoder in cuelang rejects relational operators applied to strings,
+// so a ComponentDefinition carrying `string & !=""` used to fail schema generation
+// outright, leaving Synced=False and no schema ConfigMap. The definition itself is
+// valid and renders fine, so generation now falls back to dropping only the
+// constraints the encoder cannot represent.
+var _ = Describe("ComponentDefinition OpenAPI schema generation", func() {
+	ctx := context.Background()
+
+	var namespace string
+	var ns corev1.Namespace
+
+	BeforeEach(func() {
+		namespace = randomNamespaceName("def-schema-e2e")
+		ns = corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Eventually(func() error {
+			return k8sClient.Create(ctx, &ns)
+		}, time.Second*3, time.Microsecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		By("Clean up resources after a test")
+		Expect(k8sClient.DeleteAllOf(ctx, &v1beta1.ComponentDefinition{}, client.InNamespace(namespace))).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(Succeed())
+	})
+
+	// applyAndGetSchema creates a ComponentDefinition from a CUE template, waits for
+	// the controller to report Synced=True and publish a ConfigMapRef, then returns
+	// the decoded `properties` block of the stored schema.
+	applyAndGetSchema := func(name, template string) map[string]any {
+		cd := &v1beta1.ComponentDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v1beta1.ComponentDefinitionSpec{
+				Workload: common.WorkloadTypeDescriptor{
+					Definition: common.WorkloadGVK{APIVersion: "v1", Kind: "ConfigMap"},
+				},
+				Schematic: &common.Schematic{
+					CUE: &common.CUE{Template: template},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cd)).Should(Succeed())
+
+		By("Wait for the definition to report Synced=True")
+		got := new(v1beta1.ComponentDefinition)
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, got)).Should(Succeed())
+			synced := got.Status.GetCondition(condition.TypeSynced)
+			g.Expect(string(synced.Status)).Should(Equal(string(corev1.ConditionTrue)),
+				fmt.Sprintf("Synced condition was %q: %s", synced.Status, synced.Message))
+		}, 30*time.Second, time.Second).Should(Succeed())
+
+		By("Wait for the schema ConfigMap to be published")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, got)).Should(Succeed())
+			g.Expect(got.Status.ConfigMapRef).ShouldNot(BeEmpty())
+		}, 30*time.Second, time.Second).Should(Succeed())
+
+		Expect(got.Status.ConfigMapRef).Should(Equal(fmt.Sprintf("component-%s%s", types.CapabilityConfigMapNamePrefix, name)))
+
+		cm := new(corev1.ConfigMap)
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: got.Status.ConfigMapRef, Namespace: namespace}, cm)
+		}, 30*time.Second, time.Second).Should(Succeed())
+
+		raw := cm.Data[types.OpenapiV3JSONSchema]
+		Expect(raw).ShouldNot(BeEmpty())
+
+		var doc struct {
+			Properties map[string]any `json:"properties"`
+		}
+		Expect(json.Unmarshal([]byte(raw), &doc)).Should(Succeed())
+		Expect(doc.Properties).ShouldNot(BeEmpty())
+		return doc.Properties
+	}
+
+	outputBlock := `
+output: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: name: context.name
+	data: k: "v"
+}
+`
+
+	It("keeps a definition Synced and publishes a schema when a string constraint cannot be encoded", func() {
+		props := applyAndGetSchema("schema-string-constraint", outputBlock+`
+parameter: {
+	// +usage=Name of the bucket
+	bucketName: string & !=""
+	// +usage=Target region
+	region: *"us-west-2" | string
+	// +usage=Storage class
+	class?: "STANDARD" | "GLACIER"
+	// +usage=Replica count
+	replicas: int & >0 & <10
+}
+`)
+
+		By("The unencodable constraint is dropped but the field keeps its type and docs")
+		bucket := props["bucketName"].(map[string]any)
+		Expect(bucket["type"]).Should(Equal("string"))
+		Expect(bucket["description"]).Should(Equal("Name of the bucket"))
+		Expect(bucket).ShouldNot(HaveKey("minLength"))
+
+		By("Fields the encoder can represent are untouched")
+		Expect(props["region"].(map[string]any)["default"]).Should(Equal("us-west-2"))
+		Expect(props["class"].(map[string]any)["enum"]).Should(ConsistOf("STANDARD", "GLACIER"))
+		replicas := props["replicas"].(map[string]any)
+		Expect(replicas["type"]).Should(Equal("integer"))
+		Expect(replicas["minimum"]).Should(BeEquivalentTo(0))
+		Expect(replicas["maximum"]).Should(BeEquivalentTo(10))
+	})
+
+	It("preserves the binary format of a bytes field whose constraint is dropped", func() {
+		props := applyAndGetSchema("schema-bytes-constraint", outputBlock+`
+parameter: {
+	// +usage=Binary blob
+	blob: bytes & !=''
+	// +usage=Control blob
+	plain: bytes
+}
+`)
+
+		blob := props["blob"].(map[string]any)
+		plain := props["plain"].(map[string]any)
+		Expect(blob["format"]).Should(Equal("binary"), "a bytes field must not be retyped as a plain string")
+		Expect(blob["format"]).Should(Equal(plain["format"]))
+	})
+
+	It("does not let a parameter named string capture the substituted type", func() {
+		props := applyAndGetSchema("schema-shadowed-ident", outputBlock+`
+parameter: {
+	// +usage=Field literally named string
+	string: "hello"
+	// +usage=Must stay an unconstrained string
+	name: !=""
+}
+`)
+
+		Expect(props["name"].(map[string]any)).ShouldNot(HaveKey("enum"))
+		Expect(props["name"].(map[string]any)["type"]).Should(Equal("string"))
+		Expect(props["string"].(map[string]any)["enum"]).Should(ConsistOf("hello"))
+	})
+
+	It("leaves maps, open structs and referenced definitions intact alongside a dropped constraint", func() {
+		props := applyAndGetSchema("schema-mixed-shapes", `
+#Port: {
+	port:  int
+	name?: string
+}
+`+outputBlock+`
+parameter: {
+	// +usage=Bucket name
+	bucketName: string & !=""
+	// +usage=Arbitrary labels
+	labels: [string]: string
+	// +usage=Open struct
+	extra: {known: string, ...}
+	// +usage=Referenced type
+	p: #Port
+}
+`)
+
+		By("The map keeps its value type")
+		labels := props["labels"].(map[string]any)
+		Expect(labels["additionalProperties"]).Should(Equal(map[string]any{"type": "string"}))
+
+		By("The open struct keeps its ellipsis")
+		extra := props["extra"].(map[string]any)
+		Expect(extra).Should(HaveKey("additionalProperties"))
+		Expect(extra["properties"].(map[string]any)).Should(HaveKey("known"))
+
+		By("The referenced definition is still expanded")
+		Expect(props["p"].(map[string]any)["properties"].(map[string]any)).Should(And(HaveKey("port"), HaveKey("name")))
+
+		By("Only the offending field is degraded")
+		Expect(props["bucketName"].(map[string]any)["type"]).Should(Equal("string"))
+	})
+
+	It("emits an unchanged schema for a definition the encoder fully supports", func() {
+		props := applyAndGetSchema("schema-fully-encodable", outputBlock+`
+parameter: {
+	// +usage=Matched by a regular expression
+	rx: =~"^a.*"
+	// +usage=Excluded by a regular expression
+	nrx: string & !~"^x"
+	// +usage=Bounded number
+	n: int & >0 & <10
+	// +usage=One of a fixed set
+	e: "A" | "B"
+}
+`)
+
+		Expect(props["rx"].(map[string]any)["pattern"]).Should(Equal("^a.*"))
+		Expect(props["nrx"].(map[string]any)).Should(HaveKey("not"))
+		Expect(props["n"].(map[string]any)["maximum"]).Should(BeEquivalentTo(10))
+		Expect(props["e"].(map[string]any)["enum"]).Should(ConsistOf("A", "B"))
+	})
+})


### PR DESCRIPTION
### Description of your changes

`cuelang`'s OpenAPI encoder rejects relational operators on strings, so a
ComponentDefinition containing `string & !=""` fails schema generation with
`unsupported op != for string type`. The definition compiles and renders fine,
but the controller reports the failure on `Synced`, leaving working definitions
marked `Synced=False` with no schema ConfigMap.

The schema is only consumed by VelaUX forms, `vela show` and SDK generation. The
render path compiles the CUE template directly and never reads it back.

`openapi.Gen` is now attempted unmodified first, so definitions that work today
produce byte-identical schemas. Only on failure is the template rewritten:
constraints the encoder cannot represent are replaced with their base type and
generation retried, with the dropped constraints logged by field path. Any
failure in that path returns the original encoder error.

VelaUX loses pre-validation of those constraints. Enforcement is unchanged —
admission still rejects `bucketName: ""` with `out of bound !=""`.

Encodable constructs are untouched: `=~`/`!~`, numeric bounds, enums, defaults,
optionality, and `+usage=` descriptions. Templates that fail to *compile* still
fail, as they should; the webhook rejects those before the controller sees them.

Files: `pkg/utils/common/openapi_sanitize.go` (new) plus two call sites in
`pkg/utils/common/common.go`, with unit and e2e tests.

**Breaking changes:** none. No API types, CRDs or conditions change.

I have:

- [ ] Read and followed KubeVela's [pull request process](https://kubevela.io/docs/contributor/code-contribute#create-a-pull-request).
- [ ] All commits are signed off (DCO).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests in `pkg/utils/common/openapi_sanitize_test.go`, 91% coverage of the
new file. Verified red/green: with the fallback reverted all 15 fallback cases
fail, while the cases pinning unchanged behaviour stay green.

E2E in `test/e2e-test/definition_schema_test.go`, 5 specs, each asserting
`Synced=True` and a published schema ConfigMap before checking the schema
contents. All pass against a k3d cluster.

Note: the wider `ComponentDefinition` e2e focus shows 3 pre-existing failures in
`definition_output_validation_test.go`. They are unrelated —
`ValidateOutputResourcesExist` has no OpenAPI call, and the failure reproduces
manually without any test harness.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/kubevela/pull/7373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

